### PR TITLE
[codex] Pin dungeon object overlap ordering

### DIFF
--- a/docs/internal/plans/dungeon-0.8.0-issue-test-backlog-2026-06-28.md
+++ b/docs/internal/plans/dungeon-0.8.0-issue-test-backlog-2026-06-28.md
@@ -35,9 +35,9 @@ Source: post-agent audit of the 0.8.0 dungeon drawing/editing slice.
 ## Medium-priority correctness tests
 
 4. **Sparse pixel overlap assertion for object stream ordering**
-   - Status: room `0x001` now has a sparse object BG1/BG2 overlap pixel
-     assertion that compares the composed pixel against the expected SNES Mode 1
-     priority winner (`BG2 low < BG1 low < BG2 high < BG1 high`).
+   - Status: room `0x001` now has a hardcoded sparse object BG1/BG2
+     overlap-pixel golden asserting BG1 high-priority palette index `33` wins
+     over BG2 low-priority palette index `34` at `(45,120)`.
    - Problem: full-buffer checksums are broad; a targeted overlap pixel would make ordering failures easier to diagnose.
    - Done when: one vanilla or synthetic room asserts the expected top pixel from primary/BG2-overlay/BG1-overlay ordering.
 

--- a/docs/internal/plans/dungeon-0.8.0-issue-test-backlog-2026-06-28.md
+++ b/docs/internal/plans/dungeon-0.8.0-issue-test-backlog-2026-06-28.md
@@ -35,6 +35,9 @@ Source: post-agent audit of the 0.8.0 dungeon drawing/editing slice.
 ## Medium-priority correctness tests
 
 4. **Sparse pixel overlap assertion for object stream ordering**
+   - Status: room `0x001` now has a sparse object BG1/BG2 overlap pixel
+     assertion that compares the composed pixel against the expected SNES Mode 1
+     priority winner (`BG2 low < BG1 low < BG2 high < BG1 high`).
    - Problem: full-buffer checksums are broad; a targeted overlap pixel would make ordering failures easier to diagnose.
    - Done when: one vanilla or synthetic room asserts the expected top pixel from primary/BG2-overlay/BG1-overlay ordering.
 

--- a/test/integration/zelda3/dungeon_room_regression_fixtures_test.cc
+++ b/test/integration/zelda3/dungeon_room_regression_fixtures_test.cc
@@ -1,6 +1,5 @@
 #include <gtest/gtest.h>
 
-#include <algorithm>
 #include <cstdint>
 #include <cstdlib>
 #include <iostream>
@@ -50,17 +49,14 @@ struct RoomLayerFingerprints {
   int composite_non_backdrop = 0;
 };
 
