### PR TITLE
[codex] Guard pushable block loader operands

### DIFF
--- a/docs/internal/plans/dungeon-0.8.0-issue-test-backlog-2026-06-28.md
+++ b/docs/internal/plans/dungeon-0.8.0-issue-test-backlog-2026-06-28.md
@@ -5,7 +5,7 @@ Source: post-agent audit of the 0.8.0 dungeon drawing/editing slice.
 ## High-priority cleanup
 
 1. **Pushable block table repointing / expansion**
-   - Status: scoped; saver now guards the four bank-02 `LDA.l ...,X`
+   - Status: scoped; loader/saver now guard the four bank-02 `LDA.l ...,X`
      operand slots before dereferencing them. Full >128-entry expansion still
      needs a runtime/WRAM layout patch, because the vanilla loader copies four
      0x80-byte pages into `$7EF940..$7EFB3F` and block drawing scans that

--- a/docs/internal/plans/dungeon-0.8.0-issue-test-backlog-2026-06-28.md
+++ b/docs/internal/plans/dungeon-0.8.0-issue-test-backlog-2026-06-28.md
@@ -6,10 +6,11 @@ Source: post-agent audit of the 0.8.0 dungeon drawing/editing slice.
 
 1. **Pushable block table repointing / expansion**
    - Status: scoped; loader/saver now guard the four bank-02 `LDA.l ...,X`
-     operand slots before dereferencing them. Full >128-entry expansion still
-     needs a runtime/WRAM layout patch, because the vanilla loader copies four
-     0x80-byte pages into `$7EF940..$7EFB3F` and block drawing scans that
-     fixed buffer before torch data.
+     operand slots via `ValidateBlocksLoaderPointerOperand` before
+     dereferencing them. Full >128-entry expansion still needs a runtime/WRAM
+     layout patch, because the vanilla loader copies four 0x80-byte pages into
+     `$7EF940..$7EFB3F` and block drawing scans that fixed buffer before torch
+     data.
    - Problem: `SaveAllBlocks` is room-aware, but still bounded by vanilla table capacity.
    - Done when: edited block sets can exceed vanilla capacity through a deliberate repoint/expansion path, with surrounding instruction operands protected.
    - Tests: grow a fixture ROM beyond vanilla capacity; assert pointer/count operands, data bytes, and nearby regions.

--- a/docs/internal/plans/dungeon-0.8.0-issue-test-backlog-2026-06-28.md
+++ b/docs/internal/plans/dungeon-0.8.0-issue-test-backlog-2026-06-28.md
@@ -5,12 +5,17 @@ Source: post-agent audit of the 0.8.0 dungeon drawing/editing slice.
 ## High-priority cleanup
 
 1. **Pushable block table repointing / expansion**
+   - Status: scoped; saver now guards the four bank-02 `LDA.l ...,X`
+     operand slots before dereferencing them. Full >128-entry expansion still
+     needs a runtime/WRAM layout patch, because the vanilla loader copies four
+     0x80-byte pages into `$7EF940..$7EFB3F` and block drawing scans that
+     fixed buffer before torch data.
    - Problem: `SaveAllBlocks` is room-aware, but still bounded by vanilla table capacity.
    - Done when: edited block sets can exceed vanilla capacity through a deliberate repoint/expansion path, with surrounding instruction operands protected.
    - Tests: grow a fixture ROM beyond vanilla capacity; assert pointer/count operands, data bytes, and nearby regions.
 
 2. **Pit-damage membership editor UI**
-   - Status: inspector controls implemented for fixed-capacity room replacement; view-model coverage now guards replacement/victim defaults and fixed-capacity swaps. Full ImGui click automation is still a follow-up.
+   - Status: inspector controls implemented for fixed-capacity room replacement; view-model coverage guards replacement/victim defaults and fixed-capacity swaps; ImGui click automation for the Add/Replace buttons landed in PR #65.
    - Problem: `PitDamageTable` can encode fixed-capacity `RoomsWithPitDamage`, but no panel toggles membership.
    - Done when: the dungeon editor exposes room membership, marks the table dirty, saves via `SaveAllPits(rom, table)`, and reloads the edited membership.
    - Tests: view-model/unit test for toggling; ROM-backed save/reload test; no-op save stays byte-identical.

