### PR TITLE
fix(ci): unblock Memory Sanitizer (clang-14) + repair WASM setup step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -427,7 +427,10 @@ jobs:
       working-directory: build
       env:
         ASAN_OPTIONS: detect_leaks=1:abort_on_error=1
-      run: ctest --output-on-failure
+      # Exclude suites that are not meaningful under ASan: performance benchmarks
+      # assert hard timing ceilings that the sanitizer's overhead blows past, and
+      # gui/experimental/rom-dependent suites need a display or external assets.
+      run: ctest --output-on-failure --label-exclude "benchmark|gui|experimental|rom_dependent"
 
   z3ed-agent-test:
     name: "z3ed Agent"

--- a/.github/workflows/wasm-dev.yml
+++ b/.github/workflows/wasm-dev.yml
@@ -65,7 +65,10 @@ jobs:
         run: |
           echo "=== Emscripten Configuration ==="
           emcc --version
-          emcmake --version
+          # emcmake has no --version flag; exercise the wrapper via cmake instead
+          # (`emcmake --version` treats --version as the build command and exits 1
+          # under `set -e`, failing this step before any build runs).
+          emcmake cmake --version
           echo "=== Node.js Version ==="
           node --version
           echo "=== Environment ==="

--- a/src/app/editor/dungeon/dungeon_canvas_viewer.cc
+++ b/src/app/editor/dungeon/dungeon_canvas_viewer.cc
@@ -1354,8 +1354,12 @@ void DungeonCanvasViewer::DrawDungeonCanvas(int room_id) {
 
   // Draw coordinate overlay when hovering over canvas
   if (show_coordinate_overlay_ && canvas_.IsMouseHovering()) {
-    auto [tile_x, tile_y] = DungeonRenderingHelpers::ScreenToRoomCoordinates(
+    // Plain locals (not a structured binding) so the DrawCanvasHUD lambda below
+    // can capture them: clang-14 rejects capturing structured bindings (P1091).
+    const auto tile_coords = DungeonRenderingHelpers::ScreenToRoomCoordinates(
         ImGui::GetMousePos(), canvas_.zero_point(), canvas_.global_scale());
+    const auto tile_x = tile_coords.first;
+    const auto tile_y = tile_coords.second;
 
     // Only show if within bounds
     if (tile_x >= 0 && tile_x < 64 && tile_y >= 0 && tile_y < 64) {
@@ -1365,8 +1369,10 @@ void DungeonCanvasViewer::DrawDungeonCanvas(int room_id) {
       int canvas_y = tile_y * 8;
 
       // Calculate camera/world coordinates (for minecart tracks, sprites, etc.)
-      auto [camera_x, camera_y] =
+      const auto camera_coords =
           dungeon_coords::TileToCameraCoords(room_id, tile_x, tile_y);
+      const auto camera_x = camera_coords.first;
+      const auto camera_y = camera_coords.second;
 
       // Calculate sprite coordinates (16-pixel units)
       int sprite_x = canvas_x / dungeon_coords::kSpriteTileSize;
@@ -2243,13 +2249,13 @@ void DungeonCanvasViewer::DrawCompactLayerToggles(int room_id) {
               });
 
   ImGui::SameLine();
-  draw_toggle(
-      ICON_MD_FILTER_CENTER_FOCUS "##LayerToggleCollision",
-      show_custom_collision_overlay_,
-      as_button_color(gui::ConvertColorToImVec4(theme.warning), 0.9f),
-      "Toggle custom collision overlay", [&]() {
-        show_custom_collision_overlay_ = !show_custom_collision_overlay_;
-      });
+  draw_toggle(ICON_MD_FILTER_CENTER_FOCUS "##LayerToggleCollision",
+              show_custom_collision_overlay_,
+              as_button_color(gui::ConvertColorToImVec4(theme.warning), 0.9f),
+              "Toggle custom collision overlay", [&]() {
+                show_custom_collision_overlay_ =
+                    !show_custom_collision_overlay_;
+              });
 }
 
 void DungeonCanvasViewer::DrawLayerControls(zelda3::Room& /*room*/,

--- a/src/zelda3/dungeon/object_drawer.cc
+++ b/src/zelda3/dungeon/object_drawer.cc
@@ -1592,8 +1592,12 @@ void ObjectDrawer::DrawDoor(const DoorDef& door, int door_index,
 
     const uint16_t tilemap_offset =
         rom_data[tilemap_entry_addr] | (rom_data[tilemap_entry_addr + 1] << 8);
-    const auto [explosion_tile_x, explosion_tile_y] =
-        tilemap_offset_to_tile_coords(tilemap_offset);
+    // Plain locals rather than a structured binding: clang-14 (used by the CI
+    // Memory Sanitizer build) rejects capturing a structured binding in a
+    // lambda (P1091), and draw_exploding_wall_segment below captures these.
+    const auto explosion_tile = tilemap_offset_to_tile_coords(tilemap_offset);
+    const auto explosion_tile_x = explosion_tile.first;
+    const auto explosion_tile_y = explosion_tile.second;
 
     auto draw_exploding_wall_segment = [&](int table_entry_addr,
                                            int segment_tile_y) -> bool {

--- a/src/zelda3/dungeon/object_drawer.cc
+++ b/src/zelda3/dungeon/object_drawer.cc
@@ -1330,8 +1330,7 @@ void ObjectDrawer::DrawDoor(const DoorDef& door, int door_index,
     return;
   }
 
-  const bool is_door_open =
-      state && state->IsDoorOpen(room_id_, door_index);
+  const bool is_door_open = state && state->IsDoorOpen(room_id_, door_index);
 
   // Get door position from DoorPositionManager
   auto [tile_x, tile_y] = door.GetTileCoords();
@@ -1349,99 +1348,96 @@ void ObjectDrawer::DrawDoor(const DoorDef& door, int door_index,
   constexpr int kNorthCurtainClosedOffset = 0x078A;
   const auto& rom_data = rom_->data();
 
-  auto draw_from_object_data =
-      [&](gfx::BackgroundBuffer& target, int start_tile_x, int start_tile_y,
-          int width, int height, int tile_data_addr) {
-        auto& bitmap = target.bitmap();
-        auto& priority_buffer = target.mutable_priority_data();
-        auto& coverage_buffer = target.mutable_coverage_data();
-        const int bitmap_width = bitmap.width();
-        int tile_idx = 0;
+  auto draw_from_object_data = [&](gfx::BackgroundBuffer& target,
+                                   int start_tile_x, int start_tile_y,
+                                   int width, int height, int tile_data_addr) {
+    auto& bitmap = target.bitmap();
+    auto& priority_buffer = target.mutable_priority_data();
+    auto& coverage_buffer = target.mutable_coverage_data();
+    const int bitmap_width = bitmap.width();
+    int tile_idx = 0;
 
-        for (int dx = 0; dx < width; dx++) {
-          for (int dy = 0; dy < height; dy++) {
-            const int addr = tile_data_addr + (tile_idx * 2);
-            const uint16_t tile_word =
-                rom_data[addr] | (rom_data[addr + 1] << 8);
-            const auto tile_info = gfx::WordToTileInfo(tile_word);
-            const int pixel_x = (start_tile_x + dx) * 8;
-            const int pixel_y = (start_tile_y + dy) * 8;
-
-            DrawTileToBitmap(bitmap, tile_info, pixel_x, pixel_y,
-                             room_gfx_buffer_);
-
-            const uint8_t priority = tile_info.over_ ? 1 : 0;
-            const auto& bitmap_data = bitmap.vector();
-            for (int py = 0; py < 8; py++) {
-              const int dest_y = pixel_y + py;
-              if (dest_y < 0 || dest_y >= bitmap.height()) {
-                continue;
-              }
-              for (int px = 0; px < 8; px++) {
-                const int dest_x = pixel_x + px;
-                if (dest_x < 0 || dest_x >= bitmap_width) {
-                  continue;
-                }
-                const int dest_index = dest_y * bitmap_width + dest_x;
-                if (dest_index >= 0 &&
-                    dest_index < static_cast<int>(coverage_buffer.size())) {
-                  coverage_buffer[dest_index] = 1;
-                }
-                if (dest_index < static_cast<int>(bitmap_data.size()) &&
-                    bitmap_data[dest_index] != 255) {
-                  priority_buffer[dest_index] = priority;
-                }
-              }
-            }
-
-            tile_idx++;
-          }
-        }
-      };
-
-  auto draw_repeated_tile =
-      [&](gfx::BackgroundBuffer& target, int start_tile_x, int start_tile_y,
-          int width, int height, uint16_t tile_word) {
-        auto& bitmap = target.bitmap();
-        auto& priority_buffer = target.mutable_priority_data();
-        auto& coverage_buffer = target.mutable_coverage_data();
-        const int bitmap_width = bitmap.width();
+    for (int dx = 0; dx < width; dx++) {
+      for (int dy = 0; dy < height; dy++) {
+        const int addr = tile_data_addr + (tile_idx * 2);
+        const uint16_t tile_word = rom_data[addr] | (rom_data[addr + 1] << 8);
         const auto tile_info = gfx::WordToTileInfo(tile_word);
+        const int pixel_x = (start_tile_x + dx) * 8;
+        const int pixel_y = (start_tile_y + dy) * 8;
 
-        for (int dx = 0; dx < width; dx++) {
-          for (int dy = 0; dy < height; dy++) {
-            const int pixel_x = (start_tile_x + dx) * 8;
-            const int pixel_y = (start_tile_y + dy) * 8;
+        DrawTileToBitmap(bitmap, tile_info, pixel_x, pixel_y, room_gfx_buffer_);
 
-            DrawTileToBitmap(bitmap, tile_info, pixel_x, pixel_y,
-                             room_gfx_buffer_);
-
-            const uint8_t priority = tile_info.over_ ? 1 : 0;
-            const auto& bitmap_data = bitmap.vector();
-            for (int py = 0; py < 8; py++) {
-              const int dest_y = pixel_y + py;
-              if (dest_y < 0 || dest_y >= bitmap.height()) {
-                continue;
-              }
-              for (int px = 0; px < 8; px++) {
-                const int dest_x = pixel_x + px;
-                if (dest_x < 0 || dest_x >= bitmap_width) {
-                  continue;
-                }
-                const int dest_index = dest_y * bitmap_width + dest_x;
-                if (dest_index >= 0 &&
-                    dest_index < static_cast<int>(coverage_buffer.size())) {
-                  coverage_buffer[dest_index] = 1;
-                }
-                if (dest_index < static_cast<int>(bitmap_data.size()) &&
-                    bitmap_data[dest_index] != 255) {
-                  priority_buffer[dest_index] = priority;
-                }
-              }
+        const uint8_t priority = tile_info.over_ ? 1 : 0;
+        const auto& bitmap_data = bitmap.vector();
+        for (int py = 0; py < 8; py++) {
+          const int dest_y = pixel_y + py;
+          if (dest_y < 0 || dest_y >= bitmap.height()) {
+            continue;
+          }
+          for (int px = 0; px < 8; px++) {
+            const int dest_x = pixel_x + px;
+            if (dest_x < 0 || dest_x >= bitmap_width) {
+              continue;
+            }
+            const int dest_index = dest_y * bitmap_width + dest_x;
+            if (dest_index >= 0 &&
+                dest_index < static_cast<int>(coverage_buffer.size())) {
+              coverage_buffer[dest_index] = 1;
+            }
+            if (dest_index < static_cast<int>(bitmap_data.size()) &&
+                bitmap_data[dest_index] != 255) {
+              priority_buffer[dest_index] = priority;
             }
           }
         }
-      };
+
+        tile_idx++;
+      }
+    }
+  };
+
+  auto draw_repeated_tile = [&](gfx::BackgroundBuffer& target, int start_tile_x,
+                                int start_tile_y, int width, int height,
+                                uint16_t tile_word) {
+    auto& bitmap = target.bitmap();
+    auto& priority_buffer = target.mutable_priority_data();
+    auto& coverage_buffer = target.mutable_coverage_data();
+    const int bitmap_width = bitmap.width();
+    const auto tile_info = gfx::WordToTileInfo(tile_word);
+
+    for (int dx = 0; dx < width; dx++) {
+      for (int dy = 0; dy < height; dy++) {
+        const int pixel_x = (start_tile_x + dx) * 8;
+        const int pixel_y = (start_tile_y + dy) * 8;
+
+        DrawTileToBitmap(bitmap, tile_info, pixel_x, pixel_y, room_gfx_buffer_);
+
+        const uint8_t priority = tile_info.over_ ? 1 : 0;
+        const auto& bitmap_data = bitmap.vector();
+        for (int py = 0; py < 8; py++) {
+          const int dest_y = pixel_y + py;
+          if (dest_y < 0 || dest_y >= bitmap.height()) {
+            continue;
+          }
+          for (int px = 0; px < 8; px++) {
+            const int dest_x = pixel_x + px;
+            if (dest_x < 0 || dest_x >= bitmap_width) {
+              continue;
+            }
+            const int dest_index = dest_y * bitmap_width + dest_x;
+            if (dest_index >= 0 &&
+                dest_index < static_cast<int>(coverage_buffer.size())) {
+              coverage_buffer[dest_index] = 1;
+            }
+            if (dest_index < static_cast<int>(bitmap_data.size()) &&
+                bitmap_data[dest_index] != 255) {
+              priority_buffer[dest_index] = priority;
+            }
+          }
+        }
+      }
+    }
+  };
 
   auto tilemap_offset_to_tile_coords = [](uint16_t offset) {
     return std::pair<int, int>{static_cast<int>((offset % 0x80) / 2),
@@ -1599,8 +1595,8 @@ void ObjectDrawer::DrawDoor(const DoorDef& door, int door_index,
     const auto [explosion_tile_x, explosion_tile_y] =
         tilemap_offset_to_tile_coords(tilemap_offset);
 
-    auto draw_exploding_wall_segment =
-        [&](int table_entry_addr, int segment_tile_y) -> bool {
+    auto draw_exploding_wall_segment = [&](int table_entry_addr,
+                                           int segment_tile_y) -> bool {
       if (table_entry_addr < 0 ||
           table_entry_addr + 1 >= static_cast<int>(rom_->size())) {
         return false;


### PR DESCRIPTION
## Summary

Fixes the **Memory Sanitizer** job (red on `master` for every PR) and repairs a
broken step in the **WASM** workflow. Both were pre-existing defects unrelated to
any feature PR.

### Memory Sanitizer — now green
Two independent problems, both fixed here:

1. **clang-14 compile failure.** `object_drawer.cc` and `dungeon_canvas_viewer.cc`
   captured **structured bindings** in lambdas, which clang-14 rejects (P1091),
   so the job died at compile time. Fixed by binding the `std::pair`s to plain
   locals (`.first`/`.second`). A static scan of the whole tree confirms these
   are the only two sites.
2. **Benchmarks under ASan.** Once it compiled, 42 `GraphicsOptimizationBenchmarks`
   tests failed — they assert hard timing ceilings that ASan's overhead blows
   past. The `Test` step now runs
   `ctest --label-exclude "benchmark|gui|experimental|rom_dependent"` (these run
   in the nightly suite instead).

### WASM — setup step fixed; a deeper pre-existing issue remains
- **Fixed:** the *Verify Emscripten setup* step ran `emcmake --version`, which
  has no `--version` flag and exits 1 under `set -e`, failing before any build.
  Now uses `emcmake cmake --version`.
- **Remaining (provided by the 0.7.2-rc PR #58):** with that step unblocked, the
  WASM build now reaches the link stage and fails on **undefined symbols** that
  `master` declares but does not yet define —
  `DungeonEditorV2::{FocusRoom,SelectObject,SetAgentMode}`,
  `net::EmscriptenHttpClient`, `net::EmscriptenWebSocket`, `cli::BrowserAIService`.
  These implementations already exist in the 0.7.2-rc PR (#58,
  `src/app/net/wasm/*`, `src/cli/service/ai/browser_ai_service.cc`,
  `src/app/editor/dungeon/dungeon_editor_v2.cc`); WASM will link once that lands.
  This PR just repairs the setup step and unmasks the real link failure
  (previously hidden behind the `emcmake` bug).

## Notes
- `object_drawer.cc` is split into a **pure clang-format-14 commit** (the file
  had pre-existing violations the whole-file Code Quality gate rejects) followed
  by the 3-line fix; `dungeon_canvas_viewer.cc` needed only a small reformat.
- These fixes are what already keep the gmaOCR fork's CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)