-struct ObjectOverlapPixel {
-  int index = -1;
-  int x = 0;
-  int y = 0;
-  uint8_t bg1 = 0;
-  uint8_t bg2 = 0;
-  uint8_t bg1_priority = 0;
-  uint8_t bg2_priority = 0;
-  uint8_t composite = 0;
-  uint8_t expected = 0;
-};
+constexpr int kRoom001ObjectOverlapX = 45;
+constexpr int kRoom001ObjectOverlapY = 120;
+constexpr int kRoom001ObjectOverlapIndex = 61485;
+constexpr uint8_t kRoom001ObjectOverlapBg1Pixel = 33;
+constexpr uint8_t kRoom001ObjectOverlapBg2Pixel = 34;
+constexpr uint8_t kRoom001ObjectOverlapBg1Priority = 1;
+constexpr uint8_t kRoom001ObjectOverlapBg2Priority = 0;
+constexpr uint8_t kRoom001ObjectOverlapCompositePixel = 33;
 
 RoomLayerFingerprints CaptureRoomLayerFingerprints(Rom* rom,
                                                    GameData* game_data,
@@ -100,69 +96,6 @@ RoomLayerFingerprints CaptureRoomLayerFingerprints(Rom* rom,
       .object_bg2_non_backdrop = CountNonBackdropPixels(object_bg2),
       .composite_non_backdrop = CountNonBackdropPixels(composite),
   };
-}
-
-uint8_t NormalizePriority(const std::vector<uint8_t>& priorities, int index) {
-  if (index < 0 || index >= static_cast<int>(priorities.size())) {
-    return 0;
-  }
-  const uint8_t priority = priorities[index];
-  return priority == 0xFF ? 0 : (priority ? 1 : 0);
-}
-
-int LayerRank(bool is_bg1, uint8_t priority) {
-  priority = priority ? 1 : 0;
-  if (is_bg1) {
-    return priority ? 3 : 1;
-  }
-  return priority ? 2 : 0;
-}
-
-bool FindOpaqueObjectOverlapPixel(const Room& room,
-                                  const gfx::Bitmap& composite,
-                                  ObjectOverlapPixel* out) {
-  if (out == nullptr || !composite.is_active()) {
-    return false;
-  }
-  const auto& bg1_objects = room.object_bg1_buffer();
-  const auto& bg2_objects = room.object_bg2_buffer();
-  const auto& bg1_bitmap = bg1_objects.bitmap();
-  const auto& bg2_bitmap = bg2_objects.bitmap();
-  if (!bg1_bitmap.is_active() || !bg2_bitmap.is_active()) {
-    return false;
-  }
-
-  const int pixel_count = static_cast<int>(
-      std::min({bg1_bitmap.size(), bg2_bitmap.size(), composite.size()}));
-  const auto& bg1_priority = bg1_objects.priority_data();
-  const auto& bg2_priority = bg2_objects.priority_data();
-  for (int index = 0; index < pixel_count; ++index) {
-    const uint8_t bg1 = bg1_bitmap.data()[index];
-    const uint8_t bg2 = bg2_bitmap.data()[index];
-    if (bg1 == 255 || bg2 == 255 || bg1 == bg2) {
-      continue;
-    }
-
-    const uint8_t pri1 = NormalizePriority(bg1_priority, index);
-    const uint8_t pri2 = NormalizePriority(bg2_priority, index);
-    const uint8_t expected =
-        LayerRank(/*is_bg1=*/true, pri1) >= LayerRank(/*is_bg1=*/false, pri2)
-            ? bg1
-            : bg2;
-    *out = {
-        .index = index,
-        .x = index % bg1_bitmap.width(),
-        .y = index / bg1_bitmap.width(),
-        .bg1 = bg1,
-        .bg2 = bg2,
-        .bg1_priority = pri1,
-        .bg2_priority = pri2,
-        .composite = composite.data()[index],
-        .expected = expected,
-    };
-    return true;
-  }
-  return false;
 }
 
 bool RoomContainsObjectId(const Room& room, int object_id) {
@@ -309,11 +242,10 @@ TEST_F(DungeonRoomRegressionFixturesTest, FixtureRoomsHaveThreeStreamCoverage) {
 TEST_F(DungeonRoomRegressionFixturesTest,
        Room001ObjectOverlapPixelMatchesPriorityWinner) {
   // Broad checksums catch drift but do not explain *where* compositing changed.
-  // Pin one sparse overlap pixel from room 0x001, which exercises primary,
-  // BG2-overlay, and BG1-overlay object streams. When both object buffers have
-  // opaque pixels, RoomLayerManager should pick the same top pixel as the SNES
-  // Mode 1 priority rank:
-  //   BG2 low < BG1 low < BG2 high < BG1 high.
+  // Pin one sparse golden overlap pixel from room 0x001, which exercises
+  // primary, BG2-overlay, and BG1-overlay object streams. The sampled pixel is
+  // BG1 high-priority object pixel 33 over BG2 low-priority object pixel 34,
+  // so SNES Mode 1 compositing must leave palette index 33 on top.
   Room room(0x001, &rom_, &game_data_);
   room.LoadRoomGraphics();
   room.LoadObjects();
@@ -324,18 +256,35 @@ TEST_F(DungeonRoomRegressionFixturesTest,
 
   RoomLayerManager layer_manager;
   const auto& composite = room.GetCompositeBitmap(layer_manager);
-
-  ObjectOverlapPixel sample;
-  ASSERT_TRUE(FindOpaqueObjectOverlapPixel(room, composite, &sample))
-      << "Expected room 0x001 to have at least one opaque, non-identical "
-         "BG1/BG2 object overlap pixel.";
-  EXPECT_EQ(sample.composite, sample.expected)
-      << "Room 0x001 overlap pixel (" << sample.x << "," << sample.y
-      << ") should choose the priority winner"
-      << " bg1=" << static_cast<int>(sample.bg1)
-      << " bg2=" << static_cast<int>(sample.bg2)
-      << " bg1_pri=" << static_cast<int>(sample.bg1_priority)
-      << " bg2_pri=" << static_cast<int>(sample.bg2_priority);
+  const auto& bg1_objects = room.object_bg1_buffer();
+  const auto& bg2_objects = room.object_bg2_buffer();
+  const auto& bg1_bitmap = bg1_objects.bitmap();
+  const auto& bg2_bitmap = bg2_objects.bitmap();
+  ASSERT_TRUE(bg1_bitmap.is_active());
+  ASSERT_TRUE(bg2_bitmap.is_active());
+  ASSERT_TRUE(composite.is_active());
+  ASSERT_EQ(bg2_bitmap.width(), bg1_bitmap.width());
+  ASSERT_EQ(composite.width(), bg1_bitmap.width());
+  ASSERT_LT(kRoom001ObjectOverlapX, bg1_bitmap.width());
+  ASSERT_LT(kRoom001ObjectOverlapY, bg1_bitmap.height());
+  const int sample_index =
+      kRoom001ObjectOverlapY * bg1_bitmap.width() + kRoom001ObjectOverlapX;
+  ASSERT_EQ(sample_index, kRoom001ObjectOverlapIndex);
+  ASSERT_LT(sample_index, static_cast<int>(bg1_bitmap.size()));
+  ASSERT_LT(sample_index, static_cast<int>(bg2_bitmap.size()));
+  ASSERT_LT(sample_index, static_cast<int>(composite.size()));
+  ASSERT_LT(sample_index, static_cast<int>(bg1_objects.priority_data().size()));
+  ASSERT_LT(sample_index, static_cast<int>(bg2_objects.priority_data().size()));
+  EXPECT_EQ(bg1_bitmap.data()[sample_index], kRoom001ObjectOverlapBg1Pixel);
+  EXPECT_EQ(bg2_bitmap.data()[sample_index], kRoom001ObjectOverlapBg2Pixel);
+  EXPECT_EQ(bg1_objects.priority_data()[sample_index],
+            kRoom001ObjectOverlapBg1Priority);
+  EXPECT_EQ(bg2_objects.priority_data()[sample_index],
+            kRoom001ObjectOverlapBg2Priority);
+  EXPECT_EQ(composite.data()[sample_index], kRoom001ObjectOverlapCompositePixel)
+      << "Room 0x001 overlap pixel (" << kRoom001ObjectOverlapX << ","
+      << kRoom001ObjectOverlapY << ") should preserve the golden BG1-over-BG2 "
+      << "priority winner";
 }
 
 TEST_F(DungeonRoomRegressionFixturesTest, PerLayerFingerprintsMatchGolden) {

--- a/test/integration/zelda3/dungeon_room_regression_fixtures_test.cc
+++ b/test/integration/zelda3/dungeon_room_regression_fixtures_test.cc
@@ -1,5 +1,6 @@
 #include <gtest/gtest.h>
 
+#include <algorithm>
 #include <cstdint>
 #include <cstdlib>
 #include <iostream>
@@ -49,6 +50,18 @@ struct RoomLayerFingerprints {
   int composite_non_backdrop = 0;
 };
 
+struct ObjectOverlapPixel {
+  int index = -1;
+  int x = 0;
+  int y = 0;
+  uint8_t bg1 = 0;
+  uint8_t bg2 = 0;
+  uint8_t bg1_priority = 0;
+  uint8_t bg2_priority = 0;
+  uint8_t composite = 0;
+  uint8_t expected = 0;
+};
+
 RoomLayerFingerprints CaptureRoomLayerFingerprints(Rom* rom,
                                                    GameData* game_data,
                                                    int room_id) {
@@ -87,6 +100,69 @@ RoomLayerFingerprints CaptureRoomLayerFingerprints(Rom* rom,
       .object_bg2_non_backdrop = CountNonBackdropPixels(object_bg2),
       .composite_non_backdrop = CountNonBackdropPixels(composite),
   };
+}
+
+uint8_t NormalizePriority(const std::vector<uint8_t>& priorities, int index) {
+  if (index < 0 || index >= static_cast<int>(priorities.size())) {
+    return 0;
+  }
+  const uint8_t priority = priorities[index];
+  return priority == 0xFF ? 0 : (priority ? 1 : 0);
+}
+
+int LayerRank(bool is_bg1, uint8_t priority) {
+  priority = priority ? 1 : 0;
+  if (is_bg1) {
+    return priority ? 3 : 1;
+  }
+  return priority ? 2 : 0;
+}
+
+bool FindOpaqueObjectOverlapPixel(const Room& room,
+                                  const gfx::Bitmap& composite,
+                                  ObjectOverlapPixel* out) {
+  if (out == nullptr || !composite.is_active()) {
+    return false;
+  }
+  const auto& bg1_objects = room.object_bg1_buffer();
+  const auto& bg2_objects = room.object_bg2_buffer();
+  const auto& bg1_bitmap = bg1_objects.bitmap();
+  const auto& bg2_bitmap = bg2_objects.bitmap();
+  if (!bg1_bitmap.is_active() || !bg2_bitmap.is_active()) {
+    return false;
+  }
+
+  const int pixel_count = static_cast<int>(
+      std::min({bg1_bitmap.size(), bg2_bitmap.size(), composite.size()}));
+  const auto& bg1_priority = bg1_objects.priority_data();
+  const auto& bg2_priority = bg2_objects.priority_data();
+  for (int index = 0; index < pixel_count; ++index) {
+    const uint8_t bg1 = bg1_bitmap.data()[index];
+    const uint8_t bg2 = bg2_bitmap.data()[index];
+    if (bg1 == 255 || bg2 == 255 || bg1 == bg2) {
+      continue;
+    }
+
+    const uint8_t pri1 = NormalizePriority(bg1_priority, index);
+    const uint8_t pri2 = NormalizePriority(bg2_priority, index);
+    const uint8_t expected =
+        LayerRank(/*is_bg1=*/true, pri1) >= LayerRank(/*is_bg1=*/false, pri2)
+            ? bg1
+            : bg2;
+    *out = {
+        .index = index,
+        .x = index % bg1_bitmap.width(),
+        .y = index / bg1_bitmap.width(),
+        .bg1 = bg1,
+        .bg2 = bg2,
+        .bg1_priority = pri1,
+        .bg2_priority = pri2,
+        .composite = composite.data()[index],
+        .expected = expected,
+    };
+    return true;
+  }
+  return false;
 }
 
 bool RoomContainsObjectId(const Room& room, int object_id) {
@@ -228,6 +304,38 @@ TEST_F(DungeonRoomRegressionFixturesTest, FixtureRoomsHaveThreeStreamCoverage) {
   EXPECT_TRUE(has_stream[0]) << "Room 0x001 missing primary stream";
   EXPECT_TRUE(has_stream[1]) << "Room 0x001 missing BG2 overlay stream";
   EXPECT_TRUE(has_stream[2]) << "Room 0x001 missing BG1 overlay stream";
+}
+
+TEST_F(DungeonRoomRegressionFixturesTest,
+       Room001ObjectOverlapPixelMatchesPriorityWinner) {
+  // Broad checksums catch drift but do not explain *where* compositing changed.
+  // Pin one sparse overlap pixel from room 0x001, which exercises primary,
+  // BG2-overlay, and BG1-overlay object streams. When both object buffers have
+  // opaque pixels, RoomLayerManager should pick the same top pixel as the SNES
+  // Mode 1 priority rank:
+  //   BG2 low < BG1 low < BG2 high < BG1 high.
+  Room room(0x001, &rom_, &game_data_);
+  room.LoadRoomGraphics();
+  room.LoadObjects();
+  room.CopyRoomGraphicsToBuffer();
+  room.RenderRoomGraphics();
+  ASSERT_FALSE(room.layer_merging().Layer2Translucent)
+      << "This sparse ordering assertion assumes opaque compositing.";
+
+  RoomLayerManager layer_manager;
+  const auto& composite = room.GetCompositeBitmap(layer_manager);
+
+  ObjectOverlapPixel sample;
+  ASSERT_TRUE(FindOpaqueObjectOverlapPixel(room, composite, &sample))
+      << "Expected room 0x001 to have at least one opaque, non-identical "
+         "BG1/BG2 object overlap pixel.";
+  EXPECT_EQ(sample.composite, sample.expected)
+      << "Room 0x001 overlap pixel (" << sample.x << "," << sample.y
+      << ") should choose the priority winner"
+      << " bg1=" << static_cast<int>(sample.bg1)
+      << " bg2=" << static_cast<int>(sample.bg2)
+      << " bg1_pri=" << static_cast<int>(sample.bg1_priority)
+      << " bg2_pri=" << static_cast<int>(sample.bg2_priority);
 }
 
 TEST_F(DungeonRoomRegressionFixturesTest, PerLayerFingerprintsMatchGolden) {


### PR DESCRIPTION
## Summary
- Adds a sparse room `0x001` object BG1/BG2 overlap pixel regression assertion.
- Pins the discovered golden sample at `(45,120)` / index `61485`: BG1 high-priority palette index `33` over BG2 low-priority palette index `34`, with final composite palette index `33`.
- Updates the dungeon 0.8.0 backlog item for sparse object-stream ordering coverage.

## Validation
- `clang-format -i test/integration/zelda3/dungeon_room_regression_fixtures_test.cc`
- `git diff --check`
- `cmake --build --preset mac-ai --target yaze_test_integration --parallel 8`
- `YAZE_TEST_ROM_VANILLA=/Users/scawful/src/hobby/yaze/roms/alttp_vanilla.sfc ctest --test-dir build/presets/mac-ai -C Debug -R "Room001ObjectOverlapPixelMatchesPriorityWinner|FixtureRoomsHaveThreeStreamCoverage|Bg2OverlayStreamWritesObjectBufferInRoom001" --output-on-failure`
- `YAZE_PREPUSH_BUILD_DIR=build/presets/mac-ai git push`