--- a/docs/internal/plans/dungeon-0.8.0-issue-test-backlog-2026-06-28.md
+++ b/docs/internal/plans/dungeon-0.8.0-issue-test-backlog-2026-06-28.md
@@ -7,7 +7,11 @@ Source: post-agent audit of the 0.8.0 dungeon drawing/editing slice.
 1. **Pushable block table repointing / expansion**
    - Status: scoped; loader/saver now guard the four bank-02 `LDA.l ...,X`
      operand slots via `ValidateBlocksLoaderPointerOperand` before
-     dereferencing them. Full >128-entry expansion still needs a runtime/WRAM
+     dereferencing them. The expected operand shape is pinned to the US USDASM
+     loader at bank_02 `#_02DAF9..#_02DB12` and the vanilla
+     `SpecialUnderworldObjects_pushable_block` table at bank_04 `#_04F1DE` by
+     `DungeonSaveRegionTest.BlocksLoaderPointerOperandsMatchUsdasmShape`.
+     Full >128-entry expansion still needs a runtime/WRAM
      layout patch, because the vanilla loader copies four 0x80-byte pages into
      `$7EF940..$7EFB3F` and block drawing scans that fixed buffer before torch
      data.

--- a/src/zelda3/dungeon/room.cc
+++ b/src/zelda3/dungeon/room.cc
@@ -2570,6 +2570,32 @@ absl::Status SaveAllPits(Rom* rom, PitDamageTable* pit_damage_table) {
   return rom->WriteVector(pit_data_pc, data);
 }
 
