### PR TITLE
[codex] Pin pushable block capacity boundary

### DIFF
--- a/docs/internal/plans/dungeon-0.8.0-issue-test-backlog-2026-06-28.md
+++ b/docs/internal/plans/dungeon-0.8.0-issue-test-backlog-2026-06-28.md
@@ -10,8 +10,10 @@ Source: post-agent audit of the 0.8.0 dungeon drawing/editing slice.
      dereferencing them. The expected operand shape is pinned to the US USDASM
      loader at bank_02 `#_02DAF9..#_02DB12` and the vanilla
      `SpecialUnderworldObjects_pushable_block` table at bank_04 `#_04F1DE` by
-     `DungeonSaveRegionTest.BlocksLoaderPointerOperandsMatchUsdasmShape`.
-     Full >128-entry expansion still needs a runtime/WRAM
+     `DungeonSaveRegionTest.BlocksLoaderPointerOperandsMatchUsdasmShape`. Unit
+     coverage now pins the fixed-capacity boundary: exactly 128 entries writes
+     all four 0x80-byte pages, while 129 entries fails before mutating ROM bytes
+     or clearing dirty state. Full >128-entry expansion still needs a runtime/WRAM
      layout patch, because the vanilla loader copies four 0x80-byte pages into
      `$7EF940..$7EFB3F` and block drawing scans that fixed buffer before torch
      data.

--- a/test/unit/zelda3/dungeon/dungeon_save_test.cc
+++ b/test/unit/zelda3/dungeon/dungeon_save_test.cc
@@ -7,6 +7,7 @@
 
 #include "rom/rom.h"
 #include "rom/snes.h"
+#include "zelda3/dungeon/dungeon_block_codec.h"
 #include "zelda3/dungeon/dungeon_rom_addresses.h"
 #include "zelda3/dungeon/room.h"
 #include "zelda3/dungeon/room_entrance.h"
