### PR TITLE
fix(editor): make ROM saves fail closed

### DIFF
--- a/docs/internal/plans/oracle-daily-driver-save-stability.md
+++ b/docs/internal/plans/oracle-daily-driver-save-stability.md
@@ -1,0 +1,123 @@
+# Oracle Daily-Driver Save Stability
+
+**Status:** ACTIVE - Wave 1 implemented and locally verified
+**Owner (Agent ID):** CODEX
+**Created:** 2026-07-11
+**Last Reviewed:** 2026-07-11
+**Next Review:** 2026-07-18
+**Coordination:** AFS task `task_20260711T144152Z_18414`
+
+## Summary
+
+Make yaze safe enough to finish Oracle of Secrets without waiting for every
+editor feature to reach general-purpose completeness. The daily-driver bar is
+guarded, recoverable editing of the already-developed OOS base ROM: failed
+saves must not partially mutate the ROM or lose retry state, project targets
+must be unambiguous, and unsupported growth must fail closed.
+
+This plan complements the [editor-first release ladder](release-ladder-0x-2026.md)
+and the broader [Oracle integration plan](oracle-yaze-integration.md). It does
+not move all remaining dungeon or overworld polish into the `0.7.2` release.
+
+## Decisions And Constraints
+
+- `Roms/oos168.sfc` is editable; `Roms/oos168x.sfc` is disposable build output.
+- Open `Oracle-of-Secrets.yaze` so target, manifest, hash, and write policy are
+  loaded together.
+- Use one whole-ROM transaction plus editor-state rollback for coordinated
+  saves. A failure must preserve every dirty flag needed for a retry.
+- Never infer free space from runs of `00` or `FF`. Future relocation may use
+  only allocator-owned ranges declared by the ROM profile/project manifest.
+- Shared or over-capacity dungeon streams fail without mutation until copy-on-
+  write support lands.
+- Keep OOS autosave, dungeon-map saving, and graphics-sheet saving disabled
+  during the guarded beta.
+
+## Deliverables
+
+### Wave 1 - Containment and project safety
+
+- [x] Preserve Save As targets through hash, pot-item, and conflict prompts.
+- [x] Apply build-output policy to the requested target and refresh lifecycle
+  path/hash only after a successful save.
+- [x] Block saves when an explicitly configured hack manifest is missing or
+  malformed.
+- [x] Roll back ROM bytes and editor dirty state after late save failures.
+- [x] Bound dungeon object, sprite, pot, and chest writes; reject aliases and
+  unknown headroom without mutation.
+- [x] Bound expanded-message reads/writes, reject expanded `[BANK]`, validate
+  dictionary IDs, and prevent invalid drafts from being discarded by
+  navigation.
+- [x] Use ROM-profile and adjacent-table bounds for Map32 storage; preserve
+  disabled custom overworld tables and their original enable encoding.
+- [x] Make the OOS project file and generated manifest describe the canonical
+  editable/build ROM workflow.
+- [x] Finish focused automated verification and publish this wave as a
+  dedicated safety PR; keep release PR #69 narrowly reviewable.
+
+### Wave 2 - Dungeon copy-on-write allocator
+
+1. Inventory object, sprite, and pot streams by physical address, size, bank,
+   aliases, and owners; reconcile candidate ranges with the OOS manifest.
+2. Build a deterministic allocator that produces and validates an immutable
+   write plan before changing any byte.
+3. Detach and relocate shared/overflowing object streams, including object and
+   door pointer updates.
+4. Deterministically repack all pot pointers/streams inside a declared region.
+5. Detach and relocate sprite streams inside declared bank `$09` capacity.
+6. Add `z3ed` dry-run diagnostics for planned moves, aliases, and free space.
+
+**Estimate:** 4-5 full-time weeks for an allocator beta; 6-8 full-time weeks
+including OOS soak and emulator verification. At 10-15 hours/week, plan on
+roughly 3-5 months. Proving Oracle-safe allocator ownership is the main risk.
+
+### Wave 3 - Flexible daily-driver beta
+
+- Exercise the remaining high-value OOS message, overworld-property, project,
+  backup/restore, and multi-session workflows.
+- Run repeated edit/save/reopen/build cycles on representative D6 rooms
+  `A8`, `B8`, `D8`, and `DA`.
+- Track strict-readiness content failures separately from editor corruption;
+  the current D3 readiness gap is not itself a save-stability blocker.
+
+## Exit Criteria
+
+- No-edit save is semantically identical for vanilla ALTTP and OOS/ZSCustom
+  v3, including expanded Map32 data.
+- Every failure path restores ROM bytes and all dirty/retry state.
+- Save As never modifies or backs up the source path by mistake and never
+  permits the configured build output as an editable destination.
+- Shared-stream edits affect only the selected room after Wave 2; before then,
+  they fail closed with an actionable error.
+- Exact-fit streams save; overflow either relocates through a validated plan or
+  fails with zero mutation.
+- Rebuilding through `Scripts/Build/build_rom.sh 168` preserves intended base-
+  ROM edits and refreshes manifest hashes/ownership.
+- At least 50 save/reopen cycles and one multi-hour editing session complete
+  with backup restoration tested.
+- Mesen boots and traverses representative edited rooms without bad doors,
+  objects, sprites, pots, or room loads.
+
+## Validation
+
+For each save-path change, run the narrow unit/integration filter first. Before
+publishing the safety PR, also require:
+
+1. `yaze_test_unit` and quick-editor transaction/message/dungeon filters.
+2. Vanilla plus temporary-OOS integration round trips with source hashes
+   unchanged.
+3. `z3ed project-bundle-verify`, `rom-doctor`, and non-strict
+   `oracle-smoke-check` on the current OOS base ROM.
+4. A strict smoke run whose remaining failures are recorded as content gaps.
+5. Green macOS and Windows PR checks before promoting the release candidate.
+
+### 2026-07-11 Wave 1 snapshot
+
+- Unit: 2,407 passed; one optional usdasm palette fixture skipped.
+- Quick editor: 619 passed.
+- Vanilla + temporary-OOS integration: 279 passed; two fixture-discovery
+  utilities skipped; both canonical source ROM hashes remained unchanged.
+- OOS project verification: 7 passes, zero warnings/failures, including the
+  configured manifest and expected ROM hash.
+- OOS smoke: D4 structural checks and all four required D6 track rooms pass;
+  strict readiness still records only the known D3 content gap.

--- a/src/app/editor/dungeon/dungeon_editor_v2.h
+++ b/src/app/editor/dungeon/dungeon_editor_v2.h
@@ -4,6 +4,7 @@
 #include <array>
 #include <cstdint>
 #include <deque>
+#include <functional>
 #include <memory>
 #include <optional>
 #include <string>
@@ -131,6 +132,9 @@ class DungeonEditorV2 : public Editor {
   absl::Status Paste() override;
   absl::Status Find() override { return absl::UnimplementedError("Find"); }
   absl::Status Save() override;
+  absl::Status BeginSaveTransaction() override;
+  void RollbackSaveTransaction() override;
+  void CommitSaveTransaction() override;
   void ContributeStatus(StatusBar* status_bar) override;
   absl::Status SaveRoom(int room_id);
   int LoadedRoomCount() const;
@@ -240,6 +244,10 @@ class DungeonEditorV2 : public Editor {
       DungeonEditorV2RomSafetyTest_ViewerCacheNeverEvictsActiveRooms_Test;
   friend class
       DungeonEditorV2RomSafetyTest_ViewerCacheLRUAccessOrderUpdate_Test;
+  friend class
+      DungeonEditorV2RomSafetyTest_SaveAllRoomsRollsBackEarlierWritesOnLateFailure_Test;
+  friend class
+      DungeonEditorV2RomSafetyTest_LateCoordinatorRollbackRestoresEntranceDirtyState_Test;
 
   gfx::IRenderer* renderer_ = nullptr;
 
@@ -283,12 +291,23 @@ class DungeonEditorV2 : public Editor {
   void RemoveViewerFromLru(int room_id);
 
   absl::Status SaveRoomData(int room_id);
+  absl::Status RunWithSaveTransaction(
+      const std::function<absl::Status()>& operation);
 
   // Data
   Rom* rom_;
   zelda3::GameData* game_data_ = nullptr;
   DungeonRoomStore rooms_;
   std::array<zelda3::RoomEntrance, zelda3::kNumDungeonEntranceSlots> entrances_;
+
+  struct SaveTransactionSnapshot {
+    std::vector<std::pair<int, zelda3::Room::SaveDirtySnapshot>> room_states;
+    std::array<bool, zelda3::kNumDungeonEntranceSlots> entrance_dirty_states{};
+    bool has_pit_damage_table = false;
+    bool pit_damage_dirty = false;
+    bool has_palette_transaction = false;
+  };
+  std::optional<SaveTransactionSnapshot> save_transaction_snapshot_;
 
   // Current selection state
   int current_entrance_id_ = 0;

--- a/src/app/editor/dungeon/dungeon_editor_v2_persistence.cc
+++ b/src/app/editor/dungeon/dungeon_editor_v2_persistence.cc
@@ -58,6 +58,7 @@
 #include "dungeon_editor_v2.h"
 #include "imgui/imgui.h"
 #include "rom/snes.h"
+#include "rom/transaction.h"
 #include "util/log.h"
 #include "util/macro.h"
 #include "zelda3/dungeon/custom_object.h"
@@ -146,6 +147,99 @@ absl::Status SaveWaterFillZones(Rom* rom, DungeonRoomStore& rooms) {
 }
 
 }  // namespace
+
+absl::Status DungeonEditorV2::BeginSaveTransaction() {
+  if (save_transaction_snapshot_.has_value()) {
+    return absl::FailedPreconditionError(
+        "Dungeon save transaction is already active");
+  }
+
+  SaveTransactionSnapshot snapshot;
+  auto& palette_manager = gfx::PaletteManager::Get();
+  if (core::FeatureFlags::get().dungeon.kSavePalettes &&
+      palette_manager.HasUnsavedChanges()) {
+    RETURN_IF_ERROR(palette_manager.BeginSaveTransaction());
+    snapshot.has_palette_transaction = true;
+  }
+  rooms_.ForEachMaterialized([&snapshot](int room_id,
+                                         const zelda3::Room& room) {
+    snapshot.room_states.emplace_back(room_id, room.CaptureSaveDirtySnapshot());
+  });
+  for (size_t i = 0; i < entrances_.size(); ++i) {
+    snapshot.entrance_dirty_states[i] = entrances_[i].dirty();
+  }
+  if (game_data_ != nullptr) {
+    snapshot.has_pit_damage_table = true;
+    snapshot.pit_damage_dirty = game_data_->pit_damage_table.dirty();
+  }
+  save_transaction_snapshot_ = std::move(snapshot);
+  return absl::OkStatus();
+}
+
+void DungeonEditorV2::RollbackSaveTransaction() {
+  if (!save_transaction_snapshot_.has_value()) {
+    return;
+  }
+
+  for (const auto& [room_id, state] : save_transaction_snapshot_->room_states) {
+    if (auto* room = rooms_.GetIfMaterialized(room_id); room != nullptr) {
+      room->RestoreSaveDirtySnapshot(state);
+    }
+  }
+  for (size_t i = 0; i < entrances_.size(); ++i) {
+    if (save_transaction_snapshot_->entrance_dirty_states[i]) {
+      entrances_[i].MarkDirty();
+    } else {
+      entrances_[i].ClearDirty();
+    }
+  }
+  if (save_transaction_snapshot_->has_pit_damage_table &&
+      game_data_ != nullptr) {
+    if (save_transaction_snapshot_->pit_damage_dirty) {
+      game_data_->pit_damage_table.MarkDirty();
+    } else {
+      game_data_->pit_damage_table.ClearDirty();
+    }
+  }
+  if (save_transaction_snapshot_->has_palette_transaction) {
+    gfx::PaletteManager::Get().RollbackSaveTransaction();
+  }
+  save_transaction_snapshot_.reset();
+}
+
+void DungeonEditorV2::CommitSaveTransaction() {
+  if (save_transaction_snapshot_.has_value() &&
+      save_transaction_snapshot_->has_palette_transaction) {
+    gfx::PaletteManager::Get().CommitSaveTransaction();
+  }
+  save_transaction_snapshot_.reset();
+}
+
+absl::Status DungeonEditorV2::RunWithSaveTransaction(
+    const std::function<absl::Status()>& operation) {
+  if (!rom_ || !rom_->is_loaded()) {
+    return absl::FailedPreconditionError("ROM not loaded");
+  }
+
+  // File > Save already owns a whole-ROM/editor transaction. Direct Apply Room
+  // and Apply All actions use the same guarantees without nesting it.
+  if (save_transaction_snapshot_.has_value()) {
+    return operation();
+  }
+
+  ScopedRomTransaction rom_transaction(*rom_);
+  RETURN_IF_ERROR(BeginSaveTransaction());
+
+  const absl::Status status = operation();
+  if (!status.ok()) {
+    RollbackSaveTransaction();
+    return status;
+  }
+
+  CommitSaveTransaction();
+  rom_transaction.Commit();
+  return absl::OkStatus();
+}
 
 absl::Status DungeonEditorV2::Save() {
   if (!rom_ || !rom_->is_loaded()) {
@@ -372,63 +466,62 @@ std::vector<std::pair<uint32_t, uint32_t>> DungeonEditorV2::CollectWriteRanges()
 }
 
 absl::Status DungeonEditorV2::SaveRoom(int room_id) {
-  if (!rom_ || !rom_->is_loaded()) {
-    return absl::FailedPreconditionError("ROM not loaded");
-  }
-  if (room_id < 0 || room_id >= static_cast<int>(rooms_.size())) {
-    return absl::InvalidArgumentError("Invalid room ID");
-  }
-
-  const auto& flags = core::FeatureFlags::get().dungeon;
-  if (flags.kSavePalettes && gfx::PaletteManager::Get().HasUnsavedChanges()) {
-    auto status = gfx::PaletteManager::Get().SaveAllToRom();
-    if (!status.ok()) {
-      LOG_ERROR("DungeonEditorV2", "Failed to save palette changes: %s",
-                status.message().data());
-      return status;
+  return RunWithSaveTransaction([this, room_id]() -> absl::Status {
+    if (room_id < 0 || room_id >= static_cast<int>(rooms_.size())) {
+      return absl::InvalidArgumentError("Invalid room ID");
     }
-  }
-  if (flags.kSaveObjects || flags.kSaveSprites || flags.kSaveRoomHeaders) {
-    RETURN_IF_ERROR(SaveRoomData(room_id));
-  }
 
-  if (flags.kSaveTorches) {
-    RETURN_IF_ERROR(zelda3::SaveAllTorches(
-        rom_, static_cast<int>(rooms_.size()),
-        [this](int room_id) { return rooms_.GetIfMaterialized(room_id); }));
-  }
-  if (flags.kSavePits) {
-    RETURN_IF_ERROR(zelda3::SaveAllPits(
-        rom_, game_data_ ? &game_data_->pit_damage_table : nullptr));
-  }
-  if (flags.kSaveBlocks) {
-    RETURN_IF_ERROR(zelda3::SaveAllBlocks(
-        rom_, static_cast<int>(rooms_.size()),
-        [this](int room_id) { return rooms_.GetIfMaterialized(room_id); }));
-  }
-  if (flags.kSaveCollision) {
-    RETURN_IF_ERROR(zelda3::SaveAllCollision(
-        rom_, static_cast<int>(rooms_.size()),
-        [this](int room_id) { return rooms_.GetIfMaterialized(room_id); }));
-  }
-  if (flags.kSaveWaterFillZones) {
-    RETURN_IF_ERROR(SaveWaterFillZones(rom_, rooms_));
-  }
-  if (flags.kSaveChests) {
-    RETURN_IF_ERROR(zelda3::SaveAllChests(
-        rom_, static_cast<int>(rooms_.size()),
-        [this](int room_id) { return rooms_.GetIfMaterialized(room_id); }));
-  }
-  if (flags.kSavePotItems) {
-    RETURN_IF_ERROR(zelda3::SaveAllPotItems(
-        rom_, static_cast<int>(rooms_.size()),
-        [this](int room_id) { return rooms_.GetIfMaterialized(room_id); }));
-  }
-  if (flags.kSaveEntrances) {
-    RETURN_IF_ERROR(zelda3::SaveAllDungeonEntrances(rom_, entrances_));
-  }
+    const auto& flags = core::FeatureFlags::get().dungeon;
+    if (flags.kSavePalettes && gfx::PaletteManager::Get().HasUnsavedChanges()) {
+      auto status = gfx::PaletteManager::Get().SaveAllToRom();
+      if (!status.ok()) {
+        LOG_ERROR("DungeonEditorV2", "Failed to save palette changes: %s",
+                  status.message().data());
+        return status;
+      }
+    }
+    if (flags.kSaveObjects || flags.kSaveSprites || flags.kSaveRoomHeaders) {
+      RETURN_IF_ERROR(SaveRoomData(room_id));
+    }
 
-  return absl::OkStatus();
+    if (flags.kSaveTorches) {
+      RETURN_IF_ERROR(zelda3::SaveAllTorches(
+          rom_, static_cast<int>(rooms_.size()),
+          [this](int id) { return rooms_.GetIfMaterialized(id); }));
+    }
+    if (flags.kSavePits) {
+      RETURN_IF_ERROR(zelda3::SaveAllPits(
+          rom_, game_data_ ? &game_data_->pit_damage_table : nullptr));
+    }
+    if (flags.kSaveBlocks) {
+      RETURN_IF_ERROR(zelda3::SaveAllBlocks(
+          rom_, static_cast<int>(rooms_.size()),
+          [this](int id) { return rooms_.GetIfMaterialized(id); }));
+    }
+    if (flags.kSaveCollision) {
+      RETURN_IF_ERROR(zelda3::SaveAllCollision(
+          rom_, static_cast<int>(rooms_.size()),
+          [this](int id) { return rooms_.GetIfMaterialized(id); }));
+    }
+    if (flags.kSaveWaterFillZones) {
+      RETURN_IF_ERROR(SaveWaterFillZones(rom_, rooms_));
+    }
+    if (flags.kSaveChests) {
+      RETURN_IF_ERROR(zelda3::SaveAllChests(
+          rom_, static_cast<int>(rooms_.size()),
+          [this](int id) { return rooms_.GetIfMaterialized(id); }));
+    }
+    if (flags.kSavePotItems) {
+      RETURN_IF_ERROR(zelda3::SaveAllPotItems(
+          rom_, static_cast<int>(rooms_.size()),
+          [this](int id) { return rooms_.GetIfMaterialized(id); }));
+    }
+    if (flags.kSaveEntrances) {
+      RETURN_IF_ERROR(zelda3::SaveAllDungeonEntrances(rom_, entrances_));
+    }
+
+    return absl::OkStatus();
+  });
 }
 
 absl::Status DungeonEditorV2::SaveRoomData(int room_id) {
@@ -562,7 +655,7 @@ absl::Status DungeonEditorV2::SaveRoomData(int room_id) {
 }
 
 void DungeonEditorV2::SaveAllRooms() {
-  auto status = Save();
+  auto status = RunWithSaveTransaction([this]() { return Save(); });
   if (status.ok()) {
     if (dependencies_.toast_manager) {
       dependencies_.toast_manager->Show("Applied loaded rooms to ROM buffer",

--- a/src/app/editor/editor.h
+++ b/src/app/editor/editor.h
@@ -265,6 +265,14 @@ class Editor {
   // Save the editor state.
   virtual absl::Status Save() = 0;
 
+  // Coordinated-save lifecycle. Editors that clear model-level dirty state
+  // during Save() can override these hooks to checkpoint and restore it when a
+  // later serializer, validation gate, backup, or disk write fails. Default
+  // implementations keep existing editors source-compatible.
+  virtual absl::Status BeginSaveTransaction() { return absl::OkStatus(); }
+  virtual void RollbackSaveTransaction() {}
+  virtual void CommitSaveTransaction() {}
+
   // Update the editor state, ran every frame.
   virtual absl::Status Update() = 0;
 

--- a/src/app/editor/editor_manager.cc
+++ b/src/app/editor/editor_manager.cc
@@ -88,6 +88,7 @@
 #include "editor/ui/rom_load_options_dialog.h"
 #include "rom/rom.h"
 #include "rom/rom_diff.h"
+#include "rom/transaction.h"
 #include "startup_flags.h"
 #include "util/file_util.h"
 #include "util/i18n/language_manager.h"
@@ -138,6 +139,42 @@
 namespace yaze::editor {
 
 namespace {
+class ScopedEditorSaveTransactions {
+ public:
+  ScopedEditorSaveTransactions() = default;
+  ScopedEditorSaveTransactions(const ScopedEditorSaveTransactions&) = delete;
+  ScopedEditorSaveTransactions& operator=(const ScopedEditorSaveTransactions&) =
+      delete;
+
+  ~ScopedEditorSaveTransactions() {
+    if (!committed_) {
+      for (auto it = editors_.rbegin(); it != editors_.rend(); ++it) {
+        (*it)->RollbackSaveTransaction();
+      }
+    }
+  }
+
+  absl::Status Begin(Editor* editor) {
+    if (editor == nullptr) {
+      return absl::OkStatus();
+    }
+    RETURN_IF_ERROR(editor->BeginSaveTransaction());
+    editors_.push_back(editor);
+    return absl::OkStatus();
+  }
+
+  void Commit() {
+    for (Editor* editor : editors_) {
+      editor->CommitSaveTransaction();
+    }
+    committed_ = true;
+  }
+
+ private:
+  std::vector<Editor*> editors_;
+  bool committed_ = false;
+};
+
 bool HasAnyOverride(const core::RomAddressOverrides& overrides,
                     std::initializer_list<const char*> keys) {
   for (const char* key : keys) {
@@ -1131,6 +1168,10 @@ void EditorManager::RefreshResourceLabelProvider() {
 
 void EditorManager::HandleSessionSwitched(size_t new_index,
                                           RomSession* session) {
+  // Confirmation consent and Save As targets belong to the ROM that started
+  // the request. Never carry them across a session switch.
+  CancelPendingRomSave(/*hide_popups=*/true);
+
   // Update RightDrawerManager with the new session's settings editor
   if (right_drawer_manager_ && session) {
     right_drawer_manager_->SetSettingsPanel(
@@ -1163,16 +1204,29 @@ void EditorManager::HandleSessionSwitched(size_t new_index,
   test::TestManager::Get().SetCurrentRom(session ? &session->rom : nullptr);
 #endif
 
+  // RomLifecycleManager caches both identity hash and path; refresh them for
+  // the newly active session before its next save-policy check.
+  UpdateCurrentRomHash();
+
   LOG_DEBUG("EditorManager", "Session switched to %zu via EventBus", new_index);
 }
 
 void EditorManager::HandleSessionCreated(size_t index, RomSession* session) {
+  if (pending_rom_save_.has_value() && !PendingRomSaveMatchesActiveSession()) {
+    CancelPendingRomSave(/*hide_popups=*/true);
+  }
   window_manager_.RegisterRegistryWindowContentsForSession(index);
   window_manager_.RestorePinnedState(user_settings_.prefs().pinned_panels);
+  if (session_coordinator_ &&
+      index == session_coordinator_->GetActiveSessionIndex()) {
+    UpdateCurrentRomHash();
+  }
   LOG_INFO("EditorManager", "Session %zu created via EventBus", index);
 }
 
 void EditorManager::HandleSessionClosed(size_t index) {
+  CancelPendingRomSave(/*hide_popups=*/true);
+
   // Update ContentRegistry - it will be set to new active ROM on next switch
   // If no sessions remain, clear the context
   if (session_coordinator_ &&
@@ -2533,21 +2587,27 @@ void EditorManager::UpdateEditorState() {
     last_test_rom = current_rom;
   }
 
-  // Autosave timer
-  if (user_settings_.prefs().autosave_enabled && current_rom &&
-      current_rom->dirty()) {
+  // Autosave uses the same guarded serialization, validation, backup, and
+  // atomic commit pipeline as an explicit save. Writing Rom::SaveToFile here
+  // would skip editor model serialization and could persist a partially
+  // failed buffer while clearing its dirty bit.
+  const bool current_session_has_unsaved_work =
+      current_rom && SessionHasPendingUnsavedWork(GetCurrentSessionIndex());
+  if (user_settings_.prefs().autosave_enabled &&
+      current_session_has_unsaved_work) {
     autosave_timer_ += ImGui::GetIO().DeltaTime;
     if (autosave_timer_ >= user_settings_.prefs().autosave_interval) {
       autosave_timer_ = 0.0f;
-      Rom::SaveSettings s;
-      s.backup = true;
-      s.save_new = false;
-      auto st = current_rom->SaveToFile(s);
+      auto st = SaveRom();
       if (st.ok()) {
         toast_manager_.Show("Autosave completed", editor::ToastType::kSuccess);
+      } else if (absl::IsCancelled(st)) {
+        toast_manager_.Show("Autosave paused: confirmation required",
+                            editor::ToastType::kWarning, 5.0f);
       } else {
-        toast_manager_.Show(std::string(st.message()),
-                            editor::ToastType::kError, 5.0f);
+        toast_manager_.Show(
+            absl::StrFormat("Autosave failed: %s", st.message()),
+            editor::ToastType::kError, 5.0f);
       }
     }
   } else {
@@ -3355,19 +3415,102 @@ absl::Status EditorManager::LoadAssetsLazy(uint64_t passed_handle) {
  * This stays in EditorManager because it requires knowledge of all editors
  * and the order in which they must be saved to maintain ROM integrity.
  */
-absl::Status EditorManager::CheckRomWritePolicy() {
-  return rom_lifecycle_.CheckRomWritePolicy(GetCurrentRom());
+absl::Status EditorManager::CheckRomWritePolicy(
+    const std::optional<std::string>& target_filename) {
+  return rom_lifecycle_.CheckRomWritePolicy(GetCurrentRom(), target_filename);
 }
 
 absl::Status EditorManager::CheckOracleRomSafetyPreSave(Rom* rom) {
   return rom_lifecycle_.CheckOracleRomSafetyPreSave(rom);
 }
 
+bool EditorManager::HasPendingRomSaveConfirmation() const {
+  return rom_lifecycle_.IsRomWriteConfirmPending() ||
+         rom_lifecycle_.HasPendingPotItemSaveConfirmation() ||
+         !rom_lifecycle_.pending_write_conflicts().empty();
+}
+
+bool EditorManager::PendingRomSaveMatchesActiveSession() const {
+  if (!pending_rom_save_.has_value() || !session_coordinator_) {
+    return false;
+  }
+  return pending_rom_save_->session_index == GetCurrentSessionIndex() &&
+         pending_rom_save_->rom != nullptr &&
+         pending_rom_save_->rom == GetCurrentRom();
+}
+
+void EditorManager::CancelPendingRomSave(bool hide_popups) {
+  pending_rom_save_.reset();
+  rom_lifecycle_.ResetPendingSaveState();
+
+  if (!hide_popups || !popup_manager_) {
+    return;
+  }
+  for (const char* popup :
+       {PopupID::kRomWriteConfirm, PopupID::kDungeonPotItemSaveConfirm,
+        PopupID::kWriteConflictWarning, PopupID::kSaveAs}) {
+    if (popup_manager_->IsVisible(popup)) {
+      popup_manager_->Hide(popup);
+    }
+  }
+}
+
+absl::Status EditorManager::StartPendingRomSave(
+    const std::optional<std::string>& save_as_filename) {
+  auto* rom = GetCurrentRom();
+  if (!session_coordinator_ || !session_coordinator_->GetActiveRomSession() ||
+      !rom) {
+    return absl::FailedPreconditionError("No active ROM session");
+  }
+
+  CancelPendingRomSave();
+  pending_rom_save_ =
+      PendingRomSave{save_as_filename, GetCurrentSessionIndex(), rom};
+  return absl::OkStatus();
+}
+
+void EditorManager::FinishPendingRomSaveAttempt(const absl::Status& status) {
+  // A Cancelled status is resumable only while one of this request's explicit
+  // confirmation dialogs is pending. Every other outcome is terminal and must
+  // consume all one-shot bypasses so a later Ctrl+S cannot inherit consent.
+  if (status.ok() || !absl::IsCancelled(status) ||
+      !HasPendingRomSaveConfirmation()) {
+    CancelPendingRomSave();
+  }
+}
+
 absl::Status EditorManager::SaveRom() {
+  // Do not let an autosave or an unrelated Ctrl+S replace a Save As request
+  // while one of its confirmation dialogs is still open.
+  if (pending_rom_save_.has_value()) {
+    const bool unresolved_confirmation =
+        rom_lifecycle_.IsRomWriteConfirmPending() ||
+        rom_lifecycle_.HasPendingPotItemSaveConfirmation() ||
+        (!rom_lifecycle_.pending_write_conflicts().empty() &&
+         !rom_lifecycle_.ShouldBypassWriteConflict());
+    if (unresolved_confirmation) {
+      return absl::CancelledError("Save pending confirmation");
+    }
+    // Preserve the established request after programmatic confirmation too.
+    // Older callers use ConfirmRomWrite(); SaveRom() rather than the popup's
+    // ResumePendingRomSave() helper.
+    return ResumePendingRomSave();
+  }
+  RETURN_IF_ERROR(StartPendingRomSave(std::nullopt));
+  auto status = SaveRomInternal(std::nullopt);
+  FinishPendingRomSaveAttempt(status);
+  return status;
+}
+
+absl::Status EditorManager::SaveRomInternal(
+    const std::optional<std::string>& save_as_filename) {
   auto* current_rom = GetCurrentRom();
   auto* current_editor_set = GetCurrentEditorSet();
   if (!current_rom || !current_editor_set) {
     return absl::FailedPreconditionError("No ROM or editor set loaded");
+  }
+  if (save_as_filename.has_value() && save_as_filename->empty()) {
+    return absl::InvalidArgumentError("No filename provided for save as");
   }
 
   // --- State machine checks (delegated to RomLifecycleManager) ---
@@ -3375,7 +3518,7 @@ absl::Status EditorManager::SaveRom() {
     return absl::CancelledError("Save pending confirmation");
   }
 
-  RETURN_IF_ERROR(CheckRomWritePolicy());
+  RETURN_IF_ERROR(CheckRomWritePolicy(save_as_filename));
 
   if (rom_lifecycle_.HasPendingPotItemSaveConfirmation()) {
     return absl::CancelledError("Save pending confirmation");
@@ -3437,24 +3580,34 @@ absl::Status EditorManager::SaveRom() {
         user_settings_.prefs().backup_before_save, "", 20, true, 14);
   }
 
+  // Reject an already-invalid Oracle layout before any editor serializer can
+  // mutate the ROM buffer or clear its own dirty tracking. The post-save check
+  // below remains mandatory because serializers may introduce a violation.
+  RETURN_IF_ERROR(CheckOracleRomSafetyPreSave(current_rom));
+
+  ScopedRomTransaction rom_transaction(*current_rom);
+  ScopedEditorSaveTransactions editor_transactions;
+
+  auto save_editor = [&editor_transactions](Editor* editor) -> absl::Status {
+    if (editor == nullptr) {
+      return absl::OkStatus();
+    }
+    RETURN_IF_ERROR(editor_transactions.Begin(editor));
+    return editor->Save();
+  };
+
   // --- Save editor-specific data ---
-  if (auto* editor = current_editor_set->GetEditor(EditorType::kScreen)) {
-    RETURN_IF_ERROR(editor->Save());
-  }
-
-  if (auto* editor = current_editor_set->GetEditor(EditorType::kDungeon)) {
-    RETURN_IF_ERROR(editor->Save());
-  }
-
-  if (auto* editor = current_editor_set->GetEditor(EditorType::kOverworld)) {
-    RETURN_IF_ERROR(editor->Save());
-  }
+  RETURN_IF_ERROR(
+      save_editor(current_editor_set->GetEditor(EditorType::kScreen)));
+  RETURN_IF_ERROR(
+      save_editor(current_editor_set->GetEditor(EditorType::kDungeon)));
+  RETURN_IF_ERROR(
+      save_editor(current_editor_set->GetEditor(EditorType::kOverworld)));
 
   if (core::FeatureFlags::get().kSaveMessages) {
     RETURN_IF_ERROR(EnsureEditorAssetsLoaded(EditorType::kMessage));
-    if (auto* editor = current_editor_set->GetEditor(EditorType::kMessage)) {
-      RETURN_IF_ERROR(editor->Save());
-    }
+    RETURN_IF_ERROR(
+        save_editor(current_editor_set->GetEditor(EditorType::kMessage)));
   }
 
   if (core::FeatureFlags::get().kSaveGraphicsSheet) {
@@ -3523,42 +3676,65 @@ absl::Status EditorManager::SaveRom() {
     }
   }
 
-  // Delegate final ROM file writing to RomFileManager
-  auto save_status = rom_file_manager_.SaveRom(current_rom);
+  // Delegate the final atomic disk write to RomFileManager. Save As is part of
+  // this same transaction and writes only the requested target path.
+  auto save_status =
+      save_as_filename.has_value()
+          ? rom_file_manager_.SaveRomAs(current_rom, *save_as_filename)
+          : rom_file_manager_.SaveRom(current_rom);
   if (save_status.ok()) {
+    editor_transactions.Commit();
+    rom_transaction.Commit();
+    UpdateCurrentRomHash();
     // Write-confirm bypass is single-use. Clear it after a successful save.
     rom_lifecycle_.CancelRomWriteConfirm();
+
+    if (save_as_filename.has_value()) {
+      if (session_coordinator_) {
+        if (auto* session = session_coordinator_->GetActiveRomSession()) {
+          session->filepath = *save_as_filename;
+        }
+      }
+
+      auto& manager = project::RecentFilesManager::GetInstance();
+      manager.AddFile(*save_as_filename);
+      manager.Save();
+      if (popup_manager_) {
+        popup_manager_->Hide(PopupID::kSaveAs);
+      }
+    }
   }
   return save_status;
 }
 
 absl::Status EditorManager::SaveRomAs(const std::string& filename) {
-  auto* current_rom = GetCurrentRom();
-  if (!current_rom) {
-    return absl::FailedPreconditionError("No ROM loaded");
+  if (filename.empty()) {
+    return absl::InvalidArgumentError("No filename provided for save as");
+  }
+  if (pending_rom_save_.has_value() && HasPendingRomSaveConfirmation()) {
+    return absl::CancelledError("Save pending confirmation");
+  }
+  RETURN_IF_ERROR(StartPendingRomSave(filename));
+  auto status = SaveRomInternal(filename);
+  FinishPendingRomSaveAttempt(status);
+  return status;
+}
+
+absl::Status EditorManager::ResumePendingRomSave() {
+  if (!pending_rom_save_.has_value()) {
+    rom_lifecycle_.ResetPendingSaveState();
+    return absl::FailedPreconditionError("No pending ROM save to resume");
+  }
+  if (!PendingRomSaveMatchesActiveSession()) {
+    CancelPendingRomSave(/*hide_popups=*/true);
+    return absl::FailedPreconditionError(
+        "Pending ROM save belongs to a different session");
   }
 
-  // Reuse SaveRom() logic for editor-specific data saving
-  RETURN_IF_ERROR(SaveRom());
-
-  // Now save to the new filename
-  auto save_status = rom_file_manager_.SaveRomAs(current_rom, filename);
-  if (save_status.ok()) {
-    // Update session filepath
-    if (session_coordinator_) {
-      auto* session = session_coordinator_->GetActiveRomSession();
-      if (session) {
-        session->filepath = filename;
-      }
-    }
-
-    // Add to recent files
-    auto& manager = project::RecentFilesManager::GetInstance();
-    manager.AddFile(filename);
-    manager.Save();
-  }
-
-  return save_status;
+  const auto save_as_filename = pending_rom_save_->save_as_filename;
+  auto status = SaveRomInternal(save_as_filename);
+  FinishPendingRomSaveAttempt(status);
+  return status;
 }
 
 absl::Status EditorManager::OpenRomOrProject(const std::string& filename) {
@@ -4107,11 +4283,12 @@ void EditorManager::ResolvePotItemSaveConfirmation(
   rom_lifecycle_.ResolvePotItemSaveConfirmation(lifecycle_decision);
 
   if (decision == PotItemSaveDecision::kCancel) {
+    CancelPendingRomSave();
     toast_manager_.Show("Save cancelled", ToastType::kInfo);
     return;
   }
 
-  auto status = SaveRom();
+  auto status = ResumePendingRomSave();
   if (!absl::IsCancelled(status) && !status.ok()) {
     toast_manager_.Show(
         absl::StrFormat("Failed to save ROM: %s", status.message()),
@@ -4535,8 +4712,21 @@ absl::Status EditorManager::PruneRomBackups() {
   return rom_lifecycle_.PruneRomBackups(GetCurrentRom());
 }
 
-// ConfirmRomWrite() and CancelRomWriteConfirm() are now inline in
-// editor_manager.h delegating to rom_lifecycle_.
+void EditorManager::ConfirmRomWrite() {
+  if (!PendingRomSaveMatchesActiveSession() ||
+      !rom_lifecycle_.IsRomWriteConfirmPending()) {
+    return;
+  }
+  rom_lifecycle_.ConfirmRomWrite();
+}
+
+void EditorManager::CancelRomWriteConfirm() {
+  CancelPendingRomSave();
+}
+
+void EditorManager::ClearPendingWriteConflicts() {
+  CancelPendingRomSave();
+}
 
 void EditorManager::CreateNewSession() {
   if (session_coordinator_) {
@@ -4564,6 +4754,7 @@ void EditorManager::CloseCurrentSession() {
   }
 
   session_coordinator_->CloseCurrentSession();
+  UpdateCurrentRomHash();
 }
 
 void EditorManager::RemoveSession(size_t index) {
@@ -4577,6 +4768,7 @@ void EditorManager::RemoveSession(size_t index) {
   }
 
   session_coordinator_->RemoveSession(index);
+  UpdateCurrentRomHash();
 }
 
 void EditorManager::SwitchToSession(size_t index) {
@@ -4837,6 +5029,7 @@ void EditorManager::ExecutePendingUnsavedSessionAction(
     case PendingUnsavedSessionAction::Type::kCloseSession:
       if (session_coordinator_) {
         session_coordinator_->RemoveSession(action.target_session_index);
+        UpdateCurrentRomHash();
       }
       break;
     case PendingUnsavedSessionAction::Type::kQuit:

--- a/src/app/editor/editor_manager.h
+++ b/src/app/editor/editor_manager.h
@@ -207,8 +207,8 @@ class EditorManager : public ISessionConfigurator, public IEditorSwitcher {
   std::vector<editor::RomFileManager::BackupEntry> GetRomBackups() const;
   absl::Status RestoreRomBackup(const std::string& backup_path);
   absl::Status PruneRomBackups();
-  void ConfirmRomWrite() { rom_lifecycle_.ConfirmRomWrite(); }
-  void CancelRomWriteConfirm() { rom_lifecycle_.CancelRomWriteConfirm(); }
+  void ConfirmRomWrite();
+  void CancelRomWriteConfirm();
   bool IsRomWriteConfirmPending() const {
     return rom_lifecycle_.IsRomWriteConfirmPending();
   }
@@ -218,9 +218,7 @@ class EditorManager : public ISessionConfigurator, public IEditorSwitcher {
     return rom_lifecycle_.pending_write_conflicts();
   }
   void BypassWriteConflictOnce() { rom_lifecycle_.BypassWriteConflictOnce(); }
-  void ClearPendingWriteConflicts() {
-    rom_lifecycle_.ClearPendingWriteConflicts();
-  }
+  void ClearPendingWriteConflicts();
   void SetCurrentEditor(Editor* editor) override {
     current_editor_ = editor;
     // Update ContentRegistry context for panel access
@@ -407,6 +405,7 @@ class EditorManager : public ISessionConfigurator, public IEditorSwitcher {
   absl::Status LoadRom();
   absl::Status SaveRom();
   absl::Status SaveRomAs(const std::string& filename);
+  absl::Status ResumePendingRomSave();
   absl::Status OpenRomOrProject(const std::string& filename);
   absl::Status CreateNewProject(
       const std::string& template_name = "Basic ROM Hack");
@@ -604,8 +603,17 @@ class EditorManager : public ISessionConfigurator, public IEditorSwitcher {
   absl::StatusOr<std::string> RunProjectBuildCommand();
   absl::StatusOr<std::string> ResolveProjectBuildCommand() const;
   absl::StatusOr<std::string> ResolveProjectRunTarget() const;
-  absl::Status CheckRomWritePolicy();
+  absl::Status CheckRomWritePolicy(
+      const std::optional<std::string>& target_filename = std::nullopt);
   absl::Status CheckOracleRomSafetyPreSave(Rom* rom);
+  absl::Status SaveRomInternal(
+      const std::optional<std::string>& save_as_filename);
+  bool HasPendingRomSaveConfirmation() const;
+  bool PendingRomSaveMatchesActiveSession() const;
+  void FinishPendingRomSaveAttempt(const absl::Status& status);
+  void CancelPendingRomSave(bool hide_popups = false);
+  absl::Status StartPendingRomSave(
+      const std::optional<std::string>& save_as_filename);
   absl::Status LoadRomInternal();
   absl::Status OpenRomOrProjectInternal(const std::string& filename);
   absl::Status OpenProjectInternal();
@@ -645,6 +653,12 @@ class EditorManager : public ISessionConfigurator, public IEditorSwitcher {
   // ROM lifecycle state (hash, write policy, confirmation dialogs, backups)
   // Mutable because some const accessors delegate to it.
   mutable RomLifecycleManager rom_lifecycle_;
+  struct PendingRomSave {
+    std::optional<std::string> save_as_filename;
+    size_t session_index = SIZE_MAX;
+    Rom* rom = nullptr;
+  };
+  std::optional<PendingRomSave> pending_rom_save_;
 
   // Deferred action queue - executed at the start of each frame
   std::vector<std::function<void()>> deferred_actions_;

--- a/src/app/editor/message/message_data.cc
+++ b/src/app/editor/message/message_data.cc
@@ -1,16 +1,19 @@
 #include "message_data.h"
 
+#include <algorithm>
 #include <cctype>
 #include <fstream>
 #include <optional>
 #include <sstream>
 #include <string>
+#include <utility>
 
 #include "absl/strings/ascii.h"
 #include "absl/strings/str_format.h"
 #include "absl/strings/str_split.h"
 #include "core/rom_settings.h"
 #include "rom/snes.h"
+#include "rom/transaction.h"
 #include "rom/write_fence.h"
 #include "util/hex.h"
 #include "util/log.h"
@@ -133,8 +136,12 @@ ParsedElement FindMatchingElement(const std::string& str) {
     try {
       // match[1] captures ":XX" — strip the leading colon
       std::string dict_arg = match[1].str().substr(1);
-      return ParsedElement(dictionary_element,
-                           DICTOFF + std::stoi(dict_arg, nullptr, 16));
+      const int dictionary_index = std::stoi(dict_arg, nullptr, 16);
+      if (dictionary_index < 0 || dictionary_index >= kNumDictionaryEntries) {
+        util::logf("Dictionary index out of range: %s", dict_arg.c_str());
+        return ParsedElement();
+      }
+      return ParsedElement(dictionary_element, DICTOFF + dictionary_index);
     } catch (const std::exception& e) {
       util::logf("Error parsing dictionary token: %s", match[1].str().c_str());
       return ParsedElement();
@@ -390,8 +397,7 @@ std::optional<size_t> FindTextMatch(std::string_view text,
 int ReplaceTextMatches(std::string* text, std::string_view query,
                        std::string_view replacement, size_t start_pos,
                        bool replace_all, bool case_sensitive,
-                       bool match_whole_word,
-                       size_t* first_replaced_pos) {
+                       bool match_whole_word, size_t* first_replaced_pos) {
   if (!text || query.empty() || start_pos > text->size()) {
     return 0;
   }
@@ -592,7 +598,8 @@ std::vector<std::string> ParseMessageData(
   return parsed_messages;
 }
 
-std::vector<MessageData> ReadAllTextData(uint8_t* rom, int pos, int max_pos) {
+std::vector<MessageData> ReadAllTextData(uint8_t* rom, int pos, int max_pos,
+                                         bool allow_bank_switch) {
   std::vector<MessageData> list_of_texts;
   int message_id = 0;
 
@@ -643,7 +650,8 @@ std::vector<MessageData> ReadAllTextData(uint8_t* rom, int pos, int max_pos) {
       current_raw_message.append(text_element->GetParamToken(current_byte));
       current_parsed_message.append(text_element->GetParamToken(current_byte));
 
-      if (text_element->Token == kBankToken && !did_bank_switch) {
+      if (allow_bank_switch && text_element->Token == kBankToken &&
+          !did_bank_switch) {
         did_bank_switch = true;
         pos = kTextData2;
       }
@@ -1112,8 +1120,19 @@ std::string ExportToOrgFormat(
 // ===========================================================================
 
 std::vector<MessageData> ReadExpandedTextData(uint8_t* rom, int pos) {
-  // Reuse ReadAllTextData — it already handles 0x7F terminators and 0xFF end
-  return ReadAllTextData(rom, pos);
+  // Expanded messages occupy one contiguous region. A vanilla [BANK] command
+  // must not redirect parsing into the vanilla second text bank.
+  return ReadAllTextData(rom, pos, /*max_pos=*/-1,
+                         /*allow_bank_switch=*/false);
+}
+
+std::vector<MessageData> ReadExpandedTextData(uint8_t* rom, int pos, int end) {
+  if (end < pos) {
+    return {};
+  }
+  // ReadAllTextData's max_pos is exclusive; expanded-region ends are
+  // configured as inclusive addresses.
+  return ReadAllTextData(rom, pos, end + 1, /*allow_bank_switch=*/false);
 }
 
 absl::Status WriteExpandedTextData(Rom* rom, int start, int end,
@@ -1143,7 +1162,19 @@ absl::Status WriteExpandedTextData(Rom* rom, int start, int end,
 
   int used = 0;
   for (size_t i = 0; i < messages.size(); ++i) {
-    auto bytes = ParseMessageToData(messages[i]);
+    auto parsed = ParseMessageToDataWithDiagnostics(messages[i]);
+    if (!parsed.ok()) {
+      return absl::InvalidArgumentError(
+          absl::StrFormat("Expanded message %d is invalid: %s",
+                          static_cast<int>(i), parsed.errors.front()));
+    }
+    if (messages[i].find("[BANK]") != std::string::npos) {
+      return absl::InvalidArgumentError(absl::StrFormat(
+          "Expanded message %d contains [BANK], which is only valid in the "
+          "vanilla message stream",
+          static_cast<int>(i)));
+    }
+    auto bytes = std::move(parsed.bytes);
     const int needed = static_cast<int>(bytes.size()) + 1;  // +0x7F
 
     // Always reserve space for the final 0xFF.
@@ -1179,38 +1210,49 @@ absl::Status WriteExpandedTextData(Rom* rom, int start, int end,
 
 absl::Status WriteExpandedTextData(uint8_t* rom, int start, int end,
                                    const std::vector<std::string>& messages) {
-  int pos = start;
-  int capacity = end - start + 1;
+  if (rom == nullptr || start < 0 || end < start) {
+    return absl::InvalidArgumentError("Invalid expanded message region");
+  }
+
+  const int capacity = end - start + 1;
+  int used = 0;
+  std::vector<std::vector<uint8_t>> encoded_messages;
+  encoded_messages.reserve(messages.size());
 
   for (size_t i = 0; i < messages.size(); ++i) {
-    auto bytes = ParseMessageToData(messages[i]);
-
-    // Check space: bytes + terminator (0x7F) + final end marker (0xFF)
-    int needed = static_cast<int>(bytes.size()) + 1;  // +1 for 0x7F
-    if (i == messages.size() - 1) {
-      needed += 1;  // +1 for final 0xFF
+    auto parsed = ParseMessageToDataWithDiagnostics(messages[i]);
+    if (!parsed.ok()) {
+      return absl::InvalidArgumentError(
+          absl::StrFormat("Expanded message %d is invalid: %s",
+                          static_cast<int>(i), parsed.errors.front()));
     }
+    if (messages[i].find("[BANK]") != std::string::npos) {
+      return absl::InvalidArgumentError(absl::StrFormat(
+          "Expanded message %d contains [BANK], which is only valid in the "
+          "vanilla message stream",
+          static_cast<int>(i)));
+    }
+    auto bytes = std::move(parsed.bytes);
 
-    if (pos + needed - start > capacity) {
+    const int needed = static_cast<int>(bytes.size()) + 1;  // +1 for 0x7F
+    if (used + needed + 1 > capacity) {
       return absl::ResourceExhaustedError(
           absl::StrFormat("Expanded message data exceeds bank boundary "
-                          "(at message %d, pos 0x%06X, end 0x%06X)",
-                          static_cast<int>(i), pos, end));
+                          "(at message %d, used %d, end 0x%06X)",
+                          static_cast<int>(i), used, end));
     }
+    used += needed;
+    encoded_messages.push_back(std::move(bytes));
+  }
 
-    // Write encoded bytes
+  int pos = start;
+  for (const auto& bytes : encoded_messages) {
     for (uint8_t byte : bytes) {
       rom[pos++] = byte;
     }
-    // Write message terminator
     rom[pos++] = kMessageTerminator;
   }
 
-  // Write end-of-region marker
-  if (pos - start >= capacity) {
-    return absl::ResourceExhaustedError(
-        "No space for end-of-region marker (0xFF)");
-  }
   rom[pos++] = 0xFF;
 
   return absl::OkStatus();
@@ -1221,6 +1263,8 @@ absl::Status WriteAllTextData(Rom* rom,
   if (rom == nullptr || !rom->is_loaded()) {
     return absl::InvalidArgumentError("ROM not loaded");
   }
+
+  ScopedRomTransaction transaction(*rom);
 
   int pos = kTextData;
   bool in_second_bank = false;
@@ -1255,6 +1299,7 @@ absl::Status WriteAllTextData(Rom* rom,
   }
 
   RETURN_IF_ERROR(rom->WriteByte(pos, 0xFF));
+  transaction.Commit();
   return absl::OkStatus();
 }
 

--- a/src/app/editor/message/message_data.h
+++ b/src/app/editor/message/message_data.h
@@ -217,8 +217,7 @@ std::string ReplaceAllDictionaryWords(
 // Returns std::nullopt when no match is found or query is empty.
 std::optional<size_t> FindTextMatch(std::string_view text,
                                     std::string_view query, size_t start_pos,
-                                    bool case_sensitive,
-                                    bool match_whole_word);
+                                    bool case_sensitive, bool match_whole_word);
 
 // Replaces query occurrences in text and returns replacement count.
 // If replace_all is false, only the first matching occurrence at/after
@@ -500,8 +499,10 @@ constexpr int kTextData2End = 0x773FF;
 
 // Reads all text data from the ROM and returns a vector of MessageData objects.
 // When max_pos > 0, the parser stops if pos exceeds max_pos (safety bound).
+// Set allow_bank_switch=false for contiguous banks such as expanded messages.
 std::vector<MessageData> ReadAllTextData(uint8_t* rom, int pos = kTextData,
-                                         int max_pos = -1);
+                                         int max_pos = -1,
+                                         bool allow_bank_switch = true);
 
 // Calls the file dialog and loads expanded messages from a BIN file.
 absl::Status LoadExpandedMessages(std::string& expanded_message_path,
@@ -510,7 +511,8 @@ absl::Status LoadExpandedMessages(std::string& expanded_message_path,
                                   std::vector<DictionaryEntry>& dictionary);
 
 // Serializes a vector of MessageData to a JSON object.
-nlohmann::json SerializeMessagesToJson(const std::vector<MessageData>& messages);
+nlohmann::json SerializeMessagesToJson(
+    const std::vector<MessageData>& messages);
 
 // Exports messages to a JSON file at the specified path.
 absl::Status ExportMessagesToJson(const std::string& path,
@@ -582,6 +584,10 @@ int GetExpandedTextDataEnd();
 // Messages are 0x7F-terminated, region is 0xFF-terminated.
 // Uses the same parsing as ReadAllTextData but for the expanded bank.
 std::vector<MessageData> ReadExpandedTextData(uint8_t* rom, int pos);
+
+// Bounded expanded-message reader. `end` is the inclusive final PC address;
+// parsing stops there even when the 0xFF region terminator is missing.
+std::vector<MessageData> ReadExpandedTextData(uint8_t* rom, int pos, int end);
 
 // Writes encoded messages to the expanded region of a ROM buffer.
 // Each message text is encoded via ParseMessageToData, terminated with 0x7F.

--- a/src/app/editor/message/message_editor.cc
+++ b/src/app/editor/message/message_editor.cc
@@ -24,6 +24,7 @@
 #include "imgui.h"
 #include "imgui/misc/cpp/imgui_stdlib.h"
 #include "rom/rom.h"
+#include "rom/transaction.h"
 #include "util/file_util.h"
 #include "util/hex.h"
 #include "util/log.h"
@@ -121,6 +122,8 @@ void MessageEditor::Initialize() {
     current_message_index_ = current_message_.ID;
     current_message_is_expanded_ = false;
     message_text_box_.text = parsed_messages_[current_message_.ID];
+    current_parse_errors_.clear();
+    current_parse_warnings_.clear();
     DrawMessagePreview();
   } else {
     LOG_ERROR("MessageEditor", "No messages found in ROM!");
@@ -128,6 +131,12 @@ void MessageEditor::Initialize() {
 }
 
 bool MessageEditor::OpenMessageById(int display_id) {
+  // Do not discard an invalid in-progress draft by navigating away. The user
+  // can correct it or undo it before selecting another message.
+  if (!current_parse_errors_.empty()) {
+    return false;
+  }
+
   const int vanilla_count = static_cast<int>(list_of_texts_.size());
   const int expanded_base_id = expanded_message_base_id_;
 
@@ -191,6 +200,8 @@ bool MessageEditor::OpenMessageById(int display_id) {
       message_text_box_.text.clear();
     }
 
+    current_parse_errors_.clear();
+    current_parse_warnings_.clear();
     DrawMessagePreview();
     return true;
   }
@@ -214,6 +225,8 @@ bool MessageEditor::OpenMessageById(int display_id) {
     message_text_box_.text.clear();
   }
 
+  current_parse_errors_.clear();
+  current_parse_warnings_.clear();
   DrawMessagePreview();
   return true;
 }
@@ -451,12 +464,10 @@ void MessageEditor::DrawMessageList() {
             TableNextColumn();
             PushID(message.ID);
             if (Button(util::HexWord(message.ID).c_str())) {
-              FinalizePendingUndo();
-              current_message_ = message;
-              current_message_index_ = message.ID;
-              current_message_is_expanded_ = false;
-              message_text_box_.text = parsed_messages_[message.ID];
-              DrawMessagePreview();
+              if (current_parse_errors_.empty()) {
+                FinalizePendingUndo();
+                OpenMessageById(message.ID);
+              }
             }
             PopID();
 
@@ -482,12 +493,10 @@ void MessageEditor::DrawMessageList() {
             TableNextColumn();
             PushID(display_id);
             if (Button(util::HexWord(display_id).c_str())) {
-              FinalizePendingUndo();
-              current_message_ = expanded_message;
-              current_message_index_ = expanded_message.ID;
-              current_message_is_expanded_ = true;
-              message_text_box_.text = display_text;
-              DrawMessagePreview();
+              if (current_parse_errors_.empty()) {
+                FinalizePendingUndo();
+                OpenMessageById(display_id);
+              }
             }
             PopID();
 
@@ -517,6 +526,18 @@ void MessageEditor::DrawCurrentMessage() {
   }
   if (ImGui::IsItemDeactivatedAfterEdit()) {
     FinalizePendingUndo();
+  }
+  if (!current_parse_errors_.empty()) {
+    ImGui::TextColored(gui::GetErrorColor(), tr("Message parse errors"));
+    for (const auto& error : current_parse_errors_) {
+      ImGui::BulletText("%s", error.c_str());
+    }
+  }
+  if (!current_parse_warnings_.empty()) {
+    ImGui::TextColored(gui::GetWarningColor(), tr("Message parse warnings"));
+    for (const auto& warning : current_parse_warnings_) {
+      ImGui::BulletText("%s", warning.c_str());
+    }
   }
   auto line_warnings = ValidateMessageLineWidths(message_text_box_.text);
   if (!line_warnings.empty()) {
@@ -823,13 +844,26 @@ void MessageEditor::DrawDictionary() {
 void MessageEditor::UpdateCurrentMessageFromText(const std::string& text) {
   PushUndoSnapshot();
 
+  auto parse_result = ParseMessageToDataWithDiagnostics(text);
+  current_parse_errors_ = parse_result.errors;
+  current_parse_warnings_ = parse_result.warnings;
+  if (rom_) {
+    // Invalid intermediate input is still unsaved work. Save() will fail
+    // closed until the diagnostics are resolved rather than silently dropping
+    // unsupported characters or unknown tokens.
+    rom_->set_dirty(true);
+  }
+  if (!parse_result.ok()) {
+    return;
+  }
+
   std::string raw_text = text;
   raw_text.erase(std::remove(raw_text.begin(), raw_text.end(), '\n'),
                  raw_text.end());
 
   current_message_.RawString = raw_text;
   current_message_.ContentsParsed = text;
-  current_message_.Data = ParseMessageToData(raw_text);
+  current_message_.Data = std::move(parse_result.bytes);
 
   int parsed_index = current_message_index_;
   if (current_message_is_expanded_) {
@@ -1008,6 +1042,9 @@ void MessageEditor::ImportMessageBundleFromFile(const std::string& path) {
         "created, %d warnings).",
         applied, vanilla_updated, expanded_updated, expanded_created, warnings);
   }
+  if (applied > 0 && rom_) {
+    rom_->set_dirty(true);
+  }
 }
 
 void MessageEditor::DrawMessagePreview() {
@@ -1063,7 +1100,15 @@ void MessageEditor::DrawMessagePreview() {
 }
 
 absl::Status MessageEditor::Save() {
-  std::vector<uint8_t> backup = rom()->vector();
+  if (!rom_ || !rom_->is_loaded()) {
+    return absl::FailedPreconditionError("ROM not loaded");
+  }
+  if (!current_parse_errors_.empty()) {
+    return absl::FailedPreconditionError(absl::StrFormat(
+        "Current message has parse errors: %s", current_parse_errors_.front()));
+  }
+
+  ScopedRomTransaction transaction(*rom());
 
   for (int i = 0; i < kWidthArraySize; i++) {
     RETURN_IF_ERROR(rom()->WriteByte(kCharactersWidth + i,
@@ -1097,8 +1142,10 @@ absl::Status MessageEditor::Save() {
 
   // Verify that we didn't go over the space available for the second block.
   // 0x14BF available.
+  if (!in_second_bank && pos > kTextDataEnd) {
+    return absl::InternalError(DisplayTextOverflowError(pos, true));
+  }
   if (in_second_bank && pos > kTextData2End) {
-    std::copy(backup.begin(), backup.end(), rom()->mutable_data());
     return absl::InternalError(DisplayTextOverflowError(pos, false));
   }
 
@@ -1108,11 +1155,11 @@ absl::Status MessageEditor::Save() {
   if (!expanded_messages_.empty()) {
     auto status = SaveExpandedMessages();
     if (!status.ok()) {
-      std::copy(backup.begin(), backup.end(), rom()->mutable_data());
       return status;
     }
   }
 
+  transaction.Commit();
   return absl::OkStatus();
 }
 
@@ -1133,16 +1180,14 @@ absl::Status MessageEditor::SaveExpandedMessages() {
   }
 
   // Write to main ROM buffer at the expanded text data region
-  RETURN_IF_ERROR(WriteExpandedTextData(rom_->mutable_data(),
-                                        GetExpandedTextDataStart(),
+  RETURN_IF_ERROR(WriteExpandedTextData(rom_, GetExpandedTextDataStart(),
                                         GetExpandedTextDataEnd(), all_texts));
 
   // Recalculate addresses after sequential write
   int pos = GetExpandedTextDataStart();
   for (auto& msg : expanded_messages_) {
     msg.Address = pos;
-    auto bytes = ParseMessageToData(msg.RawString);
-    pos += static_cast<int>(bytes.size()) + 1;  // +1 for 0x7F terminator
+    pos += static_cast<int>(msg.Data.size()) + 1;  // +1 for 0x7F terminator
   }
 
   return absl::OkStatus();
@@ -1157,8 +1202,9 @@ absl::Status MessageEditor::LoadExpandedMessagesFromRom() {
   parsed_messages_.resize(expanded_message_base_id_);
 
   expanded_messages_.clear();
-  expanded_messages_ =
-      ReadExpandedTextData(rom_->mutable_data(), GetExpandedTextDataStart());
+  expanded_messages_ = ReadExpandedTextData(
+      rom_->mutable_data(), GetExpandedTextDataStart(),
+      std::min(GetExpandedTextDataEnd(), static_cast<int>(rom_->size()) - 1));
 
   if (expanded_messages_.empty()) {
     return absl::NotFoundError(
@@ -1291,6 +1337,10 @@ void MessageEditor::ApplySnapshot(const MessageSnapshot& snapshot) {
   current_message_index_ = snapshot.message_index;
   current_message_is_expanded_ = snapshot.is_expanded;
   message_text_box_.text = snapshot.parsed_text;
+  const auto diagnostics =
+      ParseMessageToDataWithDiagnostics(snapshot.message.RawString);
+  current_parse_errors_ = diagnostics.errors;
+  current_parse_warnings_ = diagnostics.warnings;
 
   int parsed_index = snapshot.message_index;
   if (snapshot.is_expanded) {
@@ -1313,6 +1363,9 @@ void MessageEditor::ApplySnapshot(const MessageSnapshot& snapshot) {
     }
   }
 
+  if (rom_) {
+    rom_->set_dirty(true);
+  }
   DrawMessagePreview();
 }
 
@@ -1383,9 +1436,11 @@ absl::Status MessageEditor::Find() {
       search_text_ = find_text;
       replace_text_ = replace_text;
       int count = ReplaceAllMatches();
-      replace_status_ = absl::StrFormat("Replaced %d occurrence%s", count,
-                                        count == 1 ? "" : "s");
-      replace_status_error_ = (count == 0);
+      if (count >= 0) {
+        replace_status_ = absl::StrFormat("Replaced %d occurrence%s", count,
+                                          count == 1 ? "" : "s");
+        replace_status_error_ = (count == 0);
+      }
     }
 
     ImGui::Checkbox(tr("Case Sensitive"), &case_sensitive_);
@@ -1448,10 +1503,15 @@ int MessageEditor::ReplaceCurrentMatch() {
 }
 
 int MessageEditor::ReplaceAllMatches() {
-  if (search_text_.empty())
+  if (search_text_.empty()) {
     return 0;
-
-  int total_replacements = 0;
+  }
+  if (!current_parse_errors_.empty()) {
+    replace_status_ =
+        "Replace All blocked: resolve the current message parse errors first";
+    replace_status_error_ = true;
+    return -1;
+  }
 
   auto replace_in_text = [&](std::string& text) -> int {
     int count = 0;
@@ -1489,72 +1549,73 @@ int MessageEditor::ReplaceAllMatches() {
     return count;
   };
 
-  // Replace in vanilla messages
-  for (size_t i = 0; i < list_of_texts_.size(); ++i) {
-    int parsed_idx = static_cast<int>(i);
-    if (parsed_idx < 0 ||
-        parsed_idx >= static_cast<int>(parsed_messages_.size())) {
-      continue;
+  struct PlannedReplacement {
+    int message_index;
+    bool is_expanded;
+    std::string text;
+    int count;
+  };
+  std::vector<PlannedReplacement> plan;
+
+  const auto plan_replacements = [&](const std::vector<MessageData>& messages,
+                                     bool is_expanded) -> bool {
+    for (size_t i = 0; i < messages.size(); ++i) {
+      const int parsed_index =
+          (is_expanded ? expanded_message_base_id_ : 0) + static_cast<int>(i);
+      if (parsed_index < 0 ||
+          parsed_index >= static_cast<int>(parsed_messages_.size())) {
+        continue;
+      }
+
+      std::string text = parsed_messages_[parsed_index];
+      const int count = replace_in_text(text);
+      if (count == 0) {
+        continue;
+      }
+
+      const auto parsed = ParseMessageToDataWithDiagnostics(text);
+      if (!parsed.ok() ||
+          (is_expanded && text.find("[BANK]") != std::string::npos)) {
+        const std::string error =
+            !parsed.ok() ? parsed.errors.front()
+                         : "[BANK] is not valid in expanded messages";
+        replace_status_ = absl::StrFormat(
+            "Replace All aborted at %s message %d: %s",
+            is_expanded ? "expanded" : "vanilla", static_cast<int>(i), error);
+        replace_status_error_ = true;
+        return false;
+      }
+
+      plan.push_back(
+          {static_cast<int>(i), is_expanded, std::move(text), count});
     }
+    return true;
+  };
 
-    std::string text = parsed_messages_[parsed_idx];
-    int count = replace_in_text(text);
-    if (count > 0) {
-      // Save current state, apply replacement, push undo
-      int prev_index = current_message_index_;
-      bool prev_expanded = current_message_is_expanded_;
-      MessageData prev_message = current_message_;
-      std::string prev_textbox = message_text_box_.text;
-
-      current_message_ = list_of_texts_[i];
-      current_message_index_ = static_cast<int>(i);
-      current_message_is_expanded_ = false;
-      message_text_box_.text = text;
-      UpdateCurrentMessageFromText(text);
-      FinalizePendingUndo();
-
-      total_replacements += count;
-
-      // Restore previous editing context
-      current_message_ = prev_message;
-      current_message_index_ = prev_index;
-      current_message_is_expanded_ = prev_expanded;
-      message_text_box_.text = prev_textbox;
-    }
+  // Validate the complete batch before changing any message or undo state.
+  if (!plan_replacements(list_of_texts_, false) ||
+      !plan_replacements(expanded_messages_, true)) {
+    return -1;
   }
 
-  // Replace in expanded messages
-  for (size_t i = 0; i < expanded_messages_.size(); ++i) {
-    int parsed_idx = expanded_message_base_id_ + static_cast<int>(i);
-    if (parsed_idx < 0 ||
-        parsed_idx >= static_cast<int>(parsed_messages_.size())) {
-      continue;
-    }
+  const int previous_index = current_message_index_;
+  const bool previous_expanded = current_message_is_expanded_;
+  int total_replacements = 0;
 
-    std::string text = parsed_messages_[parsed_idx];
-    int count = replace_in_text(text);
-    if (count > 0) {
-      int prev_index = current_message_index_;
-      bool prev_expanded = current_message_is_expanded_;
-      MessageData prev_message = current_message_;
-      std::string prev_textbox = message_text_box_.text;
-
-      current_message_ = expanded_messages_[i];
-      current_message_index_ = static_cast<int>(i);
-      current_message_is_expanded_ = true;
-      message_text_box_.text = text;
-      UpdateCurrentMessageFromText(text);
-      FinalizePendingUndo();
-
-      total_replacements += count;
-
-      // Restore previous editing context
-      current_message_ = prev_message;
-      current_message_index_ = prev_index;
-      current_message_is_expanded_ = prev_expanded;
-      message_text_box_.text = prev_textbox;
-    }
+  for (const auto& replacement : plan) {
+    current_message_ = replacement.is_expanded
+                           ? expanded_messages_[replacement.message_index]
+                           : list_of_texts_[replacement.message_index];
+    current_message_index_ = replacement.message_index;
+    current_message_is_expanded_ = replacement.is_expanded;
+    message_text_box_.text = replacement.text;
+    UpdateCurrentMessageFromText(replacement.text);
+    FinalizePendingUndo();
+    total_replacements += replacement.count;
   }
+
+  current_message_index_ = previous_index;
+  current_message_is_expanded_ = previous_expanded;
 
   // Refresh the current message's text box from updated data
   int current_parsed_idx = current_message_index_;
@@ -1578,6 +1639,11 @@ int MessageEditor::ReplaceAllMatches() {
       current_message_ = list_of_texts_[current_message_index_];
     }
   }
+
+  const auto current_diagnostics =
+      ParseMessageToDataWithDiagnostics(message_text_box_.text);
+  current_parse_errors_ = current_diagnostics.errors;
+  current_parse_warnings_ = current_diagnostics.warnings;
 
   return total_replacements;
 }

--- a/src/app/editor/message/message_editor.h
+++ b/src/app/editor/message/message_editor.h
@@ -21,6 +21,8 @@
 namespace yaze {
 namespace editor {
 
+class MessageEditorTestPeer;
+
 constexpr int kGfxFont = 0x70000;  // 2bpp format
 constexpr int kCharactersWidth = 0x74ADF;
 constexpr int kNumMessages = 396;
@@ -80,6 +82,8 @@ class MessageEditor : public Editor {
   Rom* rom() const { return rom_; }
 
  private:
+  friend class MessageEditorTestPeer;
+
   bool case_sensitive_ = false;
   bool match_whole_word_ = false;
   std::string search_text_ = "";
@@ -138,6 +142,8 @@ class MessageEditor : public Editor {
   bool font_graphics_loaded_ = false;
   std::string message_bundle_status_;
   bool message_bundle_status_error_ = false;
+  std::vector<std::string> current_parse_errors_;
+  std::vector<std::string> current_parse_warnings_;
 };
 
 }  // namespace editor

--- a/src/app/editor/overworld/overworld_editor.cc
+++ b/src/app/editor/overworld/overworld_editor.cc
@@ -1266,6 +1266,7 @@ absl::Status OverworldEditor::Save() {
   if (core::FeatureFlags::get().overworld.kSaveOverworldProperties) {
     RETURN_IF_ERROR(overworld_.SaveMapProperties());
     RETURN_IF_ERROR(overworld_.SaveMusic());
+    RETURN_IF_ERROR(overworld_.SaveCustomOverworldData());
   }
   return absl::OkStatus();
 }

--- a/src/app/editor/shell/feedback/popup_manager.cc
+++ b/src/app/editor/shell/feedback/popup_manager.cc
@@ -1422,7 +1422,7 @@ void PopupManager::DrawRomWriteConfirmPopup() {
   if (Button(tr("Save anyway"), ImVec2(0, 0))) {
     editor_manager_->ConfirmRomWrite();
     Hide(PopupID::kRomWriteConfirm);
-    auto status = editor_manager_->SaveRom();
+    auto status = editor_manager_->ResumePendingRomSave();
     if (!status.ok() && !absl::IsCancelled(status)) {
       if (auto* toast = editor_manager_->toast_manager()) {
         toast->Show(absl::StrFormat("Save failed: %s", status.message()),
@@ -1494,7 +1494,7 @@ void PopupManager::DrawWriteConflictWarningPopup() {
   if (Button(tr("Save Anyway"), ImVec2(0, 0))) {
     editor_manager_->BypassWriteConflictOnce();
     Hide(PopupID::kWriteConflictWarning);
-    auto status = editor_manager_->SaveRom();
+    auto status = editor_manager_->ResumePendingRomSave();
     if (!status.ok() && !absl::IsCancelled(status)) {
       if (auto* toast = editor_manager_->toast_manager()) {
         toast->Show(absl::StrFormat("Save failed: %s", status.message()),

--- a/src/app/editor/system/commands/shortcut_configurator.cc
+++ b/src/app/editor/system/commands/shortcut_configurator.cc
@@ -226,13 +226,8 @@ void ConfigureEditorShortcuts(const ShortcutDependencies& deps,
   RegisterIfValid(
       shortcut_manager, "Save As", {ImGuiMod_Ctrl, ImGuiMod_Shift, ImGuiKey_S},
       [editor_manager]() {
-        if (editor_manager) {
-          // Use project-aware default filename when possible
-          std::string filename =
-              editor_manager->GetCurrentRom()
-                  ? editor_manager->GetCurrentRom()->filename()
-                  : "";
-          editor_manager->SaveRomAs(filename);
+        if (editor_manager && editor_manager->popup_manager()) {
+          editor_manager->popup_manager()->Show(PopupID::kSaveAs);
         }
       },
       Shortcut::Scope::kGlobal);
@@ -240,8 +235,8 @@ void ConfigureEditorShortcuts(const ShortcutDependencies& deps,
   RegisterIfValid(
       shortcut_manager, "Close ROM", {ImGuiMod_Ctrl, ImGuiKey_W},
       [editor_manager]() {
-        if (editor_manager && editor_manager->GetCurrentRom()) {
-          editor_manager->GetCurrentRom()->Close();
+        if (editor_manager) {
+          editor_manager->CloseCurrentSession();
         }
       },
       Shortcut::Scope::kGlobal);

--- a/src/app/editor/system/session/rom_file_manager.cc
+++ b/src/app/editor/system/session/rom_file_manager.cc
@@ -93,8 +93,13 @@ absl::Status RomFileManager::SaveRomAs(Rom* rom, const std::string& filename) {
     return absl::InvalidArgumentError("No filename provided for save as");
   }
 
-  if (backup_before_save_) {
+  // Save As must not overwrite or back up the source ROM. If the requested
+  // target already exists, back up that target before replacing it.
+  if (backup_before_save_ && std::filesystem::exists(filename)) {
+    const std::string source_filename = rom->filename();
+    rom->set_filename(filename);
     auto backup_status = CreateBackup(rom);
+    rom->set_filename(source_filename);
     if (!backup_status.ok()) {
       if (toast_manager_) {
         toast_manager_->Show(
@@ -107,7 +112,7 @@ absl::Status RomFileManager::SaveRomAs(Rom* rom, const std::string& filename) {
 
   Rom::SaveSettings settings;
   settings.backup = false;
-  settings.save_new = true;
+  settings.save_new = false;
   settings.filename = filename;
   // settings.z3_save = true; // Deprecated
 
@@ -119,6 +124,9 @@ absl::Status RomFileManager::SaveRomAs(Rom* rom, const std::string& filename) {
   } else if (toast_manager_) {
     toast_manager_->Show(absl::StrFormat("ROM saved as: %s", filename),
                          ToastType::kSuccess);
+  }
+  if (status.ok()) {
+    rom->set_filename(filename);
   }
   return status;
 }
@@ -262,10 +270,9 @@ std::string RomFileManager::GenerateBackupFilename(
 
   std::filesystem::path backup_dir = GetBackupDirectory(original_filename);
 
-  std::string filename =
-      absl::StrFormat("%s_backup_%lld_%03lld%s", stem,
-                      static_cast<long long>(time_t),
-                      static_cast<long long>(ms_part), extension);
+  std::string filename = absl::StrFormat(
+      "%s_backup_%lld_%03lld%s", stem, static_cast<long long>(time_t),
+      static_cast<long long>(ms_part), extension);
   return (backup_dir / filename).string();
 }
 
@@ -295,7 +302,8 @@ std::vector<RomFileManager::BackupEntry> RomFileManager::ListBackups(
   std::filesystem::path backup_dir = GetBackupDirectory(rom_filename);
 
   std::error_code ec;
-  for (const auto& entry : std::filesystem::directory_iterator(backup_dir, ec)) {
+  for (const auto& entry :
+       std::filesystem::directory_iterator(backup_dir, ec)) {
     if (ec || !entry.is_regular_file()) {
       continue;
     }
@@ -360,8 +368,9 @@ absl::Status RomFileManager::PruneBackups(
     }
   }
 
-  for (size_t i = 0; i < backups.size() &&
-                     keep_paths.size() < static_cast<size_t>(backup_retention_count_);
+  for (size_t i = 0;
+       i < backups.size() &&
+       keep_paths.size() < static_cast<size_t>(backup_retention_count_);
        ++i) {
     keep_paths.insert(backups[i].path);
   }

--- a/src/app/editor/system/session/rom_lifecycle_manager.cc
+++ b/src/app/editor/system/session/rom_lifecycle_manager.cc
@@ -10,9 +10,9 @@
 #include "absl/strings/ascii.h"
 #include "absl/strings/match.h"
 #include "absl/strings/str_format.h"
-#include "app/editor/system/session/rom_file_manager.h"
 #include "app/editor/shell/feedback/popup_manager.h"
 #include "app/editor/shell/feedback/toast_manager.h"
+#include "app/editor/system/session/rom_file_manager.h"
 #include "core/hack_manifest.h"
 #include "core/project.h"
 #include "rom/rom.h"
@@ -208,13 +208,22 @@ absl::Status RomLifecycleManager::CheckRomOpenPolicy(Rom* rom) {
       editable_target));
 }
 
-absl::Status RomLifecycleManager::CheckRomWritePolicy(Rom* /*rom*/) {
+absl::Status RomLifecycleManager::CheckRomWritePolicy(
+    Rom* rom, const std::optional<std::string>& target_filename) {
   if (!project_ || !project_->project_opened()) {
     return absl::OkStatus();
   }
 
   const auto policy = project_->rom_metadata.write_policy;
-  const auto target_info = GetRomTargetInfo(project_, current_rom_path_);
+  const std::string target_path =
+      target_filename.has_value()
+          ? *target_filename
+          : (rom && !rom->filename().empty() ? rom->filename()
+                                             : current_rom_path_);
+  const std::string source_path =
+      rom && !rom->filename().empty() ? rom->filename() : current_rom_path_;
+  const auto target_info = GetRomTargetInfo(project_, target_path);
+  const auto source_info = GetRomTargetInfo(project_, source_path);
   if (target_info.matches_build_output) {
     if (policy == project::RomWritePolicy::kAllow) {
       return absl::OkStatus();
@@ -223,20 +232,19 @@ absl::Status RomLifecycleManager::CheckRomWritePolicy(Rom* /*rom*/) {
       toast_manager_->Show(
           absl::StrFormat(
               "ROM write blocked: '%s' is the project's build output",
-              target_info.loaded_path.empty() ? current_rom_path_
+              target_info.loaded_path.empty() ? target_path
                                               : target_info.loaded_path),
           ToastType::kError);
     }
     return absl::PermissionDeniedError(absl::StrFormat(
         "ROM write blocked: '%s' is the project's build output. Edit '%s' "
         "instead.",
-        target_info.loaded_path.empty() ? current_rom_path_
-                                        : target_info.loaded_path,
+        target_info.loaded_path.empty() ? target_path : target_info.loaded_path,
         GetEditableTargetPath(target_info)));
   }
 
-  if (target_info.matches_editable_target &&
-      !target_info.matches_build_output) {
+  if (source_info.matches_editable_target &&
+      !source_info.matches_build_output) {
     return absl::OkStatus();
   }
 
@@ -281,8 +289,29 @@ absl::Status RomLifecycleManager::CheckOracleRomSafetyPreSave(Rom* rom) {
     return absl::InvalidArgumentError("ROM not loaded");
   }
 
-  if (!project_ || !project_->project_opened() ||
-      !project_->hack_manifest.loaded() ||
+  if (!project_ || !project_->project_opened()) {
+    return absl::OkStatus();
+  }
+
+  // An explicitly configured manifest is part of the project's save-safety
+  // contract. Never silently disable those guardrails when the file is missing
+  // or malformed.
+  if (!project_->hack_manifest_file.empty() &&
+      !project_->hack_manifest.loaded()) {
+    const std::string manifest_path =
+        project_->GetAbsolutePath(project_->hack_manifest_file);
+    if (toast_manager_) {
+      toast_manager_->Show(
+          absl::StrFormat(
+              "Save blocked: configured hack manifest is unavailable: %s",
+              manifest_path),
+          ToastType::kError);
+    }
+    return absl::FailedPreconditionError(absl::StrFormat(
+        "Configured hack manifest is missing or malformed: %s", manifest_path));
+  }
+
+  if (!project_->hack_manifest.loaded() ||
       !project_->hack_manifest.HasProjectRegistry()) {
     return absl::OkStatus();
   }

--- a/src/app/editor/system/session/rom_lifecycle_manager.h
+++ b/src/app/editor/system/session/rom_lifecycle_manager.h
@@ -1,6 +1,7 @@
 #ifndef YAZE_APP_EDITOR_SYSTEM_ROM_LIFECYCLE_MANAGER_H_
 #define YAZE_APP_EDITOR_SYSTEM_ROM_LIFECYCLE_MANAGER_H_
 
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -69,7 +70,9 @@ class RomLifecycleManager {
   absl::Status CheckRomOpenPolicy(Rom* rom);
 
   /// Enforce project write policy; may set pending_rom_write_confirm.
-  absl::Status CheckRomWritePolicy(Rom* rom);
+  absl::Status CheckRomWritePolicy(
+      Rom* rom,
+      const std::optional<std::string>& target_filename = std::nullopt);
 
   /// Run Oracle-specific ROM safety preflight before saving.
   absl::Status CheckOracleRomSafetyPreSave(Rom* rom);
@@ -130,9 +133,25 @@ class RomLifecycleManager {
   bool ShouldSuppressPotItemSave() const {
     return suppress_pot_item_save_once_;
   }
+  void CancelPotItemSaveConfirmation() {
+    pending_pot_item_save_confirm_ = false;
+    pending_pot_item_unloaded_rooms_ = 0;
+    pending_pot_item_total_rooms_ = 0;
+    ClearPotItemBypass();
+  }
   void ClearPotItemBypass() {
     bypass_pot_item_confirm_once_ = false;
     suppress_pot_item_save_once_ = false;
+  }
+
+  /// Clear every confirmation and one-shot bypass associated with a logical
+  /// save request. This must be called when that request succeeds, fails, is
+  /// cancelled, or loses its originating ROM session.
+  void ResetPendingSaveState() {
+    CancelRomWriteConfirm();
+    CancelPotItemSaveConfirmation();
+    pending_write_conflicts_.clear();
+    bypass_write_conflict_once_ = false;
   }
 
   // =========================================================================

--- a/src/app/gfx/util/palette_manager.cc
+++ b/src/app/gfx/util/palette_manager.cc
@@ -49,6 +49,7 @@ void PaletteManager::Initialize(zelda3::GameData* game_data) {
   // Clear any existing state
   modified_palettes_.clear();
   modified_colors_.clear();
+  save_transaction_snapshot_.reset();
   ClearHistory();
 }
 
@@ -64,6 +65,7 @@ void PaletteManager::Initialize(Rom* rom) {
   // Clear any existing state
   modified_palettes_.clear();
   modified_colors_.clear();
+  save_transaction_snapshot_.reset();
   ClearHistory();
 }
 
@@ -77,6 +79,7 @@ void PaletteManager::ResetForTesting() {
   next_callback_id_ = 1;
   batch_depth_ = 0;
   batch_changes_.clear();
+  save_transaction_snapshot_.reset();
   ClearHistory();
 }
 
@@ -335,6 +338,30 @@ absl::Status PaletteManager::SaveAllToRom() {
   NotifyListeners(event);
 
   return absl::OkStatus();
+}
+
+absl::Status PaletteManager::BeginSaveTransaction() {
+  if (save_transaction_snapshot_.has_value()) {
+    return absl::FailedPreconditionError(
+        "Palette save transaction is already active");
+  }
+  save_transaction_snapshot_ = SaveTransactionSnapshot{
+      original_palettes_, modified_palettes_, modified_colors_};
+  return absl::OkStatus();
+}
+
+void PaletteManager::RollbackSaveTransaction() {
+  if (!save_transaction_snapshot_.has_value()) {
+    return;
+  }
+  original_palettes_ = std::move(save_transaction_snapshot_->original_palettes);
+  modified_palettes_ = std::move(save_transaction_snapshot_->modified_palettes);
+  modified_colors_ = std::move(save_transaction_snapshot_->modified_colors);
+  save_transaction_snapshot_.reset();
+}
+
+void PaletteManager::CommitSaveTransaction() {
+  save_transaction_snapshot_.reset();
 }
 
 absl::Status PaletteManager::ApplyPreviewChanges() {

--- a/src/app/gfx/util/palette_manager.h
+++ b/src/app/gfx/util/palette_manager.h
@@ -5,6 +5,7 @@
 #include <deque>
 #include <functional>
 #include <memory>
+#include <optional>
 #include <string>
 #include <unordered_map>
 #include <unordered_set>
@@ -104,7 +105,9 @@ class PaletteManager {
   /**
    * @brief Check if manager is initialized
    */
-  bool IsInitialized() const { return game_data_ != nullptr || rom_ != nullptr; }
+  bool IsInitialized() const {
+    return game_data_ != nullptr || rom_ != nullptr;
+  }
 
   /**
    * @brief Reset all state for test isolation
@@ -190,6 +193,13 @@ class PaletteManager {
    * @brief Save ALL modified palettes to ROM
    */
   absl::Status SaveAllToRom();
+
+  // Checkpoint persistence metadata that SaveGroup/SaveAllToRom clear. This is
+  // used by the coordinated ROM-save pipeline so a later serializer,
+  // validation gate, backup, or disk failure leaves palette edits retryable.
+  absl::Status BeginSaveTransaction();
+  void RollbackSaveTransaction();
+  void CommitSaveTransaction();
 
   /**
    * @brief Discard changes for a specific group
@@ -328,6 +338,15 @@ class PaletteManager {
   std::unordered_map<std::string,
                      std::unordered_map<int, std::unordered_set<int>>>
       modified_colors_;
+
+  struct SaveTransactionSnapshot {
+    std::unordered_map<std::string, std::vector<SnesPalette>> original_palettes;
+    std::unordered_map<std::string, std::unordered_set<int>> modified_palettes;
+    std::unordered_map<std::string,
+                       std::unordered_map<int, std::unordered_set<int>>>
+        modified_colors;
+  };
+  std::optional<SaveTransactionSnapshot> save_transaction_snapshot_;
 
   /// Undo/redo stacks
   std::deque<PaletteColorChange> undo_stack_;

--- a/src/app/platform/app_delegate.mm
+++ b/src/app/platform/app_delegate.mm
@@ -8,6 +8,7 @@
 #import "app/platform/app_delegate.h"
 #import "app/controller.h"
 #import "app/application.h"
+#import "app/editor/shell/feedback/popup_manager.h"
 #import "util/file_util.h"
 #import "app/editor/editor.h"
 #import "rom/rom.h"
@@ -150,17 +151,12 @@
 }
 
 - (void)saveAsAction:(id)sender {
-    // Trigger Save As logic
-    // Manager->SaveRomAs("") usually triggers dialog
     auto& app = yaze::Application::Instance();
     if (app.IsReady() && app.GetController()) {
         if (auto* manager = app.GetController()->editor_manager()) {
-            // We need a method to trigger Save As dialog from manager, 
-            // usually passing empty string does it or there's a specific method.
-            // EditorManager::SaveRomAs(string) saves immediately.
-            // We might need to expose a method to show the dialog.
-            // For now, let's assume we can use the file dialog wrapper from C++ side.
-             (void)manager->SaveRomAs(""); // This might fail if empty string isn't handled as "ask user"
+            if (auto* popup_manager = manager->popup_manager()) {
+                popup_manager->Show(yaze::editor::PopupID::kSaveAs);
+            }
         }
     }
 }

--- a/src/cli/handlers/game/dungeon_edit_commands.cc
+++ b/src/cli/handlers/game/dungeon_edit_commands.cc
@@ -163,6 +163,7 @@ absl::Status DungeonPlaceSpriteCommandHandler::Execute(
       static_cast<uint8_t>(sprite_id), static_cast<uint8_t>(x),
       static_cast<uint8_t>(y), static_cast<uint8_t>(subtype),
       static_cast<uint8_t>(layer));
+  room.MarkSpritesDirty();
 
   formatter.BeginObject("Place Sprite");
   formatter.AddHexField("room_id", room_id, 2);
@@ -298,6 +299,7 @@ absl::Status DungeonRemoveSpriteCommandHandler::Execute(
 
   // Remove
   sprites.erase(sprites.begin() + remove_index);
+  room.MarkSpritesDirty();
   formatter.AddField("sprites_after", static_cast<int>(sprites.size()));
   formatter.AddField("mode", do_write ? "write" : "dry-run");
 

--- a/src/cli/handlers/game/message_commands.cc
+++ b/src/cli/handlers/game/message_commands.cc
@@ -1,5 +1,6 @@
 #include "cli/handlers/game/message_commands.h"
 
+#include <algorithm>
 #include <fstream>
 #include <sstream>
 
@@ -32,6 +33,17 @@ bool IncludeExpanded(const std::string& range) {
 std::string BankLabel(editor::MessageBank bank) {
   return editor::MessageBankToString(bank);
 }
+
+std::vector<editor::MessageData> ReadExpandedMessages(const Rom& rom) {
+  const int start = editor::GetExpandedTextDataStart();
+  if (start < 0 || static_cast<size_t>(start) >= rom.size()) {
+    return {};
+  }
+  const int end = std::min(editor::GetExpandedTextDataEnd(),
+                           static_cast<int>(rom.size()) - 1);
+  return editor::ReadExpandedTextData(const_cast<uint8_t*>(rom.data()), start,
+                                      end);
+}
 }  // namespace
 
 // ===========================================================================
@@ -46,9 +58,8 @@ absl::Status MessageListCommandHandler::Execute(
     limit = 0;
   }
 
-  auto messages =
-      editor::ReadAllTextData(const_cast<uint8_t*>(rom->data()),
-                              editor::kTextData);
+  auto messages = editor::ReadAllTextData(const_cast<uint8_t*>(rom->data()),
+                                          editor::kTextData);
   if (limit > static_cast<int>(messages.size())) {
     limit = static_cast<int>(messages.size());
   }
@@ -83,13 +94,12 @@ absl::Status MessageReadCommandHandler::Execute(
   }
   int message_id = message_id_or.value();
 
-  auto messages =
-      editor::ReadAllTextData(const_cast<uint8_t*>(rom->data()),
-                              editor::kTextData);
+  auto messages = editor::ReadAllTextData(const_cast<uint8_t*>(rom->data()),
+                                          editor::kTextData);
   if (message_id < 0 || message_id >= static_cast<int>(messages.size())) {
-    return absl::NotFoundError(absl::StrFormat(
-        "Message ID %d not found (max: %d)", message_id,
-        static_cast<int>(messages.size()) - 1));
+    return absl::NotFoundError(
+        absl::StrFormat("Message ID %d not found (max: %d)", message_id,
+                        static_cast<int>(messages.size()) - 1));
   }
 
   const auto& msg = messages[message_id];
@@ -113,9 +123,8 @@ absl::Status MessageSearchCommandHandler::Execute(
     limit = 0;
   }
 
-  auto messages =
-      editor::ReadAllTextData(const_cast<uint8_t*>(rom->data()),
-                              editor::kTextData);
+  auto messages = editor::ReadAllTextData(const_cast<uint8_t*>(rom->data()),
+                                          editor::kTextData);
 
   formatter.BeginObject("Message Search Results");
   formatter.AddField("query", query);
@@ -167,7 +176,8 @@ absl::Status MessageEncodeCommandHandler::Execute(
   // Build hex string
   std::string hex_str;
   for (size_t i = 0; i < bytes.size(); ++i) {
-    if (i > 0) hex_str += " ";
+    if (i > 0)
+      hex_str += " ";
     hex_str += absl::StrFormat("%02X", bytes[i]);
   }
 
@@ -227,8 +237,7 @@ absl::Status MessageDecodeCommandHandler::Execute(
   std::string hex_byte;
   while (hex_stream >> hex_byte) {
     try {
-      bytes.push_back(
-          static_cast<uint8_t>(std::stoi(hex_byte, nullptr, 16)));
+      bytes.push_back(static_cast<uint8_t>(std::stoi(hex_byte, nullptr, 16)));
     } catch (const std::exception&) {
       return absl::InvalidArgumentError(
           absl::StrFormat("Invalid hex byte: '%s'", hex_byte));
@@ -281,7 +290,7 @@ absl::Status MessageImportOrgCommandHandler::Execute(
   }
 
   std::string content((std::istreambuf_iterator<char>(file)),
-                       std::istreambuf_iterator<char>());
+                      std::istreambuf_iterator<char>());
   file.close();
 
   auto messages = editor::ParseOrgContent(content);
@@ -299,7 +308,8 @@ absl::Status MessageImportOrgCommandHandler::Execute(
 
     std::string hex_str;
     for (size_t i = 0; i < bytes.size(); ++i) {
-      if (i > 0) hex_str += " ";
+      if (i > 0)
+        hex_str += " ";
       hex_str += absl::StrFormat("%02X", bytes[i]);
     }
 
@@ -400,8 +410,7 @@ absl::Status MessageExportBundleCommandHandler::Execute(
   }
 
   if (IncludeExpanded(range)) {
-    expanded = editor::ReadExpandedTextData(
-        const_cast<uint8_t*>(rom->data()), editor::GetExpandedTextDataStart());
+    expanded = ReadExpandedMessages(*rom);
   }
 
   auto status =
@@ -473,7 +482,8 @@ absl::Status MessageImportBundleCommandHandler::Execute(
       continue;
     }
 
-    ParsedEntry parsed{entry, editor::ParseMessageToDataWithDiagnostics(entry.text),
+    ParsedEntry parsed{entry,
+                       editor::ParseMessageToDataWithDiagnostics(entry.text),
                        editor::ValidateMessageLineWidths(entry.text)};
     if (!parsed.parse.ok()) {
       has_errors = true;
@@ -558,8 +568,7 @@ absl::Status MessageImportBundleCommandHandler::Execute(
 
     if (has_errors) {
       formatter.AddField("status", "error");
-      formatter.AddField("error",
-                          "Parse errors present; no changes applied");
+      formatter.AddField("error", "Parse errors present; no changes applied");
       formatter.AddField("parse_error_count", parse_error_count);
       formatter.AddField("error_count", error_count);
       formatter.EndObject();
@@ -605,9 +614,7 @@ absl::Status MessageImportBundleCommandHandler::Execute(
     }
 
     if (IncludeExpanded(range) && has_expanded_entries) {
-      auto expanded_messages = editor::ReadExpandedTextData(
-          const_cast<uint8_t*>(active_rom->data()),
-          editor::GetExpandedTextDataStart());
+      auto expanded_messages = ReadExpandedMessages(*active_rom);
       std::vector<std::string> expanded_texts;
       expanded_texts.reserve(expanded_messages.size());
       for (const auto& msg : expanded_messages) {
@@ -645,8 +652,7 @@ absl::Status MessageImportBundleCommandHandler::Execute(
 
     if (has_errors) {
       formatter.AddField("status", "error");
-      formatter.AddField("error",
-                          "Invalid message IDs; no changes applied");
+      formatter.AddField("error", "Invalid message IDs; no changes applied");
     } else {
       if (active_rom->dirty()) {
         auto save_status = active_rom->SaveToFile({.save_new = false});
@@ -683,7 +689,8 @@ absl::Status MessageWriteCommandHandler::Execute(
     Rom* rom, const resources::ArgumentParser& parser,
     resources::OutputFormatter& formatter) {
   auto id_or = parser.GetInt("id");
-  if (!id_or.ok()) return id_or.status();
+  if (!id_or.ok())
+    return id_or.status();
   int msg_id = id_or.value();
 
   auto text = parser.GetString("text").value();
@@ -698,8 +705,7 @@ absl::Status MessageWriteCommandHandler::Execute(
   }
 
   // Read existing expanded messages to find the target
-  auto expanded = editor::ReadExpandedTextData(
-      const_cast<uint8_t*>(rom->data()), editor::GetExpandedTextDataStart());
+  auto expanded = ReadExpandedMessages(*rom);
 
   // Build the full message list, inserting/replacing at msg_id
   std::vector<std::string> all_texts;
@@ -721,7 +727,8 @@ absl::Status MessageWriteCommandHandler::Execute(
   auto status = editor::WriteExpandedTextData(
       rom, editor::GetExpandedTextDataStart(), editor::GetExpandedTextDataEnd(),
       all_texts);
-  if (!status.ok()) return status;
+  if (!status.ok())
+    return status;
 
   formatter.BeginObject("Message Write Result");
   formatter.AddField("id", msg_id);
@@ -812,8 +819,8 @@ absl::Status MessageExportAsmCommandHandler::Execute(
   }
 
   // Read messages from the specified region
-  auto messages = editor::ReadAllTextData(
-      const_cast<uint8_t*>(rom->data()), start);
+  auto messages =
+      editor::ReadAllTextData(const_cast<uint8_t*>(rom->data()), start);
 
   std::ofstream file(output_path);
   if (!file.is_open()) {
@@ -833,7 +840,8 @@ absl::Status MessageExportAsmCommandHandler::Execute(
                             msg.ContentsParsed.substr(0, 60));
     file << "db ";
     for (size_t i = 0; i < msg.Data.size(); ++i) {
-      if (i > 0) file << ", ";
+      if (i > 0)
+        file << ", ";
       file << absl::StrFormat("$%02X", msg.Data[i]);
     }
     file << ", $7F  ; terminator\n\n";

--- a/src/cli/handlers/rom/project_bundle_verify_commands.cc
+++ b/src/cli/handlers/rom/project_bundle_verify_commands.cc
@@ -1,5 +1,6 @@
 #include "cli/handlers/rom/project_bundle_verify_commands.h"
 
+#include <algorithm>
 #include <cctype>
 #include <filesystem>
 #include <fstream>
@@ -11,6 +12,7 @@
 #include "absl/strings/str_format.h"
 #include "core/project.h"
 #include "nlohmann/json.hpp"
+#include "rom/rom.h"
 #include "util/rom_hash.h"
 
 namespace yaze::cli::handlers {
@@ -24,10 +26,17 @@ std::string NormalizeHash(const std::string& hash) {
   std::string result;
   result.reserve(hash.size());
   for (char ch : hash) {
-    if (ch == ' ' || ch == '\t' || ch == '\n' || ch == '\r') continue;
+    if (ch == ' ' || ch == '\t' || ch == '\n' || ch == '\r')
+      continue;
     result += static_cast<char>(std::tolower(static_cast<unsigned char>(ch)));
   }
   return result;
+}
+
+bool IsHexHash(const std::string& hash) {
+  return !hash.empty() &&
+         std::all_of(hash.begin(), hash.end(),
+                     [](unsigned char ch) { return std::isxdigit(ch); });
 }
 
 struct CheckResult {
@@ -36,30 +45,109 @@ struct CheckResult {
   std::string detail;
 };
 
-bool HasAbsolutePaths(const project::YazeProject& proj) {
-  auto is_abs = [](const std::string& p) {
-    return !p.empty() && fs::path(p).is_absolute();
+std::string Trim(std::string value) {
+  auto is_space = [](unsigned char ch) {
+    return std::isspace(ch);
   };
-  return is_abs(proj.rom_filename) || is_abs(proj.code_folder) ||
-         is_abs(proj.assets_folder) || is_abs(proj.patches_folder) ||
-         is_abs(proj.labels_filename) || is_abs(proj.custom_objects_folder);
+  while (!value.empty() && is_space(value.front())) {
+    value.erase(value.begin());
+  }
+  while (!value.empty() && is_space(value.back())) {
+    value.pop_back();
+  }
+  return value;
 }
 
-std::vector<std::string> ListAbsolutePaths(
-    const project::YazeProject& proj) {
-  std::vector<std::string> results;
-  auto check = [&](const std::string& field_name, const std::string& value) {
-    if (!value.empty() && fs::path(value).is_absolute()) {
-      results.push_back(
-          absl::StrFormat("%s = %s", field_name, value));
-    }
+bool IsAbsoluteConfigPath(const std::string& value) {
+  if (value.empty()) {
+    return false;
+  }
+  const auto is_windows_separator = [](char ch) {
+    return ch == '/' || ch == '\\';
   };
-  check("rom_filename", proj.rom_filename);
-  check("code_folder", proj.code_folder);
-  check("assets_folder", proj.assets_folder);
-  check("patches_folder", proj.patches_folder);
-  check("labels_filename", proj.labels_filename);
-  check("custom_objects_folder", proj.custom_objects_folder);
+  // std::filesystem only recognizes the host platform's absolute-path syntax.
+  // Detect Windows paths explicitly so a project authored on Windows is still
+  // audited correctly on macOS/Linux.
+  if (value.size() >= 2 && is_windows_separator(value[0]) &&
+      is_windows_separator(value[1])) {
+    return true;  // UNC or Windows device path.
+  }
+  if (fs::path(value).is_absolute()) {
+    return true;
+  }
+  return value.size() >= 3 &&
+         std::isalpha(static_cast<unsigned char>(value[0])) &&
+         value[1] == ':' && (value[2] == '/' || value[2] == '\\');
+}
+
+std::string StripMatchingQuotes(std::string value) {
+  value = Trim(std::move(value));
+  if (value.size() >= 2 && ((value.front() == '"' && value.back() == '"') ||
+                            (value.front() == '\'' && value.back() == '\''))) {
+    return value.substr(1, value.size() - 2);
+  }
+  return value;
+}
+
+std::vector<std::string> ConfigPathValues(const std::string& key,
+                                          const std::string& raw_value) {
+  if (key != "additional_roms") {
+    return {StripMatchingQuotes(raw_value)};
+  }
+
+  std::vector<std::string> values;
+  size_t begin = 0;
+  while (begin <= raw_value.size()) {
+    const size_t comma = raw_value.find(',', begin);
+    const size_t count =
+        comma == std::string::npos ? std::string::npos : comma - begin;
+    std::string value = StripMatchingQuotes(raw_value.substr(begin, count));
+    if (!value.empty()) {
+      values.push_back(std::move(value));
+    }
+    if (comma == std::string::npos) {
+      break;
+    }
+    begin = comma + 1;
+  }
+  return values;
+}
+
+std::vector<std::string> ListAbsolutePathsInProjectFile(
+    const fs::path& project_file) {
+  std::vector<std::string> results;
+  std::ifstream input(project_file);
+  if (!input.is_open()) {
+    return results;
+  }
+
+  bool in_files_section = false;
+  std::string line;
+  while (std::getline(input, line)) {
+    line = Trim(line);
+    if (line.empty() || line[0] == '#' || line[0] == ';') {
+      continue;
+    }
+    if (line.front() == '[' && line.back() == ']') {
+      in_files_section = line == "[files]";
+      continue;
+    }
+    if (!in_files_section) {
+      continue;
+    }
+
+    const size_t equals = line.find('=');
+    if (equals == std::string::npos) {
+      continue;
+    }
+    const std::string key = Trim(line.substr(0, equals));
+    const std::string raw_value = line.substr(equals + 1);
+    for (const auto& value : ConfigPathValues(key, raw_value)) {
+      if (IsAbsoluteConfigPath(value)) {
+        results.push_back(absl::StrFormat("%s = %s", key, value));
+      }
+    }
+  }
   return results;
 }
 
@@ -79,10 +167,11 @@ ProjectBundleVerifyCommandHandler::Describe() const {
        "Path to .yaze project file or .yazeproj bundle directory (required)",
        ""},
       {"--check-rom-hash",
-       "Verify ROM SHA1 hash against manifest.json (if present in bundle)",
+       "Verify bundle manifest rom_sha1 or standalone expected_hash "
+       "(CRC32/SHA1)",
        ""},
-      {"--report",
-       "Write full JSON summary to this path in addition to stdout", ""},
+      {"--report", "Write full JSON summary to this path in addition to stdout",
+       ""},
   };
   return desc;
 }
@@ -96,8 +185,7 @@ absl::Status ProjectBundleVerifyCommandHandler::ValidateArgs(
   }
 
   // Probe --report path writability.
-  if (auto rp = parser.GetString("report");
-      rp.has_value() && !rp->empty()) {
+  if (auto rp = parser.GetString("report"); rp.has_value() && !rp->empty()) {
     const fs::path rp_path(*rp);
     std::error_code ec;
     const bool existed_before = fs::exists(rp_path, ec);
@@ -179,12 +267,11 @@ absl::Status ProjectBundleVerifyCommandHandler::Execute(
     fs::path project_yaze = bundle_dir / "project.yaze";
     std::error_code ec;
     if (fs::exists(project_yaze, ec) && !ec) {
-      checks.push_back({"bundle_project_yaze", "pass",
-                         "project.yaze found in bundle root"});
-    } else {
       checks.push_back(
-          {"bundle_project_yaze", "warn",
-           "project.yaze missing — will be auto-created on open"});
+          {"bundle_project_yaze", "pass", "project.yaze found in bundle root"});
+    } else {
+      checks.push_back({"bundle_project_yaze", "warn",
+                        "project.yaze missing — will be auto-created on open"});
     }
   }
 
@@ -198,13 +285,11 @@ absl::Status ProjectBundleVerifyCommandHandler::Execute(
     if (status.ok()) {
       parse_ok = true;
       checks.push_back(
-          {"project_parses", "pass",
-           absl::StrFormat("name=%s", proj.name)});
+          {"project_parses", "pass", absl::StrFormat("name=%s", proj.name)});
     } else {
       checks.push_back(
           {"project_parses", "fail",
-           absl::StrFormat("Parse failed: %s",
-                           std::string(status.message()))});
+           absl::StrFormat("Parse failed: %s", std::string(status.message()))});
       any_fail = true;
     }
   }
@@ -213,22 +298,51 @@ absl::Status ProjectBundleVerifyCommandHandler::Execute(
   // Check 5: Path portability (warnings for absolute paths)
   // ------------------------------------------------------------------
   if (parse_ok) {
-    if (HasAbsolutePaths(proj)) {
-      auto abs_paths = ListAbsolutePaths(proj);
+    const fs::path project_config =
+        is_bundle ? fs::path(resolved_path) / "project.yaze"
+                  : fs::path(resolved_path);
+    const auto abs_paths = ListAbsolutePathsInProjectFile(project_config);
+    if (!abs_paths.empty()) {
       std::string detail = "Absolute paths reduce portability: ";
       for (size_t i = 0; i < abs_paths.size(); ++i) {
-        if (i > 0) detail += "; ";
+        if (i > 0)
+          detail += "; ";
         detail += abs_paths[i];
       }
       checks.push_back({"path_portability", "warn", detail});
     } else {
-      checks.push_back(
-          {"path_portability", "pass", "All paths are relative"});
+      checks.push_back({"path_portability", "pass", "All paths are relative"});
     }
   }
 
   // ------------------------------------------------------------------
-  // Check 6: ROM accessibility
+  // Check 6: Explicit hack manifest readiness
+  // ------------------------------------------------------------------
+  if (parse_ok && !proj.hack_manifest_file.empty()) {
+    const std::string manifest_abs =
+        proj.GetAbsolutePath(proj.hack_manifest_file);
+    std::error_code ec;
+    if (!fs::exists(manifest_abs, ec) || ec) {
+      checks.push_back(
+          {"hack_manifest_ready", "fail",
+           absl::StrFormat("Configured hack manifest not found: %s",
+                           manifest_abs)});
+      any_fail = true;
+    } else if (!proj.hack_manifest.loaded()) {
+      checks.push_back(
+          {"hack_manifest_ready", "fail",
+           absl::StrFormat("Configured hack manifest failed to load: %s",
+                           manifest_abs)});
+      any_fail = true;
+    } else {
+      checks.push_back({"hack_manifest_ready", "pass",
+                        absl::StrFormat("Loaded configured hack manifest: %s",
+                                        manifest_abs)});
+    }
+  }
+
+  // ------------------------------------------------------------------
+  // Check 7: ROM accessibility
   // ------------------------------------------------------------------
   if (parse_ok && !proj.rom_filename.empty()) {
     std::string rom_abs = proj.GetAbsolutePath(proj.rom_filename);
@@ -236,19 +350,17 @@ absl::Status ProjectBundleVerifyCommandHandler::Execute(
     if (fs::exists(rom_abs, ec) && !ec) {
       auto fsize = fs::file_size(rom_abs, ec);
       if (ec) {
-        checks.push_back({"rom_accessible", "warn",
-                           absl::StrFormat("ROM exists but size unreadable: %s",
-                                           rom_abs)});
-      } else {
         checks.push_back(
-            {"rom_accessible", "pass",
-             absl::StrFormat("%s (%zu bytes)", rom_abs, fsize)});
+            {"rom_accessible", "warn",
+             absl::StrFormat("ROM exists but size unreadable: %s", rom_abs)});
+      } else {
+        checks.push_back({"rom_accessible", "pass",
+                          absl::StrFormat("%s (%zu bytes)", rom_abs, fsize)});
       }
     } else {
-      checks.push_back(
-          {"rom_accessible", "fail",
-           absl::StrFormat("ROM not found: %s (resolved: %s)",
-                           proj.rom_filename, rom_abs)});
+      checks.push_back({"rom_accessible", "fail",
+                        absl::StrFormat("ROM not found: %s (resolved: %s)",
+                                        proj.rom_filename, rom_abs)});
       any_fail = true;
     }
   } else if (parse_ok) {
@@ -256,53 +368,109 @@ absl::Status ProjectBundleVerifyCommandHandler::Execute(
   }
 
   // ------------------------------------------------------------------
-  // Check 7: ROM hash verification (optional, --check-rom-hash)
+  // Check 8: ROM hash verification (optional, --check-rom-hash)
   // ------------------------------------------------------------------
   if (parser.HasFlag("check-rom-hash") && parse_ok) {
-    if (!is_bundle) {
-      checks.push_back({"rom_hash_check", "warn",
-                         "Hash check only supported for .yazeproj bundles"});
-    } else {
+    std::string raw_expected;
+    bool hash_metadata_ready = true;
+
+    if (is_bundle) {
       fs::path manifest_path = fs::path(resolved_path) / "manifest.json";
       std::error_code ec;
       if (!fs::exists(manifest_path, ec) || ec) {
         checks.push_back({"rom_hash_check", "warn",
-                           "No manifest.json in bundle (hash unavailable)"});
+                          "No manifest.json in bundle (hash unavailable)"});
+        hash_metadata_ready = false;
       } else {
         std::ifstream mf(manifest_path);
         auto manifest = nlohmann::json::parse(mf, nullptr, false);
         if (manifest.is_discarded()) {
-          checks.push_back({"rom_hash_check", "fail",
-                             "manifest.json parse failed"});
+          checks.push_back(
+              {"rom_hash_check", "fail", "manifest.json parse failed"});
           any_fail = true;
+          hash_metadata_ready = false;
         } else {
-          std::string raw_expected =
-              manifest.value("rom_sha1", std::string{});
+          raw_expected = manifest.value("rom_sha1", std::string{});
           if (raw_expected.empty()) {
             checks.push_back({"rom_hash_check", "warn",
-                               "No rom_sha1 field in manifest.json"});
-          } else {
-            std::string expected_sha1 = NormalizeHash(raw_expected);
-            std::string rom_abs = proj.GetAbsolutePath(proj.rom_filename);
-            std::string actual_sha1 = util::ComputeFileSha1Hex(rom_abs);
-            if (actual_sha1.empty()) {
-              checks.push_back(
-                  {"rom_hash_check", "fail",
-                   absl::StrFormat("Cannot read ROM for hashing: %s",
-                                   rom_abs)});
-              any_fail = true;
-            } else if (NormalizeHash(actual_sha1) == expected_sha1) {
-              checks.push_back(
-                  {"rom_hash_check", "pass",
-                   absl::StrFormat("SHA1 match: %s", actual_sha1)});
-            } else {
-              checks.push_back(
-                  {"rom_hash_check", "fail",
-                   absl::StrFormat("SHA1 mismatch: expected=%s actual=%s",
-                                   expected_sha1, actual_sha1)});
-              any_fail = true;
-            }
+                              "No rom_sha1 field in manifest.json"});
+            hash_metadata_ready = false;
           }
+        }
+      }
+    } else {
+      raw_expected = proj.rom_metadata.expected_hash;
+      if (raw_expected.empty()) {
+        checks.push_back({"rom_hash_check", "warn",
+                          "No expected_hash in standalone project"});
+        hash_metadata_ready = false;
+      }
+    }
+
+    if (hash_metadata_ready) {
+      const std::string expected = NormalizeHash(raw_expected);
+      const std::string rom_abs = proj.GetAbsolutePath(proj.rom_filename);
+      std::string actual;
+      std::string algorithm;
+
+      if (is_bundle) {
+        // Bundle manifests explicitly declare a raw-file SHA1. Keep that
+        // contract distinct from standalone project hashes, which describe
+        // the header-stripped ROM buffer loaded by the editor.
+        algorithm = "SHA1";
+        if (expected.size() != 40 || !IsHexHash(expected)) {
+          checks.push_back(
+              {"rom_hash_check", "fail",
+               "manifest.json rom_sha1 must be 40 hexadecimal characters"});
+          any_fail = true;
+          hash_metadata_ready = false;
+        } else {
+          actual = util::ComputeFileSha1Hex(rom_abs);
+        }
+      } else if ((expected.size() == 8 || expected.size() == 40) &&
+                 IsHexHash(expected)) {
+        algorithm = expected.size() == 8 ? "CRC32" : "SHA1";
+        Rom loaded_rom;
+        Rom::LoadOptions load_options;
+        load_options.load_resource_labels = false;
+        const auto load_status = loaded_rom.LoadFromFile(rom_abs, load_options);
+        if (!load_status.ok()) {
+          checks.push_back(
+              {"rom_hash_check", "fail",
+               absl::StrFormat("Cannot load ROM for hashing: %s (%s)", rom_abs,
+                               load_status.message())});
+          any_fail = true;
+          hash_metadata_ready = false;
+        } else if (expected.size() == 8) {
+          actual = util::ComputeRomHash(loaded_rom.data(), loaded_rom.size());
+        } else {
+          actual = util::ComputeSha1Hex(loaded_rom.data(), loaded_rom.size());
+        }
+      } else {
+        checks.push_back(
+            {"rom_hash_check", "fail",
+             "Standalone expected_hash must be an 8-character CRC32 or "
+             "40-character SHA1 hexadecimal digest"});
+        any_fail = true;
+        hash_metadata_ready = false;
+      }
+
+      if (hash_metadata_ready) {
+        if (actual.empty()) {
+          checks.push_back(
+              {"rom_hash_check", "fail",
+               absl::StrFormat("Cannot read ROM for hashing: %s", rom_abs)});
+          any_fail = true;
+        } else if (NormalizeHash(actual) == expected) {
+          checks.push_back(
+              {"rom_hash_check", "pass",
+               absl::StrFormat("%s match: %s", algorithm, actual)});
+        } else {
+          checks.push_back(
+              {"rom_hash_check", "fail",
+               absl::StrFormat("%s mismatch: expected=%s actual=%s", algorithm,
+                               expected, actual)});
+          any_fail = true;
         }
       }
     }
@@ -314,9 +482,12 @@ absl::Status ProjectBundleVerifyCommandHandler::Execute(
   bool overall_ok = !any_fail;
   int pass_count = 0, warn_count = 0, fail_count = 0;
   for (const auto& chk : checks) {
-    if (chk.status == "pass") ++pass_count;
-    else if (chk.status == "warn") ++warn_count;
-    else ++fail_count;
+    if (chk.status == "pass")
+      ++pass_count;
+    else if (chk.status == "warn")
+      ++warn_count;
+    else
+      ++fail_count;
   }
 
   formatter.AddField("ok", overall_ok);
@@ -341,8 +512,7 @@ absl::Status ProjectBundleVerifyCommandHandler::Execute(
   // ------------------------------------------------------------------
   // Write report file
   // ------------------------------------------------------------------
-  if (auto rp = parser.GetString("report");
-      rp.has_value() && !rp->empty()) {
+  if (auto rp = parser.GetString("report"); rp.has_value() && !rp->empty()) {
     // Build a standalone JSON report (formatter may be text mode)
     nlohmann::json report;
     report["ok"] = overall_ok;
@@ -354,9 +524,8 @@ absl::Status ProjectBundleVerifyCommandHandler::Execute(
     report["fail_count"] = fail_count;
     nlohmann::json checks_json = nlohmann::json::array();
     for (const auto& chk : checks) {
-      checks_json.push_back({{"name", chk.name},
-                              {"status", chk.status},
-                              {"detail", chk.detail}});
+      checks_json.push_back(
+          {{"name", chk.name}, {"status", chk.status}, {"detail", chk.detail}});
     }
     report["checks"] = std::move(checks_json);
 

--- a/src/cli/handlers/rom/project_bundle_verify_commands.cc
+++ b/src/cli/handlers/rom/project_bundle_verify_commands.cc
@@ -62,15 +62,11 @@ bool IsAbsoluteConfigPath(const std::string& value) {
   if (value.empty()) {
     return false;
   }
-  const auto is_windows_separator = [](char ch) {
-    return ch == '/' || ch == '\\';
-  };
   // std::filesystem only recognizes the host platform's absolute-path syntax.
-  // Detect Windows paths explicitly so a project authored on Windows is still
-  // audited correctly on macOS/Linux.
-  if (value.size() >= 2 && is_windows_separator(value[0]) &&
-      is_windows_separator(value[1])) {
-    return true;  // UNC or Windows device path.
+  // Detect POSIX and Windows rooted paths explicitly so projects authored on
+  // another platform are still audited correctly.
+  if (value.front() == '/' || value.front() == '\\') {
+    return true;
   }
   if (fs::path(value).is_absolute()) {
     return true;

--- a/src/cli/handlers/tools/sprite_doctor_commands.cc
+++ b/src/cli/handlers/tools/sprite_doctor_commands.cc
@@ -44,7 +44,7 @@ void ValidateSpritePointerTable(Rom* rom, DiagnosticReport& report,
 
     // Validate pointer points to valid sprite data region
     if (sprite_addr < zelda3::kSpritesData ||
-        sprite_addr >= zelda3::kSpritesEndData) {
+        sprite_addr >= zelda3::kSpritesDataEndExclusive) {
       if (verbose || invalid_count < 10) {
         DiagnosticFinding finding;
         finding.id = "invalid_sprite_ptr";

--- a/src/core/project.cc
+++ b/src/core/project.cc
@@ -331,6 +331,19 @@ absl::Status YazeProject::Open(const std::string& project_path) {
     resolved_path = bundle_root;
   }
 
+#ifndef __EMSCRIPTEN__
+  // Keep the project root stable even when a caller supplies a relative path.
+  // All project-relative files and registry fallbacks must resolve beside the
+  // project, not against whichever working directory happens to be active
+  // later in the session.
+  std::error_code absolute_ec;
+  const auto absolute_path =
+      std::filesystem::absolute(resolved_path, absolute_ec).lexically_normal();
+  if (!absolute_ec) {
+    resolved_path = absolute_path.string();
+  }
+#endif
+
   filepath = resolved_path;
 
 #ifdef __EMSCRIPTEN__
@@ -1229,6 +1242,16 @@ absl::Status YazeProject::Validate() const {
       !std::filesystem::exists(GetAbsolutePath(labels_filename))) {
     errors.push_back("Labels file does not exist: " + labels_filename);
   }
+
+  if (!hack_manifest_file.empty()) {
+    if (!std::filesystem::exists(GetAbsolutePath(hack_manifest_file))) {
+      errors.push_back("Hack manifest file does not exist: " +
+                       hack_manifest_file);
+    } else if (!hack_manifest.loaded()) {
+      errors.push_back("Hack manifest file failed to load: " +
+                       hack_manifest_file);
+    }
+  }
 #endif  // __EMSCRIPTEN__
 
   if (!errors.empty()) {
@@ -1253,6 +1276,10 @@ std::vector<std::string> YazeProject::GetMissingFiles() const {
   if (!symbols_filename.empty() &&
       !std::filesystem::exists(GetAbsolutePath(symbols_filename))) {
     missing.push_back(symbols_filename);
+  }
+  if (!hack_manifest_file.empty() &&
+      !std::filesystem::exists(GetAbsolutePath(hack_manifest_file))) {
+    missing.push_back(hack_manifest_file);
   }
 #endif  // __EMSCRIPTEN__
 
@@ -1624,20 +1651,24 @@ void YazeProject::TryLoadHackManifest() {
     return true;
   };
 
-  // Priority 1: Explicit hack_manifest_file setting from project.
-  if (!hack_manifest_file.empty()) {
+  // Priority 1: An explicit hack_manifest_file setting is authoritative. Do
+  // not silently replace a missing or malformed configured manifest with an
+  // auto-discovered file; project validation must surface the bad reference.
+  const bool has_explicit_manifest = !hack_manifest_file.empty();
+  if (has_explicit_manifest) {
     (void)load_manifest(GetAbsolutePath(hack_manifest_file), false);
   }
 
   // Priority 2: Auto-discover hack_manifest.json in code_folder.
-  if (!hack_manifest.loaded() && !code_folder.empty()) {
+  if (!has_explicit_manifest && !hack_manifest.loaded() &&
+      !code_folder.empty()) {
     auto code_path = GetAbsolutePath(code_folder);
     auto candidate = std::filesystem::path(code_path) / "hack_manifest.json";
     (void)load_manifest(candidate, true);
   }
 
   // Priority 3: Fallback to the project file directory (or its parent).
-  if (!hack_manifest.loaded() && !filepath.empty()) {
+  if (!has_explicit_manifest && !hack_manifest.loaded() && !filepath.empty()) {
     const std::filesystem::path project_dir =
         std::filesystem::path(filepath).parent_path();
     (void)load_manifest(project_dir / "hack_manifest.json", true);

--- a/src/rom/transaction.h
+++ b/src/rom/transaction.h
@@ -10,6 +10,7 @@
 // Commit() will Rollback() previously applied writes in reverse order.
 
 #include <cstdint>
+#include <string>
 #include <variant>
 #include <vector>
 
@@ -159,6 +160,50 @@ class Transaction {
   Rom& rom_;
   absl::Status status_;
   std::vector<Operation> operations_;
+};
+
+// Whole-buffer transaction used by coordinated editor saves. Individual
+// editor serializers do not share a Transaction instance and may resize the
+// ROM, so recording only writes made through Transaction is insufficient for
+// the File > Save ROM pipeline. This guard snapshots the complete in-memory
+// state and restores it unless the caller commits after the atomic disk write.
+class ScopedRomTransaction {
+ public:
+  explicit ScopedRomTransaction(Rom& rom)
+      : rom_(rom),
+        data_(rom.vector()),
+        filename_(rom.filename()),
+        dirty_(rom.dirty()) {}
+
+  ScopedRomTransaction(const ScopedRomTransaction&) = delete;
+  ScopedRomTransaction& operator=(const ScopedRomTransaction&) = delete;
+
+  ~ScopedRomTransaction() {
+    if (!committed_) {
+      Rollback();
+    }
+  }
+
+  void Commit() { committed_ = true; }
+
+  void Rollback() {
+    if (committed_) {
+      return;
+    }
+    rom_.mutable_vector() = data_;
+    // Keep Rom::size() synchronized if a serializer resized the buffer.
+    rom_.Expand(static_cast<int>(data_.size()));
+    rom_.set_filename(filename_);
+    rom_.set_dirty(dirty_);
+    committed_ = true;
+  }
+
+ private:
+  Rom& rom_;
+  std::vector<uint8_t> data_;
+  std::string filename_;
+  bool dirty_ = false;
+  bool committed_ = false;
 };
 
 }  // namespace yaze

--- a/src/zelda3/dungeon/dungeon_object_editor.cc
+++ b/src/zelda3/dungeon/dungeon_object_editor.cc
@@ -333,8 +333,15 @@ absl::Status DungeonObjectEditor::MoveObject(size_t object_index, int new_x,
   }
 
   // Move the object
+  const bool changed = object.x() != new_x || object.y() != new_y;
+  if (changed) {
+    current_room_->MarkSaveDirtyForTileObject(object);
+  }
   object.set_x(new_x);
   object.set_y(new_y);
+  if (changed) {
+    current_room_->MarkSaveDirtyForTileObject(object);
+  }
 
   // Notify callbacks
   if (object_changed_callback_) {
@@ -370,7 +377,14 @@ absl::Status DungeonObjectEditor::ResizeObject(size_t object_index,
 
   // Resize the object
   auto& object = current_room_->GetTileObject(object_index);
+  const bool changed = object.size() != new_size;
+  if (changed) {
+    current_room_->MarkSaveDirtyForTileObject(object);
+  }
   object.set_size(new_size);
+  if (changed) {
+    current_room_->MarkSaveDirtyForTileObject(object);
+  }
 
   // Notify callbacks
   if (object_changed_callback_) {
@@ -413,8 +427,15 @@ absl::Status DungeonObjectEditor::BatchMoveObjects(
     new_x = std::max(0, std::min(63, new_x));
     new_y = std::max(0, std::min(63, new_y));
 
+    const bool changed = object.x() != new_x || object.y() != new_y;
+    if (changed) {
+      current_room_->MarkSaveDirtyForTileObject(object);
+    }
     object.set_x(new_x);
     object.set_y(new_y);
+    if (changed) {
+      current_room_->MarkSaveDirtyForTileObject(object);
+    }
 
     if (object_changed_callback_) {
       object_changed_callback_(index, object);
@@ -453,7 +474,15 @@ absl::Status DungeonObjectEditor::BatchChangeObjectLayer(
       // BothBG objects are rendered to BG1+BG2 regardless of their stored layer.
       continue;
     }
-    object.layer_ = static_cast<RoomObject::LayerType>(new_layer);
+    const auto target_layer = static_cast<RoomObject::LayerType>(new_layer);
+    const bool changed = object.layer_ != target_layer;
+    if (changed) {
+      current_room_->MarkSaveDirtyForTileObject(object);
+    }
+    object.layer_ = target_layer;
+    if (changed) {
+      current_room_->MarkSaveDirtyForTileObject(object);
+    }
 
     if (object_changed_callback_) {
       object_changed_callback_(index, object);
@@ -490,7 +519,14 @@ absl::Status DungeonObjectEditor::BatchResizeObjects(
     auto& object = current_room_->GetTileObject(index);
     // Only Type 1 objects typically support arbitrary sizing, but we allow it
     // for all here as the validation logic might vary.
+    const bool changed = object.size() != new_size;
+    if (changed) {
+      current_room_->MarkSaveDirtyForTileObject(object);
+    }
     object.set_size(new_size);
+    if (changed) {
+      current_room_->MarkSaveDirtyForTileObject(object);
+    }
 
     if (object_changed_callback_) {
       object_changed_callback_(index, object);
@@ -618,7 +654,14 @@ absl::Status DungeonObjectEditor::ChangeObjectType(size_t object_index,
   }
 
   auto& object = current_room_->GetTileObject(object_index);
+  const bool changed = object.id_ != new_type;
+  if (changed) {
+    current_room_->MarkSaveDirtyForTileObject(object);
+  }
   object.set_id(static_cast<int16_t>(new_type));
+  if (changed) {
+    current_room_->MarkSaveDirtyForTileObject(object);
+  }
 
   if (object_changed_callback_) {
     object_changed_callback_(object_index, object);
@@ -794,6 +837,14 @@ absl::Status DungeonObjectEditor::AlignSelectedObjects(Alignment alignment) {
       continue;
     auto& obj = current_room_->GetTileObject(index);
 
+    const bool changes_x = alignment == Alignment::Left ||
+                           alignment == Alignment::Right ||
+                           alignment == Alignment::CenterX;
+    const bool changed = changes_x ? obj.x() != ref_val : obj.y() != ref_val;
+    if (changed) {
+      current_room_->MarkSaveDirtyForTileObject(obj);
+    }
+
     switch (alignment) {
       case Alignment::Left:
       case Alignment::Right:
@@ -805,6 +856,10 @@ absl::Status DungeonObjectEditor::AlignSelectedObjects(Alignment alignment) {
       case Alignment::CenterY:
         obj.set_y(ref_val);
         break;
+    }
+
+    if (changed) {
+      current_room_->MarkSaveDirtyForTileObject(obj);
     }
 
     if (object_changed_callback_) {
@@ -844,7 +899,15 @@ absl::Status DungeonObjectEditor::ChangeObjectLayer(size_t object_index,
     // BothBG objects are rendered to BG1+BG2 regardless of their stored layer.
     return absl::OkStatus();
   }
-  object.layer_ = static_cast<RoomObject::LayerType>(new_layer);
+  const auto target_layer = static_cast<RoomObject::LayerType>(new_layer);
+  const bool changed = object.layer_ != target_layer;
+  if (changed) {
+    current_room_->MarkSaveDirtyForTileObject(object);
+  }
+  object.layer_ = target_layer;
+  if (changed) {
+    current_room_->MarkSaveDirtyForTileObject(object);
+  }
 
   if (object_changed_callback_) {
     object_changed_callback_(object_index, object);
@@ -1533,8 +1596,10 @@ void DungeonObjectEditor::DrawPropertyUI() {
         int x = obj.x();
         ImGui::SetNextItemWidth(-1);
         if (ImGui::InputInt("##X", &x, 1, 4)) {
-          if (x >= 0 && x < 64) {
+          if (x >= 0 && x < 64 && obj.x() != x) {
+            current_room_->MarkSaveDirtyForTileObject(obj);
             obj.set_x(x);
+            current_room_->MarkSaveDirtyForTileObject(obj);
             if (object_changed_callback_) {
               object_changed_callback_(obj_idx, obj);
             }
@@ -1549,8 +1614,10 @@ void DungeonObjectEditor::DrawPropertyUI() {
         int y = obj.y();
         ImGui::SetNextItemWidth(-1);
         if (ImGui::InputInt("##Y", &y, 1, 4)) {
-          if (y >= 0 && y < 64) {
+          if (y >= 0 && y < 64 && obj.y() != y) {
+            current_room_->MarkSaveDirtyForTileObject(obj);
             obj.set_y(y);
+            current_room_->MarkSaveDirtyForTileObject(obj);
             if (object_changed_callback_) {
               object_changed_callback_(obj_idx, obj);
             }
@@ -1574,7 +1641,9 @@ void DungeonObjectEditor::DrawPropertyUI() {
           int size = obj.size();
           ImGui::SetNextItemWidth(-1);
           if (ImGui::SliderInt("##Size", &size, 0, 15, "0x%02X")) {
+            current_room_->MarkSaveDirtyForTileObject(obj);
             obj.set_size(size);
+            current_room_->MarkSaveDirtyForTileObject(obj);
             if (object_changed_callback_) {
               object_changed_callback_(obj_idx, obj);
             }
@@ -1590,8 +1659,10 @@ void DungeonObjectEditor::DrawPropertyUI() {
         ImGui::SetNextItemWidth(-1);
         if (ImGui::InputInt("##ID", &id, 1, 16,
                             ImGuiInputTextFlags_CharsHexadecimal)) {
-          if (id >= 0 && id <= 0xFFF) {
+          if (id >= 0 && id <= 0xFFF && obj.id_ != id) {
+            current_room_->MarkSaveDirtyForTileObject(obj);
             obj.set_id(static_cast<int16_t>(id));
+            current_room_->MarkSaveDirtyForTileObject(obj);
             if (object_changed_callback_) {
               object_changed_callback_(obj_idx, obj);
             }
@@ -1615,7 +1686,8 @@ void DungeonObjectEditor::DrawPropertyUI() {
         if (semantics.draws_to_both_bgs) {
           ImGui::TextColored(theme.text_warning_yellow, "Both (BG1 + BG2)");
         } else {
-          ImGui::Text("%s", EffectiveBgLayerLabel(semantics.effective_bg_layer));
+          ImGui::Text("%s",
+                      EffectiveBgLayerLabel(semantics.effective_bg_layer));
         }
 
         ImGui::TableNextRow();
@@ -1629,8 +1701,10 @@ void DungeonObjectEditor::DrawPropertyUI() {
         }
         if (ImGui::Combo("##Layer", &layer,
                          "BG1 (Floor)\0BG2 (Objects)\0BG3 (Overlay)\0")) {
-          if (!semantics.draws_to_both_bgs) {
+          if (!semantics.draws_to_both_bgs && obj.GetLayerValue() != layer) {
+            current_room_->MarkSaveDirtyForTileObject(obj);
             obj.layer_ = static_cast<RoomObject::LayerType>(layer);
+            current_room_->MarkSaveDirtyForTileObject(obj);
             if (object_changed_callback_) {
               object_changed_callback_(obj_idx, obj);
             }
@@ -1686,7 +1760,8 @@ void DungeonObjectEditor::DrawPropertyUI() {
     gui::SectionHeader(ICON_MD_LAYERS, "Batch Layer", theme.text_info);
     size_t both_bg_count = 0;
     for (size_t idx : selection_state_.selected_objects) {
-      if (idx >= current_room_->GetTileObjectCount()) continue;
+      if (idx >= current_room_->GetTileObjectCount())
+        continue;
       const auto& obj = current_room_->GetTileObject(idx);
       if (GetObjectLayerSemantics(obj).draws_to_both_bgs) {
         ++both_bg_count;
@@ -1694,8 +1769,9 @@ void DungeonObjectEditor::DrawPropertyUI() {
     }
     if (both_bg_count > 0) {
       ImGui::TextColored(theme.text_warning_yellow,
-                         ICON_MD_INFO " %zu object%s draw%s to Both BGs and "
-                                      "won't be affected by layer changes",
+                         ICON_MD_INFO
+                         " %zu object%s draw%s to Both BGs and "
+                         "won't be affected by layer changes",
                          both_bg_count, both_bg_count == 1 ? "" : "s",
                          both_bg_count == 1 ? "s" : "");
       ImGui::Spacing();
@@ -1863,8 +1939,15 @@ absl::Status DungeonObjectEditor::HandleDragOperation(int current_x,
     new_x = std::max(0, std::min(63, new_x));
     new_y = std::max(0, std::min(63, new_y));
 
+    const bool changed = obj.x() != new_x || obj.y() != new_y;
+    if (changed) {
+      current_room_->MarkSaveDirtyForTileObject(obj);
+    }
     obj.set_x(new_x);
     obj.set_y(new_y);
+    if (changed) {
+      current_room_->MarkSaveDirtyForTileObject(obj);
+    }
 
     if (object_changed_callback_) {
       object_changed_callback_(obj_idx, obj);

--- a/src/zelda3/dungeon/dungeon_rom_addresses.h
+++ b/src/zelda3/dungeon/dungeon_rom_addresses.h
@@ -20,12 +20,37 @@ constexpr int kRoomObjectPointer = 0x874C;        // Object data pointer (Long)
 constexpr int kRoomHeaderPointer = 0xB5DD;        // Room header pointer (LONG)
 constexpr int kRoomHeaderPointerBank = 0xB5E7;    // Room header bank byte
 
+struct DungeonObjectDataRegion {
+  int begin;
+  int end;
+};
+
+// Half-open ZScream room-object sections. In-place saves may use the containing
+// section's end as a physical boundary when there is no later room pointer.
+constexpr std::array<DungeonObjectDataRegion, 5> kDungeonObjectDataRegions = {{
+    {0x050008, 0x053730},
+    {0x0F878A, 0x100000},
+    {0x01EB90, 0x020000},
+    {0x138000, 0x140000},
+    {0x148000, 0x150000},
+}};
+
+constexpr int GetDungeonObjectDataRegionEnd(int pc_address) {
+  for (const auto& region : kDungeonObjectDataRegions) {
+    if (pc_address >= region.begin && pc_address < region.end) {
+      return region.end;
+    }
+  }
+  return -1;
+}
+
 // === Palette Data ===
 constexpr int kDungeonsMainBgPalettePointers = 0xDEC4B;  // JP Same
 constexpr int kDungeonsPalettes = 0xDD734;               // Dungeon palette data
 
 // === Item & Sprite Data ===
 constexpr int kRoomItemsPointers = 0xDB69;      // JP 0xDB67
+constexpr int kRoomItemsDataEnd = 0xE6B2;       // Exclusive PC boundary
 constexpr int kRoomsSpritePointer = 0x4C298;    // JP Same (2-byte bank 09D62E)
 constexpr int kSpriteBlocksetPointer = 0x5B57;  // Sprite graphics pointer
 
@@ -93,7 +118,9 @@ constexpr int kDoorPosRight = 0x19C6;         // Door position (right)
 // === Sprites ===
 constexpr int kSpritesData = 0x4D8B0;           // Sprite data start
 constexpr int kSpritesDataEmptyRoom = 0x4D8AE;  // Empty room sprite marker
-constexpr int kSpritesEndData = 0x4EC9E;        // Sprite data end
+constexpr int kSpritesEndData = 0x4EC9E;        // Last valid data byte
+constexpr int kSpritesDataEndExclusive =
+    kSpritesEndData + 1;  // Half-open sprite data boundary
 constexpr int kDungeonSpritePointers =
     0x090000;  // Dungeon sprite pointer table
 

--- a/src/zelda3/dungeon/dungeon_rom_addresses.h
+++ b/src/zelda3/dungeon/dungeon_rom_addresses.h
@@ -42,8 +42,14 @@ constexpr int kBlocksPointer3 = 0x15B08;  // Block data pointer 3
 constexpr int kBlocksPointer4 = 0x15B0F;  // Block data pointer 4
 
 // === Chests ===
-constexpr int kChestsLengthPointer = 0xEBF6;  // Chest count pointer
-constexpr int kChestsDataPointer1 = 0xEBFB;   // Chest data start
+// The value at kChestsLengthPointer is a byte length, not a record count.
+// Vanilla reserves 0x01F8 bytes: 168 records at 3 bytes per record.
+constexpr int kChestsLengthPointer = 0xEBF6;
+constexpr int kChestsDataPointer1 = 0xEBFB;  // Chest data start
+constexpr int kChestTableRecordSize = 3;
+constexpr int kChestTableCapacityRecords = 168;
+constexpr int kChestTableCapacityBytes =
+    kChestTableRecordSize * kChestTableCapacityRecords;
 
 // === Torches ===
 constexpr int kTorchData = 0x2736A;            // JP 0x2704A

--- a/src/zelda3/dungeon/room.cc
+++ b/src/zelda3/dungeon/room.cc
@@ -249,10 +249,15 @@ PhysicalStreamInfo AnalyzePhysicalStream(const std::vector<int>& room_addresses,
   }
 
   // A stream cannot safely grow across a LoROM bank boundary even when the
-  // next pointer happens to live in the following physical bank.
+  // next pointer happens to live in the following physical bank. The bank end
+  // alone is not a physical data boundary, so fail closed unless an actual
+  // pointer or a supplied region end bounds this bank.
   constexpr int kLoRomBankSize = 0x8000;
   const int bank_end = ((info.address / kLoRomBankSize) + 1) * kLoRomBankSize;
-  info.physical_end = std::min(next_address, bank_end);
+  if (next_address > bank_end) {
+    return info;
+  }
+  info.physical_end = next_address;
   return info;
 }
 
@@ -315,7 +320,8 @@ absl::StatusOr<PhysicalStreamInfo> GetObjectStreamInfo(
   for (int id = 0; id < kNumberOfRooms; ++id) {
     addresses[id] = ReadRoomObjectAddressPc(rom_data, table_pc, id);
   }
-  PhysicalStreamInfo info = AnalyzePhysicalStream(addresses, room_id);
+  const int hard_end = GetDungeonObjectDataRegionEnd(addresses[room_id]);
+  PhysicalStreamInfo info = AnalyzePhysicalStream(addresses, room_id, hard_end);
   if (info.address < 0) {
     return absl::OutOfRangeError("Object stream pointer is out of range");
   }
@@ -378,7 +384,7 @@ absl::StatusOr<PhysicalStreamInfo> GetSpriteStreamInfo(
     addresses[id] = ReadRoomSpriteAddressPc(rom_data, table_pc, id);
   }
   const int hard_end =
-      std::min(static_cast<int>(rom_data.size()), kSpritesEndData);
+      std::min(static_cast<int>(rom_data.size()), kSpritesDataEndExclusive);
   PhysicalStreamInfo info = AnalyzePhysicalStream(addresses, room_id, hard_end);
   if (info.address < 0 || info.address >= hard_end) {
     return absl::OutOfRangeError("Sprite stream pointer is out of range");
@@ -1823,19 +1829,19 @@ std::vector<uint8_t> Room::EncodeSprites() const {
 
 int FindMaxUsedSpriteAddress(Rom* rom) {
   if (!rom || !rom->is_loaded()) {
-    return kSpritesEndData;
+    return kSpritesDataEndExclusive;
   }
 
   const auto& rom_data = rom->vector();
   int sprite_pointer = 0;
   if (!GetSpritePointerTablePc(rom_data, &sprite_pointer).ok()) {
-    return kSpritesEndData;
+    return kSpritesDataEndExclusive;
   }
 
   const int hard_end =
-      std::min(static_cast<int>(rom_data.size()), kSpritesEndData);
+      std::min(static_cast<int>(rom_data.size()), kSpritesDataEndExclusive);
   if (hard_end <= 0) {
-    return kSpritesEndData;
+    return kSpritesDataEndExclusive;
   }
 
   int max_used = std::min(hard_end, kSpritesData);
@@ -1887,7 +1893,7 @@ absl::Status RelocateSpriteData(Rom* rom, int room_id,
   }
 
   const int hard_end =
-      std::min(static_cast<int>(rom_data.size()), kSpritesEndData);
+      std::min(static_cast<int>(rom_data.size()), kSpritesDataEndExclusive);
   const int old_stream_size =
       MeasureSpriteStreamSize(rom_data, old_sprite_address, hard_end);
   const uint8_t sort_mode = rom_data[old_sprite_address];
@@ -1898,11 +1904,11 @@ absl::Status RelocateSpriteData(Rom* rom, int room_id,
   const size_t required_size = 1u + encoded_bytes.size();
   if (write_pos < kSpritesData ||
       static_cast<size_t>(write_pos) + required_size >
-          static_cast<size_t>(kSpritesEndData)) {
+          static_cast<size_t>(kSpritesDataEndExclusive)) {
     return absl::ResourceExhaustedError(absl::StrFormat(
         "Not enough sprite data space. Need %d bytes at 0x%06X, "
         "region ends at 0x%06X",
-        static_cast<int>(required_size), write_pos, kSpritesEndData));
+        static_cast<int>(required_size), write_pos, kSpritesDataEndExclusive));
   }
   if (static_cast<size_t>(write_pos) + required_size > rom_data.size()) {
     const int required_end = write_pos + static_cast<int>(required_size);
@@ -3076,10 +3082,12 @@ absl::StatusOr<PhysicalStreamInfo> GetPotItemStreamInfo(
   for (int id = 0; id < kNumberOfRooms; ++id) {
     addresses[id] = ReadRoomPotItemAddressPc(rom_data, id);
   }
-  PhysicalStreamInfo info = AnalyzePhysicalStream(addresses, room_id);
-  if (info.address < 0) {
+  const int hard_end =
+      std::min(static_cast<int>(rom_data.size()), kRoomItemsDataEnd);
+  PhysicalStreamInfo info = AnalyzePhysicalStream(addresses, room_id, hard_end);
+  if (info.address < 0 || info.address >= hard_end) {
     return absl::FailedPreconditionError(
-        "Room pot item pointer is null or invalid");
+        "Room pot item pointer is null, invalid, or outside the item region");
   }
   return info;
 }

--- a/src/zelda3/dungeon/room.cc
+++ b/src/zelda3/dungeon/room.cc
@@ -203,6 +203,125 @@ const std::string RoomTag[65] = {"Nothing",
 
 namespace {
 
+struct PhysicalStreamInfo {
+  int address = -1;
+  int physical_end = -1;
+  bool shared = false;
+
+  int capacity() const {
+    return physical_end > address ? physical_end - address : 0;
+  }
+};
+
+PhysicalStreamInfo AnalyzePhysicalStream(const std::vector<int>& room_addresses,
+                                         int room_id,
+                                         int known_region_end = -1) {
+  PhysicalStreamInfo info;
+  if (room_id < 0 || room_id >= static_cast<int>(room_addresses.size())) {
+    return info;
+  }
+
+  info.address = room_addresses[room_id];
+  if (info.address < 0) {
+    return info;
+  }
+
+  int next_address = std::numeric_limits<int>::max();
+  for (int other_room_id = 0;
+       other_room_id < static_cast<int>(room_addresses.size());
+       ++other_room_id) {
+    if (other_room_id == room_id || room_addresses[other_room_id] < 0) {
+      continue;
+    }
+    const int other_address = room_addresses[other_room_id];
+    if (other_address == info.address) {
+      info.shared = true;
+    } else if (other_address > info.address) {
+      next_address = std::min(next_address, other_address);
+    }
+  }
+
+  if (known_region_end > info.address) {
+    next_address = std::min(next_address, known_region_end);
+  }
+  if (next_address == std::numeric_limits<int>::max()) {
+    return info;
+  }
+
+  // A stream cannot safely grow across a LoROM bank boundary even when the
+  // next pointer happens to live in the following physical bank.
+  constexpr int kLoRomBankSize = 0x8000;
+  const int bank_end = ((info.address / kLoRomBankSize) + 1) * kLoRomBankSize;
+  info.physical_end = std::min(next_address, bank_end);
+  return info;
+}
+
+absl::Status GetObjectPointerTablePc(const std::vector<uint8_t>& rom_data,
+                                     int* table_pc) {
+  if (table_pc == nullptr) {
+    return absl::InvalidArgumentError("table_pc pointer is null");
+  }
+  if (kRoomObjectPointer + 2 >= static_cast<int>(rom_data.size())) {
+    return absl::OutOfRangeError(
+        "Object pointer table address is out of range");
+  }
+
+  const uint32_t table_snes =
+      (static_cast<uint32_t>(rom_data[kRoomObjectPointer + 2]) << 16) |
+      (static_cast<uint32_t>(rom_data[kRoomObjectPointer + 1]) << 8) |
+      rom_data[kRoomObjectPointer];
+  const int pc = static_cast<int>(SnesToPc(table_snes));
+  if (pc < 0 || pc + (kNumberOfRooms * 3) > static_cast<int>(rom_data.size())) {
+    return absl::OutOfRangeError("Object pointer table is out of range");
+  }
+
+  *table_pc = pc;
+  return absl::OkStatus();
+}
+
+uint32_t ReadRoomObjectAddressSnes(const std::vector<uint8_t>& rom_data,
+                                   int table_pc, int room_id) {
+  if (room_id < 0 || room_id >= kNumberOfRooms) {
+    return 0;
+  }
+  const int ptr_off = table_pc + (room_id * 3);
+  if (ptr_off < 0 || ptr_off + 2 >= static_cast<int>(rom_data.size())) {
+    return 0;
+  }
+  return (static_cast<uint32_t>(rom_data[ptr_off + 2]) << 16) |
+         (static_cast<uint32_t>(rom_data[ptr_off + 1]) << 8) |
+         rom_data[ptr_off];
+}
+
+int ReadRoomObjectAddressPc(const std::vector<uint8_t>& rom_data, int table_pc,
+                            int room_id) {
+  const uint32_t snes = ReadRoomObjectAddressSnes(rom_data, table_pc, room_id);
+  if ((snes & 0xFFFF) < 0x8000) {
+    return -1;
+  }
+  const int pc = static_cast<int>(SnesToPc(snes));
+  return pc >= 0 && pc < static_cast<int>(rom_data.size()) ? pc : -1;
+}
+
+absl::StatusOr<PhysicalStreamInfo> GetObjectStreamInfo(
+    const std::vector<uint8_t>& rom_data, int room_id) {
+  if (room_id < 0 || room_id >= kNumberOfRooms) {
+    return absl::OutOfRangeError("Room ID out of range");
+  }
+  int table_pc = 0;
+  RETURN_IF_ERROR(GetObjectPointerTablePc(rom_data, &table_pc));
+
+  std::vector<int> addresses(kNumberOfRooms, -1);
+  for (int id = 0; id < kNumberOfRooms; ++id) {
+    addresses[id] = ReadRoomObjectAddressPc(rom_data, table_pc, id);
+  }
+  PhysicalStreamInfo info = AnalyzePhysicalStream(addresses, room_id);
+  if (info.address < 0) {
+    return absl::OutOfRangeError("Object stream pointer is out of range");
+  }
+  return info;
+}
+
 absl::Status GetSpritePointerTablePc(const std::vector<uint8_t>& rom_data,
                                      int* table_pc) {
   if (table_pc == nullptr) {
@@ -234,9 +353,37 @@ int ReadRoomSpriteAddressPc(const std::vector<uint8_t>& rom_data, int table_pc,
     return -1;
   }
 
-  int sprite_address_snes =
-      (0x09 << 16) | (rom_data[ptr_off + 1] << 8) | rom_data[ptr_off];
-  return SnesToPc(sprite_address_snes);
+  const uint16_t pointer =
+      (static_cast<uint16_t>(rom_data[ptr_off + 1]) << 8) | rom_data[ptr_off];
+  if (pointer < 0x8000) {
+    return -1;
+  }
+  const int sprite_address = static_cast<int>(SnesToPc((0x09 << 16) | pointer));
+  return sprite_address >= 0 &&
+                 sprite_address < static_cast<int>(rom_data.size())
+             ? sprite_address
+             : -1;
+}
+
+absl::StatusOr<PhysicalStreamInfo> GetSpriteStreamInfo(
+    const std::vector<uint8_t>& rom_data, int room_id) {
+  if (room_id < 0 || room_id >= kNumberOfRooms) {
+    return absl::OutOfRangeError("Room ID out of range");
+  }
+  int table_pc = 0;
+  RETURN_IF_ERROR(GetSpritePointerTablePc(rom_data, &table_pc));
+
+  std::vector<int> addresses(kNumberOfRooms, -1);
+  for (int id = 0; id < kNumberOfRooms; ++id) {
+    addresses[id] = ReadRoomSpriteAddressPc(rom_data, table_pc, id);
+  }
+  const int hard_end =
+      std::min(static_cast<int>(rom_data.size()), kSpritesEndData);
+  PhysicalStreamInfo info = AnalyzePhysicalStream(addresses, room_id, hard_end);
+  if (info.address < 0 || info.address >= hard_end) {
+    return absl::OutOfRangeError("Sprite stream pointer is out of range");
+  }
+  return info;
 }
 
 int MeasureSpriteStreamSize(const std::vector<uint8_t>& rom_data,
@@ -278,72 +425,25 @@ bool IsSpritePointerShared(const std::vector<uint8_t>& rom_data, int table_pc,
 }  // namespace
 
 RoomSize CalculateRoomSize(Rom* rom, int room_id) {
-  // Calculate the size of the room based on how many objects are used per room
-  // Some notes from hacker Zarby89
-  // vanilla rooms are using in average ~0x80 bytes
-  // a "normal" person who wants more details than vanilla will use around 0x100
-  // bytes per rooms you could fit 128 rooms like that in 1 bank
-  // F8000 I don't remember if that's PC or snes tho
-  // Check last rooms
-  // F8000+(roomid*3)
-  // So we want to search the rom() object at this addressed based on the room
-  // ID since it's the roomid * 3 we will by pulling 3 bytes at a time We can do
-  // this with the rom()->ReadByteVector(addr, size)
-  // Existing room size address calculation...
-  RoomSize room_size;
-  room_size.room_size_pointer = 0;
-  room_size.room_size = 0;
-
-  if (!rom || !rom->is_loaded() || rom->size() == 0) {
+  RoomSize room_size{};
+  if (!rom || !rom->is_loaded() || rom->size() == 0 || room_id < 0 ||
+      room_id >= kNumberOfRooms) {
     return room_size;
   }
 
-  auto room_size_address = 0xF8000 + (room_id * 3);
-
-  // Bounds check
-  if (room_size_address < 0 ||
-      room_size_address + 2 >= static_cast<int>(rom->size())) {
+  const auto& rom_data = rom->vector();
+  int table_pc = 0;
+  if (!GetObjectPointerTablePc(rom_data, &table_pc).ok()) {
     return room_size;
   }
+  room_size.room_size_pointer =
+      ReadRoomObjectAddressSnes(rom_data, table_pc, room_id);
 
-  // Reading bytes for long address construction
-  uint8_t low = rom->data()[room_size_address];
-  uint8_t high = rom->data()[room_size_address + 1];
-  uint8_t bank = rom->data()[room_size_address + 2];
-
-  // Constructing the long address
-  int long_address = (bank << 16) | (high << 8) | low;
-  room_size.room_size_pointer = long_address;
-
-  if (long_address == 0x0A8000) {
-    // Blank room disregard in size calculation
-    room_size.room_size = 0;
-  } else {
-    // use the long address to calculate the size of the room
-    // we will use the room_id_ to calculate the next room's address
-    // and subtract the two to get the size of the room
-
-    int next_room_address = 0xF8000 + ((room_id + 1) * 3);
-
-    // Bounds check for next room address
-    if (next_room_address < 0 ||
-        next_room_address + 2 >= static_cast<int>(rom->size())) {
-      return room_size;
-    }
-
-    // Reading bytes for long address construction
-    uint8_t next_low = rom->data()[next_room_address];
-    uint8_t next_high = rom->data()[next_room_address + 1];
-    uint8_t next_bank = rom->data()[next_room_address + 2];
-
-    // Constructing the long address
-    int next_long_address = (next_bank << 16) | (next_high << 8) | next_low;
-
-    // Calculate the size of the room
-    int actual_room_size = next_long_address - long_address;
-    room_size.room_size = actual_room_size;
+  auto stream_info = GetObjectStreamInfo(rom_data, room_id);
+  if (!stream_info.ok() || stream_info->shared) {
+    return room_size;
   }
-
+  room_size.room_size = stream_info->capacity();
   return room_size;
 }
 
@@ -1837,62 +1937,56 @@ absl::Status Room::SaveObjects() {
   if (rom_ == nullptr) {
     return absl::InvalidArgumentError("ROM pointer is null");
   }
-
-  auto rom_data = rom()->vector();
-
-  // Get object pointer
-  int object_pointer = (rom_data[kRoomObjectPointer + 2] << 16) +
-                       (rom_data[kRoomObjectPointer + 1] << 8) +
-                       (rom_data[kRoomObjectPointer]);
-  object_pointer = SnesToPc(object_pointer);
-
-  if (object_pointer < 0 || object_pointer >= (int)rom_->size()) {
-    return absl::OutOfRangeError("Object pointer out of range");
+  if (!object_stream_dirty()) {
+    return absl::OkStatus();
   }
 
-  int room_address = object_pointer + (room_id_ * 3);
-
-  if (room_address < 0 || room_address + 2 >= (int)rom_->size()) {
-    return absl::OutOfRangeError("Room address out of range");
+  const auto& rom_data = rom()->vector();
+  ASSIGN_OR_RETURN(const PhysicalStreamInfo stream_info,
+                   GetObjectStreamInfo(rom_data, room_id_));
+  if (stream_info.shared) {
+    return absl::FailedPreconditionError(absl::StrFormat(
+        "Room %d object stream at PC 0x%06X is shared; repacking is required",
+        room_id_, stream_info.address));
   }
-
-  int tile_address = (rom_data[room_address + 2] << 16) +
-                     (rom_data[room_address + 1] << 8) + rom_data[room_address];
-
-  int objects_location = SnesToPc(tile_address);
-
-  if (objects_location < 0 || objects_location >= (int)rom_->size()) {
-    return absl::OutOfRangeError("Objects location out of range");
+  if (stream_info.capacity() <= 2) {
+    return absl::FailedPreconditionError(absl::StrFormat(
+        "Room %d object stream has no safe physical boundary", room_id_));
   }
-
-  // Calculate available space
-  RoomSize room_size_info = CalculateRoomSize(rom_, room_id_);
-  int available_size = room_size_info.room_size;
 
   // Skip graphics/layout header (2 bytes)
-  int write_pos = objects_location + 2;
+  const int write_pos = stream_info.address + 2;
 
   // Encode all objects
-  auto encoded_bytes = EncodeObjects();
+  const auto encoded_bytes = EncodeObjects();
+  const int available_payload_size = stream_info.capacity() - 2;
 
-  // VALIDATION: Check if new data fits in available space
-  // We subtract 2 bytes for the header which is not part of encoded_bytes
-  if (encoded_bytes.size() > available_size - 2) {
-    return absl::OutOfRangeError(absl::StrFormat(
+  // Validate against the nearest greater physical pointer, not the next room
+  // ID. Pointer tables are not ordered by room ID in vanilla or expanded ROMs.
+  if (encoded_bytes.size() > static_cast<size_t>(available_payload_size)) {
+    return absl::ResourceExhaustedError(absl::StrFormat(
         "Room %d object data too large! Size: %d, Available: %d", room_id_,
-        encoded_bytes.size(), available_size - 2));
+        static_cast<int>(encoded_bytes.size()), available_payload_size));
   }
+
+  const int door_list_offset = static_cast<int>(encoded_bytes.size()) -
+                               static_cast<int>(doors_.size()) * 2 - 2;
+  if (door_list_offset < 0) {
+    return absl::FailedPreconditionError("Invalid encoded door list offset");
+  }
+  const int door_pointer_slot = kDoorPointers + (room_id_ * 3);
+  if (door_pointer_slot < 0 ||
+      door_pointer_slot + 2 >= static_cast<int>(rom_data.size())) {
+    return absl::OutOfRangeError("Door pointer slot is out of range");
+  }
+  const int door_pointer_pc = write_pos + door_list_offset;
 
   // Write encoded bytes to ROM (includes 0xF0 0xFF + door list)
   RETURN_IF_ERROR(rom_->WriteVector(write_pos, encoded_bytes));
 
   // Write door pointer: first byte after 0xF0 0xFF (per ZScreamDungeon Save.cs)
-  const int door_list_offset = static_cast<int>(encoded_bytes.size()) -
-                               static_cast<int>(doors_.size()) * 2 - 2;
-  const int door_pointer_pc = write_pos + door_list_offset;
-  RETURN_IF_ERROR(
-      rom_->WriteLong(kDoorPointers + (room_id_ * 3),
-                      static_cast<uint32_t>(PcToSnes(door_pointer_pc))));
+  RETURN_IF_ERROR(rom_->WriteLong(
+      door_pointer_slot, static_cast<uint32_t>(PcToSnes(door_pointer_pc))));
 
   ClearObjectStreamDirty();
 
@@ -1903,52 +1997,42 @@ absl::Status Room::SaveSprites() {
   if (rom_ == nullptr) {
     return absl::InvalidArgumentError("ROM pointer is null");
   }
+  if (!sprites_dirty()) {
+    return absl::OkStatus();
+  }
 
   const auto& rom_data = rom()->vector();
   if (room_id_ < 0 || room_id_ >= kNumberOfRooms) {
     return absl::OutOfRangeError("Room ID out of range");
   }
 
-  int sprite_pointer = 0;
-  RETURN_IF_ERROR(GetSpritePointerTablePc(rom_data, &sprite_pointer));
-  int sprite_address =
-      ReadRoomSpriteAddressPc(rom_data, sprite_pointer, room_id_);
-  if (sprite_address < 0 || sprite_address >= static_cast<int>(rom_->size())) {
-    return absl::OutOfRangeError("Sprite address out of range");
+  ASSIGN_OR_RETURN(const PhysicalStreamInfo stream_info,
+                   GetSpriteStreamInfo(rom_data, room_id_));
+  if (stream_info.shared) {
+    return absl::FailedPreconditionError(absl::StrFormat(
+        "Room %d sprite stream at PC 0x%06X is shared; repacking is required",
+        room_id_, stream_info.address));
+  }
+  if (stream_info.capacity() <= 1) {
+    return absl::FailedPreconditionError(absl::StrFormat(
+        "Room %d sprite stream has no safe physical boundary", room_id_));
   }
 
-  int available_payload_size = 0;
-  if (room_id_ + 1 < kNumberOfRooms) {
-    int next_sprite_address =
-        ReadRoomSpriteAddressPc(rom_data, sprite_pointer, room_id_ + 1);
-    if (next_sprite_address >= 0) {
-      int available_size = next_sprite_address - sprite_address;
-      if (available_size > 0 && available_size <= 0x1000) {
-        available_payload_size = std::max(0, available_size - 1);
-      }
-    }
-  }
-
-  if (available_payload_size == 0) {
-    const int hard_end =
-        std::min(static_cast<int>(rom_data.size()), kSpritesEndData);
-    const int current_stream_size =
-        MeasureSpriteStreamSize(rom_data, sprite_address, hard_end);
-    available_payload_size = std::max(0, current_stream_size - 1);
-  }
-
-  const int payload_address = sprite_address + 1;
+  const int available_payload_size = stream_info.capacity() - 1;
+  const int payload_address = stream_info.address + 1;
   if (payload_address < 0 ||
       payload_address >= static_cast<int>(rom_->size())) {
     return absl::OutOfRangeError(absl::StrFormat(
         "Room %d has invalid sprite payload address", room_id_));
   }
 
-  auto encoded_bytes = EncodeSprites();
+  const auto encoded_bytes = EncodeSprites();
   if (static_cast<int>(encoded_bytes.size()) > available_payload_size) {
-    RETURN_IF_ERROR(RelocateSpriteData(rom_, room_id_, encoded_bytes));
-    ClearSpritesDirty();
-    return absl::OkStatus();
+    return absl::ResourceExhaustedError(absl::StrFormat(
+        "Room %d sprite data too large! Size: %d, Available: %d; repacking "
+        "is required",
+        room_id_, static_cast<int>(encoded_bytes.size()),
+        available_payload_size));
   }
 
   RETURN_IF_ERROR(rom_->WriteVector(payload_address, encoded_bytes));
@@ -2215,27 +2299,44 @@ void Room::LoadSprites() {
 }
 
 void Room::LoadChests() {
-  auto rom_data = rom()->vector();
   chests_in_room_.clear();
   chests_loaded_ = false;
-  uint32_t cpos = SnesToPc((rom_data[kChestsDataPointer1 + 2] << 16) +
-                           (rom_data[kChestsDataPointer1 + 1] << 8) +
-                           (rom_data[kChestsDataPointer1]));
-  size_t clength = (rom_data[kChestsLengthPointer + 1] << 8) +
-                   (rom_data[kChestsLengthPointer]);
+  if (!rom_ || !rom_->is_loaded()) {
+    return;
+  }
+  const auto& rom_data = rom()->vector();
+  if (kChestsDataPointer1 + 2 >= static_cast<int>(rom_data.size()) ||
+      kChestsLengthPointer + 1 >= static_cast<int>(rom_data.size())) {
+    return;
+  }
 
-  for (size_t i = 0; i < clength; i++) {
-    if ((((rom_data[cpos + (i * 3) + 1] << 8) + (rom_data[cpos + (i * 3)])) &
-         0x7FFF) == room_id_) {
+  const int cpos = static_cast<int>(SnesToPc(
+      (static_cast<uint32_t>(rom_data[kChestsDataPointer1 + 2]) << 16) |
+      (static_cast<uint32_t>(rom_data[kChestsDataPointer1 + 1]) << 8) |
+      rom_data[kChestsDataPointer1]));
+  const size_t byte_length =
+      (static_cast<size_t>(rom_data[kChestsLengthPointer + 1]) << 8) |
+      rom_data[kChestsLengthPointer];
+  const size_t bounded_byte_length = std::min<size_t>(
+      byte_length, cpos >= 0 && cpos < static_cast<int>(rom_data.size())
+                       ? rom_data.size() - static_cast<size_t>(cpos)
+                       : 0);
+  const size_t record_count = std::min<size_t>(
+      bounded_byte_length / kChestTableRecordSize, kChestTableCapacityRecords);
+
+  for (size_t i = 0; i < record_count; ++i) {
+    const size_t offset =
+        static_cast<size_t>(cpos) + (i * kChestTableRecordSize);
+    if ((((rom_data[offset + 1] << 8) + rom_data[offset]) & 0x7FFF) ==
+        room_id_) {
       // There's a chest in that room !
       bool big = false;
-      if ((((rom_data[cpos + (i * 3) + 1] << 8) + (rom_data[cpos + (i * 3)])) &
-           0x8000) == 0x8000) {
+      if ((((rom_data[offset + 1] << 8) + rom_data[offset]) & 0x8000) ==
+          0x8000) {
         big = true;
       }
 
-      chests_in_room_.emplace_back(
-          chest_data{rom_data[cpos + (i * 3) + 2], big});
+      chests_in_room_.emplace_back(chest_data{rom_data[offset + 2], big});
     }
   }
   chests_loaded_ = true;
@@ -2919,13 +3020,17 @@ absl::Status SaveAllCollision(Rom* rom, int room_count,
 namespace {
 
 // Parse current ROM chest data into per-room lists (room_id, chest_data).
+// `byte_length` is the runtime byte count at kChestsLengthPointer.
 std::vector<std::vector<std::pair<uint8_t, bool>>> ParseRomChests(
-    const std::vector<uint8_t>& rom_data, int cpos, int clength) {
+    const std::vector<uint8_t>& rom_data, int cpos, int byte_length) {
   std::vector<std::vector<std::pair<uint8_t, bool>>> per_room(kNumberOfRooms);
-  for (int i = 0;
-       i < clength && cpos + i * 3 + 2 < static_cast<int>(rom_data.size());
-       ++i) {
-    int off = cpos + i * 3;
+  const int record_count = byte_length / kChestTableRecordSize;
+  for (int i = 0; i < record_count; ++i) {
+    const int off = cpos + i * kChestTableRecordSize;
+    if (off < 0 ||
+        off + kChestTableRecordSize > static_cast<int>(rom_data.size())) {
+      break;
+    }
     uint16_t word = (rom_data[off + 1] << 8) | rom_data[off];
     uint16_t room_id = word & 0x7FFF;
     bool big = (word & 0x8000) != 0;
@@ -2937,52 +3042,46 @@ std::vector<std::vector<std::pair<uint8_t, bool>>> ParseRomChests(
   return per_room;
 }
 
-std::vector<std::vector<uint8_t>> ParseRomPotItems(
-    const std::vector<uint8_t>& rom_data) {
-  std::vector<std::vector<uint8_t>> per_room(kNumberOfRooms);
-  int table_addr = kRoomItemsPointers;
-  if (table_addr + (kNumberOfRooms * 2) > static_cast<int>(rom_data.size())) {
-    return per_room;
+int ReadRoomPotItemAddressPc(const std::vector<uint8_t>& rom_data,
+                             int room_id) {
+  if (room_id < 0 || room_id >= kNumberOfRooms) {
+    return -1;
   }
-  for (int room_id = 0; room_id < kNumberOfRooms; ++room_id) {
-    int ptr_off = table_addr + (room_id * 2);
-    uint16_t item_ptr = (rom_data[ptr_off + 1] << 8) | rom_data[ptr_off];
-    int item_addr = SnesToPc(0x010000 | item_ptr);
-    if (item_addr < 0 || item_addr >= static_cast<int>(rom_data.size())) {
-      continue;
-    }
-    int next_ptr_off = table_addr + ((room_id + 1) * 2);
-    int next_item_addr =
-        (room_id + 1 < kNumberOfRooms)
-            ? SnesToPc(0x010000 | ((rom_data[next_ptr_off + 1] << 8) |
-                                   rom_data[next_ptr_off]))
-            : item_addr + 0x100;
-    int max_len = next_item_addr - item_addr;
-    if (max_len <= 0)
-      continue;
+  const int ptr_off = kRoomItemsPointers + (room_id * 2);
+  if (ptr_off < 0 || ptr_off + 1 >= static_cast<int>(rom_data.size())) {
+    return -1;
+  }
+  const uint16_t item_ptr =
+      (static_cast<uint16_t>(rom_data[ptr_off + 1]) << 8) | rom_data[ptr_off];
+  if (item_ptr < 0x8000) {
+    return -1;
+  }
+  const int item_addr = static_cast<int>(SnesToPc(0x010000 | item_ptr));
+  return item_addr >= 0 && item_addr < static_cast<int>(rom_data.size())
+             ? item_addr
+             : -1;
+}
 
-    std::vector<uint8_t> bytes;
-    int cursor = item_addr;
-    const int limit =
-        std::min(item_addr + max_len, static_cast<int>(rom_data.size()));
-    while (cursor + 1 < limit) {
-      uint8_t b1 = rom_data[cursor++];
-      uint8_t b2 = rom_data[cursor++];
-      bytes.push_back(b1);
-      bytes.push_back(b2);
-      if (b1 == 0xFF && b2 == 0xFF) {
-        break;
-      }
-      if (cursor >= limit) {
-        break;
-      }
-      bytes.push_back(rom_data[cursor++]);
-    }
-    if (!bytes.empty()) {
-      per_room[room_id] = std::move(bytes);
-    }
+absl::StatusOr<PhysicalStreamInfo> GetPotItemStreamInfo(
+    const std::vector<uint8_t>& rom_data, int room_id) {
+  if (kRoomItemsPointers + (kNumberOfRooms * 2) >
+      static_cast<int>(rom_data.size())) {
+    return absl::OutOfRangeError("Room items pointer table out of range");
   }
-  return per_room;
+  if (room_id < 0 || room_id >= kNumberOfRooms) {
+    return absl::OutOfRangeError("Room ID out of range");
+  }
+
+  std::vector<int> addresses(kNumberOfRooms, -1);
+  for (int id = 0; id < kNumberOfRooms; ++id) {
+    addresses[id] = ReadRoomPotItemAddressPc(rom_data, id);
+  }
+  PhysicalStreamInfo info = AnalyzePhysicalStream(addresses, room_id);
+  if (info.address < 0) {
+    return absl::FailedPreconditionError(
+        "Room pot item pointer is null or invalid");
+  }
+  return info;
 }
 
 }  // namespace
@@ -2998,22 +3097,41 @@ absl::Status SaveAllChestsImpl(Rom* rom, int room_count,
       kChestsDataPointer1 + 2 >= static_cast<int>(rom_data.size())) {
     return absl::OutOfRangeError("Chest pointers out of range");
   }
-  int clength = (rom_data[kChestsLengthPointer + 1] << 8) |
-                rom_data[kChestsLengthPointer];
-  int cpos = SnesToPc((rom_data[kChestsDataPointer1 + 2] << 16) |
-                      (rom_data[kChestsDataPointer1 + 1] << 8) |
-                      rom_data[kChestsDataPointer1]);
-  auto rom_chests = ParseRomChests(rom_data, cpos, clength);
-
-  std::vector<uint8_t> bytes;
-  const int room_limit =
-      std::min(room_count, static_cast<int>(rom_chests.size()));
+  const int room_limit = std::min(room_count, kNumberOfRooms);
+  bool any_dirty = false;
   for (int room_id = 0; room_id < room_limit; ++room_id) {
     const Room* room = room_lookup(room_id);
+    any_dirty = any_dirty || (room != nullptr && room->chests_dirty());
+  }
+  if (!any_dirty) {
+    return absl::OkStatus();
+  }
+
+  const int byte_length = (rom_data[kChestsLengthPointer + 1] << 8) |
+                          rom_data[kChestsLengthPointer];
+  if (byte_length < 0 || byte_length > kChestTableCapacityBytes ||
+      (byte_length % kChestTableRecordSize) != 0) {
+    return absl::FailedPreconditionError(
+        absl::StrFormat("Chest table byte length %d is invalid (capacity %d)",
+                        byte_length, kChestTableCapacityBytes));
+  }
+  const int cpos = static_cast<int>(SnesToPc(
+      (static_cast<uint32_t>(rom_data[kChestsDataPointer1 + 2]) << 16) |
+      (static_cast<uint32_t>(rom_data[kChestsDataPointer1 + 1]) << 8) |
+      rom_data[kChestsDataPointer1]));
+  if (cpos < 0 ||
+      cpos + kChestTableCapacityBytes > static_cast<int>(rom_data.size())) {
+    return absl::OutOfRangeError("Chest data region out of range");
+  }
+  const auto rom_chests = ParseRomChests(rom_data, cpos, byte_length);
+
+  std::vector<uint8_t> bytes;
+  bytes.reserve(byte_length);
+  for (int room_id = 0; room_id < kNumberOfRooms; ++room_id) {
+    const Room* room = room_id < room_limit ? room_lookup(room_id) : nullptr;
     const bool room_dirty = room != nullptr && room->chests_dirty();
-    const bool room_loaded = room != nullptr && room->AreChestsLoaded();
     const auto* chests = room != nullptr ? &room->GetChests() : nullptr;
-    if (!room_dirty && !room_loaded) {
+    if (!room_dirty) {
       for (const auto& [id, big] : rom_chests[room_id]) {
         uint16_t word = room_id | (big ? 0x8000 : 0);
         bytes.push_back(word & 0xFF);
@@ -3030,13 +3148,23 @@ absl::Status SaveAllChestsImpl(Rom* rom, int room_count,
     }
   }
 
-  if (cpos < 0 || cpos + static_cast<int>(bytes.size()) >
-                      static_cast<int>(rom_data.size())) {
-    return absl::OutOfRangeError("Chest data region out of range");
+  if (bytes.size() > static_cast<size_t>(kChestTableCapacityBytes)) {
+    return absl::ResourceExhaustedError(
+        absl::StrFormat("Chest table has %d records; capacity is %d",
+                        static_cast<int>(bytes.size() / kChestTableRecordSize),
+                        kChestTableCapacityRecords));
   }
-  RETURN_IF_ERROR(rom->WriteWord(kChestsLengthPointer,
-                                 static_cast<uint16_t>(bytes.size() / 3)));
-  RETURN_IF_ERROR(rom->WriteVector(cpos, bytes));
+
+  const bool length_changed = byte_length != static_cast<int>(bytes.size());
+  const bool data_changed =
+      !std::equal(bytes.begin(), bytes.end(), rom_data.begin() + cpos);
+  if (length_changed) {
+    RETURN_IF_ERROR(rom->WriteWord(kChestsLengthPointer,
+                                   static_cast<uint16_t>(bytes.size())));
+  }
+  if (data_changed) {
+    RETURN_IF_ERROR(rom->WriteVector(cpos, bytes));
+  }
   for (int room_id = 0; room_id < room_limit; ++room_id) {
     if (const Room* room = room_lookup(room_id);
         room != nullptr && room->chests_dirty()) {
@@ -3063,65 +3191,69 @@ absl::Status SaveAllPotItemsImpl(Rom* rom, int room_count,
     return absl::InvalidArgumentError("ROM not loaded");
   }
   const auto& rom_data = rom->vector();
-  const auto rom_pot_items = ParseRomPotItems(rom_data);
-  int table_addr = kRoomItemsPointers;
-  if (table_addr + (kNumberOfRooms * 2) > static_cast<int>(rom_data.size())) {
+  if (kRoomItemsPointers + (kNumberOfRooms * 2) >
+      static_cast<int>(rom_data.size())) {
     return absl::OutOfRangeError("Room items pointer table out of range");
   }
+
+  struct PendingPotItemWrite {
+    int room_id = -1;
+    int address = -1;
+    std::vector<uint8_t> bytes;
+  };
+
+  // Build and validate every dirty write before touching the ROM. A later
+  // shared/overfull stream must not leave earlier rooms partially written.
+  std::vector<PendingPotItemWrite> pending_writes;
   const int room_limit = std::min(room_count, kNumberOfRooms);
   for (int room_id = 0; room_id < room_limit; ++room_id) {
     const Room* room = room_lookup(room_id);
-    const bool room_dirty = room != nullptr && room->pot_items_dirty();
-    const bool room_loaded = room != nullptr && room->ArePotItemsLoaded();
-    const auto* pot_items = room != nullptr ? &room->GetPotItems() : nullptr;
-    int ptr_off = table_addr + (room_id * 2);
-    uint16_t item_ptr = (rom_data[ptr_off + 1] << 8) | rom_data[ptr_off];
-    if (item_ptr == 0) {
+    if (room == nullptr || !room->pot_items_dirty()) {
       continue;
     }
-    int item_addr = SnesToPc(0x010000 | item_ptr);
-    if (item_addr < 0 || item_addr + 2 >= static_cast<int>(rom_data.size())) {
-      continue;
+
+    ASSIGN_OR_RETURN(const PhysicalStreamInfo stream_info,
+                     GetPotItemStreamInfo(rom_data, room_id));
+    if (stream_info.shared) {
+      return absl::FailedPreconditionError(absl::StrFormat(
+          "Room %d pot item stream at PC 0x%06X is shared; repacking is "
+          "required",
+          room_id, stream_info.address));
     }
-    int next_ptr_off = table_addr + ((room_id + 1) * 2);
-    int next_item_addr =
-        (room_id + 1 < kNumberOfRooms)
-            ? SnesToPc(0x010000 | ((rom_data[next_ptr_off + 1] << 8) |
-                                   rom_data[next_ptr_off]))
-            : item_addr + 0x100;
-    int max_len = next_item_addr - item_addr;
-    if (max_len <= 0)
-      continue;
-    std::vector<uint8_t> bytes;
-    if (!room_dirty && !room_loaded) {
-      if (room_id < rom_pot_items.size()) {
-        bytes = rom_pot_items[room_id];
-      }
-      if (bytes.empty()) {
-        continue;  // Preserve ROM data if room not loaded and nothing parsed.
-      }
-    } else {
-      for (const auto& pi : *pot_items) {
-        bytes.push_back(pi.position & 0xFF);
-        bytes.push_back((pi.position >> 8) & 0xFF);
-        bytes.push_back(pi.item);
-      }
-      bytes.push_back(0xFF);
-      bytes.push_back(0xFF);
+    if (stream_info.capacity() <= 0) {
+      return absl::FailedPreconditionError(absl::StrFormat(
+          "Room %d pot item stream has no safe physical boundary", room_id));
     }
-    if (static_cast<int>(bytes.size()) > max_len) {
-      if (room_dirty) {
-        return absl::OutOfRangeError(absl::StrFormat(
-            "Room %d pot item data too large! Size: %d, Available: %d", room_id,
-            bytes.size(), max_len));
-      }
-      continue;
+
+    PendingPotItemWrite pending;
+    pending.room_id = room_id;
+    pending.address = stream_info.address;
+    for (const auto& pi : room->GetPotItems()) {
+      pending.bytes.push_back(pi.position & 0xFF);
+      pending.bytes.push_back((pi.position >> 8) & 0xFF);
+      pending.bytes.push_back(pi.item);
     }
-    RETURN_IF_ERROR(rom->WriteVector(item_addr, bytes));
+    pending.bytes.push_back(0xFF);
+    pending.bytes.push_back(0xFF);
+    if (static_cast<int>(pending.bytes.size()) > stream_info.capacity()) {
+      return absl::ResourceExhaustedError(absl::StrFormat(
+          "Room %d pot item data too large! Size: %d, Available: %d", room_id,
+          static_cast<int>(pending.bytes.size()), stream_info.capacity()));
+    }
+    pending_writes.push_back(std::move(pending));
   }
-  for (int room_id = 0; room_id < room_limit; ++room_id) {
-    if (const Room* room = room_lookup(room_id);
-        room != nullptr && room->pot_items_dirty()) {
+
+  for (const auto& pending : pending_writes) {
+    const bool data_changed =
+        !std::equal(pending.bytes.begin(), pending.bytes.end(),
+                    rom_data.begin() + pending.address);
+    if (data_changed) {
+      RETURN_IF_ERROR(rom->WriteVector(pending.address, pending.bytes));
+    }
+  }
+
+  for (const auto& pending : pending_writes) {
+    if (const Room* room = room_lookup(pending.room_id); room != nullptr) {
       const_cast<Room*>(room)->ClearPotItemsDirty();
     }
   }

--- a/src/zelda3/dungeon/room.h
+++ b/src/zelda3/dungeon/room.h
@@ -194,6 +194,18 @@ struct WaterFillZoneMap {
 
 class Room {
  public:
+  struct SaveDirtySnapshot {
+    bool header = false;
+    bool object_stream = false;
+    bool sprites = false;
+    bool chests = false;
+    bool pot_items = false;
+    bool torches = false;
+    bool blocks = false;
+    bool custom_collision = false;
+    bool water_fill = false;
+  };
+
   Room();
   Room(int room_id, Rom* rom, GameData* game_data = nullptr);
   ~Room();
@@ -566,6 +578,32 @@ class Room {
   }
 
   void ClearSaveDirtyState() { save_dirty_state_ = {}; }
+
+  SaveDirtySnapshot CaptureSaveDirtySnapshot() const {
+    return SaveDirtySnapshot{
+        .header = save_dirty_state_.header,
+        .object_stream = save_dirty_state_.object_stream,
+        .sprites = save_dirty_state_.sprites,
+        .chests = save_dirty_state_.chests,
+        .pot_items = save_dirty_state_.pot_items,
+        .torches = save_dirty_state_.torches,
+        .blocks = save_dirty_state_.blocks,
+        .custom_collision = custom_collision_dirty_,
+        .water_fill = water_fill_dirty_,
+    };
+  }
+
+  void RestoreSaveDirtySnapshot(const SaveDirtySnapshot& snapshot) {
+    save_dirty_state_.header = snapshot.header;
+    save_dirty_state_.object_stream = snapshot.object_stream;
+    save_dirty_state_.sprites = snapshot.sprites;
+    save_dirty_state_.chests = snapshot.chests;
+    save_dirty_state_.pot_items = snapshot.pot_items;
+    save_dirty_state_.torches = snapshot.torches;
+    save_dirty_state_.blocks = snapshot.blocks;
+    custom_collision_dirty_ = snapshot.custom_collision;
+    water_fill_dirty_ = snapshot.water_fill;
+  }
 
   // For undo/redo functionality
   void SetTileObjects(const std::vector<RoomObject>& objects) {

--- a/src/zelda3/overworld/overworld.cc
+++ b/src/zelda3/overworld/overworld.cc
@@ -6,6 +6,7 @@
 #include <cstdint>
 #include <future>
 #include <iostream>
+#include <limits>
 #include <ostream>
 #include <set>
 #include <string>
@@ -32,6 +33,100 @@
 #include "zelda3/overworld/overworld_version_helper.h"
 
 namespace yaze::zelda3 {
+
+namespace {
+
+struct Map32StorageLayout {
+  std::array<int, 4> destinations{};
+  int storage_bytes_per_quadrant = 0;
+  int definition_capacity = 0;
+  bool expanded = false;
+};
+
+absl::StatusOr<Map32StorageLayout> ResolveMap32StorageLayout(
+    const Rom& rom, const zelda3_version_pointers& version_constants) {
+  const auto profile = DetectOverworldRomProfile(rom);
+
+  Map32StorageLayout layout;
+  layout.expanded = profile.has_expanded_tile32;
+  layout.destinations = {
+      static_cast<int>(version_constants.kMap32TileTL),
+      layout.expanded ? GetMap32TileTRExpanded()
+                      : static_cast<int>(version_constants.kMap32TileTR),
+      layout.expanded ? GetMap32TileBLExpanded()
+                      : static_cast<int>(version_constants.kMap32TileBL),
+      layout.expanded ? GetMap32TileBRExpanded()
+                      : static_cast<int>(version_constants.kMap32TileBR),
+  };
+
+  int usable_bytes = Map32StorageBytesForProfile(profile);
+  for (int destination : layout.destinations) {
+    if (destination < 0 || static_cast<size_t>(destination) >= rom.size()) {
+      return absl::OutOfRangeError(absl::StrFormat(
+          "Tile32 destination 0x%06X is outside the ROM", destination));
+    }
+    const size_t available = rom.size() - static_cast<size_t>(destination);
+    usable_bytes = std::min(usable_bytes,
+                            static_cast<int>(std::min<size_t>(
+                                available, std::numeric_limits<int>::max())));
+  }
+
+  // ROM EOF is not the only boundary: quadrant tables must not grow into the
+  // next configured destination. This matters for layouts such as the JP ROM,
+  // whose vanilla TL/TR and BL/BR spans are 0x33C0 rather than 0x33F0 bytes.
+  auto ordered_destinations = layout.destinations;
+  std::sort(ordered_destinations.begin(), ordered_destinations.end());
+  for (size_t i = 1; i < ordered_destinations.size(); ++i) {
+    const int span = ordered_destinations[i] - ordered_destinations[i - 1];
+    if (span <= 0) {
+      return absl::FailedPreconditionError(
+          "Tile32 destinations overlap or share the same address");
+    }
+    usable_bytes = std::min(usable_bytes, span);
+  }
+
+  // A partial packed group cannot store any additional definitions.
+  usable_bytes -= usable_bytes % kMap32BytesPerPackedGroup;
+  if (usable_bytes <= 0) {
+    return absl::ResourceExhaustedError(
+        "Tile32 destinations have no usable packed storage");
+  }
+
+  layout.storage_bytes_per_quadrant = usable_bytes;
+  layout.definition_capacity =
+      Map32DefinitionCapacityForStorageBytes(usable_bytes);
+  return layout;
+}
+
+absl::Status ValidateMap32DefinitionCount(size_t definition_count,
+                                          const Map32StorageLayout& layout) {
+  if (definition_count % kMap32DefinitionsPerPackedGroup != 0) {
+    return absl::InvalidArgumentError(absl::StrFormat(
+        "Tile32 definition count %zu is not aligned to a packed group of %d",
+        definition_count, kMap32DefinitionsPerPackedGroup));
+  }
+  if (definition_count > static_cast<size_t>(layout.definition_capacity)) {
+    return absl::ResourceExhaustedError(absl::StrFormat(
+        "Number of unique Tiles32: %zu Out of: %d\n"
+        "Unique Tile32 count exceeds the %s destination capacity; the ROM has "
+        "not been written",
+        definition_count, layout.definition_capacity,
+        layout.expanded ? "expanded" : "vanilla"));
+  }
+
+  const size_t required_bytes =
+      (definition_count / kMap32DefinitionsPerPackedGroup) *
+      kMap32BytesPerPackedGroup;
+  if (required_bytes > static_cast<size_t>(layout.storage_bytes_per_quadrant)) {
+    return absl::ResourceExhaustedError(absl::StrFormat(
+        "Tile32 definitions require %zu bytes per quadrant; destination "
+        "capacity is %d bytes",
+        required_bytes, layout.storage_bytes_per_quadrant));
+  }
+  return absl::OkStatus();
+}
+
+}  // namespace
 
 absl::Status Overworld::Load(Rom* rom) {
   gfx::ScopedTimer timer("Overworld::Load");
@@ -1304,9 +1399,8 @@ absl::Status Overworld::Save(Rom* rom) {
   RETURN_IF_ERROR(SaveMapOverlays())
   RETURN_IF_ERROR(SaveOverworldTilesType())
   RETURN_IF_ERROR(SaveDiggableTiles())
-  RETURN_IF_ERROR(SaveAreaSpecificBGColors())
   RETURN_IF_ERROR(SaveMusic())
-  RETURN_IF_ERROR(SaveAreaSizes())
+  RETURN_IF_ERROR(SaveCustomOverworldData())
   return absl::OkStatus();
 }
 
@@ -2538,6 +2632,9 @@ absl::Status Overworld::CreateTile32Tilemap() {
   tiles32_unique_.clear();
   tiles32_list_.clear();
 
+  ASSIGN_OR_RETURN(const auto storage_layout,
+                   ResolveMap32StorageLayout(*rom(), version_constants()));
+
   // Get all tiles16 and packs them into tiles32
   std::vector<uint64_t> all_tile_16 = GetAllTile16(map_tiles_);
 
@@ -2570,35 +2667,33 @@ absl::Status Overworld::CreateTile32Tilemap() {
     tiles32_unique_.emplace_back(padding_tile.GetPackedValue());
   }
 
-  if (tiles32_unique_.size() > LimitOfMap32) {
-    return absl::InternalError(absl::StrFormat(
-        "Number of unique Tiles32: %d Out of: %d\nUnique Tile32 count exceed "
-        "the limit\nThe ROM Has not been saved\nYou can fill maps with grass "
-        "tiles to free some space\nOr use the option Clear DW Tiles in the "
-        "Overworld Menu",
-        unique_tiles.size(), LimitOfMap32));
-  }
+  RETURN_IF_ERROR(
+      ValidateMap32DefinitionCount(tiles32_unique_.size(), storage_layout));
 
   if (core::FeatureFlags::get().kLogToConsole) {
     std::cout << "Number of unique Tiles32: " << tiles32_unique_.size()
               << " Saved:" << tiles32_unique_.size()
-              << " Out of: " << LimitOfMap32 << std::endl;
-  }
-
-  int v = tiles32_unique_.size();
-  for (int i = v; i < LimitOfMap32; i++) {
-    gfx::Tile32 padding_tile(420, 420, 420, 420);
-    tiles32_unique_.emplace_back(padding_tile.GetPackedValue());
+              << " Out of: " << storage_layout.definition_capacity << std::endl;
   }
 
   return absl::OkStatus();
 }
 
 absl::Status Overworld::SaveMap32Expanded() {
+  ASSIGN_OR_RETURN(const auto storage_layout,
+                   ResolveMap32StorageLayout(*rom(), version_constants()));
+  if (!storage_layout.expanded) {
+    return absl::FailedPreconditionError(
+        "Expanded Tile32 save requested for a vanilla Tile32 layout");
+  }
+  // Capacity and alignment must be checked before updating relocation pointers
+  // or writing any quadrant bytes.
+  RETURN_IF_ERROR(
+      ValidateMap32DefinitionCount(tiles32_unique_.size(), storage_layout));
+
   const int bottomLeft = GetMap32TileBLExpanded();
   const int bottomRight = GetMap32TileBRExpanded();
   const int topRight = GetMap32TileTRExpanded();
-  int limit = 0x8A80;
 
   // Updates the pointers too for the tile32
   // Top Right
@@ -2625,15 +2720,12 @@ absl::Status Overworld::SaveMap32Expanded() {
   RETURN_IF_ERROR(rom()->WriteLong(0x017788, PcToSnes(bottomRight + 4)));
   RETURN_IF_ERROR(rom()->WriteLong(0x01779A, PcToSnes(bottomRight + 5)));
 
-  constexpr int kTilesPer32x32Tile = 6;
   int unique_tile_index = 0;
-  int num_unique_tiles = tiles32_unique_.size();
+  const int encoded_bytes = static_cast<int>(tiles32_unique_.size() /
+                                             kMap32DefinitionsPerPackedGroup) *
+                            kMap32BytesPerPackedGroup;
 
-  for (int i = 0; i < num_unique_tiles; i += kTilesPer32x32Tile) {
-    if (unique_tile_index >= limit) {
-      return absl::AbortedError("Too many unique tile32 definitions.");
-    }
-
+  for (int i = 0; i < encoded_bytes; i += kMap32BytesPerPackedGroup) {
     // Top Left.
     auto top_left = version_constants().kMap32TileTL;
     RETURN_IF_ERROR(rom()->WriteByte(
@@ -2750,17 +2842,21 @@ absl::Status Overworld::SaveMap32Expanded() {
 
 absl::Status Overworld::SaveMap32Tiles() {
   util::logf("Saving Map32 Tiles");
-  constexpr int kMaxUniqueTiles = 0x4540;
-  constexpr int kTilesPer32x32Tile = 6;
+  ASSIGN_OR_RETURN(const auto storage_layout,
+                   ResolveMap32StorageLayout(*rom(), version_constants()));
+  if (storage_layout.expanded) {
+    return absl::FailedPreconditionError(
+        "Vanilla Tile32 save requested for an expanded Tile32 layout");
+  }
+  RETURN_IF_ERROR(
+      ValidateMap32DefinitionCount(tiles32_unique_.size(), storage_layout));
 
   int unique_tile_index = 0;
-  int num_unique_tiles = tiles32_unique_.size();
+  const int encoded_bytes = static_cast<int>(tiles32_unique_.size() /
+                                             kMap32DefinitionsPerPackedGroup) *
+                            kMap32BytesPerPackedGroup;
 
-  for (int i = 0; i < num_unique_tiles; i += kTilesPer32x32Tile) {
-    if (unique_tile_index >= kMaxUniqueTiles) {
-      return absl::AbortedError("Too many unique tile32 definitions.");
-    }
-
+  for (int i = 0; i < encoded_bytes; i += kMap32BytesPerPackedGroup) {
     // Top Left.
     auto top_left = version_constants().kMap32TileTL;
 
@@ -2871,7 +2967,6 @@ absl::Status Overworld::SaveMap32Tiles() {
                    0x0F))));
 
     unique_tile_index += 4;
-    num_unique_tiles += 2;
   }
 
   return absl::OkStatus();
@@ -3181,70 +3276,80 @@ absl::Status Overworld::SaveCustomOverworldASM(bool enable_bg_color,
 
   util::logf("Applying Custom Overworld ASM");
 
+  const auto write_enable_flag = [this](int address,
+                                        bool enabled) -> absl::Status {
+    ASSIGN_OR_RETURN(const uint8_t current, rom()->ReadByte(address));
+    if ((current != 0x00) == enabled) {
+      return absl::OkStatus();
+    }
+    return rom()->WriteByte(address, enabled ? 0xFF : 0x00);
+  };
+
   // v2+ features: BG color, main palette enable flags
   if (OverworldVersionHelper::SupportsCustomBGColors(cached_version_)) {
-    uint8_t enable_value = enable_bg_color ? 0xFF : 0x00;
-    RETURN_IF_ERROR(
-        rom()->WriteByte(OverworldCustomAreaSpecificBGEnabled, enable_value));
-
-    enable_value = enable_main_palette ? 0xFF : 0x00;
-    RETURN_IF_ERROR(
-        rom()->WriteByte(OverworldCustomMainPaletteEnabled, enable_value));
+    RETURN_IF_ERROR(write_enable_flag(OverworldCustomAreaSpecificBGEnabled,
+                                      enable_bg_color));
+    RETURN_IF_ERROR(write_enable_flag(OverworldCustomMainPaletteEnabled,
+                                      enable_main_palette));
 
     // Write the main palette table
-    for (int i = 0; i < kNumOverworldMaps; i++) {
-      RETURN_IF_ERROR(rom()->WriteByte(OverworldCustomMainPaletteArray + i,
-                                       overworld_maps_[i].main_palette()));
+    if (enable_main_palette) {
+      for (int i = 0; i < kNumOverworldMaps; i++) {
+        RETURN_IF_ERROR(rom()->WriteByte(OverworldCustomMainPaletteArray + i,
+                                         overworld_maps_[i].main_palette()));
+      }
     }
   }
 
   // v3+ features: mosaic, gfx groups, animated, overlays
   if (OverworldVersionHelper::SupportsAreaEnum(cached_version_)) {
-    uint8_t enable_value = enable_mosaic ? 0xFF : 0x00;
     RETURN_IF_ERROR(
-        rom()->WriteByte(OverworldCustomMosaicEnabled, enable_value));
-
-    enable_value = enable_gfx_groups ? 0xFF : 0x00;
+        write_enable_flag(OverworldCustomMosaicEnabled, enable_mosaic));
+    RETURN_IF_ERROR(write_enable_flag(OverworldCustomTileGFXGroupEnabled,
+                                      enable_gfx_groups));
     RETURN_IF_ERROR(
-        rom()->WriteByte(OverworldCustomTileGFXGroupEnabled, enable_value));
-
-    enable_value = enable_animated ? 0xFF : 0x00;
-    RETURN_IF_ERROR(
-        rom()->WriteByte(OverworldCustomAnimatedGFXEnabled, enable_value));
-
-    enable_value = enable_subscreen_overlay ? 0xFF : 0x00;
-    RETURN_IF_ERROR(
-        rom()->WriteByte(OverworldCustomSubscreenOverlayEnabled, enable_value));
+        write_enable_flag(OverworldCustomAnimatedGFXEnabled, enable_animated));
+    RETURN_IF_ERROR(write_enable_flag(OverworldCustomSubscreenOverlayEnabled,
+                                      enable_subscreen_overlay));
 
     // Write the mosaic table
-    for (int i = 0; i < kNumOverworldMaps; i++) {
-      const auto& mosaic = overworld_maps_[i].mosaic_expanded();
-      // .... udlr bit format
-      uint8_t mosaic_byte = (mosaic[0] ? 0x08 : 0x00) |  // up
-                            (mosaic[1] ? 0x04 : 0x00) |  // down
-                            (mosaic[2] ? 0x02 : 0x00) |  // left
-                            (mosaic[3] ? 0x01 : 0x00);   // right
+    if (enable_mosaic) {
+      for (int i = 0; i < kNumOverworldMaps; i++) {
+        const auto& mosaic = overworld_maps_[i].mosaic_expanded();
+        // .... udlr bit format
+        uint8_t mosaic_byte = (mosaic[0] ? 0x08 : 0x00) |  // up
+                              (mosaic[1] ? 0x04 : 0x00) |  // down
+                              (mosaic[2] ? 0x02 : 0x00) |  // left
+                              (mosaic[3] ? 0x01 : 0x00);   // right
 
-      RETURN_IF_ERROR(
-          rom()->WriteByte(OverworldCustomMosaicArray + i, mosaic_byte));
+        RETURN_IF_ERROR(
+            rom()->WriteByte(OverworldCustomMosaicArray + i, mosaic_byte));
+      }
     }
 
-    // Write the main and animated gfx tiles table
-    for (int i = 0; i < kNumOverworldMaps; i++) {
-      for (int j = 0; j < 8; j++) {
-        RETURN_IF_ERROR(
-            rom()->WriteByte(OverworldCustomTileGFXGroupArray + (i * 8) + j,
-                             overworld_maps_[i].custom_tileset(j)));
+    if (enable_gfx_groups) {
+      for (int i = 0; i < kNumOverworldMaps; i++) {
+        for (int j = 0; j < 8; j++) {
+          RETURN_IF_ERROR(
+              rom()->WriteByte(OverworldCustomTileGFXGroupArray + (i * 8) + j,
+                               overworld_maps_[i].custom_tileset(j)));
+        }
       }
-      RETURN_IF_ERROR(rom()->WriteByte(OverworldCustomAnimatedGFXArray + i,
-                                       overworld_maps_[i].animated_gfx()));
+    }
+    if (enable_animated) {
+      for (int i = 0; i < kNumOverworldMaps; i++) {
+        RETURN_IF_ERROR(rom()->WriteByte(OverworldCustomAnimatedGFXArray + i,
+                                         overworld_maps_[i].animated_gfx()));
+      }
     }
 
     // Write the subscreen overlay table
-    for (int i = 0; i < kNumOverworldMaps; i++) {
-      RETURN_IF_ERROR(
-          rom()->WriteShort(OverworldCustomSubscreenOverlayArray + (i * 2),
-                            overworld_maps_[i].subscreen_overlay()));
+    if (enable_subscreen_overlay) {
+      for (int i = 0; i < kNumOverworldMaps; i++) {
+        RETURN_IF_ERROR(
+            rom()->WriteShort(OverworldCustomSubscreenOverlayArray + (i * 2),
+                              overworld_maps_[i].subscreen_overlay()));
+      }
     }
   }
 
@@ -3266,6 +3371,37 @@ absl::Status Overworld::SaveAreaSpecificBGColors() {
         OverworldCustomAreaSpecificBGPalette + (i * 2), bg_color));
   }
 
+  return absl::OkStatus();
+}
+
+absl::Status Overworld::SaveCustomOverworldData() {
+  if (!rom_ || !rom_->is_loaded()) {
+    return absl::FailedPreconditionError("ROM not loaded");
+  }
+
+  cached_version_ = OverworldVersionHelper::GetVersion(*rom_);
+  if (cached_version_ == OverworldVersion::kVanilla ||
+      cached_version_ == OverworldVersion::kZSCustomV1) {
+    return absl::OkStatus();
+  }
+
+  const auto enabled = [this](int address) {
+    return ReadRomByteOr(*rom_, address, 0x00) != 0x00;
+  };
+  const bool bg_color_enabled = enabled(OverworldCustomAreaSpecificBGEnabled);
+  const bool main_palette_enabled = enabled(OverworldCustomMainPaletteEnabled);
+  const bool mosaic_enabled = enabled(OverworldCustomMosaicEnabled);
+  const bool gfx_groups_enabled = enabled(OverworldCustomTileGFXGroupEnabled);
+  const bool subscreen_overlay_enabled =
+      enabled(OverworldCustomSubscreenOverlayEnabled);
+  const bool animated_enabled = enabled(OverworldCustomAnimatedGFXEnabled);
+  RETURN_IF_ERROR(SaveCustomOverworldASM(
+      bg_color_enabled, main_palette_enabled, mosaic_enabled,
+      gfx_groups_enabled, subscreen_overlay_enabled, animated_enabled));
+  if (bg_color_enabled) {
+    RETURN_IF_ERROR(SaveAreaSpecificBGColors());
+  }
+  RETURN_IF_ERROR(SaveAreaSizes());
   return absl::OkStatus();
 }
 

--- a/src/zelda3/overworld/overworld.h
+++ b/src/zelda3/overworld/overworld.h
@@ -242,7 +242,27 @@ constexpr int kNumTile16Individual = 4096;
 constexpr int Map32PerScreen = 256;
 constexpr int NumberOfMap16 = 3752;    // 4096
 constexpr int NumberOfMap16Ex = 4096;  // 4096
-constexpr int LimitOfMap32 = 8864;
+// Tile32 definitions are packed four-at-a-time into six bytes in each of the
+// four quadrant tables. Keep byte spans and definition capacities distinct:
+// the expanded table length is a byte count, not a Tile32 count.
+constexpr int kMap32DefinitionsPerPackedGroup = 4;
+constexpr int kMap32BytesPerPackedGroup = 6;
+constexpr int kMap32TileStorageBytesVanilla = 0x33F0;
+constexpr int kMap32TileStorageBytesExpanded = kMap32TileCountExpanded;
+
+constexpr int Map32DefinitionCapacityForStorageBytes(int storage_bytes) {
+  return storage_bytes <= 0 ? 0
+                            : (storage_bytes / kMap32BytesPerPackedGroup) *
+                                  kMap32DefinitionsPerPackedGroup;
+}
+
+constexpr int kMap32DefinitionCapacityVanilla =
+    Map32DefinitionCapacityForStorageBytes(kMap32TileStorageBytesVanilla);
+constexpr int kMap32DefinitionCapacityExpanded =
+    Map32DefinitionCapacityForStorageBytes(kMap32TileStorageBytesExpanded);
+
+// Compatibility alias for callers that still use the historical name.
+constexpr int LimitOfMap32 = kMap32DefinitionCapacityVanilla;
 constexpr int NumberOfOWSprites = 352;
 constexpr int NumberOfMap32 = Map32PerScreen * kNumOverworldMaps;
 constexpr int kNumMapsPerWorld = 0x40;
@@ -260,6 +280,17 @@ struct OverworldRomProfile {
   bool has_tail_map_expansion = false;
   int editable_map_count = kSpecialWorldMapIdStart + 0x20;
 };
+
+inline int Map32StorageBytesForProfile(const OverworldRomProfile& profile) {
+  return profile.has_expanded_tile32 ? kMap32TileStorageBytesExpanded
+                                     : kMap32TileStorageBytesVanilla;
+}
+
+inline int Map32DefinitionCapacityForProfile(
+    const OverworldRomProfile& profile) {
+  return Map32DefinitionCapacityForStorageBytes(
+      Map32StorageBytesForProfile(profile));
+}
 
 inline bool IsValidRomAddress(const Rom& rom, int address) {
   return address >= 0 && static_cast<size_t>(address) < rom.size();
@@ -507,6 +538,9 @@ class Overworld {
 
   /// @brief Save per-area background colors (v2+)
   absl::Status SaveAreaSpecificBGColors();
+
+  /// @brief Save all v2/v3 property tables using the ROM's current feature flags
+  absl::Status SaveCustomOverworldData();
 
   // ===========================================================================
   // Save Methods - Tile Definitions

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -323,6 +323,7 @@ if(YAZE_BUILD_TESTS)
     unit/zelda3/dungeon/room_object_set_id_test.cc
     unit/zelda3/custom_object_test.cc
     unit/zelda3/dungeon/room_manipulation_test.cc
+    unit/zelda3/dungeon/dungeon_object_editor_dirty_test.cc
     unit/zelda3/dungeon/dungeon_save_test.cc
     unit/zelda3/dungeon/dungeon_editor_system_test.cc
     unit/zelda3/dungeon/sprite_relocation_test.cc
@@ -609,6 +610,7 @@ if(YAZE_BUILD_TESTS)
     unit/zelda3/dungeon/dungeon_limits_test.cc
     unit/zelda3/dungeon/dungeon_block_codec_test.cc
     unit/zelda3/dungeon/dungeon_validator_test.cc
+    unit/zelda3/dungeon/dungeon_object_editor_dirty_test.cc
     unit/zelda3/dungeon/object_layer_semantics_test.cc
     unit/zelda3/dungeon/draw_routine_bothbg_metadata_test.cc
     unit/zelda3/dungeon/room_graphics_palette_test.cc

--- a/test/integration/overworld_editor_test.cc
+++ b/test/integration/overworld_editor_test.cc
@@ -25,6 +25,88 @@ TEST_F(OverworldEditorTest, LoadAndSave) {
   EXPECT_TRUE(status.ok()) << "Save failed: " << status.message();
 }
 
+TEST_F(OverworldExpandedEditorTest, NoEditSaveUsesExpandedTile32Capacity) {
+  const auto profile = zelda3::DetectOverworldRomProfile(*rom_);
+  ASSERT_TRUE(profile.has_expanded_tile32);
+  const auto before = overworld_editor_->overworld().map_tiles();
+
+  const auto status = overworld_editor_->Save();
+  ASSERT_TRUE(status.ok()) << "Expanded save failed: " << status.message();
+  EXPECT_LE(
+      overworld_editor_->overworld().tiles32_unique().size(),
+      static_cast<size_t>(zelda3::Map32DefinitionCapacityForProfile(profile)));
+
+  zelda3::Overworld reloaded(rom_.get(), game_data_.get());
+  ASSERT_TRUE(reloaded.Load(rom_.get()).ok());
+  const auto after = reloaded.map_tiles();
+  EXPECT_TRUE(after.light_world == before.light_world);
+  EXPECT_TRUE(after.dark_world == before.dark_world);
+  EXPECT_TRUE(after.special_world == before.special_world);
+}
+
+TEST_F(OverworldExpandedEditorTest, SavePersistsV3PropertyTables) {
+  const auto profile = zelda3::DetectOverworldRomProfile(*rom_);
+  ASSERT_TRUE(profile.supports_area_enum);
+
+  constexpr int kMapId = 5;
+  constexpr uint8_t kMainPalette = 3;
+  constexpr uint8_t kAnimatedGfx = 7;
+  constexpr uint16_t kSubscreenOverlay = 0x0083;
+  constexpr uint16_t kBackgroundColor = 0x1234;
+  constexpr uint16_t kMessageId = 0x3456;
+  constexpr uint8_t kCustomTileset = 0x21;
+  auto* map = overworld_editor_->overworld().mutable_overworld_map(kMapId);
+  ASSERT_NE(map, nullptr);
+  map->set_main_palette(kMainPalette);
+  map->set_animated_gfx(kAnimatedGfx);
+  map->set_subscreen_overlay(kSubscreenOverlay);
+  map->set_area_specific_bg_color(kBackgroundColor);
+  map->set_message_id(kMessageId);
+  map->set_custom_tileset(0, kCustomTileset);
+
+  const auto status = overworld_editor_->Save();
+  ASSERT_TRUE(status.ok()) << "Expanded save failed: " << status.message();
+
+  EXPECT_EQ(
+      rom_->ReadByte(zelda3::OverworldCustomMainPaletteArray + kMapId).value(),
+      kMainPalette);
+  EXPECT_EQ(
+      rom_->ReadByte(zelda3::OverworldCustomAnimatedGFXArray + kMapId).value(),
+      kAnimatedGfx);
+  EXPECT_EQ(rom_->ReadWord(zelda3::OverworldCustomSubscreenOverlayArray +
+                           (kMapId * 2))
+                .value(),
+            kSubscreenOverlay);
+  EXPECT_EQ(rom_->ReadWord(zelda3::OverworldCustomAreaSpecificBGPalette +
+                           (kMapId * 2))
+                .value(),
+            kBackgroundColor);
+  EXPECT_EQ(
+      rom_->ReadWord(zelda3::GetOverworldMessagesExpanded() + (kMapId * 2))
+          .value(),
+      kMessageId);
+  EXPECT_EQ(
+      rom_->ReadByte(zelda3::OverworldCustomTileGFXGroupArray + (kMapId * 8))
+          .value(),
+      kCustomTileset);
+}
+
+TEST_F(OverworldExpandedEditorTest, PublicSavePersistsV3CustomProperties) {
+  constexpr int kMapId = 6;
+  constexpr uint8_t kMainPalette = 4;
+  auto* map = overworld_editor_->overworld().mutable_overworld_map(kMapId);
+  ASSERT_NE(map, nullptr);
+  map->set_main_palette(kMainPalette);
+
+  const auto status = overworld_editor_->overworld().Save(rom_.get());
+  ASSERT_TRUE(status.ok()) << "Expanded public save failed: "
+                           << status.message();
+
+  EXPECT_EQ(
+      rom_->ReadByte(zelda3::OverworldCustomMainPaletteArray + kMapId).value(),
+      kMainPalette);
+}
+
 TEST_F(OverworldEditorTest, SwitchMaps) {
   // Test switching maps
   overworld_editor_->set_current_map(0);

--- a/test/integration/overworld_editor_test.h
+++ b/test/integration/overworld_editor_test.h
@@ -4,6 +4,7 @@
 #include <string>
 
 #include "app/editor/overworld/overworld_editor.h"
+#include "core/features.h"
 #include "framework/headless_editor_test.h"
 #include "gtest/gtest.h"
 #include "rom/rom.h"
@@ -58,6 +59,56 @@ class OverworldEditorTest : public HeadlessEditorTest {
   std::unique_ptr<editor::OverworldEditor> overworld_editor_;
   std::unique_ptr<zelda3::GameData> game_data_;
   std::unique_ptr<editor::SharedClipboard> shared_clipboard_;
+};
+
+class OverworldExpandedEditorTest : public HeadlessEditorTest {
+ protected:
+  void SetUp() override {
+    HeadlessEditorTest::SetUp();
+
+    saved_feature_flags_ = core::FeatureFlags::get();
+    auto& overworld_flags = core::FeatureFlags::get().overworld;
+    overworld_flags.kSaveOverworldMaps = true;
+    overworld_flags.kSaveOverworldEntrances = true;
+    overworld_flags.kSaveOverworldExits = true;
+    overworld_flags.kSaveOverworldItems = true;
+    overworld_flags.kSaveOverworldProperties = true;
+
+    YAZE_SKIP_IF_ROM_MISSING(RomRole::kExpanded, "OverworldExpandedEditorTest");
+    const std::string rom_path = TestRomManager::GetRomPath(RomRole::kExpanded);
+    rom_ = std::make_unique<Rom>();
+    ASSERT_TRUE(rom_->LoadFromFile(rom_path).ok())
+        << "Could not load expanded ROM from " << rom_path;
+
+    game_data_ = std::make_unique<zelda3::GameData>(rom_.get());
+    ASSERT_TRUE(zelda3::LoadGameData(*rom_, *game_data_).ok());
+
+    shared_clipboard_ = std::make_unique<editor::SharedClipboard>();
+    editor::EditorDependencies deps;
+    deps.rom = rom_.get();
+    deps.game_data = game_data_.get();
+    deps.window_manager = window_manager_.get();
+    deps.renderer = renderer_.get();
+    deps.shared_clipboard = shared_clipboard_.get();
+
+    overworld_editor_ =
+        std::make_unique<editor::OverworldEditor>(rom_.get(), deps);
+    overworld_editor_->SetGameData(game_data_.get());
+    overworld_editor_->Initialize();
+    ASSERT_TRUE(overworld_editor_->Load().ok());
+  }
+
+  void TearDown() override {
+    overworld_editor_.reset();
+    game_data_.reset();
+    core::FeatureFlags::get() = saved_feature_flags_;
+    HeadlessEditorTest::TearDown();
+  }
+
+  std::unique_ptr<editor::OverworldEditor> overworld_editor_;
+  std::unique_ptr<zelda3::GameData> game_data_;
+  std::unique_ptr<editor::SharedClipboard> shared_clipboard_;
+  core::FeatureFlags::Flags saved_feature_flags_;
 };
 
 }  // namespace test

--- a/test/integration/palette_manager_test.cc
+++ b/test/integration/palette_manager_test.cc
@@ -5,6 +5,7 @@
 #include "app/gfx/types/snes_color.h"
 #include "app/gfx/types/snes_palette.h"
 #include "rom/rom.h"
+#include "zelda3/game_data.h"
 
 namespace yaze {
 namespace gfx {
@@ -252,6 +253,33 @@ TEST_F(PaletteManagerTest, SaveAllWithoutInitializationFails) {
 
   EXPECT_FALSE(status.ok());
   EXPECT_EQ(status.code(), absl::StatusCode::kFailedPrecondition);
+}
+
+TEST_F(PaletteManagerTest, SaveTransactionRollbackRestoresRetryState) {
+  Rom rom;
+  ASSERT_TRUE(rom.LoadFromData(std::vector<uint8_t>(0x100000, 0)).ok());
+  zelda3::GameData game_data(&rom);
+  auto* group = game_data.palette_groups.get_group("ow_main");
+  ASSERT_NE(group, nullptr);
+  group->clear();
+  SnesPalette palette;
+  palette.AddColor(SnesColor(0x0000));
+  group->AddPalette(palette);
+
+  auto& manager = PaletteManager::Get();
+  manager.Initialize(&game_data);
+  ASSERT_TRUE(manager.SetColor("ow_main", 0, 0, SnesColor(0x001F)).ok());
+  ASSERT_TRUE(manager.HasUnsavedChanges());
+  ASSERT_TRUE(manager.BeginSaveTransaction().ok());
+  ASSERT_TRUE(manager.SaveAllToRom().ok());
+  ASSERT_FALSE(manager.HasUnsavedChanges());
+
+  manager.RollbackSaveTransaction();
+  EXPECT_TRUE(manager.HasUnsavedChanges());
+  EXPECT_TRUE(manager.IsColorModified("ow_main", 0, 0));
+
+  ASSERT_TRUE(manager.ResetColor("ow_main", 0, 0).ok());
+  EXPECT_EQ(manager.GetColor("ow_main", 0, 0).snes(), 0x0000);
 }
 
 TEST_F(PaletteManagerTest, DiscardGroupWithoutInitializationIsNoOp) {

--- a/test/integration/zelda3/dungeon_editor_system_integration_test.cc
+++ b/test/integration/zelda3/dungeon_editor_system_integration_test.cc
@@ -176,29 +176,34 @@ TEST_F(DungeonEditorSystemIntegrationTest, UndoRedoFunctionality) {
 
 // Test save/load functionality
 TEST_F(DungeonEditorSystemIntegrationTest, SaveLoadFunctionality) {
-  // Set current room and capture the loaded baseline so the round-trip
-  // assertion measures save/reload preservation rather than absolute
-  // object count. Room::SaveObjects serializes the full tile_objects_
-  // vector (vanilla + inserts), so a successful save+reload should
-  // restore initial_count + 2 objects, not just the inserts.
+  // Vanilla object streams are tightly packed. Exercise an in-place edit with
+  // unchanged encoded size; growth is covered separately by fail-closed tests
+  // until the copy-on-write allocator is available.
   ASSERT_TRUE(dungeon_editor_system_->SetCurrentRoom(0x0000).ok());
 
   auto object_editor = dungeon_editor_system_->GetObjectEditor();
   ASSERT_NE(object_editor, nullptr);
   const size_t initial_count = object_editor->GetObjectCount();
+  ASSERT_GT(initial_count, 0u);
 
-  ASSERT_TRUE(object_editor->InsertObject(5, 5, 0x10, 0x0F, 0).ok());
-  ASSERT_TRUE(object_editor->InsertObject(10, 10, 0x20, 0x0F, 1).ok());
+  const auto& initial_object = object_editor->GetObjects().front();
+  const int moved_x = (initial_object.x() + 1) & 0x3F;
+  const int moved_y = (initial_object.y() + 1) & 0x3F;
+  ASSERT_TRUE(object_editor->MoveObject(0, moved_x, moved_y).ok());
+  ASSERT_TRUE(object_editor->GetRoom().object_stream_dirty());
 
   // Save room
-  ASSERT_TRUE(dungeon_editor_system_->SaveRoom(0x0000).ok());
+  const auto save_status = dungeon_editor_system_->SaveRoom(0x0000);
+  ASSERT_TRUE(save_status.ok()) << save_status.message();
 
   // Reload room
   ASSERT_TRUE(dungeon_editor_system_->ReloadRoom(0x0000).ok());
 
-  // Verify objects are still there
-  auto reloaded_objects = object_editor->GetObjects();
-  EXPECT_EQ(reloaded_objects.size(), initial_count + 2);
+  // Verify the edit and object count survived the round trip.
+  const auto& reloaded_objects = object_editor->GetObjects();
+  ASSERT_EQ(reloaded_objects.size(), initial_count);
+  EXPECT_EQ(reloaded_objects.front().x(), moved_x);
+  EXPECT_EQ(reloaded_objects.front().y(), moved_y);
 
   // Save entire dungeon
   ASSERT_TRUE(dungeon_editor_system_->SaveDungeon().ok());

--- a/test/integration/zelda3/message_test.cc
+++ b/test/integration/zelda3/message_test.cc
@@ -1,11 +1,45 @@
 #include <gtest/gtest.h>
 
+#include <memory>
 #include <string>
 
 #include "app/editor/message/message_data.h"
 #include "app/editor/message/message_editor.h"
+#include "framework/headless_editor_test.h"
 #include "test_utils.h"
 #include "testing.h"
+
+namespace yaze::editor {
+
+class MessageEditorTestPeer {
+ public:
+  static void EditCurrent(MessageEditor& editor, const std::string& text) {
+    editor.message_text_box_.text = text;
+    editor.UpdateCurrentMessageFromText(text);
+  }
+
+  static int ReplaceAll(MessageEditor& editor, const std::string& search,
+                        const std::string& replacement) {
+    editor.search_text_ = search;
+    editor.replace_text_ = replacement;
+    return editor.ReplaceAllMatches();
+  }
+
+  static const std::vector<std::string>& ParsedMessages(
+      const MessageEditor& editor) {
+    return editor.parsed_messages_;
+  }
+
+  static const std::string& CurrentDraft(const MessageEditor& editor) {
+    return editor.message_text_box_.text;
+  }
+
+  static bool HasParseErrors(const MessageEditor& editor) {
+    return !editor.current_parse_errors_.empty();
+  }
+};
+
+}  // namespace yaze::editor
 
 namespace yaze {
 namespace test {
@@ -288,6 +322,77 @@ TEST_F(MessageRomTest, ParseMessageData_MixedCommands) {
   auto parsed = editor::ParseMessageData(message_data_vector, dictionary_);
 
   EXPECT_EQ(parsed[0], "[W:01]A[K]B[C:02]C");
+}
+
+class MessageEditorNavigationTest : public HeadlessEditorTest {
+ protected:
+  void SetUp() override {
+    HeadlessEditorTest::SetUp();
+    YAZE_SKIP_IF_ROM_MISSING(RomRole::kVanilla, "MessageEditorNavigationTest");
+    LoadRom(TestRomManager::GetRomPath(RomRole::kVanilla));
+
+    editor::EditorDependencies deps;
+    deps.rom = rom_.get();
+    deps.game_data = game_data_.get();
+    deps.window_manager = window_manager_.get();
+    deps.renderer = renderer_.get();
+    message_editor_ = std::make_unique<editor::MessageEditor>(rom_.get(), deps);
+    message_editor_->SetGameData(game_data_.get());
+    message_editor_->Initialize();
+  }
+
+  void TearDown() override {
+    message_editor_.reset();
+    HeadlessEditorTest::TearDown();
+  }
+
+  std::unique_ptr<editor::MessageEditor> message_editor_;
+};
+
+TEST_F(MessageEditorNavigationTest, InvalidDraftBlocksNavigation) {
+  ASSERT_TRUE(message_editor_->OpenMessageById(0));
+
+  editor::MessageEditorTestPeer::EditCurrent(*message_editor_, "A@");
+  EXPECT_FALSE(message_editor_->OpenMessageById(1));
+
+  editor::MessageEditorTestPeer::EditCurrent(*message_editor_, "A");
+  EXPECT_TRUE(message_editor_->OpenMessageById(1));
+}
+
+TEST_F(MessageEditorNavigationTest, ReplaceAllRefusesInvalidDraft) {
+  ASSERT_TRUE(message_editor_->OpenMessageById(0));
+  editor::MessageEditorTestPeer::EditCurrent(*message_editor_, "A@");
+  const auto before =
+      editor::MessageEditorTestPeer::ParsedMessages(*message_editor_);
+
+  EXPECT_EQ(
+      editor::MessageEditorTestPeer::ReplaceAll(*message_editor_, "A", "B"),
+      -1);
+  EXPECT_EQ(editor::MessageEditorTestPeer::ParsedMessages(*message_editor_),
+            before);
+  EXPECT_EQ(editor::MessageEditorTestPeer::CurrentDraft(*message_editor_),
+            "A@");
+  EXPECT_TRUE(editor::MessageEditorTestPeer::HasParseErrors(*message_editor_));
+}
+
+TEST_F(MessageEditorNavigationTest,
+       ReplaceAllPreflightsEntireBatchBeforeMutation) {
+  ASSERT_TRUE(message_editor_->OpenMessageById(0));
+  editor::MessageEditorTestPeer::EditCurrent(*message_editor_, "BA");
+  ASSERT_TRUE(message_editor_->OpenMessageById(1));
+  editor::MessageEditorTestPeer::EditCurrent(*message_editor_, "[A]");
+  const auto before =
+      editor::MessageEditorTestPeer::ParsedMessages(*message_editor_);
+
+  // Message 0 would become valid "B", while message 1 would become invalid
+  // "[]". The valid earlier candidate must not be committed first.
+  EXPECT_EQ(
+      editor::MessageEditorTestPeer::ReplaceAll(*message_editor_, "A", ""), -1);
+  EXPECT_EQ(editor::MessageEditorTestPeer::ParsedMessages(*message_editor_),
+            before);
+  EXPECT_EQ(editor::MessageEditorTestPeer::CurrentDraft(*message_editor_),
+            "[A]");
+  EXPECT_FALSE(editor::MessageEditorTestPeer::HasParseErrors(*message_editor_));
 }
 
 }  // namespace test

--- a/test/unit/cli/dungeon_edit_commands_test.cc
+++ b/test/unit/cli/dungeon_edit_commands_test.cc
@@ -202,7 +202,8 @@ TEST(DungeonEditCommandsTest, SetCollisionTileRejectsMalformedTileTuple) {
   ExpectInvalidArgument(status, "Invalid tile spec");
 }
 
-TEST(DungeonEditCommandsTest, PlaceSpriteWriteRelocatesAndRoundTrips) {
+TEST(DungeonEditCommandsTest,
+     PlaceSpriteWriteFailsClosedWhenRepackingRequired) {
   Rom rom;
   ASSERT_TRUE(rom.LoadFromData(std::vector<uint8_t>(0x200000, 0x00)).ok());
 
@@ -251,33 +252,12 @@ TEST(DungeonEditCommandsTest, PlaceSpriteWriteRelocatesAndRoundTrips) {
       place_handler.Run({"--room=0x00", "--id=0xA3", "--x=16", "--y=21",
                          "--subtype=4", "--write", "--format=json"},
                         &rom, &write_output);
-  ASSERT_TRUE(write_status.ok()) << write_status.message();
-  EXPECT_THAT(write_output, HasSubstr("\"write_status\": \"success\""));
-  EXPECT_THAT(write_output, HasSubstr("\"save_status\": \"saved\""));
-  EXPECT_NE(rom.vector(), before);
-  EXPECT_GE(CountBackupArtifacts(cleanup.rom_path), 1);
-
-  const int relocated_pc = ReadRoomSpritePointerPc(rom, table_pc, 0);
-  EXPECT_NE(relocated_pc, zelda3::kSpritesData);
-  EXPECT_EQ(rom.data()[relocated_pc], 0x00);  // Preserved sort mode.
-  EXPECT_EQ(rom.data()[relocated_pc + 1], 0x15);
-  EXPECT_EQ(rom.data()[relocated_pc + 2], 0x90);
-  EXPECT_EQ(rom.data()[relocated_pc + 3], 0xA3);
-  EXPECT_EQ(rom.data()[relocated_pc + 4], 0xFF);
-
-  EXPECT_EQ(rom.data()[zelda3::kSpritesData], 0x00);
-  EXPECT_EQ(rom.data()[zelda3::kSpritesData + 1], 0x00);
-
-  handlers::DungeonListSpritesCommandHandler list_handler;
-  std::string list_output;
-  auto list_status =
-      list_handler.Run({"--room=0x00", "--format=json"}, &rom, &list_output);
-  ASSERT_TRUE(list_status.ok()) << list_status.message();
-  EXPECT_THAT(list_output, HasSubstr("\"total_sprites\": 1"));
-  EXPECT_THAT(list_output, HasSubstr("\"sprite_id\": \"0xA3\""));
-  EXPECT_THAT(list_output, HasSubstr("\"x\": 16"));
-  EXPECT_THAT(list_output, HasSubstr("\"y\": 21"));
-  EXPECT_THAT(list_output, HasSubstr("\"subtype\": 4"));
+  EXPECT_TRUE(absl::IsResourceExhausted(write_status))
+      << write_status.message();
+  EXPECT_THAT(write_output, HasSubstr("repacking is required"));
+  EXPECT_EQ(rom.vector(), before);
+  EXPECT_EQ(ReadRoomSpritePointerPc(rom, table_pc, 0), zelda3::kSpritesData);
+  EXPECT_EQ(CountBackupArtifacts(cleanup.rom_path), 0);
 }
 
 }  // namespace

--- a/test/unit/cli/project_bundle_verify_test.cc
+++ b/test/unit/cli/project_bundle_verify_test.cc
@@ -6,6 +6,7 @@
 #include "cli/handlers/rom/project_bundle_verify_commands.h"
 
 #include <cctype>
+#include <cstdint>
 #include <cstdio>
 #include <filesystem>
 #include <fstream>
@@ -29,9 +30,10 @@ using json = nlohmann::json;
 struct ScopedTempDir {
   fs::path path;
   ScopedTempDir() {
-    path = fs::temp_directory_path() / ("yaze_pbv_test_" +
-           std::to_string(std::hash<std::string>{}(
-               std::to_string(reinterpret_cast<uintptr_t>(this)))));
+    path = fs::temp_directory_path() /
+           ("yaze_pbv_test_" +
+            std::to_string(std::hash<std::string>{}(
+                std::to_string(reinterpret_cast<uintptr_t>(this)))));
     fs::create_directories(path);
   }
   ~ScopedTempDir() {
@@ -41,7 +43,7 @@ struct ScopedTempDir {
 };
 
 std::string MakeProjectYaze(const std::string& name,
-                             const std::string& rom = "rom") {
+                            const std::string& rom = "rom") {
   return "[project]\nname=" + name + "\n\n[files]\nrom_filename=" + rom + "\n";
 }
 
@@ -61,15 +63,16 @@ void CreateFullBundle(const fs::path& bundle_dir,
 
   // ROM file (minimal)
   {
-    std::ofstream f(bundle_dir / "rom",
-                    std::ios::out | std::ios::binary);
+    std::ofstream f(bundle_dir / "rom", std::ios::out | std::ios::binary);
     std::vector<char> rom_data(0x8000, 0);
     f.write(rom_data.data(), static_cast<std::streamsize>(rom_data.size()));
   }
 }
 
 // The formatter at depth 0 emits fields directly (no wrapping key).
-const json& GetVerify(const json& doc) { return doc; }
+const json& GetVerify(const json& doc) {
+  return doc;
+}
 
 // ============================================================================
 // Argument validation
@@ -101,8 +104,8 @@ TEST(ProjectBundleVerifyTest, ValidBundlePasses) {
 
   handlers::ProjectBundleVerifyCommandHandler handler;
   std::string out;
-  auto status = handler.Run(
-      {"--project=" + bundle.string(), "--format=json"}, nullptr, &out);
+  auto status = handler.Run({"--project=" + bundle.string(), "--format=json"},
+                            nullptr, &out);
   EXPECT_TRUE(status.ok()) << status.message() << "\n" << out;
 
   auto doc = json::parse(out, nullptr, false);
@@ -122,8 +125,8 @@ TEST(ProjectBundleVerifyTest, BundleWithoutProjectYazeWarns) {
 
   handlers::ProjectBundleVerifyCommandHandler handler;
   std::string out;
-  auto status = handler.Run(
-      {"--project=" + bundle.string(), "--format=json"}, nullptr, &out);
+  auto status = handler.Run({"--project=" + bundle.string(), "--format=json"},
+                            nullptr, &out);
   // Should pass (auto-creation) or at least not fail hard
   auto doc = json::parse(out, nullptr, false);
   ASSERT_FALSE(doc.is_discarded()) << out;
@@ -157,12 +160,15 @@ TEST(ProjectBundleVerifyTest, NonexistentPathFails) {
 TEST(ProjectBundleVerifyTest, UnrecognizedFormatFails) {
   ScopedTempDir tmp;
   fs::path bad_file = tmp.path / "test.bin";
-  { std::ofstream f(bad_file); f << "data"; }
+  {
+    std::ofstream f(bad_file);
+    f << "data";
+  }
 
   handlers::ProjectBundleVerifyCommandHandler handler;
   std::string out;
-  auto status = handler.Run(
-      {"--project=" + bad_file.string(), "--format=json"}, nullptr, &out);
+  auto status = handler.Run({"--project=" + bad_file.string(), "--format=json"},
+                            nullptr, &out);
   EXPECT_FALSE(status.ok());
 
   auto doc = json::parse(out, nullptr, false);
@@ -198,6 +204,16 @@ TEST(ProjectBundleVerifyTest, ValidYazeFilePasses) {
   const auto& verify = GetVerify(doc);
   EXPECT_TRUE(verify.value("ok", false));
   EXPECT_FALSE(verify.value("is_bundle", true));
+  EXPECT_EQ(verify.value("warn_count", -1), 0) << out;
+
+  bool found_portability_pass = false;
+  for (const auto& chk : verify.value("checks", json::array())) {
+    if (chk.value("name", "") == "path_portability" &&
+        chk.value("status", "") == "pass") {
+      found_portability_pass = true;
+    }
+  }
+  EXPECT_TRUE(found_portability_pass) << out;
 }
 
 TEST(ProjectBundleVerifyTest, MissingRomFails) {
@@ -228,6 +244,91 @@ TEST(ProjectBundleVerifyTest, MissingRomFails) {
   EXPECT_TRUE(found_rom_fail) << "Expected rom_accessible fail\n" << out;
 }
 
+TEST(ProjectBundleVerifyTest, ExplicitMissingHackManifestFails) {
+  ScopedTempDir tmp;
+  fs::path yaze_file = tmp.path / "test.yaze";
+  {
+    std::ofstream f(yaze_file, std::ios::out | std::ios::binary);
+    f << MakeProjectYaze("TestProject", "rom.sfc")
+      << "hack_manifest_file=manifests/missing.json\n";
+  }
+  {
+    std::ofstream f(tmp.path / "rom.sfc", std::ios::out | std::ios::binary);
+    std::vector<char> rom_data(0x8000, 0);
+    f.write(rom_data.data(), static_cast<std::streamsize>(rom_data.size()));
+  }
+  // A conventional fallback must not mask a broken explicit reference.
+  {
+    std::ofstream f(tmp.path / "hack_manifest.json");
+    f << "{}";
+  }
+
+  handlers::ProjectBundleVerifyCommandHandler handler;
+  std::string out;
+  auto status = handler.Run(
+      {"--project=" + yaze_file.string(), "--format=json"}, nullptr, &out);
+  EXPECT_FALSE(status.ok());
+
+  auto doc = json::parse(out, nullptr, false);
+  ASSERT_FALSE(doc.is_discarded()) << out;
+  const auto& verify = GetVerify(doc);
+  EXPECT_FALSE(verify.value("ok", true));
+
+  bool found_manifest_fail = false;
+  for (const auto& chk : verify.value("checks", json::array())) {
+    if (chk.value("name", "") == "hack_manifest_ready" &&
+        chk.value("status", "") == "fail") {
+      found_manifest_fail = true;
+    }
+  }
+  EXPECT_TRUE(found_manifest_fail) << "Expected hack_manifest_ready fail\n"
+                                   << out;
+}
+
+TEST(ProjectBundleVerifyTest, ExplicitMalformedHackManifestFails) {
+  ScopedTempDir tmp;
+  fs::path yaze_file = tmp.path / "test.yaze";
+  {
+    std::ofstream f(yaze_file, std::ios::out | std::ios::binary);
+    f << MakeProjectYaze("TestProject", "rom.sfc")
+      << "hack_manifest_file=manifests/broken.json\n";
+  }
+  {
+    std::ofstream f(tmp.path / "rom.sfc", std::ios::out | std::ios::binary);
+    std::vector<char> rom_data(0x8000, 0);
+    f.write(rom_data.data(), static_cast<std::streamsize>(rom_data.size()));
+  }
+  fs::create_directories(tmp.path / "manifests");
+  {
+    std::ofstream f(tmp.path / "manifests" / "broken.json");
+    f << "{not-json";
+  }
+  // A valid conventional fallback must not mask the malformed explicit file.
+  {
+    std::ofstream f(tmp.path / "hack_manifest.json");
+    f << "{}";
+  }
+
+  handlers::ProjectBundleVerifyCommandHandler handler;
+  std::string out;
+  auto status = handler.Run(
+      {"--project=" + yaze_file.string(), "--format=json"}, nullptr, &out);
+  EXPECT_FALSE(status.ok());
+
+  auto doc = json::parse(out, nullptr, false);
+  ASSERT_FALSE(doc.is_discarded()) << out;
+  const auto& verify = GetVerify(doc);
+  bool found_manifest_fail = false;
+  for (const auto& chk : verify.value("checks", json::array())) {
+    if (chk.value("name", "") == "hack_manifest_ready" &&
+        chk.value("status", "") == "fail") {
+      found_manifest_fail = true;
+    }
+  }
+  EXPECT_TRUE(found_manifest_fail) << "Expected hack_manifest_ready fail\n"
+                                   << out;
+}
+
 // ============================================================================
 // Report file
 // ============================================================================
@@ -240,17 +341,16 @@ TEST(ProjectBundleVerifyTest, ReportWritesJsonFile) {
 
   handlers::ProjectBundleVerifyCommandHandler handler;
   std::string out;
-  auto status = handler.Run(
-      {"--project=" + bundle.string(), "--report=" + report.string(),
-       "--format=json"},
-      nullptr, &out);
+  auto status = handler.Run({"--project=" + bundle.string(),
+                             "--report=" + report.string(), "--format=json"},
+                            nullptr, &out);
   EXPECT_TRUE(status.ok()) << status.message();
 
   // Report file should exist and be valid JSON
   std::ifstream rf(report);
   ASSERT_TRUE(rf.is_open());
   std::string report_content((std::istreambuf_iterator<char>(rf)),
-                              std::istreambuf_iterator<char>());
+                             std::istreambuf_iterator<char>());
   auto report_doc = json::parse(report_content, nullptr, false);
   ASSERT_FALSE(report_doc.is_discarded()) << report_content;
   EXPECT_TRUE(report_doc.value("ok", false));
@@ -263,7 +363,8 @@ TEST(ProjectBundleVerifyTest, AbsolutePathsWarn) {
   {
     std::ofstream f(yaze_file, std::ios::out | std::ios::binary);
     // Use an absolute ROM path to trigger portability warning
-    f << "[project]\nname=AbsTest\n\n[files]\nrom_filename=/absolute/path/rom.sfc\n";
+    f << "[project]\nname=AbsTest\n\n[files]\nrom_filename=/absolute/path/"
+         "rom.sfc\n";
   }
 
   handlers::ProjectBundleVerifyCommandHandler handler;
@@ -282,8 +383,81 @@ TEST(ProjectBundleVerifyTest, AbsolutePathsWarn) {
       found_portability_warn = true;
     }
   }
-  EXPECT_TRUE(found_portability_warn)
-      << "Expected path_portability warn\n" << out;
+  EXPECT_TRUE(found_portability_warn) << "Expected path_portability warn\n"
+                                      << out;
+}
+
+TEST(ProjectBundleVerifyTest, AdditionalRomsNonFirstAbsolutePathWarns) {
+  ScopedTempDir tmp;
+  const fs::path yaze_file = tmp.path / "additional_roms.yaze";
+  {
+    std::ofstream f(yaze_file, std::ios::out | std::ios::binary);
+    f << MakeProjectYaze("AdditionalRoms", "rom.sfc")
+      << "additional_roms=relative.sfc,/absolute/second.sfc\n";
+  }
+  {
+    std::ofstream rom(tmp.path / "rom.sfc", std::ios::out | std::ios::binary);
+    const std::vector<char> data(0x8000, 0);
+    rom.write(data.data(), static_cast<std::streamsize>(data.size()));
+  }
+
+  handlers::ProjectBundleVerifyCommandHandler handler;
+  std::string out;
+  const auto status = handler.Run(
+      {"--project=" + yaze_file.string(), "--format=json"}, nullptr, &out);
+  EXPECT_TRUE(status.ok()) << status.message() << "\n" << out;
+
+  const auto doc = json::parse(out, nullptr, false);
+  ASSERT_FALSE(doc.is_discarded()) << out;
+  bool found_absolute_entry = false;
+  for (const auto& chk : GetVerify(doc).value("checks", json::array())) {
+    if (chk.value("name", "") == "path_portability" &&
+        chk.value("status", "") == "warn") {
+      found_absolute_entry =
+          chk.value("detail", "").find("/absolute/second.sfc") !=
+          std::string::npos;
+    }
+  }
+  EXPECT_TRUE(found_absolute_entry) << out;
+}
+
+TEST(ProjectBundleVerifyTest, WindowsDriveAndUncPathsWarnOnAnyHost) {
+  ScopedTempDir tmp;
+  const fs::path yaze_file = tmp.path / "windows_paths.yaze";
+  {
+    std::ofstream f(yaze_file, std::ios::out | std::ios::binary);
+    f << MakeProjectYaze("WindowsPaths", "rom.sfc")
+      << "code_folder=C:\\Oracle\\asm\n"
+      << "assets_folder=\\\\server\\share\\assets\n";
+  }
+  {
+    std::ofstream rom(tmp.path / "rom.sfc", std::ios::out | std::ios::binary);
+    const std::vector<char> data(0x8000, 0);
+    rom.write(data.data(), static_cast<std::streamsize>(data.size()));
+  }
+
+  handlers::ProjectBundleVerifyCommandHandler handler;
+  std::string out;
+  const auto status = handler.Run(
+      {"--project=" + yaze_file.string(), "--format=json"}, nullptr, &out);
+  EXPECT_TRUE(status.ok()) << status.message() << "\n" << out;
+
+  const auto doc = json::parse(out, nullptr, false);
+  ASSERT_FALSE(doc.is_discarded()) << out;
+  bool found_drive_path = false;
+  bool found_unc_path = false;
+  for (const auto& chk : GetVerify(doc).value("checks", json::array())) {
+    if (chk.value("name", "") != "path_portability" ||
+        chk.value("status", "") != "warn") {
+      continue;
+    }
+    const std::string detail = chk.value("detail", "");
+    found_drive_path = detail.find("C:\\Oracle\\asm") != std::string::npos;
+    found_unc_path =
+        detail.find("\\\\server\\share\\assets") != std::string::npos;
+  }
+  EXPECT_TRUE(found_drive_path) << out;
+  EXPECT_TRUE(found_unc_path) << out;
 }
 
 // ============================================================================
@@ -300,8 +474,8 @@ TEST(ProjectBundleVerifyTest, NestedPathResolvesToBundleRoot) {
 
   handlers::ProjectBundleVerifyCommandHandler handler;
   std::string out;
-  auto status = handler.Run(
-      {"--project=" + nested.string(), "--format=json"}, nullptr, &out);
+  auto status = handler.Run({"--project=" + nested.string(), "--format=json"},
+                            nullptr, &out);
   EXPECT_TRUE(status.ok()) << status.message() << "\n" << out;
 
   auto doc = json::parse(out, nullptr, false);
@@ -314,6 +488,187 @@ TEST(ProjectBundleVerifyTest, NestedPathResolvesToBundleRoot) {
 // --check-rom-hash tests
 // ============================================================================
 
+TEST(ProjectBundleVerifyTest, CheckStandaloneCrc32HashUsesLoadedRomBytes) {
+  ScopedTempDir tmp;
+  const fs::path rom_path = tmp.path / "rom.sfc";
+  const std::vector<uint8_t> data(0x8000, 0x2A);
+  {
+    std::ofstream rom(rom_path, std::ios::out | std::ios::binary);
+    rom.write(reinterpret_cast<const char*>(data.data()),
+              static_cast<std::streamsize>(data.size()));
+  }
+  const std::string crc32 =
+      yaze::util::ComputeRomHash(data.data(), data.size());
+  ASSERT_EQ(crc32.size(), 8);
+
+  const fs::path project_path = tmp.path / "standalone.yaze";
+  {
+    std::ofstream project(project_path);
+    project << MakeProjectYaze("Standalone", "rom.sfc")
+            << "\n[rom]\nexpected_hash=" << crc32 << "\n";
+  }
+
+  handlers::ProjectBundleVerifyCommandHandler handler;
+  std::string out;
+  const auto status = handler.Run({"--project=" + project_path.string(),
+                                   "--check-rom-hash", "--format=json"},
+                                  nullptr, &out);
+  EXPECT_TRUE(status.ok()) << status.message() << "\n" << out;
+
+  const auto doc = json::parse(out, nullptr, false);
+  ASSERT_FALSE(doc.is_discarded()) << out;
+  bool found_crc32_pass = false;
+  for (const auto& chk : GetVerify(doc).value("checks", json::array())) {
+    found_crc32_pass |=
+        chk.value("name", "") == "rom_hash_check" &&
+        chk.value("status", "") == "pass" &&
+        chk.value("detail", "").find("CRC32 match") != std::string::npos;
+  }
+  EXPECT_TRUE(found_crc32_pass) << out;
+}
+
+TEST(ProjectBundleVerifyTest, CheckStandaloneSha1HashUsesLoadedRomBytes) {
+  ScopedTempDir tmp;
+  const fs::path rom_path = tmp.path / "rom.sfc";
+  const std::vector<uint8_t> data(0x8000, 0x2A);
+  {
+    std::ofstream rom(rom_path, std::ios::out | std::ios::binary);
+    rom.write(reinterpret_cast<const char*>(data.data()),
+              static_cast<std::streamsize>(data.size()));
+  }
+  const std::string sha1 = yaze::util::ComputeSha1Hex(data.data(), data.size());
+  ASSERT_FALSE(sha1.empty());
+
+  const fs::path project_path = tmp.path / "standalone.yaze";
+  {
+    std::ofstream project(project_path);
+    project << MakeProjectYaze("Standalone", "rom.sfc")
+            << "\n[rom]\nexpected_hash=" << sha1 << "\n";
+  }
+
+  handlers::ProjectBundleVerifyCommandHandler handler;
+  std::string out;
+  const auto status = handler.Run({"--project=" + project_path.string(),
+                                   "--check-rom-hash", "--format=json"},
+                                  nullptr, &out);
+  EXPECT_TRUE(status.ok()) << status.message() << "\n" << out;
+
+  const auto doc = json::parse(out, nullptr, false);
+  ASSERT_FALSE(doc.is_discarded()) << out;
+  bool found_pass = false;
+  for (const auto& chk : GetVerify(doc).value("checks", json::array())) {
+    found_pass |= chk.value("name", "") == "rom_hash_check" &&
+                  chk.value("status", "") == "pass";
+  }
+  EXPECT_TRUE(found_pass) << out;
+}
+
+TEST(ProjectBundleVerifyTest, CheckStandaloneHashStripsSmcHeader) {
+  ScopedTempDir tmp;
+  const fs::path rom_path = tmp.path / "headered.sfc";
+  const std::vector<uint8_t> header(0x200, 0x7E);
+  const std::vector<uint8_t> data(0x100000, 0x2A);
+  {
+    std::ofstream rom(rom_path, std::ios::out | std::ios::binary);
+    rom.write(reinterpret_cast<const char*>(header.data()),
+              static_cast<std::streamsize>(header.size()));
+    rom.write(reinterpret_cast<const char*>(data.data()),
+              static_cast<std::streamsize>(data.size()));
+  }
+  const std::string crc32 =
+      yaze::util::ComputeRomHash(data.data(), data.size());
+
+  const fs::path project_path = tmp.path / "standalone.yaze";
+  {
+    std::ofstream project(project_path);
+    project << MakeProjectYaze("Standalone", "headered.sfc")
+            << "\n[rom]\nexpected_hash=" << crc32 << "\n";
+  }
+
+  handlers::ProjectBundleVerifyCommandHandler handler;
+  std::string out;
+  const auto status = handler.Run({"--project=" + project_path.string(),
+                                   "--check-rom-hash", "--format=json"},
+                                  nullptr, &out);
+  EXPECT_TRUE(status.ok()) << status.message() << "\n" << out;
+
+  const auto doc = json::parse(out, nullptr, false);
+  ASSERT_FALSE(doc.is_discarded()) << out;
+  bool found_pass = false;
+  for (const auto& chk : GetVerify(doc).value("checks", json::array())) {
+    found_pass |= chk.value("name", "") == "rom_hash_check" &&
+                  chk.value("status", "") == "pass";
+  }
+  EXPECT_TRUE(found_pass) << out;
+}
+
+TEST(ProjectBundleVerifyTest, CheckStandaloneHashRejectsInvalidMetadata) {
+  ScopedTempDir tmp;
+  const fs::path rom_path = tmp.path / "rom.sfc";
+  {
+    std::ofstream rom(rom_path, std::ios::out | std::ios::binary);
+    const std::vector<char> data(0x8000, 0x2A);
+    rom.write(data.data(), static_cast<std::streamsize>(data.size()));
+  }
+  const fs::path project_path = tmp.path / "standalone.yaze";
+  {
+    std::ofstream project(project_path);
+    project << MakeProjectYaze("Standalone", "rom.sfc")
+            << "\n[rom]\nexpected_hash=not-a-hash\n";
+  }
+
+  handlers::ProjectBundleVerifyCommandHandler handler;
+  std::string out;
+  const auto status = handler.Run({"--project=" + project_path.string(),
+                                   "--check-rom-hash", "--format=json"},
+                                  nullptr, &out);
+  EXPECT_FALSE(status.ok());
+
+  const auto doc = json::parse(out, nullptr, false);
+  ASSERT_FALSE(doc.is_discarded()) << out;
+  bool found_metadata_fail = false;
+  for (const auto& chk : GetVerify(doc).value("checks", json::array())) {
+    found_metadata_fail |=
+        chk.value("name", "") == "rom_hash_check" &&
+        chk.value("status", "") == "fail" &&
+        chk.value("detail", "").find("expected_hash") != std::string::npos;
+  }
+  EXPECT_TRUE(found_metadata_fail) << out;
+}
+
+TEST(ProjectBundleVerifyTest, CheckStandaloneRomHashMismatchFails) {
+  ScopedTempDir tmp;
+  const fs::path rom_path = tmp.path / "rom.sfc";
+  {
+    std::ofstream rom(rom_path, std::ios::out | std::ios::binary);
+    const std::vector<char> data(0x8000, 0x2A);
+    rom.write(data.data(), static_cast<std::streamsize>(data.size()));
+  }
+  const fs::path project_path = tmp.path / "standalone.yaze";
+  {
+    std::ofstream project(project_path);
+    project << MakeProjectYaze("Standalone", "rom.sfc")
+            << "\n[rom]\nexpected_hash="
+            << "0000000000000000000000000000000000000000\n";
+  }
+
+  handlers::ProjectBundleVerifyCommandHandler handler;
+  std::string out;
+  const auto status = handler.Run({"--project=" + project_path.string(),
+                                   "--check-rom-hash", "--format=json"},
+                                  nullptr, &out);
+  EXPECT_FALSE(status.ok());
+
+  const auto doc = json::parse(out, nullptr, false);
+  ASSERT_FALSE(doc.is_discarded()) << out;
+  bool found_fail = false;
+  for (const auto& chk : GetVerify(doc).value("checks", json::array())) {
+    found_fail |= chk.value("name", "") == "rom_hash_check" &&
+                  chk.value("status", "") == "fail";
+  }
+  EXPECT_TRUE(found_fail) << out;
+}
+
 TEST(ProjectBundleVerifyTest, CheckRomHashSkippedByDefault) {
   ScopedTempDir tmp;
   fs::path bundle = tmp.path / "HashSkip.yazeproj";
@@ -321,8 +676,8 @@ TEST(ProjectBundleVerifyTest, CheckRomHashSkippedByDefault) {
 
   handlers::ProjectBundleVerifyCommandHandler handler;
   std::string out;
-  auto status = handler.Run(
-      {"--project=" + bundle.string(), "--format=json"}, nullptr, &out);
+  auto status = handler.Run({"--project=" + bundle.string(), "--format=json"},
+                            nullptr, &out);
   EXPECT_TRUE(status.ok()) << status.message();
 
   auto doc = json::parse(out, nullptr, false);
@@ -401,6 +756,56 @@ TEST(ProjectBundleVerifyTest, CheckRomHashMatchPasses) {
   EXPECT_TRUE(found_pass) << "Expected rom_hash_check pass\n" << out;
 }
 
+TEST(ProjectBundleVerifyTest, CheckBundleHashIncludesSmcHeader) {
+  ScopedTempDir tmp;
+  const fs::path bundle = tmp.path / "HeaderedHash.yazeproj";
+  CreateFullBundle(bundle);
+
+  const fs::path rom_path = bundle / "rom";
+  const std::vector<uint8_t> header(0x200, 0x7E);
+  const std::vector<uint8_t> data(0x100000, 0x2A);
+  {
+    std::ofstream rom(rom_path,
+                      std::ios::out | std::ios::binary | std::ios::trunc);
+    rom.write(reinterpret_cast<const char*>(header.data()),
+              static_cast<std::streamsize>(header.size()));
+    rom.write(reinterpret_cast<const char*>(data.data()),
+              static_cast<std::streamsize>(data.size()));
+  }
+
+  const std::string raw_file_sha1 =
+      yaze::util::ComputeFileSha1Hex(rom_path.string());
+  const std::string loaded_bytes_sha1 =
+      yaze::util::ComputeSha1Hex(data.data(), data.size());
+  ASSERT_FALSE(raw_file_sha1.empty());
+  ASSERT_NE(raw_file_sha1, loaded_bytes_sha1);
+  {
+    nlohmann::json manifest;
+    manifest["rom_sha1"] = raw_file_sha1;
+    std::ofstream mf(bundle / "manifest.json",
+                     std::ios::out | std::ios::binary);
+    mf << manifest.dump(2);
+  }
+
+  handlers::ProjectBundleVerifyCommandHandler handler;
+  std::string out;
+  const auto status = handler.Run(
+      {"--project=" + bundle.string(), "--check-rom-hash", "--format=json"},
+      nullptr, &out);
+  EXPECT_TRUE(status.ok()) << status.message() << "\n" << out;
+
+  const auto doc = json::parse(out, nullptr, false);
+  ASSERT_FALSE(doc.is_discarded()) << out;
+  bool found_pass = false;
+  for (const auto& chk : GetVerify(doc).value("checks", json::array())) {
+    found_pass |=
+        chk.value("name", "") == "rom_hash_check" &&
+        chk.value("status", "") == "pass" &&
+        chk.value("detail", "").find("SHA1 match") != std::string::npos;
+  }
+  EXPECT_TRUE(found_pass) << out;
+}
+
 TEST(ProjectBundleVerifyTest, CheckRomHashMatchNormalizesCaseAndWhitespace) {
   ScopedTempDir tmp;
   fs::path bundle = tmp.path / "HashNormalize.yazeproj";
@@ -417,7 +822,8 @@ TEST(ProjectBundleVerifyTest, CheckRomHashMatchNormalizesCaseAndWhitespace) {
   }
   {
     nlohmann::json manifest;
-    manifest["rom_sha1"] = std::string("  \n\t") + normalized + std::string("  ");
+    manifest["rom_sha1"] =
+        std::string("  \n\t") + normalized + std::string("  ");
     std::ofstream mf(bundle / "manifest.json",
                      std::ios::out | std::ios::binary);
     mf << manifest.dump(2);

--- a/test/unit/core/project_paths_test.cc
+++ b/test/unit/core/project_paths_test.cc
@@ -35,6 +35,22 @@ class ScopedTempDir {
   std::filesystem::path path_;
 };
 
+class ScopedCurrentPath {
+ public:
+  explicit ScopedCurrentPath(const std::filesystem::path& path)
+      : original_path_(std::filesystem::current_path()) {
+    std::filesystem::current_path(path);
+  }
+
+  ~ScopedCurrentPath() {
+    std::error_code ec;
+    std::filesystem::current_path(original_path_, ec);
+  }
+
+ private:
+  std::filesystem::path original_path_;
+};
+
 void WriteTextFile(const std::filesystem::path& path, const std::string& data) {
   std::filesystem::create_directories(path.parent_path());
   std::ofstream file(path, std::ios::out | std::ios::trunc);
@@ -245,22 +261,22 @@ hack_manifest_file=hack_manifest.json
 37=Thieves' Town
 )");
 
-  std::error_code relative_ec;
-  const auto relative_project_file = std::filesystem::relative(
-      project_file, std::filesystem::current_path(), relative_ec);
-  ASSERT_FALSE(relative_ec) << relative_ec.message();
-  ASSERT_FALSE(relative_project_file.is_absolute());
+  {
+    ScopedCurrentPath current_path(temp.path());
+    const auto relative_project_file = project_file.filename();
+    ASSERT_FALSE(relative_project_file.is_absolute());
 
-  YazeProject project;
-  ASSERT_TRUE(project.Open(relative_project_file.string()).ok());
-  EXPECT_TRUE(std::filesystem::path(project.filepath).is_absolute());
-  EXPECT_FALSE(project.hack_manifest.loaded());
-  ASSERT_TRUE(project.hack_manifest.HasProjectRegistry());
+    YazeProject project;
+    ASSERT_TRUE(project.Open(relative_project_file.string()).ok());
+    EXPECT_TRUE(std::filesystem::path(project.filepath).is_absolute());
+    EXPECT_FALSE(project.hack_manifest.loaded());
+    ASSERT_TRUE(project.hack_manifest.HasProjectRegistry());
 
-  ASSERT_TRUE(project.resource_labels.contains("room"));
-  EXPECT_EQ(project.resource_labels["room"]["37"], "Water Grate");
+    ASSERT_TRUE(project.resource_labels.contains("room"));
+    EXPECT_EQ(project.resource_labels["room"]["37"], "Water Grate");
 
-  ASSERT_TRUE(project.Save().ok());
+    ASSERT_TRUE(project.Save().ok());
+  }
   const auto saved = ReadTextFile(project_file);
   EXPECT_NE(saved.find("[labels_room]"), std::string::npos);
   EXPECT_NE(saved.find("37=Water Grate"), std::string::npos);

--- a/test/unit/core/project_paths_test.cc
+++ b/test/unit/core/project_paths_test.cc
@@ -1,5 +1,6 @@
 #include "core/project.h"
 
+#include <algorithm>
 #include <chrono>
 #include <filesystem>
 #include <fstream>
@@ -244,8 +245,15 @@ hack_manifest_file=hack_manifest.json
 37=Thieves' Town
 )");
 
+  std::error_code relative_ec;
+  const auto relative_project_file = std::filesystem::relative(
+      project_file, std::filesystem::current_path(), relative_ec);
+  ASSERT_FALSE(relative_ec) << relative_ec.message();
+  ASSERT_FALSE(relative_project_file.is_absolute());
+
   YazeProject project;
-  ASSERT_TRUE(project.Open(project_file.string()).ok());
+  ASSERT_TRUE(project.Open(relative_project_file.string()).ok());
+  EXPECT_TRUE(std::filesystem::path(project.filepath).is_absolute());
   EXPECT_FALSE(project.hack_manifest.loaded());
   ASSERT_TRUE(project.hack_manifest.HasProjectRegistry());
 
@@ -257,6 +265,69 @@ hack_manifest_file=hack_manifest.json
   EXPECT_NE(saved.find("[labels_room]"), std::string::npos);
   EXPECT_NE(saved.find("37=Water Grate"), std::string::npos);
   EXPECT_EQ(saved.find("37=Thieves' Town"), std::string::npos);
+}
+
+TEST(ProjectPathsTest, ExplicitMissingHackManifestDoesNotUseFallback) {
+  ScopedTempDir temp(MakeUniqueTempDir("yaze_project_manifest_paths"));
+
+  WriteTextFile(temp.path() / "rom.sfc", "not a real rom");
+  WriteTextFile(temp.path() / "hack_manifest.json", "{}");
+
+  const auto project_file = temp.path() / "Oracle.yaze";
+  WriteTextFile(project_file,
+                R"(
+[project]
+name=Oracle of Secrets
+
+[files]
+rom_filename=rom.sfc
+hack_manifest_file=manifests/missing.json
+)");
+
+  YazeProject project;
+  ASSERT_TRUE(project.Open(project_file.string()).ok());
+
+  const auto missing_manifest = temp.path() / "manifests" / "missing.json";
+  EXPECT_EQ(project.hack_manifest_file, missing_manifest.string());
+  EXPECT_FALSE(project.hack_manifest.loaded());
+
+  const auto validation = project.Validate();
+  EXPECT_FALSE(validation.ok());
+  EXPECT_NE(validation.message().find("Hack manifest file does not exist"),
+            std::string::npos);
+
+  const auto missing_files = project.GetMissingFiles();
+  EXPECT_NE(std::find(missing_files.begin(), missing_files.end(),
+                      missing_manifest.string()),
+            missing_files.end());
+}
+
+TEST(ProjectPathsTest, ExplicitMalformedHackManifestFailsValidation) {
+  ScopedTempDir temp(MakeUniqueTempDir("yaze_project_malformed_manifest"));
+
+  WriteTextFile(temp.path() / "rom.sfc", "not a real rom");
+  WriteTextFile(temp.path() / "manifests" / "broken.json", "{not-json");
+  WriteTextFile(temp.path() / "hack_manifest.json", "{}");
+
+  const auto project_file = temp.path() / "Oracle.yaze";
+  WriteTextFile(project_file,
+                R"(
+[project]
+name=Oracle of Secrets
+
+[files]
+rom_filename=rom.sfc
+hack_manifest_file=manifests/broken.json
+)");
+
+  YazeProject project;
+  ASSERT_TRUE(project.Open(project_file.string()).ok());
+  EXPECT_FALSE(project.hack_manifest.loaded());
+
+  const auto validation = project.Validate();
+  EXPECT_FALSE(validation.ok());
+  EXPECT_NE(validation.message().find("Hack manifest file failed to load"),
+            std::string::npos);
 }
 
 }  // namespace yaze::project

--- a/test/unit/editor/dungeon_editor_v2_rom_safety_test.cc
+++ b/test/unit/editor/dungeon_editor_v2_rom_safety_test.cc
@@ -10,6 +10,7 @@
 #include "mocks/mock_rom.h"
 #include "rom/rom.h"
 #include "rom/snes.h"
+#include "rom/transaction.h"
 #include "zelda3/dungeon/dungeon_rom_addresses.h"
 #include "zelda3/dungeon/room.h"
 #include "zelda3/dungeon/water_fill_zone.h"
@@ -65,7 +66,8 @@ void SetupChestTable(Rom& rom) {
   WriteLongPointer(rom, zelda3::kChestsDataPointer1, PcToSnes(kChestDataPc));
   rom.mutable_data()[zelda3::kChestsLengthPointer] = 0x00;
   rom.mutable_data()[zelda3::kChestsLengthPointer + 1] = 0x00;
-  std::fill_n(rom.mutable_data() + kChestDataPc, 0x100, 0x00);
+  std::fill_n(rom.mutable_data() + kChestDataPc,
+              zelda3::kChestTableCapacityBytes, 0x00);
 }
 
 void WriteEmptyObjectStream(Rom& rom, int room_data_pc) {
@@ -109,7 +111,8 @@ void SetupSpritePointers(Rom& rom) {
 
 void SeedChestEntry(Rom& rom, int room_id, uint8_t chest_id, bool big) {
   const uint16_t word = static_cast<uint16_t>(room_id) | (big ? 0x8000 : 0);
-  rom.mutable_data()[zelda3::kChestsLengthPointer] = 0x01;
+  rom.mutable_data()[zelda3::kChestsLengthPointer] =
+      zelda3::kChestTableRecordSize;
   rom.mutable_data()[zelda3::kChestsLengthPointer + 1] = 0x00;
   rom.mutable_data()[kChestDataPc + 0] = word & 0xFF;
   rom.mutable_data()[kChestDataPc + 1] = (word >> 8) & 0xFF;
@@ -213,6 +216,99 @@ TEST(DungeonEditorV2RomSafetyTest, SaveRoomBlocksInvalidRoomBeforeWriting) {
 }
 
 TEST(DungeonEditorV2RomSafetyTest,
+     SaveRoomRollsBackEarlierWritesOnLateFailure) {
+  Rom rom;
+  ASSERT_TRUE(rom.LoadFromData(std::vector<uint8_t>(0x200000, 0)).ok());
+  SetupHeaderPointers(rom);
+  SetupChestTable(rom);
+  // The chest length operand is a byte count and must be divisible by three.
+  rom.mutable_data()[zelda3::kChestsLengthPointer] = 0x01;
+
+  auto editor = std::make_unique<DungeonEditorV2>(&rom);
+  auto& room = editor->rooms()[0];
+  room.SetLoaded(true);
+  room.SetPalette(0x2A);
+  room.MarkChestsDirty();
+
+  DungeonSaveFlagsGuard guard;
+  ConfigureMinimalDungeonSave();
+  auto& flags = core::FeatureFlags::get().dungeon;
+  flags.kSaveObjects = false;
+  flags.kSaveRoomHeaders = true;
+  flags.kSaveChests = true;
+
+  const auto before = rom.vector();
+  const auto status = editor->SaveRoom(0);
+
+  EXPECT_EQ(status.code(), absl::StatusCode::kFailedPrecondition) << status;
+  EXPECT_EQ(rom.vector(), before);
+  EXPECT_EQ(rom.data()[kRoom0HeaderPc + 1], 0x00);
+  EXPECT_TRUE(room.header_dirty());
+  EXPECT_TRUE(room.chests_dirty());
+}
+
+TEST(DungeonEditorV2RomSafetyTest,
+     SaveAllRoomsRollsBackEarlierWritesOnLateFailure) {
+  Rom rom;
+  ASSERT_TRUE(rom.LoadFromData(std::vector<uint8_t>(0x200000, 0)).ok());
+  SetupHeaderPointers(rom);
+  SetupChestTable(rom);
+  rom.mutable_data()[zelda3::kChestsLengthPointer] = 0x01;
+
+  auto editor = std::make_unique<DungeonEditorV2>(&rom);
+  auto& room = editor->rooms()[0];
+  room.SetLoaded(true);
+  room.SetPalette(0x2A);
+  room.MarkChestsDirty();
+
+  DungeonSaveFlagsGuard guard;
+  ConfigureMinimalDungeonSave();
+  auto& flags = core::FeatureFlags::get().dungeon;
+  flags.kSaveObjects = false;
+  flags.kSaveRoomHeaders = true;
+  flags.kSaveChests = true;
+
+  const auto before = rom.vector();
+  editor->SaveAllRooms();
+
+  EXPECT_EQ(rom.vector(), before);
+  EXPECT_EQ(rom.data()[kRoom0HeaderPc + 1], 0x00);
+  EXPECT_TRUE(room.header_dirty());
+  EXPECT_TRUE(room.chests_dirty());
+}
+
+TEST(DungeonEditorV2RomSafetyTest,
+     LateCoordinatorRollbackRestoresEntranceDirtyState) {
+  Rom rom;
+  ASSERT_TRUE(rom.LoadFromData(std::vector<uint8_t>(0x200000, 0)).ok());
+  auto editor = std::make_unique<DungeonEditorV2>(&rom);
+
+  DungeonSaveFlagsGuard guard;
+  ConfigureMinimalDungeonSave();
+  auto& flags = core::FeatureFlags::get().dungeon;
+  flags.kSaveObjects = false;
+  flags.kSaveEntrances = true;
+
+  auto& entrance = editor->entrances_[0];
+  entrance.room_ = 0x0123;
+  entrance.MarkDirty();
+  const auto before = rom.vector();
+
+  ScopedRomTransaction rom_transaction(rom);
+  ASSERT_TRUE(editor->BeginSaveTransaction().ok());
+  ASSERT_TRUE(editor->Save().ok());
+  EXPECT_FALSE(entrance.dirty());
+  EXPECT_EQ(rom.ReadWord(zelda3::kStartingEntranceroom).value(), 0x0123);
+
+  // Simulate a later editor/conflict/disk failure in EditorManager.
+  editor->RollbackSaveTransaction();
+  rom_transaction.Rollback();
+
+  EXPECT_TRUE(entrance.dirty());
+  EXPECT_EQ(rom.vector(), before);
+}
+
+TEST(DungeonEditorV2RomSafetyTest,
      SaveWritesWaterFillZonesWhenCollisionSavingDisabled) {
   Rom rom;
   ASSERT_TRUE(rom.LoadFromData(std::vector<uint8_t>(0x200000, 0)).ok());
@@ -265,7 +361,7 @@ TEST(DungeonEditorV2RomSafetyTest, SaveWritesChestsWhenEnabled) {
   auto status = editor->Save();
   ASSERT_TRUE(status.ok()) << status.message();
 
-  EXPECT_EQ(rom.data()[zelda3::kChestsLengthPointer], 0x02);
+  EXPECT_EQ(rom.data()[zelda3::kChestsLengthPointer], 0x06);
   EXPECT_EQ(rom.data()[zelda3::kChestsLengthPointer + 1], 0x00);
 
   zelda3::Room reloaded_room(0, &rom);
@@ -297,7 +393,7 @@ TEST(DungeonEditorV2RomSafetyTest, SaveSkipsChestsWhenDisabled) {
   auto status = editor->Save();
   ASSERT_TRUE(status.ok()) << status.message();
 
-  EXPECT_EQ(rom.data()[zelda3::kChestsLengthPointer], 0x01);
+  EXPECT_EQ(rom.data()[zelda3::kChestsLengthPointer], 0x03);
   EXPECT_EQ(rom.data()[zelda3::kChestsLengthPointer + 1], 0x00);
 
   zelda3::Room reloaded_room(0, &rom);
@@ -511,6 +607,46 @@ TEST(DungeonEditorV2RomSafetyTest, PendingRoomCountTracksRoomDirtyState) {
 
   EXPECT_EQ(editor->PendingRoomCount(), 0);
   EXPECT_FALSE(editor->HasPendingRoomChanges());
+}
+
+TEST(DungeonEditorV2RomSafetyTest,
+     SaveTransactionRollbackRestoresRoomAndPitDirtyState) {
+  Rom rom;
+  ASSERT_TRUE(rom.LoadFromData(std::vector<uint8_t>(0x200000, 0)).ok());
+  zelda3::GameData game_data(&rom);
+  auto editor = std::make_unique<DungeonEditorV2>(&rom);
+  editor->SetGameData(&game_data);
+
+  auto& room = editor->rooms()[0];
+  room.MarkHeaderDirty();
+  room.MarkObjectStreamDirty();
+  room.MarkSpritesDirty();
+  room.MarkChestsDirty();
+  room.MarkPotItemsDirty();
+  room.MarkTorchesDirty();
+  room.MarkBlocksDirty();
+  room.MarkCustomCollisionDirty();
+  room.MarkWaterFillDirty();
+  game_data.pit_damage_table.MarkDirty();
+
+  ASSERT_TRUE(editor->BeginSaveTransaction().ok());
+  room.ClearSaveDirtyState();
+  room.ClearCustomCollisionDirty();
+  room.ClearWaterFillDirty();
+  game_data.pit_damage_table.ClearDirty();
+
+  editor->RollbackSaveTransaction();
+
+  EXPECT_TRUE(room.header_dirty());
+  EXPECT_TRUE(room.object_stream_dirty());
+  EXPECT_TRUE(room.sprites_dirty());
+  EXPECT_TRUE(room.chests_dirty());
+  EXPECT_TRUE(room.pot_items_dirty());
+  EXPECT_TRUE(room.torches_dirty());
+  EXPECT_TRUE(room.blocks_dirty());
+  EXPECT_TRUE(room.custom_collision_dirty());
+  EXPECT_TRUE(room.water_fill_dirty());
+  EXPECT_TRUE(game_data.pit_damage_table.dirty());
 }
 
 TEST(DungeonEditorV2RomSafetyTest,

--- a/test/unit/editor/editor_manager_oracle_rom_safety_test.cc
+++ b/test/unit/editor/editor_manager_oracle_rom_safety_test.cc
@@ -90,8 +90,10 @@ void DisableRomWritesForTest() {
   d.kSavePits = false;
   d.kSaveBlocks = false;
   d.kSaveCollision = false;
+  d.kSaveWaterFillZones = false;
   d.kSaveChests = false;
   d.kSavePotItems = false;
+  d.kSaveEntrances = false;
   d.kSavePalettes = false;
 
   auto& o = flags.overworld;
@@ -114,7 +116,8 @@ TEST(EditorManagerOracleRomSafetyTest,
 
   // Create a ROM large enough to contain the expanded collision bank tail where
   // the Oracle WaterFill table is reserved.
-  const std::filesystem::path rom_path = MakeTempPath("yaze_oracle_rom_safety.sfc");
+  const std::filesystem::path rom_path =
+      MakeTempPath("yaze_oracle_rom_safety.sfc");
   ScopedFileCleanup cleanup{rom_path};
   std::vector<uint8_t> rom_data(2 * 1024 * 1024, 0x00);
   const std::string title = "YAZE TEST ROM";
@@ -165,11 +168,12 @@ TEST(EditorManagerOracleRomSafetyTest,
   // table region. SaveRom must refuse to write this to disk.
   const uint32_t snes_ptr = PcToSnes(zelda3::kWaterFillTableStart);
   const int ptr_offset = zelda3::kCustomCollisionRoomPointers;  // room 0
-  ASSERT_OK(rom->WriteByte(ptr_offset + 0, static_cast<uint8_t>(snes_ptr & 0xFF)));
   ASSERT_OK(
-      rom->WriteByte(ptr_offset + 1, static_cast<uint8_t>((snes_ptr >> 8) & 0xFF)));
-  ASSERT_OK(
-      rom->WriteByte(ptr_offset + 2, static_cast<uint8_t>((snes_ptr >> 16) & 0xFF)));
+      rom->WriteByte(ptr_offset + 0, static_cast<uint8_t>(snes_ptr & 0xFF)));
+  ASSERT_OK(rom->WriteByte(ptr_offset + 1,
+                           static_cast<uint8_t>((snes_ptr >> 8) & 0xFF)));
+  ASSERT_OK(rom->WriteByte(ptr_offset + 2,
+                           static_cast<uint8_t>((snes_ptr >> 16) & 0xFF)));
 
   // Also mutate an unrelated byte so we can verify the disk write is blocked.
   constexpr uint32_t kPcOffset = 0x1234;
@@ -183,6 +187,51 @@ TEST(EditorManagerOracleRomSafetyTest,
             original);
 }
 
+TEST(EditorManagerOracleRomSafetyTest,
+     SaveRomBlocksWhenConfiguredHackManifestDidNotLoad) {
+  FeatureFlagsGuard guard;
+  ScopedImGuiContext imgui;
+
+  auto renderer = std::make_unique<gfx::NullRenderer>();
+  auto manager = std::make_unique<EditorManager>();
+  manager->Initialize(renderer.get(), "");
+  manager->SetAssetLoadMode(AssetLoadMode::kLazy);
+
+  const auto rom_path = MakeTempPath("yaze_missing_manifest_save.sfc");
+  ScopedFileCleanup cleanup{rom_path};
+  std::vector<uint8_t> rom_data(512 * 1024, 0x00);
+  {
+    std::ofstream out(rom_path, std::ios::binary | std::ios::trunc);
+    ASSERT_TRUE(out.is_open());
+    out.write(reinterpret_cast<const char*>(rom_data.data()),
+              static_cast<std::streamsize>(rom_data.size()));
+    ASSERT_TRUE(out.good());
+  }
+
+  ASSERT_OK(manager->OpenRomOrProject(rom_path.string()));
+  DisableRomWritesForTest();
+
+  auto* project = manager->GetCurrentProject();
+  ASSERT_NE(project, nullptr);
+  project->name = "MissingManifestSave";
+  project->filepath = (rom_path.parent_path() / "project.yaze").string();
+  project->workspace_settings.backup_on_save = false;
+  project->rom_metadata.expected_hash.clear();
+  project->hack_manifest.Clear();
+  project->hack_manifest_file =
+      (rom_path.parent_path() / "missing-hack-manifest.json").string();
+
+  Rom* rom = manager->GetCurrentRom();
+  ASSERT_NE(rom, nullptr);
+  constexpr uint32_t kPcOffset = 0x1234;
+  ASSERT_OK(rom->WriteByte(kPcOffset, 0xA5));
+
+  auto status = manager->SaveRom();
+  EXPECT_EQ(status.code(), absl::StatusCode::kFailedPrecondition) << status;
+  EXPECT_NE(std::string(status.message()).find("missing or malformed"),
+            std::string::npos);
+  EXPECT_EQ(ReadByteAt(rom_path, kPcOffset), 0x00);
+}
+
 }  // namespace
 }  // namespace yaze::editor
-

--- a/test/unit/editor/editor_manager_rom_write_policy_test.cc
+++ b/test/unit/editor/editor_manager_rom_write_policy_test.cc
@@ -95,8 +95,10 @@ void DisableRomWritesForTest() {
   d.kSavePits = false;
   d.kSaveBlocks = false;
   d.kSaveCollision = false;
+  d.kSaveWaterFillZones = false;
   d.kSaveChests = false;
   d.kSavePotItems = false;
+  d.kSaveEntrances = false;
   d.kSavePalettes = false;
 
   auto& o = flags.overworld;
@@ -166,11 +168,11 @@ TEST(EditorManagerRomWritePolicyTest,
   EXPECT_EQ(ReadByteAt(rom_path, static_cast<std::streamoff>(kPcOffset)),
             original);
 
-  // Confirm once and retry: should save successfully.
+  // Confirm once and resume the bound request: should save successfully.
   manager->ConfirmRomWrite();
   EXPECT_FALSE(manager->IsRomWriteConfirmPending());
 
-  auto status2 = manager->SaveRom();
+  auto status2 = manager->ResumePendingRomSave();
   EXPECT_TRUE(status2.ok()) << status2.message();
   EXPECT_EQ(ReadByteAt(rom_path, static_cast<std::streamoff>(kPcOffset)),
             mutated);
@@ -344,6 +346,299 @@ TEST(EditorManagerRomWritePolicyTest,
   EXPECT_FALSE(manager->IsRomWriteConfirmPending());
   EXPECT_EQ(ReadByteAt(build_rom_path, static_cast<std::streamoff>(kPcOffset)),
             original);
+}
+
+TEST(EditorManagerRomWritePolicyTest,
+     SaveRomAsPreservesTargetAcrossWriteConfirmation) {
+  FeatureFlagsGuard guard;
+  ScopedImGuiContext imgui;
+
+  auto renderer = std::make_unique<gfx::NullRenderer>();
+  auto manager = std::make_unique<EditorManager>();
+  manager->Initialize(renderer.get(), "");
+  manager->SetAssetLoadMode(AssetLoadMode::kLazy);
+
+  const auto source_path = MakeTempFilePath("yaze_save_as_confirm_source.sfc");
+  const auto target_path = MakeTempFilePath("yaze_save_as_confirm_target.sfc");
+  ScopedFileCleanup source_cleanup{source_path};
+  ScopedFileCleanup target_cleanup{target_path};
+  WriteTestRom(source_path);
+
+  ASSERT_OK(manager->OpenRomOrProject(source_path.string()));
+  DisableRomWritesForTest();
+
+  auto* project = manager->GetCurrentProject();
+  ASSERT_NE(project, nullptr);
+  project->name = "SaveAsConfirmation";
+  project->filepath = (source_path.parent_path() / "project.yaze").string();
+  project->workspace_settings.backup_on_save = false;
+  project->rom_metadata.write_policy = project::RomWritePolicy::kWarn;
+  project->rom_metadata.expected_hash = "deadbeef";
+
+  Rom* rom = manager->GetCurrentRom();
+  ASSERT_NE(rom, nullptr);
+  constexpr uint32_t kPcOffset = 0x1234;
+  constexpr uint8_t kMutated = 0xA5;
+  ASSERT_OK(rom->WriteByte(kPcOffset, kMutated));
+
+  auto status = manager->SaveRomAs(target_path.string());
+  EXPECT_EQ(status.code(), absl::StatusCode::kCancelled) << status;
+  EXPECT_TRUE(manager->IsRomWriteConfirmPending());
+  EXPECT_EQ(ReadByteAt(source_path, kPcOffset), 0x00);
+  EXPECT_FALSE(std::filesystem::exists(target_path));
+
+  manager->ConfirmRomWrite();
+  auto resumed = manager->ResumePendingRomSave();
+  ASSERT_OK(resumed);
+
+  EXPECT_EQ(ReadByteAt(source_path, kPcOffset), 0x00);
+  EXPECT_EQ(ReadByteAt(target_path, kPcOffset), kMutated);
+  EXPECT_EQ(rom->filename(), target_path.string());
+}
+
+TEST(EditorManagerRomWritePolicyTest, SaveRomAsCannotTargetProjectBuildOutput) {
+  FeatureFlagsGuard guard;
+  ScopedImGuiContext imgui;
+
+  auto renderer = std::make_unique<gfx::NullRenderer>();
+  auto manager = std::make_unique<EditorManager>();
+  manager->Initialize(renderer.get(), "");
+  manager->SetAssetLoadMode(AssetLoadMode::kLazy);
+
+  const auto dev_rom_path = MakeTempFilePath("yaze_save_as_policy_dev.sfc");
+  const auto build_rom_path = MakeTempFilePath("yaze_save_as_policy_build.sfc");
+  ScopedFileCleanup dev_cleanup{dev_rom_path};
+  ScopedFileCleanup build_cleanup{build_rom_path};
+  WriteTestRom(dev_rom_path, "YAZE DEV TARGET");
+  WriteTestRom(build_rom_path, "YAZE BUILD OUT");
+
+  ASSERT_OK(manager->OpenRomOrProject(dev_rom_path.string()));
+  DisableRomWritesForTest();
+
+  auto* project = manager->GetCurrentProject();
+  ASSERT_NE(project, nullptr);
+  project->name = "SaveAsBuildOutputPolicy";
+  project->filepath = (dev_rom_path.parent_path() / "project.yaze").string();
+  project->workspace_settings.backup_on_save = false;
+  project->rom_filename = dev_rom_path.filename().string();
+  project->rom_metadata.write_policy = project::RomWritePolicy::kWarn;
+  project->rom_metadata.expected_hash.clear();
+  ASSERT_OK(project->hack_manifest.LoadFromString(absl::StrFormat(
+      R"json({
+        "manifest_version": 2,
+        "hack_name": "Save As Build Output Policy",
+        "build_pipeline": {
+          "dev_rom": "%s",
+          "patched_rom": "%s"
+        }
+      })json",
+      dev_rom_path.filename().string(), build_rom_path.filename().string())));
+
+  Rom* rom = manager->GetCurrentRom();
+  ASSERT_NE(rom, nullptr);
+  constexpr uint32_t kPcOffset = 0x1234;
+  ASSERT_OK(rom->WriteByte(kPcOffset, 0xA5));
+
+  auto status = manager->SaveRomAs(build_rom_path.string());
+  EXPECT_EQ(status.code(), absl::StatusCode::kPermissionDenied) << status;
+  EXPECT_EQ(ReadByteAt(dev_rom_path, kPcOffset), 0x00);
+  EXPECT_EQ(ReadByteAt(build_rom_path, kPcOffset), 0x00);
+  EXPECT_EQ(rom->filename(), dev_rom_path.string());
+}
+
+TEST(EditorManagerRomWritePolicyTest, SaveRomAsRefreshesLifecycleHashAndPath) {
+  FeatureFlagsGuard guard;
+  ScopedImGuiContext imgui;
+
+  auto renderer = std::make_unique<gfx::NullRenderer>();
+  auto manager = std::make_unique<EditorManager>();
+  manager->Initialize(renderer.get(), "");
+  manager->SetAssetLoadMode(AssetLoadMode::kLazy);
+
+  const auto source_path = MakeTempFilePath("yaze_save_as_hash_source.sfc");
+  const auto target_path = MakeTempFilePath("yaze_save_as_hash_target.sfc");
+  ScopedFileCleanup source_cleanup{source_path};
+  ScopedFileCleanup target_cleanup{target_path};
+  WriteTestRom(source_path);
+
+  ASSERT_OK(manager->OpenRomOrProject(source_path.string()));
+  DisableRomWritesForTest();
+
+  auto* project = manager->GetCurrentProject();
+  ASSERT_NE(project, nullptr);
+  project->name = "SaveAsLifecycleRefresh";
+  project->filepath = (source_path.parent_path() / "project.yaze").string();
+  project->workspace_settings.backup_on_save = false;
+  project->rom_filename = source_path.string();
+  project->rom_metadata.write_policy = project::RomWritePolicy::kAllow;
+  project->rom_metadata.expected_hash = manager->GetCurrentRomHash();
+  EXPECT_FALSE(manager->IsRomHashMismatch());
+
+  Rom* rom = manager->GetCurrentRom();
+  ASSERT_NE(rom, nullptr);
+  ASSERT_OK(rom->WriteByte(0x1234, 0xA5));
+  ASSERT_OK(manager->SaveRomAs(target_path.string()));
+
+  EXPECT_EQ(rom->filename(), target_path.string());
+  EXPECT_TRUE(manager->IsRomHashMismatch());
+}
+
+TEST(EditorManagerRomWritePolicyTest,
+     FailedResumeConsumesHashConfirmationBypass) {
+  FeatureFlagsGuard guard;
+  ScopedImGuiContext imgui;
+
+  auto renderer = std::make_unique<gfx::NullRenderer>();
+  auto manager = std::make_unique<EditorManager>();
+  manager->Initialize(renderer.get(), "");
+  manager->SetAssetLoadMode(AssetLoadMode::kLazy);
+
+  const auto source_path = MakeTempFilePath("yaze_resume_failure_source.sfc");
+  const auto target_path = MakeTempFilePath("yaze_resume_failure_target.sfc");
+  ScopedFileCleanup source_cleanup{source_path};
+  ScopedFileCleanup target_cleanup{target_path};
+  WriteTestRom(source_path);
+
+  ASSERT_OK(manager->OpenRomOrProject(source_path.string()));
+  DisableRomWritesForTest();
+
+  auto* project = manager->GetCurrentProject();
+  ASSERT_NE(project, nullptr);
+  project->name = "ResumeFailureConsumesBypass";
+  project->filepath = (source_path.parent_path() / "project.yaze").string();
+  project->workspace_settings.backup_on_save = false;
+  project->rom_metadata.write_policy = project::RomWritePolicy::kWarn;
+  project->rom_metadata.expected_hash = "deadbeef";
+  project->hack_manifest.Clear();
+  project->hack_manifest_file =
+      (source_path.parent_path() / "missing-save-manifest.json").string();
+
+  Rom* rom = manager->GetCurrentRom();
+  ASSERT_NE(rom, nullptr);
+  ASSERT_OK(rom->WriteByte(0x1234, 0xA5));
+
+  EXPECT_TRUE(absl::IsCancelled(manager->SaveRomAs(target_path.string())));
+  manager->ConfirmRomWrite();
+  const auto failed_resume = manager->ResumePendingRomSave();
+  EXPECT_EQ(failed_resume.code(), absl::StatusCode::kFailedPrecondition)
+      << failed_resume;
+
+  // Removing the downstream failure must not let the next, unrelated save
+  // inherit the prior confirmation.
+  project->hack_manifest_file.clear();
+  const auto retry = manager->SaveRom();
+  EXPECT_TRUE(absl::IsCancelled(retry)) << retry;
+  EXPECT_TRUE(manager->IsRomWriteConfirmPending());
+  EXPECT_EQ(ReadByteAt(source_path, 0x1234), 0x00);
+  EXPECT_FALSE(std::filesystem::exists(target_path));
+}
+
+TEST(EditorManagerRomWritePolicyTest,
+     CancellingLaterPromptConsumesHashConfirmationBypass) {
+  FeatureFlagsGuard guard;
+  ScopedImGuiContext imgui;
+
+  auto renderer = std::make_unique<gfx::NullRenderer>();
+  auto manager = std::make_unique<EditorManager>();
+  manager->Initialize(renderer.get(), "");
+  manager->SetAssetLoadMode(AssetLoadMode::kLazy);
+
+  const auto source_path = MakeTempFilePath("yaze_prompt_cancel_source.sfc");
+  const auto target_path = MakeTempFilePath("yaze_prompt_cancel_target.sfc");
+  ScopedFileCleanup source_cleanup{source_path};
+  ScopedFileCleanup target_cleanup{target_path};
+  WriteTestRom(source_path);
+
+  ASSERT_OK(manager->OpenRomOrProject(source_path.string()));
+  DisableRomWritesForTest();
+  core::FeatureFlags::get().dungeon.kSavePotItems = true;
+  ASSERT_NE(manager->GetCurrentEditorSet()->GetEditor(EditorType::kDungeon),
+            nullptr);
+
+  auto* project = manager->GetCurrentProject();
+  ASSERT_NE(project, nullptr);
+  project->name = "LaterPromptCancelConsumesBypass";
+  project->filepath = (source_path.parent_path() / "project.yaze").string();
+  project->workspace_settings.backup_on_save = false;
+  project->rom_metadata.write_policy = project::RomWritePolicy::kWarn;
+  project->rom_metadata.expected_hash = "deadbeef";
+
+  Rom* rom = manager->GetCurrentRom();
+  ASSERT_NE(rom, nullptr);
+  ASSERT_OK(rom->WriteByte(0x1234, 0xA5));
+
+  EXPECT_TRUE(absl::IsCancelled(manager->SaveRomAs(target_path.string())));
+  manager->ConfirmRomWrite();
+  EXPECT_TRUE(absl::IsCancelled(manager->ResumePendingRomSave()));
+  EXPECT_TRUE(manager->HasPendingPotItemSaveConfirmation());
+
+  manager->ResolvePotItemSaveConfirmation(
+      EditorManager::PotItemSaveDecision::kCancel);
+  core::FeatureFlags::get().dungeon.kSavePotItems = false;
+
+  const auto retry = manager->SaveRom();
+  EXPECT_TRUE(absl::IsCancelled(retry)) << retry;
+  EXPECT_TRUE(manager->IsRomWriteConfirmPending());
+  EXPECT_EQ(ReadByteAt(source_path, 0x1234), 0x00);
+  EXPECT_FALSE(std::filesystem::exists(target_path));
+}
+
+TEST(EditorManagerRomWritePolicyTest,
+     PendingSaveAsCannotResumeAfterSessionSwitch) {
+  FeatureFlagsGuard guard;
+  ScopedImGuiContext imgui;
+
+  auto renderer = std::make_unique<gfx::NullRenderer>();
+  auto manager = std::make_unique<EditorManager>();
+  manager->Initialize(renderer.get(), "");
+  manager->SetAssetLoadMode(AssetLoadMode::kLazy);
+
+  const auto source_a = MakeTempFilePath("yaze_session_a.sfc");
+  const auto source_b = MakeTempFilePath("yaze_session_b.sfc");
+  const auto target_a = MakeTempFilePath("yaze_session_a_target.sfc");
+  ScopedFileCleanup cleanup_a{source_a};
+  ScopedFileCleanup cleanup_b{source_b};
+  ScopedFileCleanup cleanup_target{target_a};
+  WriteTestRom(source_a, "YAZE SESSION A");
+  WriteTestRom(source_b, "YAZE SESSION B");
+
+  ASSERT_OK(manager->OpenRomOrProject(source_a.string()));
+  const size_t session_a = manager->GetCurrentSessionIndex();
+  ASSERT_OK(manager->OpenRomOrProject(source_b.string()));
+  const size_t session_b = manager->GetCurrentSessionIndex();
+  const std::string session_b_hash = manager->GetCurrentRomHash();
+  ASSERT_NE(session_a, session_b);
+
+  manager->SwitchToSession(session_a);
+  DisableRomWritesForTest();
+
+  auto* project = manager->GetCurrentProject();
+  ASSERT_NE(project, nullptr);
+  project->name = "PendingSaveSessionBinding";
+  project->filepath = (source_a.parent_path() / "project.yaze").string();
+  project->workspace_settings.backup_on_save = false;
+  project->rom_metadata.write_policy = project::RomWritePolicy::kWarn;
+  project->rom_metadata.expected_hash = "deadbeef";
+
+  ASSERT_OK(manager->GetCurrentRom()->WriteByte(0x1234, 0xA5));
+  EXPECT_TRUE(absl::IsCancelled(manager->SaveRomAs(target_a.string())));
+  EXPECT_TRUE(manager->IsRomWriteConfirmPending());
+
+  manager->SwitchToSession(session_b);
+  ASSERT_TRUE(manager->HasPendingUnsavedSessionAction());
+  manager->ConfirmPendingUnsavedSessionActionDiscardAndContinue();
+  ASSERT_EQ(manager->GetCurrentSessionIndex(), session_b);
+  EXPECT_EQ(manager->GetCurrentRomHash(), session_b_hash);
+
+  // Simulate a stale confirmation callback after the session switch. It must
+  // not serialize session B or write it to session A's Save As target.
+  manager->ConfirmRomWrite();
+  const auto stale_resume = manager->ResumePendingRomSave();
+  EXPECT_EQ(stale_resume.code(), absl::StatusCode::kFailedPrecondition)
+      << stale_resume;
+  EXPECT_FALSE(std::filesystem::exists(target_a));
+  EXPECT_EQ(ReadByteAt(source_a, 0x1234), 0x00);
+  EXPECT_EQ(ReadByteAt(source_b, 0x1234), 0x00);
 }
 
 }  // namespace

--- a/test/unit/editor/editor_manager_write_conflict_test.cc
+++ b/test/unit/editor/editor_manager_write_conflict_test.cc
@@ -16,6 +16,7 @@
 #include "rom/rom_diff.h"
 #include "rom/snes.h"
 #include "testing.h"
+#include "zelda3/dungeon/dungeon_rom_addresses.h"
 
 #include "imgui/imgui.h"
 
@@ -121,6 +122,15 @@ void MarkCurrentDungeonRoomPending(EditorManager* manager) {
   ASSERT_NE(dungeon, nullptr);
   dungeon->rooms()[0].SetPalette(0x2A);
   EXPECT_EQ(dungeon->PendingRoomCount(), 1);
+}
+
+void WriteLongPointer(std::vector<uint8_t>* data, int offset, uint32_t value) {
+  ASSERT_NE(data, nullptr);
+  ASSERT_GE(offset, 0);
+  ASSERT_LT(offset + 2, static_cast<int>(data->size()));
+  (*data)[offset] = static_cast<uint8_t>(value & 0xFF);
+  (*data)[offset + 1] = static_cast<uint8_t>((value >> 8) & 0xFF);
+  (*data)[offset + 2] = static_cast<uint8_t>((value >> 16) & 0xFF);
 }
 
 TEST(EditorManagerWriteConflictTest, SaveRomBlocksAndAllowsBypass) {
@@ -248,6 +258,92 @@ TEST(EditorManagerWriteConflictTest, SaveRomBlocksAndAllowsBypass) {
   EXPECT_TRUE(manager->pending_write_conflicts().empty());
   EXPECT_EQ(ReadByteAt(rom_path, static_cast<std::streamoff>(kPcOffset)),
             mutated);
+}
+
+TEST(EditorManagerWriteConflictTest,
+     LateConflictRollsBackSerializedRomAndDungeonDirtyState) {
+  FeatureFlagsGuard guard;
+  ScopedImGuiContext imgui;
+
+  auto renderer = std::make_unique<gfx::NullRenderer>();
+  auto manager = std::make_unique<EditorManager>();
+  manager->Initialize(renderer.get(), "");
+  manager->SetAssetLoadMode(AssetLoadMode::kLazy);
+
+  constexpr int kHeaderTablePc = 0x10000;
+  constexpr int kHeaderPc = 0x12000;
+  constexpr uint32_t kProtectedPc = 0x1234;
+  const std::filesystem::path rom_path =
+      MakeTempFilePath("yaze_transaction_rollback_test.sfc");
+  ScopedFileCleanup cleanup{rom_path};
+  std::vector<uint8_t> rom_data(512 * 1024, 0x00);
+  WriteLongPointer(&rom_data, zelda3::kRoomHeaderPointer,
+                   PcToSnes(kHeaderTablePc));
+  const uint32_t header_snes = PcToSnes(kHeaderPc);
+  rom_data[zelda3::kRoomHeaderPointerBank] =
+      static_cast<uint8_t>((header_snes >> 16) & 0xFF);
+  rom_data[kHeaderTablePc] = static_cast<uint8_t>(header_snes & 0xFF);
+  rom_data[kHeaderTablePc + 1] =
+      static_cast<uint8_t>((header_snes >> 8) & 0xFF);
+  {
+    std::ofstream out(rom_path, std::ios::binary | std::ios::trunc);
+    ASSERT_TRUE(out.is_open());
+    out.write(reinterpret_cast<const char*>(rom_data.data()),
+              static_cast<std::streamsize>(rom_data.size()));
+    ASSERT_TRUE(out.good());
+  }
+
+  ASSERT_OK(manager->OpenRomOrProject(rom_path.string()));
+  DisableRomWritesForTest();
+  core::FeatureFlags::get().dungeon.kSaveRoomHeaders = true;
+
+  auto* project = manager->GetCurrentProject();
+  ASSERT_NE(project, nullptr);
+  project->name = "TransactionRollbackTest";
+  project->filepath = (rom_path.parent_path() / "project.yaze").string();
+  project->workspace_settings.backup_on_save = false;
+  project->rom_metadata.expected_hash.clear();
+  const uint32_t protected_snes = PcToSnes(kProtectedPc);
+  ASSERT_OK(project->hack_manifest.LoadFromString(absl::StrFormat(
+      R"json({
+        "manifest_version": 1,
+        "hack_name": "transaction_test",
+        "protected_regions": {
+          "regions": [
+            {"start": "0x%06X", "end": "0x%06X", "module": "test"}
+          ]
+        }
+      })json",
+      protected_snes, protected_snes + 1)));
+
+  auto* editor_set = manager->GetCurrentEditorSet();
+  ASSERT_NE(editor_set, nullptr);
+  auto* dungeon =
+      editor_set->GetEditorAs<DungeonEditorV2>(EditorType::kDungeon);
+  ASSERT_NE(dungeon, nullptr);
+  auto& room = dungeon->rooms()[0];
+  room.SetLoaded(true);
+  room.SetPalette(0x2A);
+  ASSERT_TRUE(room.header_dirty());
+
+  Rom* rom = manager->GetCurrentRom();
+  ASSERT_NE(rom, nullptr);
+  ASSERT_OK(rom->WriteByte(kProtectedPc, 0xA5));
+  const auto before_save = rom->vector();
+
+  const auto blocked = manager->SaveRom();
+  EXPECT_EQ(blocked.code(), absl::StatusCode::kCancelled) << blocked;
+  EXPECT_EQ(rom->vector(), before_save);
+  EXPECT_TRUE(room.header_dirty());
+  EXPECT_EQ(rom->data()[kHeaderPc + 1], 0x00);
+  EXPECT_EQ(ReadByteAt(rom_path, kProtectedPc), 0x00);
+  EXPECT_EQ(ReadByteAt(rom_path, kHeaderPc + 1), 0x00);
+
+  manager->BypassWriteConflictOnce();
+  ASSERT_OK(manager->SaveRom());
+  EXPECT_FALSE(room.header_dirty());
+  EXPECT_EQ(ReadByteAt(rom_path, kProtectedPc), 0xA5);
+  EXPECT_EQ(ReadByteAt(rom_path, kHeaderPc + 1), 0x2A);
 }
 
 TEST(EditorManagerWriteConflictTest,

--- a/test/unit/editor/message/message_data_test.cc
+++ b/test/unit/editor/message/message_data_test.cc
@@ -211,6 +211,17 @@ TEST(MessageParseResultTest, ReportsNewlineWarning) {
   EXPECT_FALSE(result.warnings.empty());
 }
 
+TEST(MessageParseResultTest, RejectsOutOfRangeDictionaryIndex) {
+  auto last_valid = ParseMessageToDataWithDiagnostics("[D:60]");
+  EXPECT_TRUE(last_valid.ok());
+
+  auto first_invalid = ParseMessageToDataWithDiagnostics("[D:61]");
+  EXPECT_FALSE(first_invalid.ok());
+
+  auto wrapped_invalid = ParseMessageToDataWithDiagnostics("[D:FF]");
+  EXPECT_FALSE(wrapped_invalid.ok());
+}
+
 // ===========================================================================
 // Message Bundle Tests
 // ===========================================================================
@@ -399,6 +410,9 @@ TEST(FindMatchingElementTest, DictionaryToken) {
   elem = FindMatchingElement("[D:3F]");
   ASSERT_TRUE(elem.Active);
   EXPECT_EQ(elem.Value, DICTOFF + 0x3F);
+
+  elem = FindMatchingElement("[D:61]");
+  EXPECT_FALSE(elem.Active);
 }
 
 TEST(FindMatchingElementTest, InvalidToken) {
@@ -934,6 +948,33 @@ TEST(ExpandedBankTest, ReadExpandedTextDataEmpty) {
   auto messages =
       ReadExpandedTextData(rom_data.data(), kExpandedTextDataDefault);
   EXPECT_TRUE(messages.empty());
+}
+
+TEST(ExpandedBankTest, ReadExpandedTextDataHonorsInclusiveEnd) {
+  std::vector<uint8_t> rom_data(64, 0x00);
+  constexpr int kStart = 8;
+  rom_data[kStart + 0] = 0x00;  // A
+  rom_data[kStart + 1] = 0x7F;  // first message terminator / inclusive end
+  rom_data[kStart + 2] = 0x01;  // B, outside configured region
+  rom_data[kStart + 3] = 0x7F;
+  rom_data[kStart + 4] = 0xFF;
+
+  auto messages = ReadExpandedTextData(rom_data.data(), kStart, kStart + 1);
+  ASSERT_EQ(messages.size(), 1u);
+  EXPECT_EQ(messages[0].ContentsParsed, "A");
+}
+
+TEST(ExpandedBankTest, BankCommandDoesNotEscapeExpandedRegion) {
+  std::vector<uint8_t> rom_data(64, 0x00);
+  constexpr int kStart = 8;
+  rom_data[kStart + 0] = kBankSwitchCommand;
+  rom_data[kStart + 1] = 0x01;  // B
+  rom_data[kStart + 2] = kMessageTerminator;
+  rom_data[kStart + 3] = 0xFF;
+
+  auto messages = ReadExpandedTextData(rom_data.data(), kStart, kStart + 3);
+  ASSERT_EQ(messages.size(), 1u);
+  EXPECT_EQ(messages[0].ContentsParsed, "[BANK]B");
 }
 
 TEST(ExpandedBankTest, WriteExpandedTextData) {

--- a/test/unit/editor/message/message_expanded_write_test.cc
+++ b/test/unit/editor/message/message_expanded_write_test.cc
@@ -57,5 +57,44 @@ TEST(ExpandedMessageWriteTest, IsWriteFenceAware) {
   EXPECT_EQ(status.code(), absl::StatusCode::kPermissionDenied);
 }
 
-}  // namespace yaze::editor
+TEST(ExpandedMessageWriteTest, InvalidTextFailsBeforeRomMutation) {
+  Rom rom = MakeRom(256);
+  const auto before = rom.vector();
 
+  auto status =
+      WriteExpandedTextData(&rom, /*start=*/100, /*end=*/120, {"A[UNKNOWN]B"});
+  EXPECT_EQ(status.code(), absl::StatusCode::kInvalidArgument) << status;
+  EXPECT_EQ(rom.vector(), before);
+}
+
+TEST(ExpandedMessageWriteTest, BankCommandFailsBeforeRomMutation) {
+  Rom rom = MakeRom(256);
+  const auto before = rom.vector();
+
+  auto status =
+      WriteExpandedTextData(&rom, /*start=*/100, /*end=*/120, {"A[BANK]B"});
+  EXPECT_EQ(status.code(), absl::StatusCode::kInvalidArgument) << status;
+  EXPECT_EQ(rom.vector(), before);
+}
+
+TEST(ExpandedMessageWriteTest, BankByteIsAllowedAsCommandArgument) {
+  Rom rom = MakeRom(256);
+
+  auto status =
+      WriteExpandedTextData(&rom, /*start=*/100, /*end=*/120, {"[W:80]A"});
+  EXPECT_TRUE(status.ok()) << status;
+  EXPECT_EQ(rom.vector()[100], 0x6B);
+  EXPECT_EQ(rom.vector()[101], 0x80);
+}
+
+TEST(ExpandedMessageWriteTest, LegacyWriterPreflightsBankCommand) {
+  std::vector<uint8_t> data(256, 0x5A);
+  const auto before = data;
+
+  auto status = WriteExpandedTextData(data.data(), /*start=*/100, /*end=*/120,
+                                      {"A", "B[BANK]"});
+  EXPECT_EQ(status.code(), absl::StatusCode::kInvalidArgument) << status;
+  EXPECT_EQ(data, before);
+}
+
+}  // namespace yaze::editor

--- a/test/unit/editor/rom_file_manager_test.cc
+++ b/test/unit/editor/rom_file_manager_test.cc
@@ -41,8 +41,8 @@ void WriteBinaryFile(const std::filesystem::path& path,
                      const std::vector<uint8_t>& data) {
   std::filesystem::create_directories(path.parent_path());
   std::ofstream file(path, std::ios::binary | std::ios::trunc);
-  ASSERT_TRUE(file.is_open()) << "Failed to open file for writing: "
-                              << path.string();
+  ASSERT_TRUE(file.is_open())
+      << "Failed to open file for writing: " << path.string();
   file.write(reinterpret_cast<const char*>(data.data()),
              static_cast<std::streamsize>(data.size()));
   file.close();
@@ -50,8 +50,8 @@ void WriteBinaryFile(const std::filesystem::path& path,
 
 std::vector<uint8_t> ReadBinaryFile(const std::filesystem::path& path) {
   std::ifstream file(path, std::ios::binary);
-  EXPECT_TRUE(file.is_open()) << "Failed to open file for reading: "
-                              << path.string();
+  EXPECT_TRUE(file.is_open())
+      << "Failed to open file for reading: " << path.string();
   file.seekg(0, std::ios::end);
   const auto size = static_cast<size_t>(file.tellg());
   file.seekg(0, std::ios::beg);
@@ -93,6 +93,38 @@ TEST(RomFileManagerTest, BackupCopiesOnDiskRomNotInMemoryBuffer) {
   const auto source_data = ReadBinaryFile(rom_path);
   ASSERT_EQ(source_data.size(), original.size());
   EXPECT_EQ(source_data[0], 0xAA);
+}
+
+TEST(RomFileManagerTest, SaveRomAsWritesExactPathWithoutTouchingSource) {
+  ScopedTempDir temp(MakeUniqueTempDir("yaze_rom_save_as"));
+
+  const auto source_path = temp.path() / "source.sfc";
+  const auto target_path = temp.path() / "chosen-name.sfc";
+  const std::vector<uint8_t> original(512 * 1024, 0xAA);
+  WriteBinaryFile(source_path, original);
+
+  Rom rom;
+  ASSERT_TRUE(rom.LoadFromFile(source_path.string()).ok());
+  ASSERT_TRUE(rom.WriteByte(0, 0xBB).ok());
+
+  RomFileManager manager(/*toast_manager=*/nullptr);
+  manager.SetBackupBeforeSave(false);
+  ASSERT_TRUE(manager.SaveRomAs(&rom, target_path.string()).ok());
+
+  EXPECT_EQ(rom.filename(), target_path.string());
+  EXPECT_EQ(ReadBinaryFile(source_path), original);
+  auto target = ReadBinaryFile(target_path);
+  ASSERT_EQ(target.size(), original.size());
+  EXPECT_EQ(target[0], 0xBB);
+
+  // Save As must not manufacture a timestamped sibling path.
+  size_t sfc_count = 0;
+  for (const auto& entry : std::filesystem::directory_iterator(temp.path())) {
+    if (entry.path().extension() == ".sfc") {
+      ++sfc_count;
+    }
+  }
+  EXPECT_EQ(sfc_count, 2u);
 }
 
 }  // namespace yaze::editor

--- a/test/unit/rom/rom_test.cc
+++ b/test/unit/rom/rom_test.cc
@@ -278,5 +278,37 @@ TEST_F(RomTest, TransactionRollbackRestoresOriginals) {
   EXPECT_EQ(*b1, kMockRomData[0x01]);
 }
 
+TEST_F(RomTest, ScopedRomTransactionRollsBackBufferMetadataAndDirtyState) {
+  EXPECT_OK(rom_.LoadFromData(kMockRomData));
+  rom_.set_filename("before.sfc");
+  rom_.set_dirty(false);
+
+  {
+    yaze::ScopedRomTransaction tx{rom_};
+    EXPECT_OK(rom_.WriteByte(0x01, 0xAA));
+    rom_.Expand(0x100);
+    rom_.set_filename("after.sfc");
+  }
+
+  EXPECT_EQ(rom_.vector(), kMockRomData);
+  EXPECT_EQ(rom_.size(), kMockRomData.size());
+  EXPECT_EQ(rom_.filename(), "before.sfc");
+  EXPECT_FALSE(rom_.dirty());
+}
+
+TEST_F(RomTest, ScopedRomTransactionCommitKeepsChanges) {
+  EXPECT_OK(rom_.LoadFromData(kMockRomData));
+  {
+    yaze::ScopedRomTransaction tx{rom_};
+    EXPECT_OK(rom_.WriteByte(0x01, 0xAA));
+    tx.Commit();
+  }
+
+  const auto value = rom_.ReadByte(0x01);
+  ASSERT_TRUE(value.ok());
+  EXPECT_EQ(*value, 0xAA);
+  EXPECT_TRUE(rom_.dirty());
+}
+
 }  // namespace test
 }  // namespace yaze

--- a/test/unit/zelda3/dungeon/dungeon_editor_system_test.cc
+++ b/test/unit/zelda3/dungeon/dungeon_editor_system_test.cc
@@ -110,7 +110,8 @@ class DungeonEditorSystemTest : public ::testing::Test {
     WriteLongPointer(kChestsDataPointer1, PcToSnes(kChestDataPc));
     rom_->mutable_data()[kChestsLengthPointer] = 0x00;
     rom_->mutable_data()[kChestsLengthPointer + 1] = 0x00;
-    std::fill_n(rom_->mutable_data() + kChestDataPc, 0x100, 0x00);
+    std::fill_n(rom_->mutable_data() + kChestDataPc, kChestTableCapacityBytes,
+                0x00);
   }
 
   void SetupPotItemTable() {
@@ -133,7 +134,7 @@ class DungeonEditorSystemTest : public ::testing::Test {
 
   void SeedChestEntry(int room_id, uint8_t chest_id, bool big) {
     const uint16_t word = static_cast<uint16_t>(room_id) | (big ? 0x8000 : 0);
-    rom_->mutable_data()[kChestsLengthPointer] = 0x01;
+    rom_->mutable_data()[kChestsLengthPointer] = kChestTableRecordSize;
     rom_->mutable_data()[kChestsLengthPointer + 1] = 0x00;
     rom_->mutable_data()[kChestDataPc + 0] = word & 0xFF;
     rom_->mutable_data()[kChestDataPc + 1] = (word >> 8) & 0xFF;
@@ -171,6 +172,7 @@ TEST_F(DungeonEditorSystemTest, SaveRoomPersistsExternalRoomObjectsAndChests) {
 
   ASSERT_TRUE(object_editor->InsertObject(5, 5, 0x10, 0x0F, 0).ok());
   external_room.GetChests().push_back(chest_data{0x42, false});
+  external_room.MarkChestsDirty();
 
   ASSERT_TRUE(system.SaveRoom(0).ok());
 
@@ -189,6 +191,7 @@ TEST_F(DungeonEditorSystemTest, SaveRoomPersistsExternalRoomPotItemsAndHeader) {
   system.SetExternalRoom(&external_room);
 
   external_room.GetPotItems().push_back(PotItem{0x1234, 0x56});
+  external_room.MarkPotItemsDirty();
   external_room.SetPalette(0x2A);
   external_room.SetMessageId(0x1357);
 
@@ -214,6 +217,8 @@ TEST_F(DungeonEditorSystemTest, SaveRoomPreservesOtherRoomIndexedData) {
 
   external_room.GetChests().push_back(chest_data{0x21, false});
   external_room.GetPotItems().push_back(PotItem{0x1234, 0x56});
+  external_room.MarkChestsDirty();
+  external_room.MarkPotItemsDirty();
 
   ASSERT_TRUE(system.SaveRoom(0).ok());
 
@@ -247,12 +252,14 @@ TEST_F(DungeonEditorSystemTest, SaveDungeonPersistsAllCachedRooms) {
   ASSERT_TRUE(object_editor->InsertObject(5, 5, 0x10, 0x0F, 0).ok());
   object_editor->GetMutableRoom()->GetChests().push_back(
       chest_data{0x21, false});
+  object_editor->GetMutableRoom()->MarkChestsDirty();
 
   ASSERT_TRUE(system.SetCurrentRoom(1).ok());
   ASSERT_EQ(object_editor->GetRoom().id(), 1);
   ASSERT_TRUE(object_editor->InsertObject(10, 10, 0x20, 0x0F, 0).ok());
   object_editor->GetMutableRoom()->GetChests().push_back(
       chest_data{0x77, true});
+  object_editor->GetMutableRoom()->MarkChestsDirty();
 
   ASSERT_TRUE(system.SaveDungeon().ok());
 
@@ -287,6 +294,7 @@ TEST_F(DungeonEditorSystemTest,
   ASSERT_NE(object_editor, nullptr);
   object_editor->GetMutableRoom()->GetPotItems().push_back(
       PotItem{0x1234, 0x56});
+  object_editor->GetMutableRoom()->MarkPotItemsDirty();
   object_editor->GetMutableRoom()->SetPalette(0x11);
   object_editor->GetMutableRoom()->SetMessageId(0x2468);
 
@@ -294,6 +302,7 @@ TEST_F(DungeonEditorSystemTest,
   ASSERT_EQ(object_editor->GetRoom().id(), 1);
   object_editor->GetMutableRoom()->GetPotItems().push_back(
       PotItem{0x5678, 0x9A});
+  object_editor->GetMutableRoom()->MarkPotItemsDirty();
   object_editor->GetMutableRoom()->SetPalette(0x22);
   object_editor->GetMutableRoom()->SetMessageId(0x1357);
 

--- a/test/unit/zelda3/dungeon/dungeon_object_editor_dirty_test.cc
+++ b/test/unit/zelda3/dungeon/dungeon_object_editor_dirty_test.cc
@@ -1,0 +1,117 @@
+#include "gtest/gtest.h"
+
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+#include "rom/rom.h"
+#include "zelda3/dungeon/dungeon_object_editor.h"
+#include "zelda3/dungeon/room.h"
+
+namespace yaze::zelda3 {
+namespace {
+
+class DungeonObjectEditorDirtyTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    ASSERT_TRUE(rom_.LoadFromData(std::vector<uint8_t>(0x100000, 0)).ok());
+    room_ = std::make_unique<Room>(0, &rom_);
+    ASSERT_TRUE(room_->AddObject(RoomObject(0x21, 1, 1, 0, 0)).ok());
+    ASSERT_TRUE(room_->AddObject(RoomObject(0x22, 5, 5, 0, 0)).ok());
+    room_->ClearSaveDirtyState();
+
+    editor_ = std::make_unique<DungeonObjectEditor>(&rom_);
+    editor_->SetExternalRoom(room_.get());
+    auto config = editor_->GetConfig();
+    config.snap_to_grid = false;
+    config.validate_objects = false;
+    editor_->SetConfig(config);
+  }
+
+  Rom rom_;
+  std::unique_ptr<Room> room_;
+  std::unique_ptr<DungeonObjectEditor> editor_;
+};
+
+TEST_F(DungeonObjectEditorDirtyTest, DirectMutatorsMarkObjectStreamDirty) {
+  ASSERT_TRUE(editor_->MoveObject(0, 2, 3).ok());
+  EXPECT_TRUE(room_->object_stream_dirty());
+
+  room_->ClearSaveDirtyState();
+  ASSERT_TRUE(editor_->ResizeObject(0, 4).ok());
+  EXPECT_TRUE(room_->object_stream_dirty());
+
+  room_->ClearSaveDirtyState();
+  ASSERT_TRUE(editor_->ChangeObjectType(0, 0x23).ok());
+  EXPECT_TRUE(room_->object_stream_dirty());
+
+  room_->ClearSaveDirtyState();
+  ASSERT_TRUE(editor_->ChangeObjectLayer(0, 1).ok());
+  EXPECT_TRUE(room_->object_stream_dirty());
+}
+
+TEST_F(DungeonObjectEditorDirtyTest, BatchMutatorsMarkObjectStreamDirty) {
+  const std::vector<size_t> indices = {0, 1};
+
+  ASSERT_TRUE(editor_->BatchMoveObjects(indices, 1, 2).ok());
+  EXPECT_TRUE(room_->object_stream_dirty());
+
+  room_->ClearSaveDirtyState();
+  ASSERT_TRUE(editor_->BatchResizeObjects(indices, 5).ok());
+  EXPECT_TRUE(room_->object_stream_dirty());
+
+  room_->ClearSaveDirtyState();
+  ASSERT_TRUE(editor_->BatchChangeObjectLayer(indices, 2).ok());
+  EXPECT_TRUE(room_->object_stream_dirty());
+}
+
+TEST_F(DungeonObjectEditorDirtyTest, AlignAndDragMarkObjectStreamDirty) {
+  ASSERT_TRUE(editor_->AddToSelection(0).ok());
+  ASSERT_TRUE(editor_->AddToSelection(1).ok());
+  ASSERT_TRUE(
+      editor_->AlignSelectedObjects(DungeonObjectEditor::Alignment::Left).ok());
+  EXPECT_TRUE(room_->object_stream_dirty());
+
+  room_->ClearSaveDirtyState();
+  ASSERT_TRUE(editor_->ClearSelection().ok());
+  ASSERT_TRUE(editor_->AddToSelection(0).ok());
+  ASSERT_TRUE(editor_
+                  ->HandleMouseDrag(/*start_x=*/0, /*start_y=*/0,
+                                    /*current_x=*/16, /*current_y=*/0)
+                  .ok());
+  EXPECT_TRUE(room_->object_stream_dirty());
+}
+
+TEST_F(DungeonObjectEditorDirtyTest, NoOpMutatorsDoNotMarkDirty) {
+  const auto& object = room_->GetTileObject(0);
+  ASSERT_TRUE(editor_->MoveObject(0, object.x(), object.y()).ok());
+  ASSERT_TRUE(editor_->ResizeObject(0, object.size()).ok());
+  ASSERT_TRUE(editor_->ChangeObjectType(0, object.id_).ok());
+  ASSERT_TRUE(editor_->ChangeObjectLayer(0, object.GetLayerValue()).ok());
+  ASSERT_TRUE(editor_->BatchMoveObjects({0}, 0, 0).ok());
+  ASSERT_TRUE(editor_->BatchResizeObjects({0}, object.size()).ok());
+  ASSERT_TRUE(
+      editor_->BatchChangeObjectLayer({0}, object.GetLayerValue()).ok());
+  EXPECT_FALSE(room_->object_stream_dirty());
+
+  ASSERT_TRUE(editor_->BatchMoveObjects({99}, 1, 1).ok());
+  EXPECT_FALSE(room_->object_stream_dirty());
+}
+
+TEST_F(DungeonObjectEditorDirtyTest,
+       SpecialTableObjectMutationMarksItsOwnSaveDomain) {
+  Room special_room(1, &rom_);
+  RoomObject torch(0x150, 1, 1, 0, 0);
+  torch.set_options(ObjectOption::Torch);
+  ASSERT_TRUE(special_room.AddObject(torch).ok());
+  special_room.ClearSaveDirtyState();
+  editor_->SetExternalRoom(&special_room);
+
+  ASSERT_TRUE(editor_->MoveObject(0, 2, 2).ok());
+
+  EXPECT_TRUE(special_room.torches_dirty());
+  EXPECT_FALSE(special_room.object_stream_dirty());
+}
+
+}  // namespace
+}  // namespace yaze::zelda3

--- a/test/unit/zelda3/dungeon/dungeon_save_test.cc
+++ b/test/unit/zelda3/dungeon/dungeon_save_test.cc
@@ -118,6 +118,13 @@ class DungeonSaveTest : public ::testing::Test {
     rom_->mutable_data()[0x49001] = 0xFF;
   }
 
+  void SetSpriteRoomPointer(int room_id, int pc_addr) {
+    const uint16_t pointer = static_cast<uint16_t>(PcToSnes(pc_addr));
+    const int table_loc = 0x48000 + room_id * 2;
+    rom_->mutable_data()[table_loc] = pointer & 0xFF;
+    rom_->mutable_data()[table_loc + 1] = (pointer >> 8) & 0xFF;
+  }
+
   void WriteLongPointer(int addr, uint32_t snes_addr) {
     rom_->mutable_data()[addr + 0] = snes_addr & 0xFF;
     rom_->mutable_data()[addr + 1] = (snes_addr >> 8) & 0xFF;
@@ -128,12 +135,13 @@ class DungeonSaveTest : public ::testing::Test {
     WriteLongPointer(kChestsDataPointer1, PcToSnes(kChestDataPc));
     rom_->mutable_data()[kChestsLengthPointer] = 0x00;
     rom_->mutable_data()[kChestsLengthPointer + 1] = 0x00;
-    std::fill_n(rom_->mutable_data() + kChestDataPc, 0x100, 0x00);
+    std::fill_n(rom_->mutable_data() + kChestDataPc, kChestTableCapacityBytes,
+                0x00);
   }
 
   void SeedChestEntry(int room_id, uint8_t chest_id, bool big) {
     const uint16_t word = static_cast<uint16_t>(room_id) | (big ? 0x8000 : 0);
-    rom_->mutable_data()[kChestsLengthPointer] = 0x01;
+    rom_->mutable_data()[kChestsLengthPointer] = kChestTableRecordSize;
     rom_->mutable_data()[kChestsLengthPointer + 1] = 0x00;
     rom_->mutable_data()[kChestDataPc + 0] = word & 0xFF;
     rom_->mutable_data()[kChestDataPc + 1] = (word >> 8) & 0xFF;
@@ -158,6 +166,13 @@ class DungeonSaveTest : public ::testing::Test {
     rom_->mutable_data()[kPotRoom1Pc + 1] = 0xFF;
     rom_->mutable_data()[kPotRoom2Pc + 0] = 0xFF;
     rom_->mutable_data()[kPotRoom2Pc + 1] = 0xFF;
+  }
+
+  void SetPotRoomPointer(int room_id, int pc_addr) {
+    const uint16_t pointer = static_cast<uint16_t>(PcToSnes(pc_addr));
+    const int ptr_off = kRoomItemsPointers + room_id * 2;
+    rom_->mutable_data()[ptr_off] = pointer & 0xFF;
+    rom_->mutable_data()[ptr_off + 1] = (pointer >> 8) & 0xFF;
   }
 
   void SeedPotItemBytes(int pc_addr, std::initializer_list<uint8_t> bytes) {
@@ -230,19 +245,51 @@ TEST_F(DungeonSaveTest, SaveObjects_TooLarge) {
 
   auto status = room_->SaveObjects();
   EXPECT_FALSE(status.ok());
-  EXPECT_EQ(status.code(), absl::StatusCode::kOutOfRange);
+  EXPECT_EQ(status.code(), absl::StatusCode::kResourceExhausted);
+}
+
+TEST_F(DungeonSaveTest, SaveObjects_SharedStreamFailsWithoutMutation) {
+  WriteLongPointer(0xF8000 + 3, PcToSnes(0x100000));
+  ASSERT_TRUE(room_->AddObject(RoomObject(0x10, 10, 10, 0, 0)).ok());
+  const auto before = rom_->vector();
+
+  const auto status = room_->SaveObjects();
+
+  EXPECT_EQ(status.code(), absl::StatusCode::kFailedPrecondition);
+  EXPECT_EQ(rom_->vector(), before);
+  EXPECT_TRUE(room_->object_stream_dirty());
+}
+
+TEST_F(DungeonSaveTest,
+       SaveObjects_UsesNearestPhysicalPointerInsteadOfNextRoomId) {
+  WriteLongPointer(0xF8000 + 3, PcToSnes(0x100200));
+  WriteLongPointer(0xF8000 + 6, PcToSnes(0x100010));
+  std::fill_n(rom_->mutable_data() + 0x100010, 0x20, 0xA5);
+
+  for (int i = 0; i < 3; ++i) {
+    ASSERT_TRUE(room_->AddObject(RoomObject(0x10, 10, 10, 0, 0)).ok());
+  }
+  EXPECT_EQ(CalculateRoomSize(rom_.get(), 0).room_size, 0x10);
+  const auto before = rom_->vector();
+
+  const auto status = room_->SaveObjects();
+
+  EXPECT_EQ(status.code(), absl::StatusCode::kResourceExhausted);
+  EXPECT_EQ(rom_->vector(), before);
+  EXPECT_TRUE(room_->object_stream_dirty());
 }
 
 TEST_F(DungeonSaveTest, SaveSprites_FitsInSpace) {
   // Add a sprite
   zelda3::Sprite spr(0x10, 10, 10, 0, 0);
   room_->GetSprites().push_back(spr);
+  room_->MarkSpritesDirty();
 
   auto status = room_->SaveSprites();
   EXPECT_TRUE(status.ok()) << status.message();
 }
 
-TEST_F(DungeonSaveTest, SaveSprites_TooLargeFallsBackToRelocation) {
+TEST_F(DungeonSaveTest, SaveSprites_TooLargeFailsWithoutMutation) {
   // Add MANY sprites to exceed 0x50 (80) bytes
   // Each sprite is 3 bytes.
   // We need > 26 sprites.
@@ -250,10 +297,14 @@ TEST_F(DungeonSaveTest, SaveSprites_TooLargeFallsBackToRelocation) {
     zelda3::Sprite spr(0x10, 10, 10, 0, 0);
     room_->GetSprites().push_back(spr);
   }
+  room_->MarkSpritesDirty();
+
+  const auto before = rom_->vector();
 
   auto status = room_->SaveSprites();
-  EXPECT_TRUE(status.ok()) << status.message();
-  EXPECT_NE((rom_->data()[0x48001] << 8) | rom_->data()[0x48000], 0x9000);
+  EXPECT_EQ(status.code(), absl::StatusCode::kResourceExhausted);
+  EXPECT_EQ(rom_->vector(), before);
+  EXPECT_TRUE(room_->sprites_dirty());
 }
 
 TEST_F(DungeonSaveTest, SaveSprites_PreservesSortspriteHeaderByte) {
@@ -263,6 +314,7 @@ TEST_F(DungeonSaveTest, SaveSprites_PreservesSortspriteHeaderByte) {
 
   zelda3::Sprite spr(0x10, 10, 10, 0, 0);
   room_->GetSprites().push_back(spr);
+  room_->MarkSpritesDirty();
 
   auto status = room_->SaveSprites();
   ASSERT_TRUE(status.ok()) << status.message();
@@ -274,6 +326,34 @@ TEST_F(DungeonSaveTest, SaveSprites_PreservesSortspriteHeaderByte) {
   EXPECT_EQ(rom_->data()[0x49002], 0x0A);  // b2 (X)
   EXPECT_EQ(rom_->data()[0x49003], 0x10);  // b3 (sprite id)
   EXPECT_EQ(rom_->data()[0x49004], 0xFF);  // terminator
+}
+
+TEST_F(DungeonSaveTest, SaveSprites_SharedStreamFailsWithoutMutation) {
+  SetSpriteRoomPointer(1, 0x49000);
+  room_->GetSprites().emplace_back(0x10, 10, 10, 0, 0);
+  room_->MarkSpritesDirty();
+  const auto before = rom_->vector();
+
+  const auto status = room_->SaveSprites();
+
+  EXPECT_EQ(status.code(), absl::StatusCode::kFailedPrecondition);
+  EXPECT_EQ(rom_->vector(), before);
+  EXPECT_TRUE(room_->sprites_dirty());
+}
+
+TEST_F(DungeonSaveTest,
+       SaveSprites_UsesNearestPhysicalPointerInsteadOfNextRoomId) {
+  SetSpriteRoomPointer(1, 0x49100);
+  SetSpriteRoomPointer(2, 0x49004);
+  room_->GetSprites().emplace_back(0x10, 10, 10, 0, 0);
+  room_->MarkSpritesDirty();
+  const auto before = rom_->vector();
+
+  const auto status = room_->SaveSprites();
+
+  EXPECT_EQ(status.code(), absl::StatusCode::kResourceExhausted);
+  EXPECT_EQ(rom_->vector(), before);
+  EXPECT_TRUE(room_->sprites_dirty());
 }
 
 TEST_F(DungeonSaveTest, LoadSprites_DoesNotDuplicateOnReload) {
@@ -501,7 +581,7 @@ TEST_F(DungeonSaveTest, SaveAllChests_WritesSingleSmallChest) {
   auto status = SaveAllChests(rom_.get(), rooms);
   ASSERT_TRUE(status.ok()) << status.message();
 
-  EXPECT_EQ(rom_->data()[kChestsLengthPointer], 0x01);
+  EXPECT_EQ(rom_->data()[kChestsLengthPointer], 0x03);
   EXPECT_EQ(rom_->data()[kChestsLengthPointer + 1], 0x00);
   EXPECT_EQ(rom_->data()[kChestDataPc + 0], 0x00);
   EXPECT_EQ(rom_->data()[kChestDataPc + 1], 0x00);
@@ -519,7 +599,7 @@ TEST_F(DungeonSaveTest, SaveAllChests_WritesBigChestWithHighBit) {
   auto status = SaveAllChests(rom_.get(), rooms);
   ASSERT_TRUE(status.ok()) << status.message();
 
-  EXPECT_EQ(rom_->data()[kChestsLengthPointer], 0x01);
+  EXPECT_EQ(rom_->data()[kChestsLengthPointer], 0x03);
   EXPECT_EQ(rom_->data()[kChestsLengthPointer + 1], 0x00);
   EXPECT_EQ(rom_->data()[kChestDataPc + 0], 0x00);
   EXPECT_EQ(rom_->data()[kChestDataPc + 1], 0x80);
@@ -541,7 +621,7 @@ TEST_F(DungeonSaveTest, SaveAllChests_PreservesRomEntriesForUntouchedRooms) {
   auto status = SaveAllChests(rom_.get(), rooms);
   ASSERT_TRUE(status.ok()) << status.message();
 
-  EXPECT_EQ(rom_->data()[kChestsLengthPointer], 0x02);
+  EXPECT_EQ(rom_->data()[kChestsLengthPointer], 0x06);
   EXPECT_EQ(rom_->data()[kChestsLengthPointer + 1], 0x00);
 
   EXPECT_EQ(rom_->data()[kChestDataPc + 0], 0x00);
@@ -592,6 +672,84 @@ TEST_F(DungeonSaveTest, SaveAllChests_ReloadedRoomMatchesSerializedState) {
   EXPECT_FALSE(reloaded_room.GetChests()[0].size);
   EXPECT_EQ(reloaded_room.GetChests()[1].id, 0x77);
   EXPECT_TRUE(reloaded_room.GetChests()[1].size);
+}
+
+TEST_F(DungeonSaveTest, LoadChests_InterpretsLengthAsBytes) {
+  SetupChestTable();
+  rom_->mutable_data()[kChestsLengthPointer] = 0x06;
+  rom_->mutable_data()[kChestDataPc + 0] = 0x00;
+  rom_->mutable_data()[kChestDataPc + 1] = 0x00;
+  rom_->mutable_data()[kChestDataPc + 2] = 0x42;
+  rom_->mutable_data()[kChestDataPc + 3] = 0x01;
+  rom_->mutable_data()[kChestDataPc + 4] = 0x00;
+  rom_->mutable_data()[kChestDataPc + 5] = 0x77;
+
+  Room room0(0, rom_.get());
+  room0.LoadChests();
+  ASSERT_EQ(room0.GetChests().size(), 1u);
+  EXPECT_EQ(room0.GetChests()[0].id, 0x42);
+}
+
+TEST_F(DungeonSaveTest, SaveAllChests_NoDirtyRoomsIsNoOp) {
+  SetupChestTable();
+  SeedChestEntry(/*room_id=*/0, /*chest_id=*/0x42, /*big=*/false);
+  std::vector<Room> rooms(kNumberOfRooms);
+  const auto before = rom_->vector();
+  rom_->ClearDirty();
+
+  const auto status = SaveAllChests(rom_.get(), rooms);
+
+  ASSERT_TRUE(status.ok()) << status.message();
+  EXPECT_EQ(rom_->vector(), before);
+  EXPECT_FALSE(rom_->dirty());
+}
+
+TEST_F(DungeonSaveTest, SaveAllChests_UnchangedDirtyRoomAvoidsRomWrite) {
+  SetupChestTable();
+  SeedChestEntry(/*room_id=*/0, /*chest_id=*/0x42, /*big=*/false);
+  std::vector<Room> rooms(kNumberOfRooms);
+  rooms[0] = Room(0, rom_.get());
+  rooms[0].LoadChests();
+  rooms[0].MarkChestsDirty();
+  rom_->ClearDirty();
+
+  const auto status = SaveAllChests(rom_.get(), rooms);
+
+  ASSERT_TRUE(status.ok()) << status.message();
+  EXPECT_FALSE(rom_->dirty());
+  EXPECT_FALSE(rooms[0].chests_dirty());
+}
+
+TEST_F(DungeonSaveTest, SaveAllChests_AtCapacityWrites01F8ByteLength) {
+  SetupChestTable();
+  std::vector<Room> rooms(kNumberOfRooms);
+  for (int i = 0; i < kChestTableCapacityRecords; ++i) {
+    rooms[0].GetChests().push_back(chest_data{static_cast<uint8_t>(i), false});
+  }
+  rooms[0].MarkChestsDirty();
+
+  const auto status = SaveAllChests(rom_.get(), rooms);
+
+  ASSERT_TRUE(status.ok()) << status.message();
+  EXPECT_EQ(rom_->data()[kChestsLengthPointer], 0xF8);
+  EXPECT_EQ(rom_->data()[kChestsLengthPointer + 1], 0x01);
+  EXPECT_FALSE(rooms[0].chests_dirty());
+}
+
+TEST_F(DungeonSaveTest, SaveAllChests_OverCapacityFailsWithoutMutation) {
+  SetupChestTable();
+  std::vector<Room> rooms(kNumberOfRooms);
+  for (int i = 0; i < kChestTableCapacityRecords + 1; ++i) {
+    rooms[0].GetChests().push_back(chest_data{static_cast<uint8_t>(i), false});
+  }
+  rooms[0].MarkChestsDirty();
+  const auto before = rom_->vector();
+
+  const auto status = SaveAllChests(rom_.get(), rooms);
+
+  EXPECT_EQ(status.code(), absl::StatusCode::kResourceExhausted);
+  EXPECT_EQ(rom_->vector(), before);
+  EXPECT_TRUE(rooms[0].chests_dirty());
 }
 
 TEST_F(DungeonSaveTest, SaveAllPotItems_LoadedRoomWritesEntriesAndTerminator) {
@@ -703,6 +861,65 @@ TEST_F(DungeonSaveTest, SaveAllPotItems_DirtyRoomTooLargeFailsAndStaysDirty) {
   EXPECT_EQ(rom_->data()[kPotRoom0Pc + 0], 0x34);
   EXPECT_EQ(rom_->data()[kPotRoom0Pc + 1], 0x12);
   EXPECT_EQ(rom_->data()[kPotRoom0Pc + 2], 0x56);
+}
+
+TEST_F(DungeonSaveTest, SaveAllPotItems_SharedStreamFailsWithoutMutation) {
+  SetupPotItemTable();
+  SetPotRoomPointer(1, kPotRoom0Pc);
+  SeedPotItemBytes(kPotRoom0Pc, {0x34, 0x12, 0x56, 0xFF, 0xFF});
+
+  std::vector<Room> rooms(kNumberOfRooms);
+  rooms[0].GetPotItems().push_back(PotItem{0x5678, 0x9A});
+  rooms[0].MarkPotItemsDirty();
+  const auto before = rom_->vector();
+
+  const auto status = SaveAllPotItems(rom_.get(), rooms);
+
+  EXPECT_EQ(status.code(), absl::StatusCode::kFailedPrecondition);
+  EXPECT_EQ(rom_->vector(), before);
+  EXPECT_TRUE(rooms[0].pot_items_dirty());
+}
+
+TEST_F(DungeonSaveTest,
+       SaveAllPotItems_UsesNearestPhysicalPointerInsteadOfNextRoomId) {
+  SetupPotItemTable();
+  SetPotRoomPointer(1, kPotRoom2Pc);
+  SetPotRoomPointer(2, kPotRoom1Pc);
+
+  std::vector<Room> rooms(kNumberOfRooms);
+  for (int i = 0; i < 11; ++i) {
+    rooms[0].GetPotItems().push_back(PotItem{static_cast<uint16_t>(0x1200 + i),
+                                             static_cast<uint8_t>(0x40 + i)});
+  }
+  rooms[0].MarkPotItemsDirty();
+  const auto before = rom_->vector();
+
+  const auto status = SaveAllPotItems(rom_.get(), rooms);
+
+  EXPECT_EQ(status.code(), absl::StatusCode::kResourceExhausted);
+  EXPECT_EQ(rom_->vector(), before);
+  EXPECT_TRUE(rooms[0].pot_items_dirty());
+}
+
+TEST_F(DungeonSaveTest,
+       SaveAllPotItems_PreflightsAllDirtyRoomsBeforeFirstWrite) {
+  SetupPotItemTable();
+  SetPotRoomPointer(2, kPotRoom1Pc);
+  SeedPotItemBytes(kPotRoom0Pc, {0x34, 0x12, 0x56, 0xFF, 0xFF});
+
+  std::vector<Room> rooms(kNumberOfRooms);
+  rooms[0].GetPotItems().push_back(PotItem{0x5678, 0x9A});
+  rooms[0].MarkPotItemsDirty();
+  rooms[1].GetPotItems().push_back(PotItem{0x1111, 0x22});
+  rooms[1].MarkPotItemsDirty();
+  const auto before = rom_->vector();
+
+  const auto status = SaveAllPotItems(rom_.get(), rooms);
+
+  EXPECT_EQ(status.code(), absl::StatusCode::kFailedPrecondition);
+  EXPECT_EQ(rom_->vector(), before);
+  EXPECT_TRUE(rooms[0].pot_items_dirty());
+  EXPECT_TRUE(rooms[1].pot_items_dirty());
 }
 
 TEST_F(DungeonSaveTest, SaveAllDungeonEntrances_WritesDirtyRegularEntrance) {

--- a/test/unit/zelda3/dungeon/dungeon_save_test.cc
+++ b/test/unit/zelda3/dungeon/dungeon_save_test.cc
@@ -279,6 +279,47 @@ TEST_F(DungeonSaveTest,
   EXPECT_TRUE(room_->object_stream_dirty());
 }
 
+TEST_F(DungeonSaveTest, SaveObjects_SectionOneTailExactFitStopsAtHardEnd) {
+  constexpr int kStreamStart = 0x0535A6;
+  constexpr int kObjectCount = 128;
+  constexpr int kEncodedSize = 8 + (kObjectCount * 3);
+  static_assert(kStreamStart + 2 + kEncodedSize ==
+                kDungeonObjectDataRegions[0].end);
+  WriteLongPointer(0xF8000, PcToSnes(kStreamStart));
+  rom_->mutable_data()[kDungeonObjectDataRegions[0].end] = 0xA5;
+
+  for (int i = 0; i < kObjectCount; ++i) {
+    ASSERT_TRUE(room_->AddObject(RoomObject(0x10, 10, 10, 0, 0)).ok());
+  }
+
+  const auto status = room_->SaveObjects();
+
+  ASSERT_TRUE(status.ok()) << status.message();
+  EXPECT_EQ(rom_->data()[kDungeonObjectDataRegions[0].end], 0xA5);
+  EXPECT_FALSE(room_->object_stream_dirty());
+}
+
+TEST_F(DungeonSaveTest,
+       SaveObjects_SectionOneTailOneByteOverFailsWithoutMutation) {
+  constexpr int kStreamStart = 0x0535A7;
+  constexpr int kObjectCount = 128;
+  constexpr int kEncodedSize = 8 + (kObjectCount * 3);
+  static_assert(kStreamStart + 2 + kEncodedSize ==
+                kDungeonObjectDataRegions[0].end + 1);
+  WriteLongPointer(0xF8000, PcToSnes(kStreamStart));
+
+  for (int i = 0; i < kObjectCount; ++i) {
+    ASSERT_TRUE(room_->AddObject(RoomObject(0x10, 10, 10, 0, 0)).ok());
+  }
+  const auto before = rom_->vector();
+
+  const auto status = room_->SaveObjects();
+
+  EXPECT_EQ(status.code(), absl::StatusCode::kResourceExhausted);
+  EXPECT_EQ(rom_->vector(), before);
+  EXPECT_TRUE(room_->object_stream_dirty());
+}
+
 TEST_F(DungeonSaveTest, SaveSprites_FitsInSpace) {
   // Add a sprite
   zelda3::Sprite spr(0x10, 10, 10, 0, 0);
@@ -302,6 +343,36 @@ TEST_F(DungeonSaveTest, SaveSprites_TooLargeFailsWithoutMutation) {
   const auto before = rom_->vector();
 
   auto status = room_->SaveSprites();
+  EXPECT_EQ(status.code(), absl::StatusCode::kResourceExhausted);
+  EXPECT_EQ(rom_->vector(), before);
+  EXPECT_TRUE(room_->sprites_dirty());
+}
+
+TEST_F(DungeonSaveTest, SaveSprites_FinalTerminatorFitsExclusiveHardEnd) {
+  constexpr int kStreamStart = kSpritesDataEndExclusive - 2;
+  SetSpriteRoomPointer(0, kStreamStart);
+  rom_->mutable_data()[kStreamStart] = 0x00;
+  rom_->mutable_data()[kSpritesDataEndExclusive] = 0xA5;
+  room_->MarkSpritesDirty();
+
+  const auto status = room_->SaveSprites();
+
+  ASSERT_TRUE(status.ok()) << status.message();
+  EXPECT_EQ(rom_->data()[kSpritesEndData], 0xFF);
+  EXPECT_EQ(rom_->data()[kSpritesDataEndExclusive], 0xA5);
+  EXPECT_FALSE(room_->sprites_dirty());
+}
+
+TEST_F(DungeonSaveTest,
+       SaveSprites_FinalStreamOneByteOverHardEndFailsWithoutMutation) {
+  constexpr int kStreamStart = kSpritesDataEndExclusive - 4;
+  SetSpriteRoomPointer(0, kStreamStart);
+  room_->GetSprites().emplace_back(0x10, 10, 10, 0, 0);
+  room_->MarkSpritesDirty();
+  const auto before = rom_->vector();
+
+  const auto status = room_->SaveSprites();
+
   EXPECT_EQ(status.code(), absl::StatusCode::kResourceExhausted);
   EXPECT_EQ(rom_->vector(), before);
   EXPECT_TRUE(room_->sprites_dirty());
@@ -861,6 +932,52 @@ TEST_F(DungeonSaveTest, SaveAllPotItems_DirtyRoomTooLargeFailsAndStaysDirty) {
   EXPECT_EQ(rom_->data()[kPotRoom0Pc + 0], 0x34);
   EXPECT_EQ(rom_->data()[kPotRoom0Pc + 1], 0x12);
   EXPECT_EQ(rom_->data()[kPotRoom0Pc + 2], 0x56);
+}
+
+TEST_F(DungeonSaveTest, SaveAllPotItems_FinalStreamExactFitStopsAtHardEnd) {
+  SetupPotItemTable();
+  constexpr int kSerializedSize = (5 * 3) + 2;
+  constexpr int kStreamStart = kRoomItemsDataEnd - kSerializedSize;
+  SetPotRoomPointer(0, kStreamStart);
+  rom_->mutable_data()[kRoomItemsDataEnd] = 0xA5;
+
+  std::vector<Room> rooms(kNumberOfRooms);
+  for (int i = 0; i < 5; ++i) {
+    rooms[0].GetPotItems().push_back(PotItem{static_cast<uint16_t>(0x1200 + i),
+                                             static_cast<uint8_t>(0x40 + i)});
+  }
+  rooms[0].MarkPotItemsDirty();
+
+  const auto status = SaveAllPotItems(rom_.get(), rooms);
+
+  ASSERT_TRUE(status.ok()) << status.message();
+  EXPECT_EQ(rom_->data()[kRoomItemsDataEnd - 2], 0xFF);
+  EXPECT_EQ(rom_->data()[kRoomItemsDataEnd - 1], 0xFF);
+  EXPECT_EQ(rom_->data()[kRoomItemsDataEnd], 0xA5);
+  EXPECT_FALSE(rooms[0].pot_items_dirty());
+}
+
+TEST_F(DungeonSaveTest,
+       SaveAllPotItems_FinalStreamOneByteOverHardEndFailsWithoutMutation) {
+  SetupPotItemTable();
+  constexpr int kSerializedSize = (6 * 3) + 2;
+  constexpr int kAvailableSize = kSerializedSize - 1;
+  constexpr int kStreamStart = kRoomItemsDataEnd - kAvailableSize;
+  SetPotRoomPointer(0, kStreamStart);
+
+  std::vector<Room> rooms(kNumberOfRooms);
+  for (int i = 0; i < 6; ++i) {
+    rooms[0].GetPotItems().push_back(PotItem{static_cast<uint16_t>(0x1200 + i),
+                                             static_cast<uint8_t>(0x40 + i)});
+  }
+  rooms[0].MarkPotItemsDirty();
+  const auto before = rom_->vector();
+
+  const auto status = SaveAllPotItems(rom_.get(), rooms);
+
+  EXPECT_EQ(status.code(), absl::StatusCode::kResourceExhausted);
+  EXPECT_EQ(rom_->vector(), before);
+  EXPECT_TRUE(rooms[0].pot_items_dirty());
 }
 
 TEST_F(DungeonSaveTest, SaveAllPotItems_SharedStreamFailsWithoutMutation) {

--- a/test/unit/zelda3/dungeon/sprite_relocation_test.cc
+++ b/test/unit/zelda3/dungeon/sprite_relocation_test.cc
@@ -81,6 +81,7 @@ class SpriteRelocationTest : public ::testing::Test {
     for (int i = 0; i < count; ++i) {
       room->GetSprites().emplace_back(id_base + i, 5 + i, 6 + i, 0, 0);
     }
+    room->MarkSpritesDirty();
   }
 
   std::unique_ptr<Rom> rom_;
@@ -183,7 +184,7 @@ TEST_F(SpriteRelocationTest, RelocateSpriteData_PreservesSharedOldSlot) {
   EXPECT_EQ(rom_->data()[kSpritesData + 1], 0xFF);
 }
 
-TEST_F(SpriteRelocationTest, SaveSprites_FallsBackToRelocation) {
+TEST_F(SpriteRelocationTest, SaveSprites_InsufficientHeadroomFailsClosed) {
   SetAllRoomPointers(kSpritesData + 0x04);
   SetRoomPointer(0, kSpritesData);
   SetRoomPointer(1, kSpritesData + 0x02);
@@ -192,10 +193,13 @@ TEST_F(SpriteRelocationTest, SaveSprites_FallsBackToRelocation) {
 
   Room room(0, rom_.get());
   AddSprites(&room, 1, 0x55);
+  const auto before = rom_->vector();
   auto status = room.SaveSprites();
-  ASSERT_TRUE(status.ok()) << status.message();
+  EXPECT_EQ(status.code(), absl::StatusCode::kResourceExhausted);
 
-  EXPECT_NE(GetRoomPointerPc(0), kSpritesData);
+  EXPECT_EQ(GetRoomPointerPc(0), kSpritesData);
+  EXPECT_EQ(rom_->vector(), before);
+  EXPECT_TRUE(room.sprites_dirty());
 }
 
 TEST_F(SpriteRelocationTest, SaveSprites_InPlaceStillWorks) {
@@ -215,16 +219,17 @@ TEST_F(SpriteRelocationTest, SaveSprites_InPlaceStillWorks) {
   EXPECT_EQ(rom_->data()[kSpritesData + 4], 0xFF);
 }
 
-TEST_F(SpriteRelocationTest, SaveSprites_RelocationRoundTrip) {
-  SetAllRoomPointers(kSpritesData + 0x04);
+TEST_F(SpriteRelocationTest, SaveSprites_InPlaceRoundTrip) {
+  SetAllRoomPointers(kSpritesData + 0x40);
   SetRoomPointer(0, kSpritesData);
-  SetRoomPointer(1, kSpritesData + 0x02);
+  SetRoomPointer(1, kSpritesData + 0x20);
   WriteSpriteStream(kSpritesData, 0x01, EncodeSpritePayload(0));
-  WriteSpriteStream(kSpritesData + 0x02, 0x00, EncodeSpritePayload(0));
+  WriteSpriteStream(kSpritesData + 0x20, 0x00, EncodeSpritePayload(0));
 
   Room room(0, rom_.get());
   room.GetSprites().emplace_back(0xA3, 10, 12, 0, 0);
   room.GetSprites().emplace_back(0x21, 14, 18, 0, 0);
+  room.MarkSpritesDirty();
   auto save_status = room.SaveSprites();
   ASSERT_TRUE(save_status.ok()) << save_status.message();
 
@@ -234,7 +239,7 @@ TEST_F(SpriteRelocationTest, SaveSprites_RelocationRoundTrip) {
   EXPECT_EQ(room.GetSprites()[1].id(), 0x21);
 }
 
-TEST_F(SpriteRelocationTest, SaveSprites_MultipleRelocations) {
+TEST_F(SpriteRelocationTest, SaveSprites_DoesNotRelocateMultipleRooms) {
   SetAllRoomPointers(kSpritesData + 0x08);
   SetRoomPointer(0, kSpritesData);
   SetRoomPointer(1, kSpritesData + 0x02);
@@ -245,16 +250,14 @@ TEST_F(SpriteRelocationTest, SaveSprites_MultipleRelocations) {
 
   Room room_a(0, rom_.get());
   AddSprites(&room_a, 1, 0x60);
-  ASSERT_TRUE(room_a.SaveSprites().ok());
-  const int a_ptr = GetRoomPointerPc(0);
+  EXPECT_EQ(room_a.SaveSprites().code(), absl::StatusCode::kResourceExhausted);
 
   Room room_b(1, rom_.get());
   AddSprites(&room_b, 2, 0x70);
-  ASSERT_TRUE(room_b.SaveSprites().ok());
-  const int b_ptr = GetRoomPointerPc(1);
+  EXPECT_EQ(room_b.SaveSprites().code(), absl::StatusCode::kResourceExhausted);
 
-  EXPECT_GT(a_ptr, kSpritesData);
-  EXPECT_GT(b_ptr, a_ptr);
+  EXPECT_EQ(GetRoomPointerPc(0), kSpritesData);
+  EXPECT_EQ(GetRoomPointerPc(1), kSpritesData + 0x02);
 }
 
 TEST_F(SpriteRelocationTest, RelocateSpriteData_RegionFull) {

--- a/test/unit/zelda3/overworld_regression_test.cc
+++ b/test/unit/zelda3/overworld_regression_test.cc
@@ -254,6 +254,45 @@ TEST_F(OverworldRegressionTest, SaveCustomOverworldASM_VanillaRom_SkipsWrite) {
   EXPECT_EQ((*rom_)[OverworldCustomAreaSpecificBGEnabled], original_byte);
 }
 
+TEST_F(OverworldRegressionTest,
+       SaveCustomOverworldDataPreservesDisabledTables) {
+  (*rom_)[OverworldCustomASMHasBeenApplied] = 0x03;
+  (*rom_)[OverworldCustomAreaSpecificBGEnabled] = 0x00;
+  (*rom_)[OverworldCustomMainPaletteEnabled] = 0x00;
+  (*rom_)[OverworldCustomMosaicEnabled] = 0x00;
+  (*rom_)[OverworldCustomAnimatedGFXEnabled] = 0x00;
+  (*rom_)[OverworldCustomSubscreenOverlayEnabled] = 0x00;
+  (*rom_)[OverworldCustomTileGFXGroupEnabled] = 0x00;
+  PopulateOverworldMaps();
+
+  (*rom_)[OverworldCustomAreaSpecificBGPalette] = 0xA1;
+  (*rom_)[OverworldCustomMainPaletteArray] = 0xA2;
+  (*rom_)[OverworldCustomMosaicArray] = 0xA3;
+  (*rom_)[OverworldCustomAnimatedGFXArray] = 0xA4;
+  (*rom_)[OverworldCustomSubscreenOverlayArray] = 0xA5;
+  (*rom_)[OverworldCustomTileGFXGroupArray] = 0xA6;
+
+  ASSERT_TRUE(overworld_->SaveCustomOverworldData().ok());
+
+  EXPECT_EQ((*rom_)[OverworldCustomAreaSpecificBGPalette], 0xA1);
+  EXPECT_EQ((*rom_)[OverworldCustomMainPaletteArray], 0xA2);
+  EXPECT_EQ((*rom_)[OverworldCustomMosaicArray], 0xA3);
+  EXPECT_EQ((*rom_)[OverworldCustomAnimatedGFXArray], 0xA4);
+  EXPECT_EQ((*rom_)[OverworldCustomSubscreenOverlayArray], 0xA5);
+  EXPECT_EQ((*rom_)[OverworldCustomTileGFXGroupArray], 0xA6);
+}
+
+TEST_F(OverworldRegressionTest,
+       SaveCustomOverworldDataPreservesEnabledFlagEncoding) {
+  (*rom_)[OverworldCustomASMHasBeenApplied] = 0x03;
+  (*rom_)[OverworldCustomMosaicEnabled] = 0x01;
+  PopulateOverworldMaps();
+
+  ASSERT_TRUE(overworld_->SaveCustomOverworldData().ok());
+
+  EXPECT_EQ((*rom_)[OverworldCustomMosaicEnabled], 0x01);
+}
+
 TEST_F(OverworldRegressionTest, SaveDiggableTiles_VanillaRom_SkipsWrite) {
   // Set version to Vanilla
   (*rom_)[OverworldCustomASMHasBeenApplied] = 0xFF;

--- a/test/unit/zelda3/overworld_version_helper_test.cc
+++ b/test/unit/zelda3/overworld_version_helper_test.cc
@@ -20,6 +20,35 @@ void InitOverworldTestRom(Rom& rom, uint8_t asm_version = 0xFF) {
   EXPECT_TRUE(rom.LoadFromData(data).ok());
 }
 
+void PopulateUniqueTile32Maps(OverworldMapTiles* maps,
+                              int unique_definition_count = NumberOfMap32) {
+  ASSERT_NE(maps, nullptr);
+  const auto make_world = [] {
+    return OverworldBlockset(512, std::vector<uint16_t>(512, 0));
+  };
+  maps->light_world = make_world();
+  maps->dark_world = make_world();
+  maps->special_world = make_world();
+
+  uint16_t tile16_id = 1;
+  int definition_index = 0;
+  const auto fill = [&tile16_id, &definition_index, unique_definition_count](
+                        OverworldBlockset* world, int width, int height) {
+    for (int y = 0; y < height; y += 2) {
+      for (int x = 0; x < width; x += 2) {
+        // A distinct top-left Tile16 makes each packed Tile32 unique.
+        if (definition_index < unique_definition_count) {
+          (*world)[x][y] = tile16_id++;
+        }
+        ++definition_index;
+      }
+    }
+  };
+  fill(&maps->light_world, 256, 256);    // 64 screens
+  fill(&maps->dark_world, 256, 256);     // 64 screens
+  fill(&maps->special_world, 256, 128);  // 32 screens
+}
+
 }  // namespace
 
 TEST(OverworldVersionHelperTest, GetVersion_VanillaSmallRom) {
@@ -137,6 +166,64 @@ TEST(OverworldRomProfileTest, V3ForcesExpandedTilesAndRequiresTailMarker) {
   profile = DetectOverworldRomProfile(rom);
   EXPECT_TRUE(profile.has_tail_map_expansion);
   EXPECT_EQ(profile.editable_map_count, kExpandedMapCount);
+}
+
+TEST(OverworldMap32StorageTest, CapacityTracksDetectedRomProfile) {
+  Rom rom;
+  InitOverworldTestRom(rom, 0xFF);
+  auto profile = DetectOverworldRomProfile(rom);
+  EXPECT_EQ(Map32StorageBytesForProfile(profile),
+            kMap32TileStorageBytesVanilla);
+  EXPECT_EQ(Map32DefinitionCapacityForProfile(profile),
+            kMap32DefinitionCapacityVanilla);
+  EXPECT_EQ(kMap32DefinitionCapacityVanilla, 8864);
+
+  InitOverworldTestRom(rom, 0x03);
+  profile = DetectOverworldRomProfile(rom);
+  EXPECT_EQ(Map32StorageBytesForProfile(profile),
+            kMap32TileStorageBytesExpanded);
+  EXPECT_EQ(Map32DefinitionCapacityForProfile(profile),
+            kMap32DefinitionCapacityExpanded);
+  EXPECT_EQ(kMap32DefinitionCapacityExpanded, 17728);
+}
+
+TEST(OverworldMap32StorageTest, ExpandedOverflowFailsBeforeAnyRomWrite) {
+  Rom rom;
+  InitOverworldTestRom(rom, 0x03);
+  Overworld overworld(&rom);
+  PopulateUniqueTile32Maps(overworld.mutable_map_tiles());
+  const auto before = rom.vector();
+
+  const auto create_status = overworld.CreateTile32Tilemap();
+  EXPECT_EQ(create_status.code(), absl::StatusCode::kResourceExhausted);
+  EXPECT_GT(overworld.tiles32_unique().size(),
+            static_cast<size_t>(kMap32DefinitionCapacityExpanded));
+  EXPECT_EQ(rom.vector(), before);
+
+  // The public writer repeats the capacity preflight before relocation-pointer
+  // or quadrant writes, even if a caller ignores the CreateTile32Tilemap error.
+  const auto save_status = overworld.SaveMap32Expanded();
+  EXPECT_EQ(save_status.code(), absl::StatusCode::kResourceExhausted);
+  EXPECT_EQ(rom.vector(), before);
+}
+
+TEST(OverworldMap32StorageTest, JapaneseLayoutUsesAdjacentTableCapacity) {
+  Rom rom;
+  InitOverworldTestRom(rom, 0xFF);
+  GameData game_data(&rom);
+  game_data.version = zelda3_version::JP;
+  Overworld overworld(&rom, &game_data);
+
+  // 8,832 nonzero definitions plus the shared zero definition pad to 8,836.
+  // This fits the historical US limit (8,864) but exceeds the JP quadrant
+  // span: 0x33C0 bytes == 8,832 packed definitions.
+  PopulateUniqueTile32Maps(overworld.mutable_map_tiles(), 8832);
+  const auto before = rom.vector();
+
+  const auto status = overworld.CreateTile32Tilemap();
+  EXPECT_EQ(status.code(), absl::StatusCode::kResourceExhausted) << status;
+  EXPECT_EQ(overworld.tiles32_unique().size(), 8836u);
+  EXPECT_EQ(rom.vector(), before);
 }
 
 TEST(OverworldCompatibilityHelpersTest, LegacyParentTablesUseLocalMapIds) {


### PR DESCRIPTION
## Summary

- make coordinated editor saves whole-ROM transactional and restore editor dirty state after any late failure
- preserve Save As targets through hash, pot-item, and ASM-conflict confirmations, bind pending saves to their originating ROM session, and consume confirmation bypasses safely
- fail closed for dungeon object/sprite/pot/chest overflow or aliasing instead of guessing free space or partially repacking shared streams
- harden expanded-message, Map32/custom-overworld, palette, manifest, project-path, and CRC32/SHA1 verification boundaries
- add regression coverage for rollback, session switching, exact-fit/overflow cases, dirty tracking, headered hashes, and vanilla/OOS round trips

## Why

The previous save pipeline allowed individual serializers to mutate the in-memory ROM and clear dirty state before a later serializer, validation gate, backup, or disk write failed. Several dungeon streams also lacked trustworthy relocation ownership. For an Oracle of Secrets daily-driver workflow, unsupported growth must fail without mutation and every failed save must remain retryable.

## User impact

This is Wave 1 containment: existing in-place dungeon, overworld, message, and project edits are safer and recoverable. Shared or over-capacity dungeon growth now reports an actionable error until the allocator/copy-on-write follow-up lands.

## Validation

- `yaze`, `z3ed`, `yaze_test_unit`, `yaze_test_quick_unit_editor`, and `yaze_test_integration` build successfully with the `mac-ai` preset
- full unit: 2,407 passed; 1 optional usdasm palette fixture skipped
- quick editor: 619/619 passed
- integration with vanilla plus a temporary OOS copy: 279 passed; 2 fixture-discovery utilities skipped
- focused project/hash + write-policy: 36/36 passed
- write-conflict flow: 5/5 passed
- canonical vanilla and OOS source ROM SHA256 hashes remained unchanged
- OOS project verification: 7 passes, 0 warnings, 0 failures
- OOS smoke: D4 structural and four required D6 track rooms pass; strict mode records only the known D3 readiness gap

## Follow-up hardening

Commit `dac5cccf` closes the review/CI boundary gaps found after the initial Wave 1 publish:

- make the Windows project-path regression fixture independent of drive letters and restore the process working directory with RAII
- add all five half-open ZScream object storage sections instead of inferring capacity at a LoROM bank end
- clamp pot data at PC `0x00E6B2` and sprite data at PC `0x04EC9F` (exclusive)
- cover exact-fit and one-byte-over boundary behavior without ROM mutation on failure

Focused follow-up validation passed: project/path 31/31, dungeon save 55/55, save/relocation 40/40, and new boundary cases 6/6.

## Scope and follow-up

This is intentionally separate from release-metadata PR #69. The next major slice is the manifest-backed dungeon copy-on-write allocator; it should not be folded into this containment PR.