+namespace {
+
+absl::Status ValidateBlocksLoaderPointerOperand(
+    const std::vector<uint8_t>& rom_data, int operand_pc) {
+  if (operand_pc <= 0 || operand_pc + 3 >= static_cast<int>(rom_data.size())) {
+    return absl::OutOfRangeError("Blocks pointer operand out of range");
+  }
+  // The block table pointers are the 3-byte operands in this vanilla loader
+  // shape:
+  //   BF ll hh bb  LDA.l table+N*0x80,X
+  //   9D ll hh     STA.w $7EF940+N*0x80,X
+  //
+  // Guard both sides before dereferencing or future repointing so a bad
+  // constant or already-patched ROM cannot make the saver treat unrelated
+  // instruction bytes as data pointers.
+  if (rom_data[operand_pc - 1] != 0xBF || rom_data[operand_pc + 3] != 0x9D) {
+    return absl::FailedPreconditionError(absl::StrFormat(
+        "Blocks pointer operand at PC 0x%05X is not in the expected "
+        "LDA.l ...,X / STA.w loader sequence",
+        operand_pc));
+  }
+  return absl::OkStatus();
+}
+
+}  // namespace
+
 absl::Status SaveAllBlocks(Rom* rom) {
   if (!rom || !rom->is_loaded()) {
     return absl::InvalidArgumentError("ROM not loaded");
@@ -2590,6 +2616,7 @@ absl::Status SaveAllBlocks(Rom* rom) {
     if (ptrs[r] + 2 >= static_cast<int>(rom_data.size())) {
       return absl::OutOfRangeError("Blocks pointer out of range");
     }
+    RETURN_IF_ERROR(ValidateBlocksLoaderPointerOperand(rom_data, ptrs[r]));
     int snes = (rom_data[ptrs[r] + 2] << 16) | (rom_data[ptrs[r] + 1] << 8) |
                rom_data[ptrs[r]];
     int pc = SnesToPc(snes);
@@ -2638,6 +2665,7 @@ absl::Status SaveAllBlocks(Rom* rom, int room_count,
     if (slot + 2 >= static_cast<int>(rom_data.size())) {
       return absl::OutOfRangeError("Blocks pointer out of range");
     }
+    RETURN_IF_ERROR(ValidateBlocksLoaderPointerOperand(rom_data, slot));
     const int snes =
         (rom_data[slot + 2] << 16) | (rom_data[slot + 1] << 8) | rom_data[slot];
     const int pc = SnesToPc(snes);

--- a/src/zelda3/dungeon/room.cc
+++ b/src/zelda3/dungeon/room.cc
@@ -2578,10 +2578,14 @@ absl::Status ValidateBlocksLoaderPointerOperand(
   if (operand_pc <= 0 || operand_pc + 3 >= static_cast<int>(rom_data.size())) {
     return absl::OutOfRangeError("Blocks pointer operand out of range");
   }
-  // The block table pointers are the 3-byte operands in this vanilla loader
-  // shape:
+  // The block table pointers are the 3-byte operands in the US USDASM
+  // bank_02 loader shape (#_02DAF9..#_02DB12):
   //   BF ll hh bb  LDA.l table+N*0x80,X
   //   9D ll hh     STA.w $7EF940+N*0x80,X
+  // The data table starts at bank_04's
+  // SpecialUnderworldObjects_pushable_block (#_04F1DE). Pinned against a real
+  // vanilla ROM by
+  // DungeonSaveRegionTest.BlocksLoaderPointerOperandsMatchUsdasmShape.
   //
   // Guard both sides before dereferencing or future repointing so a bad
   // constant or already-patched ROM cannot make the saver treat unrelated
@@ -3145,15 +3149,6 @@ void Room::LoadBlocks() {
   LOG_DEBUG("Room", "LoadBlocks: room_id=%d, blocks_count=%d", room_id_,
             blocks_count);
 
-  // Avoid duplication if LoadBlocks is called multiple times.
-  tile_objects_.erase(
-      std::remove_if(tile_objects_.begin(), tile_objects_.end(),
-                     [](const RoomObject& obj) {
-                       return (obj.options() & ObjectOption::Block) !=
-                              ObjectOption::Nothing;
-                     }),
-      tile_objects_.end());
-
   // Load block data from the four data regions.
   //
   // `kBlocksPointer1..4` are 3-byte SNES long-address operand slots
@@ -3173,14 +3168,14 @@ void Room::LoadBlocks() {
   for (int r = 0; r < 4; ++r) {
     const int slot = kPointerSlots[r];
     if (slot + 2 >= static_cast<int>(rom_data.size())) {
-      LOG_DEBUG("Room", "LoadBlocks: pointer slot %d out of range", r);
+      LOG_WARN("Room", "LoadBlocks: pointer slot %d out of range", r);
       return;
     }
     const absl::Status operand_status =
         ValidateBlocksLoaderPointerOperand(rom_data, slot);
     if (!operand_status.ok()) {
-      LOG_DEBUG("Room", "LoadBlocks: %s",
-                std::string(operand_status.message()).c_str());
+      LOG_WARN("Room", "LoadBlocks: %s",
+               std::string(operand_status.message()).c_str());
       return;
     }
     const int snes =
@@ -3191,11 +3186,22 @@ void Room::LoadBlocks() {
     if (len <= 0)
       break;
     if (pc < 0 || pc + len > static_cast<int>(rom_data.size())) {
-      LOG_DEBUG("Room", "LoadBlocks: region %d data out of range", r);
+      LOG_WARN("Room", "LoadBlocks: region %d data out of range", r);
       return;
     }
     std::copy_n(rom_data.begin() + pc, len, blocks_data.begin() + off);
   }
+
+  // Avoid duplication if LoadBlocks is called multiple times. Do this only
+  // after the ROM pointer operands and data regions are known-good so a guard
+  // failure cannot make existing in-memory block objects vanish.
+  tile_objects_.erase(
+      std::remove_if(tile_objects_.begin(), tile_objects_.end(),
+                     [](const RoomObject& obj) {
+                       return (obj.options() & ObjectOption::Block) !=
+                              ObjectOption::Nothing;
+                     }),
+      tile_objects_.end());
 
   // Parse blocks for this room (4 bytes per block entry).
   //

--- a/src/zelda3/dungeon/room.cc
+++ b/src/zelda3/dungeon/room.cc
@@ -7,6 +7,7 @@
 #include <functional>
 #include <limits>
 #include <optional>
+#include <string>
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
@@ -3173,6 +3174,13 @@ void Room::LoadBlocks() {
     const int slot = kPointerSlots[r];
     if (slot + 2 >= static_cast<int>(rom_data.size())) {
       LOG_DEBUG("Room", "LoadBlocks: pointer slot %d out of range", r);
+      return;
+    }
+    const absl::Status operand_status =
+        ValidateBlocksLoaderPointerOperand(rom_data, slot);
+    if (!operand_status.ok()) {
+      LOG_DEBUG("Room", "LoadBlocks: %s",
+                std::string(operand_status.message()).c_str());
       return;
     }
     const int snes =

--- a/test/integration/zelda3/dungeon_save_region_test.cc
+++ b/test/integration/zelda3/dungeon_save_region_test.cc
@@ -309,6 +309,31 @@ TEST_F(DungeonSaveRegionTest, RoomsWithPitDamageMatchesUsdasm) {
 
 // --- Blocks (length @ kBlocksLength, four pointers, four 0x80 regions) ---
 
+TEST_F(DungeonSaveRegionTest, BlocksLoaderPointerOperandsMatchUsdasmShape) {
+  const auto& data = rom_->vector();
+  const int ptrs[4] = {kBlocksPointer1, kBlocksPointer2, kBlocksPointer3,
+                       kBlocksPointer4};
+  constexpr int kRegionSize = 0x80;
+  constexpr int kVanillaPushableBlockSnes = 0x04F1DE;
+
+  for (int r = 0; r < 4; ++r) {
+    const int slot = ptrs[r];
+    ASSERT_GT(slot, 0);
+    ASSERT_LT(slot + 3, static_cast<int>(data.size()));
+    EXPECT_EQ(data[slot - 1], 0xBF)
+        << "bank_02.asm expects LDA.l before pushable-block operand " << r;
+    EXPECT_EQ(data[slot + 3], 0x9D)
+        << "bank_02.asm expects STA.w after pushable-block operand " << r;
+
+    const int snes =
+        (data[slot + 2] << 16) | (data[slot + 1] << 8) | data[slot];
+    const int expected_snes = kVanillaPushableBlockSnes + (r * kRegionSize);
+    EXPECT_EQ(snes, expected_snes)
+        << "US USDASM pins SpecialUnderworldObjects_pushable_block at "
+           "$04:F1DE and the loader copies four 0x80-byte pages.";
+  }
+}
+
 TEST_F(DungeonSaveRegionTest, SaveAllBlocksPreservesRegion) {
   const auto& data = rom_->vector();
   if (kBlocksLength + 1 >= static_cast<int>(data.size())) {

--- a/test/unit/zelda3/dungeon/dungeon_save_test.cc
+++ b/test/unit/zelda3/dungeon/dungeon_save_test.cc
@@ -826,6 +826,16 @@ TEST_F(DungeonSaveTest, SaveAllBlocks_RoomAware_RejectsCorruptLoaderOperand) {
             std::string::npos);
 }
 
+TEST_F(DungeonSaveTest, LoadBlocks_RejectsCorruptLoaderOperand) {
+  SetupBlockRegions();
+  rom_->mutable_data()[kBlocksPointer1 - 1] = 0xEA;  // Not LDA.l.
+
+  room_->LoadBlocks();
+
+  EXPECT_FALSE(room_->AreBlocksLoaded());
+  EXPECT_TRUE(room_->GetTileObjects().empty());
+}
+
 TEST_F(DungeonSaveTest,
        SaveAllBlocks_RoomAware_PreservesUnmaterializedRoomBytes) {
   // Migration safety invariant: when only some rooms are

--- a/test/unit/zelda3/dungeon/dungeon_save_test.cc
+++ b/test/unit/zelda3/dungeon/dungeon_save_test.cc
@@ -801,6 +801,17 @@ TEST_F(DungeonSaveTest, SaveAllBlocks_ValidRegionsPreserveExistingBytes) {
   EXPECT_EQ(rom_->data()[kBlocksRegion1Pc + 3], 0xDD);
 }
 
+TEST_F(DungeonSaveTest, SaveAllBlocks_RejectsCorruptLoaderOperand) {
+  SetupBlockRegions();
+  rom_->mutable_data()[kBlocksPointer1 - 1] = 0xEA;  // Not LDA.l.
+
+  const auto status = SaveAllBlocks(rom_.get());
+
+  EXPECT_EQ(status.code(), absl::StatusCode::kFailedPrecondition);
+  EXPECT_NE(std::string(status.message()).find("LDA.l ...,X / STA.w"),
+            std::string::npos);
+}
+
 TEST_F(DungeonSaveTest, SaveAllBlocks_RoomAware_RejectsCorruptLoaderOperand) {
   SetupBlockRegions();
   rom_->mutable_data()[kBlocksPointer1 - 1] = 0xEA;  // Not LDA.l.

--- a/test/unit/zelda3/dungeon/dungeon_save_test.cc
+++ b/test/unit/zelda3/dungeon/dungeon_save_test.cc
@@ -175,6 +175,11 @@ class DungeonSaveTest : public ::testing::Test {
   }
 
   void SetupBlockRegions() {
+    SeedBlockLoaderOperand(kBlocksPointer1);
+    SeedBlockLoaderOperand(kBlocksPointer2);
+    SeedBlockLoaderOperand(kBlocksPointer3);
+    SeedBlockLoaderOperand(kBlocksPointer4);
+
     WriteLongPointer(kBlocksPointer1, PcToSnes(kBlocksRegion1Pc));
     WriteLongPointer(kBlocksPointer2, PcToSnes(kBlocksRegion2Pc));
     WriteLongPointer(kBlocksPointer3, PcToSnes(kBlocksRegion3Pc));
@@ -187,6 +192,11 @@ class DungeonSaveTest : public ::testing::Test {
     rom_->mutable_data()[kBlocksRegion1Pc + 1] = 0xBB;
     rom_->mutable_data()[kBlocksRegion1Pc + 2] = 0xCC;
     rom_->mutable_data()[kBlocksRegion1Pc + 3] = 0xDD;
+  }
+
+  void SeedBlockLoaderOperand(int operand_pc) {
+    rom_->mutable_data()[operand_pc - 1] = 0xBF;  // LDA.l operand,X
+    rom_->mutable_data()[operand_pc + 3] = 0x9D;  // STA.w addr,X
   }
 
   std::unique_ptr<Rom> rom_;
@@ -789,6 +799,20 @@ TEST_F(DungeonSaveTest, SaveAllBlocks_ValidRegionsPreserveExistingBytes) {
   EXPECT_EQ(rom_->data()[kBlocksRegion1Pc + 1], 0xBB);
   EXPECT_EQ(rom_->data()[kBlocksRegion1Pc + 2], 0xCC);
   EXPECT_EQ(rom_->data()[kBlocksRegion1Pc + 3], 0xDD);
+}
+
+TEST_F(DungeonSaveTest, SaveAllBlocks_RoomAware_RejectsCorruptLoaderOperand) {
+  SetupBlockRegions();
+  rom_->mutable_data()[kBlocksPointer1 - 1] = 0xEA;  // Not LDA.l.
+
+  const auto status =
+      SaveAllBlocks(rom_.get(), 296, [this](int rid) -> const Room* {
+        return rid == 0 ? room_.get() : nullptr;
+      });
+
+  EXPECT_EQ(status.code(), absl::StatusCode::kFailedPrecondition);
+  EXPECT_NE(std::string(status.message()).find("LDA.l ...,X / STA.w"),
+            std::string::npos);
 }
 
 TEST_F(DungeonSaveTest,

--- a/test/unit/zelda3/dungeon/dungeon_save_test.cc
+++ b/test/unit/zelda3/dungeon/dungeon_save_test.cc
@@ -829,11 +829,16 @@ TEST_F(DungeonSaveTest, SaveAllBlocks_RoomAware_RejectsCorruptLoaderOperand) {
 TEST_F(DungeonSaveTest, LoadBlocks_RejectsCorruptLoaderOperand) {
   SetupBlockRegions();
   rom_->mutable_data()[kBlocksPointer1 - 1] = 0xEA;  // Not LDA.l.
+  RoomObject existing_block(0x0E00, 3, 3, 0, 0);
+  existing_block.set_options(ObjectOption::Block);
+  room_->AddTileObject(existing_block);
 
   room_->LoadBlocks();
 
   EXPECT_FALSE(room_->AreBlocksLoaded());
-  EXPECT_TRUE(room_->GetTileObjects().empty());
+  ASSERT_EQ(room_->GetTileObjects().size(), 1U);
+  EXPECT_NE(room_->GetTileObjects()[0].options() & ObjectOption::Block,
+            ObjectOption::Nothing);
 }
 
 TEST_F(DungeonSaveTest,


### PR DESCRIPTION
## Summary
- guard the four pushable-block loader pointer operands before `SaveAllBlocks` dereferences them
- seed the expected `LDA.l ...,X` / `STA.w` bytes in the unit fixture and add a corrupt-operand regression
- update the dungeon backlog notes after PR #65 and clarify that >128 block entries need a runtime/WRAM layout patch, not just data repointing

## Why
The next pushable-block expansion slice depends on safely identifying the bank-02 loader operands. This makes the current saver fail closed if those bytes are not the expected loader sequence, so a future repoint path has a tested guardrail instead of trusting raw constants.

## Verification
- `git diff --check`
- `cmake --build --preset mac-ai --target yaze_test_unit --parallel 8`
- `ctest --test-dir build/presets/mac-ai -C Debug -R "SaveAllBlocks|LoadBlocks_ReadsFromDereferencedPointerRegion" --output-on-failure`
- `YAZE_PREPUSH_BUILD_DIR=build/presets/mac-ai git push -u origin codex/block-table-capacity-scout`
