### PR TITLE
[codex] Automate pit damage inspector clicks

### DIFF
--- a/src/app/editor/dungeon/workspace/dungeon_workbench_content.cc
+++ b/src/app/editor/dungeon/workspace/dungeon_workbench_content.cc
@@ -124,6 +124,18 @@ float GetCompactSidebarWidth(bool right_sidebar, float min_sidebar_width) {
                                          : kCompactLeftSidebarScale));
 }
 
+DungeonWorkbenchTestRect CaptureLastItemRectForTesting() {
+  DungeonWorkbenchTestRect rect;
+  rect.visible = true;
+  const ImVec2 min = ImGui::GetItemRectMin();
+  const ImVec2 max = ImGui::GetItemRectMax();
+  rect.min_x = min.x;
+  rect.min_y = min.y;
+  rect.max_x = max.x;
+  rect.max_y = max.y;
+  return rect;
+}
+
 }  // namespace
 
 DungeonWorkbenchResponsiveLayout ResolveDungeonWorkbenchResponsiveLayout(
@@ -1254,6 +1266,7 @@ void DungeonWorkbenchContent::DrawApplyScopeControls(int room_id) {
 }
 
 void DungeonWorkbenchContent::DrawPitDamageControls(int room_id) {
+  pit_damage_control_rects_ = {};
   const auto& theme = AgentUI::GetTheme();
   zelda3::PitDamageTable* table =
       get_pit_damage_table_ ? get_pit_damage_table_() : nullptr;
@@ -1320,7 +1333,10 @@ void DungeonWorkbenchContent::DrawPitDamageControls(int room_id) {
           tr("Replacement room must not already be in the table."));
     }
     ImGui::SameLine();
-    if (ImGui::Button(tr("Replace current##PitDamageReplaceCurrent"))) {
+    const bool replace_clicked =
+        ImGui::Button(tr("Replace current##PitDamageReplaceCurrent"));
+    pit_damage_control_rects_.replace_current = CaptureLastItemRectForTesting();
+    if (replace_clicked) {
       auto status = RemoveCurrentRoomFromPitDamage(
           table, current_room, pit_damage_replacement_room_id_);
       pit_damage_status_error_ = !status.ok();
@@ -1351,7 +1367,10 @@ void DungeonWorkbenchContent::DrawPitDamageControls(int room_id) {
       ImGui::SetTooltip(tr("This room will stop dealing pit damage."));
     }
     ImGui::SameLine();
-    if (ImGui::Button(tr("Add current##PitDamageAddCurrent"))) {
+    const bool add_clicked =
+        ImGui::Button(tr("Add current##PitDamageAddCurrent"));
+    pit_damage_control_rects_.add_current = CaptureLastItemRectForTesting();
+    if (add_clicked) {
       auto status = AddCurrentRoomToPitDamage(table, current_room,
                                               pit_damage_victim_room_id_);
       pit_damage_status_error_ = !status.ok();

--- a/src/app/editor/dungeon/workspace/dungeon_workbench_content.h
+++ b/src/app/editor/dungeon/workspace/dungeon_workbench_content.h
@@ -46,6 +46,19 @@ struct DungeonWorkbenchPaneLayout {
   float min_right_width = 0.0f;
 };
 
+struct DungeonWorkbenchTestRect {
+  bool visible = false;
+  float min_x = 0.0f;
+  float min_y = 0.0f;
+  float max_x = 0.0f;
+  float max_y = 0.0f;
+};
+
+struct DungeonWorkbenchPitDamageControlRects {
+  DungeonWorkbenchTestRect add_current;
+  DungeonWorkbenchTestRect replace_current;
+};
+
 DungeonWorkbenchResponsiveLayout ResolveDungeonWorkbenchResponsiveLayout(
     float total_width, float min_canvas_width, float min_sidebar_width,
     float splitter_width, bool want_left, bool want_right);
@@ -126,6 +139,13 @@ class DungeonWorkbenchContent : public WindowContent {
   bool IsToolDrawerActiveForTesting() const;
   const char* GetInspectorModeIdForTesting() const;
   const char* GetActiveToolIdForTesting() const;
+  void DrawPitDamageControlsForTesting(int room_id) {
+    DrawPitDamageControls(room_id);
+  }
+  const DungeonWorkbenchPitDamageControlRects&
+  GetPitDamageControlRectsForTesting() const {
+    return pit_damage_control_rects_;
+  }
 
   /// Called by the editor when the current room changes.
   void NotifyRoomChanged(int previous_room_id) {
@@ -259,6 +279,7 @@ class DungeonWorkbenchContent : public WindowContent {
   uint16_t pit_damage_victim_room_id_ = 0;
   std::string pit_damage_status_message_;
   bool pit_damage_status_error_ = false;
+  DungeonWorkbenchPitDamageControlRects pit_damage_control_rects_{};
   std::unique_ptr<DungeonMapPanel> embedded_dungeon_map_;
   RoomTagEditorPanel* room_tag_panel_ = nullptr;
   CustomCollisionPanel* custom_collision_panel_ = nullptr;

--- a/test/unit/editor/dungeon_workbench_content_test.cc
+++ b/test/unit/editor/dungeon_workbench_content_test.cc
@@ -14,6 +14,7 @@
 #include "app/editor/dungeon/dungeon_project_labels.h"
 #include "app/editor/dungeon/workspace/dungeon_pit_damage_view_model.h"
 #include "core/project.h"
+#include "imgui/imgui.h"
 #include "zelda3/dungeon/pit_damage_table.h"
 
 namespace yaze::editor {
@@ -49,6 +50,68 @@ zelda3::PitDamageTable MakePitDamageTable(
   table.ClearDirty();
   return table;
 }
+
+class DungeonWorkbenchPitDamageUiTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    IMGUI_CHECKVERSION();
+    context_ = ImGui::CreateContext();
+    ImGui::SetCurrentContext(context_);
+    ImGui::StyleColorsDark();
+
+    ImGuiIO& io = ImGui::GetIO();
+    io.DisplaySize = ImVec2(640.0f, 480.0f);
+    io.DeltaTime = 1.0f / 60.0f;
+    io.Fonts->AddFontDefault();
+    unsigned char* pixels = nullptr;
+    int atlas_width = 0;
+    int atlas_height = 0;
+    io.Fonts->GetTexDataAsRGBA32(&pixels, &atlas_width, &atlas_height);
+    io.AddMousePosEvent(-1000.0f, -1000.0f);
+    io.AddMouseButtonEvent(0, false);
+  }
+
+  void TearDown() override {
+    if (context_ != nullptr) {
+      ImGui::DestroyContext(context_);
+      context_ = nullptr;
+    }
+  }
+
+  void DrawPitDamageFrame(DungeonWorkbenchContent& content, int room_id) {
+    ImGuiIO& io = ImGui::GetIO();
+    io.DisplaySize = ImVec2(640.0f, 480.0f);
+    io.DeltaTime = 1.0f / 60.0f;
+
+    ImGui::NewFrame();
+    ImGui::SetNextWindowPos(ImVec2(20.0f, 20.0f), ImGuiCond_Always);
+    ImGui::SetNextWindowSize(ImVec2(520.0f, 320.0f), ImGuiCond_Always);
+    ImGui::Begin(
+        "PitDamageHost", nullptr,
+        ImGuiWindowFlags_NoSavedSettings | ImGuiWindowFlags_NoCollapse);
+    content.DrawPitDamageControlsForTesting(room_id);
+    ImGui::End();
+    ImGui::Render();
+  }
+
+  void ClickRect(DungeonWorkbenchContent& content, int room_id,
+                 const DungeonWorkbenchTestRect& rect) {
+    const float center_x = (rect.min_x + rect.max_x) * 0.5f;
+    const float center_y = (rect.min_y + rect.max_y) * 0.5f;
+
+    ImGuiIO& io = ImGui::GetIO();
+    io.AddMousePosEvent(center_x, center_y);
+    io.AddMouseButtonEvent(0, true);
+    DrawPitDamageFrame(content, room_id);
+
+    io.AddMousePosEvent(center_x, center_y);
+    io.AddMouseButtonEvent(0, false);
+    DrawPitDamageFrame(content, room_id);
+  }
+
+ private:
+  ImGuiContext* context_ = nullptr;
+};
 
 TEST(DungeonWorkbenchContentLayoutTest,
      PrefersCompactingAndHidingLeftPaneBeforeRightPane) {
@@ -261,6 +324,42 @@ TEST(DungeonWorkbenchPitDamageTest, RejectsInvalidMembershipSwaps) {
             absl::StatusCode::kFailedPrecondition);
   EXPECT_EQ(RemoveCurrentRoomFromPitDamage(&table, 0x001, 0x010).code(),
             absl::StatusCode::kFailedPrecondition);
+}
+
+TEST_F(DungeonWorkbenchPitDamageUiTest,
+       ButtonsClickThroughToPitDamageMembershipSwaps) {
+  int current_room_id = 0x020;
+  const std::deque<int> recent_rooms;
+  auto content = MakeWorkbenchForToolStateTests(current_room_id, recent_rooms);
+  auto table = MakePitDamageTable({0x001, 0x010});
+  content.SetPitDamageTableProvider([&table]() { return &table; });
+
+  DrawPitDamageFrame(content, current_room_id);
+  const auto add_rect =
+      content.GetPitDamageControlRectsForTesting().add_current;
+  ASSERT_TRUE(add_rect.visible);
+  ASSERT_LT(add_rect.min_x, add_rect.max_x);
+  ASSERT_LT(add_rect.min_y, add_rect.max_y);
+
+  ClickRect(content, current_room_id, add_rect);
+  EXPECT_TRUE(table.Contains(0x020));
+  EXPECT_FALSE(table.Contains(0x001));
+  EXPECT_TRUE(table.Contains(0x010));
+  EXPECT_TRUE(table.dirty());
+
+  table.ClearDirty();
+  DrawPitDamageFrame(content, current_room_id);
+  const auto replace_rect =
+      content.GetPitDamageControlRectsForTesting().replace_current;
+  ASSERT_TRUE(replace_rect.visible);
+  ASSERT_LT(replace_rect.min_x, replace_rect.max_x);
+  ASSERT_LT(replace_rect.min_y, replace_rect.max_y);
+
+  ClickRect(content, current_room_id, replace_rect);
+  EXPECT_FALSE(table.Contains(0x020));
+  EXPECT_TRUE(table.Contains(0x000));
+  EXPECT_TRUE(table.Contains(0x010));
+  EXPECT_TRUE(table.dirty());
 }
 
 TEST(DungeonWorkbenchProjectLabelsTest,


### PR DESCRIPTION
## Summary
- add a small pit-damage inspector test probe for rendered add/replace button bounds
- capture the real ImGui button rects after rendering the inspector controls
- add a headless ImGui unit test that clicks Add current and Replace current and asserts `PitDamageTable` membership/dirty-state changes

## Why
The pit-damage membership editor had view-model coverage, but the actual inspector button click path was still a backlog follow-up. This covers the real ImGui controls without broad GUI automation.

## Verification
- `git diff --check`
- `cmake --build --preset mac-ai --target yaze_test_unit --parallel 8`
- `ctest --test-dir build/presets/mac-ai -C Debug -R "DungeonWorkbenchPitDamage|DungeonWorkbenchContent" --output-on-failure`
- `YAZE_PREPUSH_BUILD_DIR=build/presets/mac-ai git push -u origin codex/pit-damage-ui-automation`
