### PR TITLE
build(linux): fix libprotobuf.so.NN 'cannot open shared object file' across distros (Fixes #54)

### DIFF
--- a/cmake/packaging/linux.cmake
+++ b/cmake/packaging/linux.cmake
@@ -1,11 +1,52 @@
 # Linux Packaging Configuration
 
+# --- Portability guardrail -------------------------------------------------
+# A Linux package (.deb/.tar.gz) is only portable across distributions when the
+# protobuf/gRPC stack is statically linked from source. When gRPC is enabled and
+# a *system* protobuf/gRPC is preferred, the app binaries gain a hard dependency
+# on the build host's libprotobuf SONAME (e.g. libprotobuf.so.23 on Ubuntu
+# 20.04/22.04), which does not exist on another distribution (e.g. Debian 13) and
+# fails at runtime with "libprotobuf.so.NN: cannot open shared object file".
+# The default build (and the `release` preset) links protobuf statically, so this
+# only trips when YAZE_PREFER_SYSTEM_GRPC / YAZE_USE_SYSTEM_DEPS are turned ON.
+if(NOT DEFINED YAZE_STRICT_PORTABLE_PACKAGING)
+  option(YAZE_STRICT_PORTABLE_PACKAGING
+    "Fail configure when packaging a non-portable (system-linked protobuf) Linux build" OFF)
+endif()
+if(YAZE_ENABLE_GRPC AND (YAZE_PREFER_SYSTEM_GRPC OR YAZE_USE_SYSTEM_DEPS))
+  set(_yaze_nonportable_pkg_msg
+"Packaging a build that links the SYSTEM protobuf/gRPC stack \
+(YAZE_PREFER_SYSTEM_GRPC/YAZE_USE_SYSTEM_DEPS=ON). The resulting .deb/.tar.gz \
+will NOT be portable across Linux distributions: the yaze/z3ed binaries hard-link \
+the build host's libprotobuf SONAME and fail elsewhere with \
+'libprotobuf.so.NN: cannot open shared object file'. For redistributable packages, \
+configure with -DYAZE_PREFER_SYSTEM_GRPC=OFF -DYAZE_USE_SYSTEM_DEPS=OFF (the \
+default; protobuf is then statically linked from source), as the 'release' preset \
+does. Set -DYAZE_STRICT_PORTABLE_PACKAGING=ON to make this a hard error.")
+  if(YAZE_STRICT_PORTABLE_PACKAGING)
+    message(FATAL_ERROR "${_yaze_nonportable_pkg_msg}")
+  else()
+    message(WARNING "${_yaze_nonportable_pkg_msg}")
+  endif()
+  unset(_yaze_nonportable_pkg_msg)
+endif()
+
 # DEB package
 set(CPACK_GENERATOR "DEB;TGZ")
 set(CPACK_DEBIAN_PACKAGE_MAINTAINER "scawful")
 set(CPACK_DEBIAN_PACKAGE_SECTION "games")
 set(CPACK_DEBIAN_PACKAGE_PRIORITY "optional")
 set(CPACK_DEBIAN_PACKAGE_DEPENDS "libc6, libstdc++6, libsdl2-2.0-0")
+
+# Auto-compute the real runtime library dependencies via dpkg-shlibdeps and merge
+# them with the hand-maintained base list above. This keeps the .deb honest: a
+# build that links protobuf/gRPC dynamically (YAZE_PREFER_SYSTEM_GRPC=ON) then
+# declares its libprotobuf/libgrpc dependency, so apt/dpkg refuses to install it
+# on an incompatible distribution instead of failing at runtime with
+# "libprotobuf.so.NN: cannot open shared object file". For the default static
+# release build this adds no protobuf/gRPC entries (nothing to depend on).
+# Requires dpkg-dev (dpkg-shlibdeps) on the packaging host.
+set(CPACK_DEBIAN_PACKAGE_SHLIBDEPS ON)
 
 # RPM package
 set(CPACK_RPM_PACKAGE_LICENSE "MIT")

--- a/docs/public/build/install-options.md
+++ b/docs/public/build/install-options.md
@@ -78,6 +78,7 @@ See the [.yazeproj Bundle Guide](../usage/yazeproj-bundles.md) for the full dire
 
 ## Packaging Notes
 - Prefer static/runtime-complete bundles for end users (AppImage on Linux, app bundle on macOS, zip on Windows).
+- **Linux: build redistributable packages with the from-source (statically linked) protobuf/gRPC stack** — i.e. leave `YAZE_PREFER_SYSTEM_GRPC` and `YAZE_USE_SYSTEM_DEPS` **OFF** (the default, as used by the `release` preset). Do **not** package a build made with `-DYAZE_PREFER_SYSTEM_GRPC=ON` or a system-gRPC preset (`lin-ai`, `ci-linux`): protobuf's SONAME changes between releases, so the binary would hard-link the build host's `libprotobuf.so.NN` and fail on other distributions with `libprotobuf.so.NN: cannot open shared object file`. See [Troubleshooting → Shared Library Not Found at Runtime](./troubleshooting.md#shared-library-not-found-at-runtime-libprotobufsonn-libgrpcsonn). Set `-DYAZE_STRICT_PORTABLE_PACKAGING=ON` to turn the configure-time warning into a hard error in packaging pipelines.
 - When creating packages (Homebrew/Chocolatey/winget), pin the release URL and checksum and align dependencies to the CMake presets (`mac-*/lin-*/win-*`).
 - Keep CLI and GUI in the same archive to avoid mismatched versions; CLI entry is `z3ed`, GUI entry is `yaze`.
 

--- a/docs/public/build/troubleshooting.md
+++ b/docs/public/build/troubleshooting.md
@@ -260,6 +260,49 @@ cmake --preset lin-dbg \
   -DCMAKE_CXX_COMPILER=g++-13
 ```
 
+### Shared Library Not Found at Runtime (`libprotobuf.so.NN`, `libgrpc++.so.NN`)
+
+**Error** (when launching `yaze` or `z3ed`, not while building):
+```
+error while loading shared libraries: libprotobuf.so.23: cannot open shared object file: No such file or directory
+```
+
+**Cause**: The binary was built against the distribution's **system** protobuf/gRPC
+libraries — i.e. configured with `-DYAZE_PREFER_SYSTEM_GRPC=ON` (or
+`-DYAZE_USE_SYSTEM_DEPS=ON`, or a system-gRPC preset such as `lin-ai` / `ci-linux`).
+protobuf has no stable ABI and bumps its SONAME every release: `libprotobuf.so.23`
+is protobuf 3.12 (shipped by Ubuntu 20.04/22.04), while Debian 13 ships a much newer
+protobuf under a *different* SONAME. Moving such a binary to another distribution —
+for example building on Ubuntu 22.04 and running on Debian 13 — fails because the old
+SONAME no longer exists. Debian 13 *has* protobuf; it just isn't `.so.23`.
+
+**Solution (recommended)** — rebuild with the bundled, statically-linked protobuf so
+the binary carries no system protobuf/gRPC dependency. This is exactly how the official
+release binaries are built, which is why they are portable across distributions:
+```bash
+# Default from-source path (protobuf built and linked statically):
+cmake --preset lin-ai -DYAZE_PREFER_SYSTEM_GRPC=OFF -DYAZE_USE_SYSTEM_DEPS=OFF
+cmake --build --preset lin-ai
+```
+`-DYAZE_PREFER_SYSTEM_GRPC=OFF` is the default, so simply *not* opting into system
+gRPC is enough; only presets like `lin-ai` turn it on.
+
+**Alternative** — disable gRPC entirely. This removes the protobuf dependency
+completely and drops only GUI automation / remote ROM access / emulator-debug
+services (core ROM editing and the emulator are unaffected):
+```bash
+cmake --preset lin-rel   # gRPC is already OFF in this preset — smallest, fully portable
+cmake --build --preset lin-rel
+```
+
+**Quick check** — inspect a built binary's shared-library dependencies:
+```bash
+ldd ./build/presets/<preset>/bin/yaze | grep -E 'protobuf|grpc|absl'
+```
+Any `libprotobuf` / `libgrpc` / `libabsl` line means the binary depends on the system
+stack and is **not** portable to other distributions. A statically-linked build prints
+nothing.
+
 ---
 
 ## Common Build Errors


### PR DESCRIPTION
Fixes #54

## Problem

On **Debian 13**, launching a `yaze`/`z3ed` binary can fail at runtime with:

```
Error while loading shared libraries: libprotobuf.so.23:
cannot open shared object file: No such file or directory
```

`libprotobuf.so.23` is the SONAME of **protobuf 3.12** (shipped by Ubuntu 20.04/22.04). protobuf has **no stable ABI** and bumps its SONAME on almost every release, so a binary linked against the *system* protobuf on one distribution is not portable to another. Debian 13 *does* ship protobuf — just under a newer SONAME — so the dynamic loader cannot find `.so.23`. (This is why the issue reporter's "how do I install the dependencies" has no clean answer: the exact `.so.23` is simply not packaged on Debian 13.)

## Root cause

The failure only occurs when the build links the **system** protobuf/gRPC stack, i.e. `-DYAZE_PREFER_SYSTEM_GRPC=ON` or `-DYAZE_USE_SYSTEM_DEPS=ON` (the `lin-ai` / `ci-linux` presets, or a manual system build). The **default** build and the **`release`** preset already compile protobuf from source and link it **statically**, so the official release `.deb`/`.tar.gz` are unaffected — this is a self-build / non-default-preset footgun.

Two gaps made it hard to catch:
- `cmake/packaging/linux.cmake` hard-coded `Depends: libc6, libstdc++6, libsdl2-2.0-0` and never enabled `dpkg-shlibdeps`, so a dynamically-linked `.deb` would neither declare nor bundle protobuf — a silent runtime crash.
- The error and its fix were undocumented.

## What this PR does

**`cmake/packaging/linux.cmake`**
- Enable `CPACK_DEBIAN_PACKAGE_SHLIBDEPS` so the `.deb` declares its *real* runtime dependencies. A dynamically-linked build then correctly requires `libprotobuf`/`libgrpc`, so `apt`/`dpkg` refuses to install it on an incompatible distribution instead of crashing at runtime. The default static build gains no protobuf/gRPC entries. *(Requires `dpkg-dev`/`dpkg-shlibdeps` on the packaging host — present on the `ubuntu-22.04` release runner.)*
- Add a **portability guardrail**: when gRPC is enabled **and** a system protobuf/gRPC is preferred, emit a configure-time `WARNING` explaining the package will not be portable. Opt-in `-DYAZE_STRICT_PORTABLE_PACKAGING=ON` escalates it to a `FATAL_ERROR` for packaging pipelines.

**Docs**
- `docs/public/build/troubleshooting.md`: a new "Shared Library Not Found at Runtime (`libprotobuf.so.NN`, `libgrpc++.so.NN`)" entry — root cause, the recommended static rebuild, the disable-gRPC alternative, and an `ldd` check. This directly answers #54 for anyone who already has a broken binary.
- `docs/public/build/install-options.md`: Packaging Notes now require the from-source static stack for redistributable Linux packages.

Intentionally **not** included: flipping the `install-nightly.sh` default (`YAZE_NIGHTLY_PREFER_SYSTEM_GRPC`) to static — that's a separate DX trade-off (~15-20 min nightly builds) and belongs in its own change.

## Immediate remedy for affected users (also in the new docs)

```bash
# Rebuild with the bundled, statically-linked protobuf (the default; only
# system-gRPC presets turn it off):
cmake --preset lin-ai -DYAZE_PREFER_SYSTEM_GRPC=OFF -DYAZE_USE_SYSTEM_DEPS=OFF
cmake --build --preset lin-ai

# ...or drop gRPC entirely for a fully portable, dependency-free binary:
cmake --preset lin-rel && cmake --build --preset lin-rel
```

## Validation

- **Guardrail logic** exercised with `cmake -P` across all three branches: default (system deps off) → no warning, `CPACK_DEBIAN_PACKAGE_SHLIBDEPS=ON`; gRPC + prefer-system, strict off → `WARNING`, continues; gRPC + system-deps, strict on → `FATAL_ERROR` (exit 1). The safe/default path also emits no warning in a real project `cmake` configure (CMP0077 NEW).
- **SHLIBDEPS end-to-end**: built a throwaway project that `include()`s this exact `cmake/packaging/linux.cmake`, deliberately links a shared lib absent from the manual `Depends` (`libz`), and ran `cpack -G DEB`. The generated `.deb` control shows the manual floor **plus** the auto-detected dependency:
  ```
  Depends: libc6, libstdc++6, libsdl2-2.0-0, libc6 (>= 2.34), zlib1g (>= 1:1.1.4)
  ```
  `zlib1g` was added purely from the ELF by `dpkg-shlibdeps` → `libprotobuf`/`libgrpc` would be declared the same way in a dynamically-linked build.
- **Not run**: a full `yaze`/`z3ed` build with gRPC (the SHLIBDEPS behaviour is generic CPack, proven above). No `.cc/.h` changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