@@ -197,6 +198,12 @@ class DungeonSaveTest : public ::testing::Test {
   void SeedBlockLoaderOperand(int operand_pc) {
     rom_->mutable_data()[operand_pc - 1] = 0xBF;  // LDA.l operand,X
     rom_->mutable_data()[operand_pc + 3] = 0x9D;  // STA.w addr,X
+  }
+
+  static RoomObject MakePushableBlock(int px, int py, int layer) {
+    RoomObject block(0x0E00, px, py, 0, layer);
+    block.set_options(ObjectOption::Block);
+    return block;
   }
 
   std::unique_ptr<Rom> rom_;
@@ -1045,6 +1052,88 @@ TEST_F(DungeonSaveTest, SaveAllBlocks_RoomAware_ClearsBlockDirtyAfterWrite) {
   EXPECT_EQ(rom_->data()[kBlocksRegion1Pc + 2], 0x14);
   EXPECT_EQ(rom_->data()[kBlocksRegion1Pc + 3], 0x4A);
   EXPECT_FALSE(room.blocks_dirty());
+}
+
+TEST_F(DungeonSaveTest, SaveAllBlocks_RoomAware_AllowsExactVanillaCapacity) {
+  SetupBlockRegions();
+  rom_->mutable_data()[kBlocksLength] = 0x00;
+  rom_->mutable_data()[kBlocksLength + 1] = 0x00;
+
+  Room room(0, rom_.get());
+  room.LoadBlocks();
+  ASSERT_TRUE(room.AreBlocksLoaded());
+
+  constexpr int kVanillaBlockCapacity = 128;
+  for (int i = 0; i < kVanillaBlockCapacity; ++i) {
+    room.AddTileObject(MakePushableBlock(i % 64, (i * 3) % 128, i % 2));
+  }
+
+  const auto status = SaveAllBlocks(
+      rom_.get(), 1, [&room](int rid) { return rid == 0 ? &room : nullptr; });
+  ASSERT_TRUE(status.ok()) << status.message();
+
+  EXPECT_EQ(rom_->data()[kBlocksLength], 0x00);
+  EXPECT_EQ(rom_->data()[kBlocksLength + 1], 0x02)
+      << "128 entries * 4 bytes = 0x0200 bytes";
+
+  const auto first = EncodePushableBlockEntry({0, 0, 0, 0});
+  EXPECT_EQ(rom_->data()[kBlocksRegion1Pc + 0], first.b1);
+  EXPECT_EQ(rom_->data()[kBlocksRegion1Pc + 1], first.b2);
+  EXPECT_EQ(rom_->data()[kBlocksRegion1Pc + 2], first.b3);
+  EXPECT_EQ(rom_->data()[kBlocksRegion1Pc + 3], first.b4);
+
+  const auto last = EncodePushableBlockEntry(
+      {0, static_cast<uint8_t>(127 % 64), static_cast<uint8_t>((127 * 3) % 128),
+       static_cast<uint8_t>(127 % 2)});
+  const int last_entry_pc = kBlocksRegion4Pc + 0x7C;
+  EXPECT_EQ(rom_->data()[last_entry_pc + 0], last.b1);
+  EXPECT_EQ(rom_->data()[last_entry_pc + 1], last.b2);
+  EXPECT_EQ(rom_->data()[last_entry_pc + 2], last.b3);
+  EXPECT_EQ(rom_->data()[last_entry_pc + 3], last.b4);
+  EXPECT_FALSE(room.blocks_dirty());
+}
+
+TEST_F(DungeonSaveTest,
+       SaveAllBlocks_RoomAware_RejectsOverflowWithoutPartialWrite) {
+  SetupBlockRegions();
+  rom_->mutable_data()[kBlocksLength] = 0x00;
+  rom_->mutable_data()[kBlocksLength + 1] = 0x00;
+  std::fill_n(rom_->mutable_data() + kBlocksRegion1Pc, 0x80, 0x11);
+  std::fill_n(rom_->mutable_data() + kBlocksRegion2Pc, 0x80, 0x22);
+  std::fill_n(rom_->mutable_data() + kBlocksRegion3Pc, 0x80, 0x33);
+  std::fill_n(rom_->mutable_data() + kBlocksRegion4Pc, 0x80, 0x44);
+
+  Room room(0, rom_.get());
+  room.LoadBlocks();
+  ASSERT_TRUE(room.AreBlocksLoaded());
+
+  constexpr int kOverflowEntryCount = 129;
+  for (int i = 0; i < kOverflowEntryCount; ++i) {
+    room.AddTileObject(MakePushableBlock(i % 64, (i * 3) % 128, i % 2));
+  }
+
+  const auto status = SaveAllBlocks(
+      rom_.get(), 1, [&room](int rid) { return rid == 0 ? &room : nullptr; });
+
+  EXPECT_EQ(status.code(), absl::StatusCode::kFailedPrecondition);
+  EXPECT_NE(std::string(status.message()).find("Pushable-block table overflow"),
+            std::string::npos);
+  EXPECT_EQ(rom_->data()[kBlocksLength], 0x00);
+  EXPECT_EQ(rom_->data()[kBlocksLength + 1], 0x00);
+  EXPECT_TRUE(std::all_of(rom_->data() + kBlocksRegion1Pc,
+                          rom_->data() + kBlocksRegion1Pc + 0x80,
+                          [](uint8_t b) { return b == 0x11; }));
+  EXPECT_TRUE(std::all_of(rom_->data() + kBlocksRegion2Pc,
+                          rom_->data() + kBlocksRegion2Pc + 0x80,
+                          [](uint8_t b) { return b == 0x22; }));
+  EXPECT_TRUE(std::all_of(rom_->data() + kBlocksRegion3Pc,
+                          rom_->data() + kBlocksRegion3Pc + 0x80,
+                          [](uint8_t b) { return b == 0x33; }));
+  EXPECT_TRUE(std::all_of(rom_->data() + kBlocksRegion4Pc,
+                          rom_->data() + kBlocksRegion4Pc + 0x80,
+                          [](uint8_t b) { return b == 0x44; }));
+  EXPECT_TRUE(room.blocks_dirty())
+      << "Failed saves must not mark overflowing block edits clean.";
 }
 
 TEST_F(DungeonSaveTest, LoadBlocks_ReadsFromDereferencedPointerRegion) {


### PR DESCRIPTION
## Summary

- Add unit coverage for the room-aware pushable-block encoder at the vanilla table boundary.
- Assert that exactly 128 entries writes the full four-page block table and clears dirty state.
- Assert that 129 entries fails before mutating ROM bytes or clearing dirty state.
- Update the dungeon backlog with the newly pinned fixed-capacity behavior.

## Why

PR #66 made the block loader/saver fail closed around the bank-02 operand slots. Before attempting the larger >128-entry repoint/WRAM-layout work, the current fixed-capacity boundary should be explicit and regression-tested.

## Validation

- `git diff --check`
- `cmake --build --preset mac-ai --target yaze_test_unit --parallel 8`
- `ctest --test-dir build/presets/mac-ai -C Debug -R "SaveAllBlocks_RoomAware_(AllowsExactVanillaCapacity|RejectsOverflowWithoutPartialWrite|ClearsBlockDirtyAfterWrite)|LoadBlocks_ReadsFromDereferencedPointerRegion" --output-on-failure`
- `ctest --test-dir build/presets/mac-ai -C Debug -R "SaveAllBlocks" --output-on-failure`
- `YAZE_PREPUSH_BUILD_DIR=build/presets/mac-ai git push -u origin codex/dungeon-next-scout`
