### PR TITLE
Restore dungeon editor tabs and continue rendering

### DIFF
--- a/src/app/editor/dungeon/dungeon_editor.cc
+++ b/src/app/editor/dungeon/dungeon_editor.cc
@@ -114,6 +114,9 @@ absl::Status DungeonEditor::Load() {
   object_selector_.SetRom(rom_);
   object_selector_.SetCurrentPaletteGroup(current_palette_group_);
   object_selector_.SetCurrentPaletteId(current_palette_id_);
+  object_selector_.set_dungeon_editor_system(&dungeon_editor_system_);
+  object_selector_.set_object_editor(&object_editor_);
+  object_selector_.set_rooms(&rooms_);
   
   is_loaded_ = true;
   return absl::OkStatus();
@@ -236,6 +239,9 @@ absl::Status DungeonEditor::UpdateDungeonRoomView() {
     ImGui::End();
   }
 
+  // Restored tabbed room view functionality
+  DrawDungeonTabView();
+
   // Simplified 3-column layout: Room/Entrance Selector | Canvas | Object Selector/Editor
   if (BeginTable("#DungeonEditTable", 3, kDungeonTableFlags, ImVec2(0, 0))) {
     TableSetupColumn("Room/Entrance Selector", ImGuiTableColumnFlags_WidthFixed, 250);
@@ -259,6 +265,7 @@ absl::Status DungeonEditor::UpdateDungeonRoomView() {
 
     // Column 3: Object Selector and Editor (using new component)
     TableNextColumn();
+    object_selector_.set_current_room_id(current_room);
     object_selector_.Draw();
     
     ImGui::EndTable();


### PR DESCRIPTION
Restore tab functionality to DungeonEditor and integrate object selector with editor systems.

The tabbed room view was previously removed during a canvas panel refactor, and this change reintroduces it while also ensuring the object selector is correctly connected to the editor's core systems and current room context.

---
<a href="https://cursor.com/background-agent?bcId=bc-5d9499ce-8d1a-4202-8670-0e8353dbd877"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-5d9499ce-8d1a-4202-8670-0e8353dbd877"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

