### PR TITLE
Add ValidateCompressionResult method to ROM::Compress

### DIFF
--- a/src/app/rom.h
+++ b/src/app/rom.h
@@ -67,7 +67,7 @@ struct OWMapTiles {
 class ROM {
  public:
   absl::StatusOr<Bytes> Compress(const int start, const int length,
-                                 int mode = 1);
+                                 int mode = 1, bool check = false);
   absl::StatusOr<Bytes> CompressGraphics(const int pos, const int length);
   absl::StatusOr<Bytes> CompressOverworld(const int pos, const int length);
 


### PR DESCRIPTION
Making things more readable by decomposing the sanity check/validate compression result step of the compress method into its own method that is bound by the "check" parameter (whether or not to check the compression matches the decompression)