### PR TITLE
fix(dungeon): correct canonical object payload counts

### DIFF
--- a/src/zelda3/dungeon/object_parser.cc
+++ b/src/zelda3/dungeon/object_parser.cc
@@ -38,6 +38,10 @@
 // - IDs `0xCD` and `0xCE` consume 24 words: top corner (9), vertical
 //   pattern (6), and bottom corner (9). ZScream's count of 28 crosses into
 //   the next object's data block, so yaze uses the routine-proven count.
+// - IDs `0x3C` and `0x4C` consume 8 and 12 words respectively. Their
+//   registry routines index the complete 4x2 and 4x3 payloads, while
+//   ZScream's counts of 4 and 9 under-fetch the final stamp/column and make
+//   ObjectDrawer fall back to a single tile.
 // - 2026-04-25 ZScream parity diff: full byte-for-byte comparison
 //   against ZScream's `subtype1Lengths` (`DungeonObjectData.cs:184`)
 //   remains pinned, with routine-body-proven corrections allowlisted.
@@ -49,8 +53,8 @@ static constexpr uint8_t kSubtype1TileLengths[0xF8] = {
      4,  8,  8,  8,  8,  8,  8,  4,  4,  5,  5,  5,  5,  5,  5,  5,  // 0x00-0x0F
      5,  5,  5,  5,  5,  5,  5,  5,  5,  5,  5,  5,  5,  5,  5,  5,  // 0x10-0x1F
      5,  9,  3,  3,  3,  3,  3,  3,  3,  3,  3,  3,  3,  3,  3,  6,  // 0x20-0x2F
-     6,  1,  1, 16,  1,  1, 16, 16,  6,  8, 12, 12,  4,  8,  4,  3,  // 0x30-0x3F
-     3,  3,  3,  3,  3,  3,  3, 15,  9,  8,  8,  4,  9, 16, 16, 16,  // 0x40-0x4F (0x47=Waterfall47:15, 0x48=Waterfall48:9)
+     6,  1,  1, 16,  1,  1, 16, 16,  6,  8, 12, 12,  8,  8,  4,  3,  // 0x30-0x3F (0x3C=Doubled2x2:8)
+     3,  3,  3,  3,  3,  3,  3, 15,  9,  8,  8,  4, 12, 16, 16, 16,  // 0x40-0x4F (0x47=Waterfall47:15, 0x48=Waterfall48:9, 0x4C=Bar4x3:12)
      1, 18, 18,  4,  1,  8,  8,  1,  1,  1,  1, 18, 18, 15,  4,  3,  // 0x50-0x5F
      4,  8,  8,  8,  8,  8,  8,  4,  4,  3,  1,  1,  6,  6,  1,  1,  // 0x60-0x6F
     16,  1,  1, 16, 16,  8, 16, 16,  4,  1,  1,  4,  1,  4,  1,  8,  // 0x70-0x7F

--- a/test/integration/zelda3/dungeon_object_rom_validation_test.cc
+++ b/test/integration/zelda3/dungeon_object_rom_validation_test.cc
@@ -122,7 +122,7 @@ TEST_F(DungeonObjectRomValidationTest, TileCountTable_KnownValues) {
   // 0x00-0x0F:  4,  8,  8,  8,  8,  8,  8,  4,  4,  5,  5,  5,  5,  5,  5,  5
   // 0x10-0x1F:  5,  5,  5,  5,  5,  5,  5,  5,  5,  5,  5,  5,  5,  5,  5,  5
   // 0x20-0x2F:  5,  9,  3,  3,  3,  3,  3,  3,  3,  3,  3,  3,  3,  3,  3,  6
-  // 0x30-0x3F:  6,  1,  1, 16,  1,  1, 16, 16,  6,  8, 12, 12,  4,  8,  4,  3
+  // 0x30-0x3F:  6,  1,  1, 16,  1,  1, 16, 16,  6,  8, 12, 12,  8,  8,  4,  3
   std::vector<TileCountTest> tests = {
       {0x00, 4, "Floor object"},
       {0x01, 8, "Wall rightwards 2x4"},
@@ -131,6 +131,8 @@ TEST_F(DungeonObjectRomValidationTest, TileCountTable_KnownValues) {
       {0x22, 3, "Edge rightwards has edge"},  // 3 tiles
       {0x34, 1, "Solid 1x1 block"},
       {0x33, 16, "4x4 block"},  // kSubtype1TileLengths[0x33] = 16
+      {0x3C, 8, "Doubled 2x2 decoration"},
+      {0x4C, 12, "Rightwards 4x3 bar"},
   };
 
   for (const auto& test : tests) {

--- a/test/unit/cli/dungeon_object_validate_test.cc
+++ b/test/unit/cli/dungeon_object_validate_test.cc
@@ -112,5 +112,34 @@ TEST(DungeonObjectValidateTest,
   EXPECT_THAT(output, ::testing::HasSubstr("\"mismatch_count\": 0"));
 }
 
+TEST(DungeonObjectValidateTest,
+     CanonicalDoubledAndBarPayloadsAvoidSingleTileFallbackMismatches) {
+  for (const char* object_arg : {"--object=0x03C", "--object=0x04C"}) {
+    SCOPED_TRACE(object_arg);
+    DungeonObjectValidateCommandHandler handler;
+    const auto report_base =
+        std::filesystem::temp_directory_path() /
+        (std::string("yaze_dungeon_payload_count_") + object_arg + "_test");
+    const auto json_report = report_base.string() + ".json";
+    const auto csv_report = report_base.string() + ".csv";
+    std::filesystem::remove(json_report);
+    std::filesystem::remove(csv_report);
+
+    std::string output;
+    auto status =
+        handler.Run({"--mock-rom", object_arg, "--size=0", "--format=json",
+                     "--report=" + report_base.string()},
+                    nullptr, &output);
+    std::filesystem::remove(json_report);
+    std::filesystem::remove(csv_report);
+
+    ASSERT_TRUE(status.ok()) << status;
+    EXPECT_THAT(output, ::testing::HasSubstr("\"test_cases\": 1"));
+    EXPECT_THAT(output, ::testing::HasSubstr("\"mismatch_count\": 0"));
+    EXPECT_THAT(output, ::testing::HasSubstr("\"empty_traces\": 0"));
+    EXPECT_THAT(output, ::testing::HasSubstr("\"mismatches\": []"));
+  }
+}
+
 }  // namespace
 }  // namespace yaze::cli

--- a/test/unit/zelda3/dungeon/object_drawing_comprehensive_test.cc
+++ b/test/unit/zelda3/dungeon/object_drawing_comprehensive_test.cc
@@ -25,15 +25,17 @@ namespace zelda3 {
 // Expected tile counts from kSubtype1TileLengths table in object_parser.cc
 // (kept in sync with the production table; 2026-04-25 audit corrected
 // 0x47/0x48 from 0 (fallback 8) to the real Waterfall47/48 routine
-// counts of 15/9; the moving-wall parity audit corrected 0xCD/0xCE from
-// ZScream's over-fetched 28 words to the 24 words their routines consume).
+// counts of 15/9; 0x3C/0x4C now load the full 8/12-word payloads consumed
+// by their 4x2/4x3 registry routines; the moving-wall parity audit corrected
+// 0xCD/0xCE from ZScream's over-fetched 28 words to the 24 words their
+// routines consume).
 // clang-format off
 static constexpr uint8_t kExpectedTileCounts[0xF8] = {
      4,  8,  8,  8,  8,  8,  8,  4,  4,  5,  5,  5,  5,  5,  5,  5,  // 0x00-0x0F
      5,  5,  5,  5,  5,  5,  5,  5,  5,  5,  5,  5,  5,  5,  5,  5,  // 0x10-0x1F
      5,  9,  3,  3,  3,  3,  3,  3,  3,  3,  3,  3,  3,  3,  3,  6,  // 0x20-0x2F
-     6,  1,  1, 16,  1,  1, 16, 16,  6,  8, 12, 12,  4,  8,  4,  3,  // 0x30-0x3F
-     3,  3,  3,  3,  3,  3,  3, 15,  9,  8,  8,  4,  9, 16, 16, 16,  // 0x40-0x4F (0x47=Waterfall47:15, 0x48=Waterfall48:9)
+     6,  1,  1, 16,  1,  1, 16, 16,  6,  8, 12, 12,  8,  8,  4,  3,  // 0x30-0x3F (0x3C=Doubled2x2:8)
+     3,  3,  3,  3,  3,  3,  3, 15,  9,  8,  8,  4, 12, 16, 16, 16,  // 0x40-0x4F (0x47=Waterfall47:15, 0x48=Waterfall48:9, 0x4C=Bar4x3:12)
      1, 18, 18,  4,  1,  8,  8,  1,  1,  1,  1, 18, 18, 15,  4,  3,  // 0x50-0x5F
      4,  8,  8,  8,  8,  8,  8,  4,  4,  3,  1,  1,  6,  6,  1,  1,  // 0x60-0x6F
     16,  1,  1, 16, 16,  8, 16, 16,  4,  1,  1,  4,  1,  4,  1,  8,  // 0x70-0x7F
@@ -371,6 +373,8 @@ TEST_F(ObjectDrawingComprehensiveTest, TileCountLookupTable_SpecialCases) {
       {0x00, 4, "Floor tile 2x2"},
       {0x01, 8, "Wall segment 2x4"},
       {0x33, 16, "Large block 4x4"},
+      {0x3C, 8, "Doubled 2x2 decoration (4x2 payload)"},
+      {0x4C, 12, "Rightwards bar (4x3 payload)"},
       {0xA4, 24, "Large special object"},
       {0xC1, 68, "Very large object"},
       {0xCD, 24, "Moving wall"},
@@ -397,6 +401,49 @@ TEST_F(ObjectDrawingComprehensiveTest, TileCountLookupTable_SpecialCases) {
     ASSERT_TRUE(info.ok()) << "Failed for " << tc.description;
     EXPECT_EQ(info->max_tile_count, tc.expected_tiles)
         << tc.description << " (0x" << std::hex << tc.object_id << ")";
+  }
+}
+
+TEST_F(ObjectDrawingComprehensiveTest,
+       CanonicalDoubledAndBarPayloadsReachFullDrawerRoutines) {
+  struct TestCase {
+    int16_t object_id;
+    int expected_tiles;
+    int expected_routine;
+    int expected_max_y;
+  };
+
+  for (const auto& test_case : {
+           TestCase{0x3C, 8, DrawRoutineIds::kRightwardsDoubled2x2spaced2_1to16,
+                    10},
+           TestCase{0x4C, 12, DrawRoutineIds::kRightwardsBar4x3_1to16, 11},
+       }) {
+    SCOPED_TRACE(::testing::Message()
+                 << "object_id=0x" << std::hex << test_case.object_id);
+
+    ObjectParser parser(rom_.get());
+    auto parsed = parser.ParseObject(test_case.object_id);
+    ASSERT_TRUE(parsed.ok()) << parsed.status();
+    ASSERT_EQ(parsed->size(), static_cast<size_t>(test_case.expected_tiles));
+
+    ObjectDrawer drawer(rom_.get(), /*room_id=*/0);
+    EXPECT_EQ(drawer.GetDrawRoutineId(test_case.object_id),
+              test_case.expected_routine);
+
+    RoomObject object(test_case.object_id, /*x=*/8, /*y=*/9, /*size=*/0,
+                      /*layer=*/0);
+    gfx::BackgroundBuffer bg1(512, 512);
+    gfx::BackgroundBuffer bg2(512, 512);
+    gfx::PaletteGroup palette_group;
+    std::vector<ObjectDrawer::TileTrace> trace;
+    drawer.SetTraceCollector(&trace, /*trace_only=*/true);
+
+    ASSERT_TRUE(drawer.DrawObject(object, bg1, bg2, palette_group).ok());
+    ASSERT_EQ(trace.size(), static_cast<size_t>(test_case.expected_tiles));
+    EXPECT_EQ(trace.front().x_tile, 8);
+    EXPECT_EQ(trace.front().y_tile, 9);
+    EXPECT_EQ(trace.back().x_tile, 11);
+    EXPECT_EQ(trace.back().y_tile, test_case.expected_max_y);
   }
 }
 

--- a/test/unit/zelda3/object_parser_test.cc
+++ b/test/unit/zelda3/object_parser_test.cc
@@ -180,6 +180,41 @@ TEST_F(ObjectParserTest, DrawInfoUsesSubtypeTileCountLookup) {
   EXPECT_EQ(info_waterfall48.tile_count, 9);
 }
 
+TEST_F(ObjectParserTest,
+       CanonicalDoubledAndBarPayloadCountsMatchDrawerContracts) {
+  struct TestCase {
+    int16_t object_id;
+    int expected_tiles;
+    int expected_routine;
+  };
+
+  for (const auto& test_case : {
+           TestCase{0x3C, 8,
+                    zelda3::DrawRoutineIds::kRightwardsDoubled2x2spaced2_1to16},
+           TestCase{0x4C, 12, zelda3::DrawRoutineIds::kRightwardsBar4x3_1to16},
+       }) {
+    SCOPED_TRACE(::testing::Message()
+                 << "object_id=0x" << std::hex << test_case.object_id);
+
+    auto parsed = parser_->ParseObject(test_case.object_id);
+    ASSERT_TRUE(parsed.ok()) << parsed.status();
+    EXPECT_EQ(parsed->size(), static_cast<size_t>(test_case.expected_tiles));
+
+    auto subtype = parser_->GetObjectSubtype(test_case.object_id);
+    ASSERT_TRUE(subtype.ok()) << subtype.status();
+    EXPECT_EQ(subtype->max_tile_count, test_case.expected_tiles);
+
+    const auto draw_info = parser_->GetObjectDrawInfo(test_case.object_id);
+    EXPECT_EQ(draw_info.tile_count, test_case.expected_tiles);
+    EXPECT_EQ(draw_info.draw_routine_id, test_case.expected_routine);
+
+    const auto* routine = zelda3::DrawRoutineRegistry::Get().GetRoutineInfo(
+        test_case.expected_routine);
+    ASSERT_NE(routine, nullptr);
+    EXPECT_EQ(routine->min_tiles, test_case.expected_tiles);
+  }
+}
+
 // 2026-04-25 ZScream parity diff. ZScream's `subtype1Lengths` array
 // (`ZScreamDungeon/ZeldaFullEditor/Data/DungeonObjectData.cs:184`) is the
 // upstream provenance source for `kSubtype1TileLengths` in
@@ -227,11 +262,18 @@ TEST_F(ObjectParserTest,
   // payload counts. Add entries only when the underlying routine body
   // proves the count divergence; cite the routine source location.
   static const Divergence kKnownDivergences[] = {
+      {0x3C, 8,
+       "DrawRightwardsDoubled2x2spaced2_1to16 (rightwards_routines.cc) "
+       "indexes tiles[0..7]; ZScream's 4 under-fetches the second 2x2 "
+       "stamp."},
       {0x47, 15,
        "DrawWaterfall47 (special_routines.cc) reads tiles[0..14]; "
        "ZScream's 0->8 fallback under-fetched and TileAtWrapped "
        "substituted wrong tiles for index>=8 (commits e9938002/c12c3178)."},
       {0x48, 9, "DrawWaterfall48 reads tiles[0..8]; same pattern as 0x47."},
+      {0x4C, 12,
+       "DrawRightwardsBar4x3_1to16 (rightwards_routines.cc) indexes "
+       "tiles[0..11]; ZScream's 9 under-fetches the fourth 3-tile column."},
       {0xCD, 24,
        "RoomDraw_MovingWallWest reads obj072A words 0..23; ZScream's 28 "
        "over-fetches four words from obj075A."},


### PR DESCRIPTION
## Summary
- correct subtype-1 payload counts for canonical objects `0x03C` and `0x04C`
- keep parser, drawer, and validator contracts aligned with their full 4x2 / 4x3 routines
- add regression coverage for payload parsing, trace drawing, and validator mismatch output

## Verification
- `build/presets/mac-test/bin/RelWithDebInfo/yaze_test_unit --gtest_filter='DungeonObjectValidateTest.*:ObjectDrawingComprehensiveTest.*:ObjectParserTest.*'` (71/71 passed)
- `z3ed dungeon-object-validate` against canonical US ALTTP and Oracle of Secrets `oos168.sfc` for `0x03C` and `0x04C` (4/4 runs: one case, zero mismatches, zero empty traces)
- source ROM SHA-256 values unchanged after validation
- pre-push validation (build, smoke, formatting): passed in 167s
- `git diff origin/master...HEAD --check`

## Scope
This is the smallest canonical payload correction. The size/state-aware validator matrix is being prepared as a separate follow-up so this parser fix remains independently reviewable.
