### PR TITLE
fix(dungeon): persist palette panel edits safely

### DIFF
--- a/src/app/editor/dungeon/dungeon_editor_v2_persistence.cc
+++ b/src/app/editor/dungeon/dungeon_editor_v2_persistence.cc
@@ -326,6 +326,10 @@ absl::Status DungeonEditorV2::BeginSaveTransaction() {
   auto& palette_manager = gfx::PaletteManager::Get();
   if (core::FeatureFlags::get().dungeon.kSavePalettes &&
       palette_manager.HasUnsavedChanges()) {
+    if (!palette_manager.IsManaging(game_data_)) {
+      return absl::FailedPreconditionError(
+          "Cannot save dungeon palettes from a different ROM session");
+    }
     RETURN_IF_ERROR(palette_manager.BeginSaveTransaction());
     snapshot.has_palette_transaction = true;
   }
@@ -433,15 +437,21 @@ absl::Status DungeonEditorV2::Save() {
         dependencies_.toast_manager));
   }
 
-  if (flags.kSavePalettes && gfx::PaletteManager::Get().HasUnsavedChanges()) {
-    auto status = gfx::PaletteManager::Get().SaveAllToRom();
+  auto& palette_manager = gfx::PaletteManager::Get();
+  if (flags.kSavePalettes && palette_manager.HasUnsavedChanges()) {
+    if (!palette_manager.IsManaging(game_data_)) {
+      return absl::FailedPreconditionError(
+          "Cannot save dungeon palettes from a different ROM session");
+    }
+    const size_t modified_color_count = palette_manager.GetModifiedColorCount();
+    auto status = palette_manager.SaveAllToRom();
     if (!status.ok()) {
       LOG_ERROR("DungeonEditorV2", "Failed to save palette changes: %s",
                 status.message().data());
       return status;
     }
     LOG_INFO("DungeonEditorV2", "Saved %zu modified colors to ROM",
-             gfx::PaletteManager::Get().GetModifiedColorCount());
+             modified_color_count);
   }
 
   if (flags.kSaveObjects || flags.kSaveSprites || flags.kSaveRoomHeaders) {
@@ -769,8 +779,13 @@ absl::Status DungeonEditorV2::SaveRoom(int room_id) {
           absl::StrFormat("pot items for room 0x%03X", room_id),
           dependencies_.toast_manager));
     }
-    if (flags.kSavePalettes && gfx::PaletteManager::Get().HasUnsavedChanges()) {
-      auto status = gfx::PaletteManager::Get().SaveAllToRom();
+    auto& palette_manager = gfx::PaletteManager::Get();
+    if (flags.kSavePalettes && palette_manager.HasUnsavedChanges()) {
+      if (!palette_manager.IsManaging(game_data_)) {
+        return absl::FailedPreconditionError(
+            "Cannot save dungeon palettes from a different ROM session");
+      }
+      auto status = palette_manager.SaveAllToRom();
       if (!status.ok()) {
         LOG_ERROR("DungeonEditorV2", "Failed to save palette changes: %s",
                   status.message().data());

--- a/src/app/gfx/util/palette_manager.cc
+++ b/src/app/gfx/util/palette_manager.cc
@@ -20,7 +20,7 @@ void PaletteManager::Initialize(zelda3::GameData* game_data) {
   // Editors are loaded lazily and may share the same GameData instance. Do not
   // discard another editor's pending palette edits when it initializes the
   // already-bound manager.
-  if (game_data_ == game_data && rom_ == game_data->rom()) {
+  if (IsManaging(game_data)) {
     return;
   }
 
@@ -58,6 +58,11 @@ void PaletteManager::Initialize(zelda3::GameData* game_data) {
   modified_colors_.clear();
   save_transaction_snapshot_.reset();
   ClearHistory();
+}
+
+bool PaletteManager::IsManaging(const zelda3::GameData* game_data) const {
+  return game_data != nullptr && game_data_ == game_data &&
+         rom_ == game_data->rom();
 }
 
 void PaletteManager::Initialize(Rom* rom) {

--- a/src/app/gfx/util/palette_manager.cc
+++ b/src/app/gfx/util/palette_manager.cc
@@ -17,6 +17,13 @@ void PaletteManager::Initialize(zelda3::GameData* game_data) {
     return;
   }
 
+  // Editors are loaded lazily and may share the same GameData instance. Do not
+  // discard another editor's pending palette edits when it initializes the
+  // already-bound manager.
+  if (game_data_ == game_data && rom_ == game_data->rom()) {
+    return;
+  }
+
   game_data_ = game_data;
   rom_ = game_data->rom();
 

--- a/src/app/gfx/util/palette_manager.h
+++ b/src/app/gfx/util/palette_manager.h
@@ -110,6 +110,11 @@ class PaletteManager {
   }
 
   /**
+   * @brief Check whether the manager is bound to this exact GameData and ROM.
+   */
+  bool IsManaging(const zelda3::GameData* game_data) const;
+
+  /**
    * @brief Reset all state for test isolation
    */
   void ResetForTesting();

--- a/src/app/gui/widgets/palette_editor_widget.cc
+++ b/src/app/gui/widgets/palette_editor_widget.cc
@@ -6,6 +6,7 @@
 
 #include "absl/strings/str_format.h"
 #include "app/gfx/resource/arena.h"
+#include "app/gfx/util/palette_manager.h"
 #include "app/gui/core/color.h"
 #include "app/gui/core/popup_id.h"
 #include "app/gui/core/theme_manager.h"
@@ -21,6 +22,57 @@ namespace yaze {
 namespace gui {
 
 namespace {
+
+enum class DungeonRenderPaletteSource {
+  kHud,
+  kDungeonMain,
+};
+
+struct DungeonRenderColorTarget {
+  DungeonRenderPaletteSource source;
+  int palette_index;
+  int color_index;
+};
+
+std::optional<DungeonRenderColorTarget> ResolveDungeonRenderColorTarget(
+    int display_index, int dungeon_palette_id) {
+  if (display_index < 0 || display_index >= 128) {
+    return std::nullopt;
+  }
+  if (display_index < 32) {
+    return DungeonRenderColorTarget{DungeonRenderPaletteSource::kHud, 0,
+                                    display_index};
+  }
+
+  const int local_index = display_index - 32;
+  const int row = local_index / 16;
+  const int col = local_index % 16;
+  if (row >= 6 || col == 0) {
+    return std::nullopt;
+  }
+
+  return DungeonRenderColorTarget{DungeonRenderPaletteSource::kDungeonMain,
+                                  dungeon_palette_id, row * 15 + (col - 1)};
+}
+
+const char* PaletteManagerGroupName(DungeonRenderPaletteSource source) {
+  return source == DungeonRenderPaletteSource::kHud ? "hud" : "dungeon_main";
+}
+
+const gfx::PaletteGroup& PaletteGroupForTarget(
+    const zelda3::GameData& game_data, const DungeonRenderColorTarget& target) {
+  return target.source == DungeonRenderPaletteSource::kHud
+             ? game_data.palette_groups.hud
+             : game_data.palette_groups.dungeon_main;
+}
+
+std::string DungeonRenderColorSourceLabel(
+    const DungeonRenderColorTarget& target) {
+  if (target.source == DungeonRenderPaletteSource::kHud) {
+    return "HUD / floor-ceiling";
+  }
+  return absl::StrFormat("Dungeon row %d", target.color_index / 15 + 2);
+}
 
 const char* RomPaletteGroupNameGetter(void* user_data, int idx) {
   auto* names = static_cast<std::vector<std::string>*>(user_data);
@@ -94,6 +146,38 @@ void PaletteEditorWidget::Initialize(Rom* rom) {
   // Legacy mode - no palette loading without game_data
   current_palette_id_ = 0;
   selected_color_index_ = -1;
+}
+
+absl::Status PaletteEditorWidget::ApplyDungeonRenderColorEdit(
+    int display_index, std::optional<gfx::SnesColor> color) {
+  if (!game_data_) {
+    return absl::FailedPreconditionError("GameData not loaded");
+  }
+
+  const auto target =
+      ResolveDungeonRenderColorTarget(display_index, current_palette_id_);
+  if (!target.has_value()) {
+    return absl::InvalidArgumentError(absl::StrFormat(
+        "Dungeon render palette slot %d is reserved or out of range",
+        display_index));
+  }
+
+  auto& palette_manager = gfx::PaletteManager::Get();
+  const char* group_name = PaletteManagerGroupName(target->source);
+  absl::Status status =
+      color.has_value()
+          ? palette_manager.SetColor(group_name, target->palette_index,
+                                     target->color_index, *color)
+          : palette_manager.ResetColor(group_name, target->palette_index,
+                                       target->color_index);
+  if (!status.ok()) {
+    return status;
+  }
+
+  if (on_palette_changed_) {
+    on_palette_changed_(current_palette_id_);
+  }
+  return absl::OkStatus();
 }
 
 // --- Embedded Draw Method (from simple editor) ---
@@ -233,64 +317,10 @@ void PaletteEditorWidget::DrawColorPicker() {
   }
 }
 
-bool PaletteEditorWidget::ResolveDungeonRenderSelection(
-    gfx::SnesPalette** palette, int* color_index, std::string* source_label) {
-  if (!game_data_ || !palette || !color_index || selected_color_index_ < 0) {
-    return false;
-  }
-
-  const int display_index = selected_color_index_;
-  if (display_index < 32) {
-    if (game_data_->palette_groups.hud.empty()) {
-      return false;
-    }
-    *palette = game_data_->palette_groups.hud.mutable_palette(0);
-    *color_index = display_index;
-    if (source_label) {
-      *source_label = "HUD / floor-ceiling";
-    }
-    return true;
-  }
-
-  const int local_index = display_index - 32;
-  const int row = local_index / 16;
-  const int col = local_index % 16;
-  if (row < 0 || row >= 6 || col == 0) {
-    return false;
-  }
-
-  auto& dungeon_pal_group = game_data_->palette_groups.dungeon_main;
-  if (dungeon_pal_group.empty() || current_palette_id_ < 0 ||
-      current_palette_id_ >= static_cast<int>(dungeon_pal_group.size())) {
-    return false;
-  }
-
-  *palette = dungeon_pal_group.mutable_palette(current_palette_id_);
-  *color_index = row * 15 + (col - 1);
-  if (source_label) {
-    *source_label = absl::StrFormat("Dungeon row %d", row + 2);
-  }
-  return true;
-}
-
 void PaletteEditorWidget::DrawDungeonRenderPalette() {
   ImGui::TextDisabled(
       tr("Rows 0-1: HUD / floor / ceiling  |  Rows 2-7: Dungeon main"));
   const float swatch_size = ComputeSwatchSize(/*columns=*/16, 14.0f, 28.0f);
-
-  gfx::SnesPalette* dungeon_palette = nullptr;
-  if (!game_data_->palette_groups.dungeon_main.empty() &&
-      current_palette_id_ >= 0 &&
-      current_palette_id_ <
-          static_cast<int>(game_data_->palette_groups.dungeon_main.size())) {
-    dungeon_palette = game_data_->palette_groups.dungeon_main.mutable_palette(
-        current_palette_id_);
-  }
-
-  gfx::SnesPalette* hud_palette = nullptr;
-  if (!game_data_->palette_groups.hud.empty()) {
-    hud_palette = game_data_->palette_groups.hud.mutable_palette(0);
-  }
 
   for (int i = 0; i < 128; ++i) {
     if (i % 16 != 0) {
@@ -298,28 +328,22 @@ void PaletteEditorWidget::DrawDungeonRenderPalette() {
     }
 
     gfx::SnesColor color(0);
-    gfx::SnesColor* source_color = nullptr;
     bool editable = false;
     std::string tooltip_label = "Reserved / transparent";
     int source_index = -1;
 
-    if (i < 32 && hud_palette && i < static_cast<int>(hud_palette->size())) {
-      color = (*hud_palette)[i];
-      source_color = &(*hud_palette)[i];
-      editable = true;
-      tooltip_label = "HUD / floor-ceiling";
-      source_index = i;
-    } else if (i >= 32 && dungeon_palette) {
-      const int local_index = i - 32;
-      const int row = local_index / 16;
-      const int col = local_index % 16;
-      if (row < 6 && col > 0) {
-        source_index = row * 15 + (col - 1);
-        if (source_index < static_cast<int>(dungeon_palette->size())) {
-          color = (*dungeon_palette)[source_index];
-          source_color = &(*dungeon_palette)[source_index];
+    const auto target = ResolveDungeonRenderColorTarget(i, current_palette_id_);
+    if (target.has_value()) {
+      const auto& group = PaletteGroupForTarget(*game_data_, *target);
+      if (target->palette_index >= 0 &&
+          target->palette_index < static_cast<int>(group.size())) {
+        const auto& palette = group.palette_ref(target->palette_index);
+        if (target->color_index >= 0 &&
+            target->color_index < static_cast<int>(palette.size())) {
+          color = palette[target->color_index];
           editable = true;
-          tooltip_label = absl::StrFormat("Dungeon row %d", row + 2);
+          tooltip_label = DungeonRenderColorSourceLabel(*target);
+          source_index = target->color_index;
         }
       }
     }
@@ -347,14 +371,18 @@ void PaletteEditorWidget::DrawDungeonRenderPalette() {
       temp_color_ = display_color;
       editing_color_ = display_color;
     }
+    gfx::SnesColor dropped_color = color;
     if (editable &&
-        AcceptImGuiColorDrop(source_color, swatch_min, swatch_max)) {
-      selected_color_index_ = i;
-      editing_color_index_ = i;
-      temp_color_ = source_color->rgb();
-      editing_color_ = temp_color_;
-      if (on_palette_changed_) {
-        on_palette_changed_(current_palette_id_);
+        AcceptImGuiColorDrop(&dropped_color, swatch_min, swatch_max)) {
+      const absl::Status status = ApplyDungeonRenderColorEdit(i, dropped_color);
+      if (status.ok()) {
+        selected_color_index_ = i;
+        editing_color_index_ = i;
+        temp_color_ = dropped_color.rgb();
+        editing_color_ = temp_color_;
+      } else {
+        LOG_ERROR("PaletteEditorWidget", "Failed to apply dropped color: %s",
+                  status.message().data());
       }
     }
 
@@ -384,27 +412,46 @@ float PaletteEditorWidget::ComputeSwatchSize(int columns, float min_size,
 }
 
 void PaletteEditorWidget::DrawDungeonRenderColorPicker() {
-  gfx::SnesPalette* palette = nullptr;
-  int color_index = -1;
-  std::string source_label;
-  if (!ResolveDungeonRenderSelection(&palette, &color_index, &source_label) ||
-      !palette || color_index < 0 ||
-      color_index >= static_cast<int>(palette->size())) {
+  const auto target = ResolveDungeonRenderColorTarget(selected_color_index_,
+                                                      current_palette_id_);
+  if (!game_data_ || !target.has_value()) {
     selected_color_index_ = -1;
     editing_color_index_ = -1;
     return;
   }
 
-  ImGui::SeparatorText(
-      absl::StrFormat("%s Color %d", source_label, color_index).c_str());
+  const auto& group = PaletteGroupForTarget(*game_data_, *target);
+  if (target->palette_index < 0 ||
+      target->palette_index >= static_cast<int>(group.size())) {
+    selected_color_index_ = -1;
+    editing_color_index_ = -1;
+    return;
+  }
+  const auto& palette = group.palette_ref(target->palette_index);
+  if (target->color_index < 0 ||
+      target->color_index >= static_cast<int>(palette.size())) {
+    selected_color_index_ = -1;
+    editing_color_index_ = -1;
+    return;
+  }
 
-  auto original_color = (*palette)[color_index];
+  ImGui::SeparatorText(absl::StrFormat("%s Color %d",
+                                       DungeonRenderColorSourceLabel(*target),
+                                       target->color_index)
+                           .c_str());
+
+  const gfx::SnesColor current_color = palette[target->color_index];
+  gfx::SnesColor edited_color = current_color;
   if (gui::SnesColorEdit4(
-          "Color", &(*palette)[color_index],
+          "Color", &edited_color,
           ImGuiColorEditFlags_NoAlpha | ImGuiColorEditFlags_PickerHueWheel)) {
-    editing_color_ = gui::ConvertSnesColorToImVec4((*palette)[color_index]);
-    if (on_palette_changed_) {
-      on_palette_changed_(current_palette_id_);
+    const absl::Status status =
+        ApplyDungeonRenderColorEdit(selected_color_index_, edited_color);
+    if (status.ok()) {
+      editing_color_ = gui::ConvertSnesColorToImVec4(edited_color);
+    } else {
+      LOG_ERROR("PaletteEditorWidget", "Failed to apply palette color: %s",
+                status.message().data());
     }
   }
 
@@ -412,15 +459,19 @@ void PaletteEditorWidget::DrawDungeonRenderColorPicker() {
               static_cast<int>(editing_color_.x * 255),
               static_cast<int>(editing_color_.y * 255),
               static_cast<int>(editing_color_.z * 255));
-  ImGui::Text(tr("SNES BGR555: 0x%04X"), original_color.snes());
+  ImGui::Text(tr("SNES BGR555: 0x%04X"), current_color.snes());
 
   if (gui::ThemedButton("Reset to Original")) {
-    editing_color_ =
-        ImVec4(original_color.rgb().x / 255.0f, original_color.rgb().y / 255.0f,
-               original_color.rgb().z / 255.0f, 1.0f);
-    (*palette)[color_index] = original_color;
-    if (on_palette_changed_) {
-      on_palette_changed_(current_palette_id_);
+    const absl::Status status =
+        ApplyDungeonRenderColorEdit(selected_color_index_, std::nullopt);
+    if (status.ok()) {
+      const gfx::SnesColor reset_color = gfx::PaletteManager::Get().GetColor(
+          PaletteManagerGroupName(target->source), target->palette_index,
+          target->color_index);
+      editing_color_ = gui::ConvertSnesColorToImVec4(reset_color);
+    } else {
+      LOG_ERROR("PaletteEditorWidget", "Failed to reset palette color: %s",
+                status.message().data());
     }
   }
 }

--- a/src/app/gui/widgets/palette_editor_widget.cc
+++ b/src/app/gui/widgets/palette_editor_widget.cc
@@ -163,6 +163,10 @@ absl::Status PaletteEditorWidget::ApplyDungeonRenderColorEdit(
   }
 
   auto& palette_manager = gfx::PaletteManager::Get();
+  if (!palette_manager.IsManaging(game_data_)) {
+    return absl::FailedPreconditionError(
+        "PaletteManager is bound to a different ROM session");
+  }
   const char* group_name = PaletteManagerGroupName(target->source);
   absl::Status status =
       color.has_value()

--- a/src/app/gui/widgets/palette_editor_widget.h
+++ b/src/app/gui/widgets/palette_editor_widget.h
@@ -3,8 +3,10 @@
 
 #include <functional>
 #include <map>
+#include <optional>
 #include <vector>
 
+#include "absl/status/status.h"
 #include "app/gfx/core/bitmap.h"
 #include "app/gfx/types/snes_palette.h"
 #include "imgui/imgui.h"
@@ -48,26 +50,29 @@ class PaletteEditorWidget {
     dungeon_render_palette_mode_ = enabled;
   }
 
+  // Apply one editable CGRAM slot from the dungeon render palette. Passing a
+  // color records the edit through PaletteManager; std::nullopt resets the
+  // slot to PaletteManager's original ROM snapshot. The palette-change
+  // callback is fired only after a successful managed edit.
+  absl::Status ApplyDungeonRenderColorEdit(int display_index,
+                                           std::optional<gfx::SnesColor> color);
+
   bool IsROMLoaded() const { return rom_ != nullptr; }
   int GetCurrentGroupIndex() const { return current_group_index_; }
   void DrawROMPaletteSelector();
 
  private:
- void DrawPaletteGrid(gfx::SnesPalette& palette, int cols = 15);
+  void DrawPaletteGrid(gfx::SnesPalette& palette, int cols = 15);
   void DrawColorEditControls(gfx::SnesColor& color, int color_index);
   void DrawPaletteAnalysis(const gfx::SnesPalette& palette);
   void LoadROMPalettes();
-  float ComputeSwatchSize(int columns, float min_size,
-                          float max_size) const;
+  float ComputeSwatchSize(int columns, float min_size, float max_size) const;
 
   // For embedded view
   void DrawPaletteSelector();
   void DrawColorPicker();
   void DrawDungeonRenderPalette();
   void DrawDungeonRenderColorPicker();
-  bool ResolveDungeonRenderSelection(gfx::SnesPalette** palette,
-                                     int* color_index,
-                                     std::string* source_label);
 
   zelda3::GameData* game_data_ = nullptr;
   Rom* rom_ = nullptr;  // Legacy, deprecated

--- a/test/integration/palette_manager_test.cc
+++ b/test/integration/palette_manager_test.cc
@@ -397,6 +397,99 @@ TEST_F(PaletteManagerTest, DungeonRenderEditsMapToManagedHudAndDungeonColors) {
 }
 
 TEST_F(PaletteManagerTest,
+       DungeonRenderEditRejectsManagerBoundToDifferentRomSession) {
+  Rom first_rom;
+  Rom second_rom;
+  ASSERT_TRUE(first_rom.LoadFromData(std::vector<uint8_t>(0x100000, 0)).ok());
+  ASSERT_TRUE(second_rom.LoadFromData(std::vector<uint8_t>(0x100000, 0)).ok());
+  zelda3::GameData first_game_data(&first_rom);
+  zelda3::GameData second_game_data(&second_rom);
+  SeedPaletteGroup(first_game_data.palette_groups.get_group("dungeon_main"), 2,
+                   90, 0x0200);
+  SeedPaletteGroup(second_game_data.palette_groups.get_group("dungeon_main"), 2,
+                   90, 0x0300);
+
+  auto& manager = PaletteManager::Get();
+  manager.Initialize(&first_game_data);
+
+  gui::PaletteEditorWidget stale_widget;
+  stale_widget.Initialize(&first_game_data);
+  stale_widget.SetDungeonRenderPaletteMode(true);
+  stale_widget.SetCurrentPaletteId(1);
+  int callback_count = 0;
+  stale_widget.SetOnPaletteChanged([&](int) { ++callback_count; });
+
+  constexpr int kDungeonDisplayIndex = 99;
+  constexpr int kDungeonColorIndex = 62;
+  const SnesColor first_original =
+      first_game_data.palette_groups.dungeon_main.palette_ref(
+          1)[kDungeonColorIndex];
+  const SnesColor second_original =
+      second_game_data.palette_groups.dungeon_main.palette_ref(
+          1)[kDungeonColorIndex];
+
+  manager.Initialize(&second_game_data);
+  ASSERT_TRUE(manager.IsManaging(&second_game_data));
+  ASSERT_FALSE(manager.HasUnsavedChanges());
+
+  const absl::Status edit_status = stale_widget.ApplyDungeonRenderColorEdit(
+      kDungeonDisplayIndex, SnesColor(0x7C00));
+  EXPECT_EQ(edit_status.code(), absl::StatusCode::kFailedPrecondition);
+  EXPECT_EQ(first_game_data.palette_groups.dungeon_main
+                .palette_ref(1)[kDungeonColorIndex]
+                .snes(),
+            first_original.snes());
+  EXPECT_EQ(second_game_data.palette_groups.dungeon_main
+                .palette_ref(1)[kDungeonColorIndex]
+                .snes(),
+            second_original.snes());
+  EXPECT_EQ(callback_count, 0);
+  EXPECT_FALSE(manager.HasUnsavedChanges());
+}
+
+TEST_F(PaletteManagerTest,
+       DungeonPaletteSaveRejectsManagerBoundToDifferentRomSession) {
+  Rom first_rom;
+  Rom second_rom;
+  ASSERT_TRUE(first_rom.LoadFromData(std::vector<uint8_t>(0x100000, 0)).ok());
+  ASSERT_TRUE(second_rom.LoadFromData(std::vector<uint8_t>(0x100000, 0)).ok());
+  zelda3::GameData first_game_data(&first_rom);
+  zelda3::GameData second_game_data(&second_rom);
+  SeedPaletteGroup(first_game_data.palette_groups.get_group("dungeon_main"), 2,
+                   90, 0x0200);
+  SeedPaletteGroup(second_game_data.palette_groups.get_group("dungeon_main"), 2,
+                   90, 0x0300);
+
+  auto& manager = PaletteManager::Get();
+  manager.Initialize(&second_game_data);
+  constexpr int kDungeonColorIndex = 62;
+  const uint32_t second_color_address =
+      GetPaletteAddress("dungeon_main", 1, kDungeonColorIndex);
+  ASSERT_TRUE(second_rom.ReadWord(second_color_address).ok());
+  const uint16_t second_rom_color = *second_rom.ReadWord(second_color_address);
+  ASSERT_TRUE(
+      manager.SetColor("dungeon_main", 1, kDungeonColorIndex, SnesColor(0x7C00))
+          .ok());
+  ASSERT_TRUE(manager.HasUnsavedChanges());
+
+  DungeonSaveFlagsGuard flags_guard;
+  ConfigurePaletteOnlyDungeonSave();
+  editor::DungeonEditorV2 dungeon_editor(&first_rom);
+  editor::EditorDependencies dependencies;
+  dependencies.rom = &first_rom;
+  dependencies.game_data = &first_game_data;
+  dungeon_editor.SetDependencies(dependencies);
+  dungeon_editor.SetGameData(&first_game_data);
+
+  const absl::Status save_status = dungeon_editor.Save();
+  EXPECT_EQ(save_status.code(), absl::StatusCode::kFailedPrecondition);
+  ASSERT_TRUE(second_rom.ReadWord(second_color_address).ok());
+  EXPECT_EQ(*second_rom.ReadWord(second_color_address), second_rom_color);
+  EXPECT_TRUE(manager.HasUnsavedChanges());
+  EXPECT_TRUE(manager.IsColorModified("dungeon_main", 1, kDungeonColorIndex));
+}
+
+TEST_F(PaletteManagerTest,
        DungeonRenderEditSurvivesPaletteEditorLoadAndPersistsThroughSave) {
   Rom rom;
   ASSERT_TRUE(rom.LoadFromData(std::vector<uint8_t>(0x100000, 0)).ok());

--- a/test/integration/palette_manager_test.cc
+++ b/test/integration/palette_manager_test.cc
@@ -2,14 +2,58 @@
 
 #include <gtest/gtest.h>
 
+#include <array>
+#include <memory>
+#include <optional>
+
+#include "app/editor/dungeon/dungeon_editor_v2.h"
 #include "app/gfx/types/snes_color.h"
 #include "app/gfx/types/snes_palette.h"
+#include "app/gui/widgets/palette_editor_widget.h"
+#include "core/features.h"
 #include "rom/rom.h"
+#include "zelda3/dungeon/room.h"
 #include "zelda3/game_data.h"
 
 namespace yaze {
 namespace gfx {
 namespace {
+
+struct DungeonSaveFlagsGuard {
+  decltype(core::FeatureFlags::get().dungeon) previous =
+      core::FeatureFlags::get().dungeon;
+  ~DungeonSaveFlagsGuard() { core::FeatureFlags::get().dungeon = previous; }
+};
+
+void ConfigurePaletteOnlyDungeonSave() {
+  auto& flags = core::FeatureFlags::get().dungeon;
+  flags.kSaveObjects = false;
+  flags.kSaveSprites = false;
+  flags.kSaveRoomHeaders = false;
+  flags.kSaveTorches = false;
+  flags.kSavePits = false;
+  flags.kSaveBlocks = false;
+  flags.kSaveCollision = false;
+  flags.kSaveWaterFillZones = false;
+  flags.kSaveChests = false;
+  flags.kSavePotItems = false;
+  flags.kSaveEntrances = false;
+  flags.kSavePalettes = true;
+}
+
+void SeedPaletteGroup(PaletteGroup* group, int palette_count, int color_count,
+                      uint16_t seed) {
+  ASSERT_NE(group, nullptr);
+  group->clear();
+  for (int palette_index = 0; palette_index < palette_count; ++palette_index) {
+    SnesPalette palette;
+    for (int color_index = 0; color_index < color_count; ++color_index) {
+      palette.AddColor(SnesColor(static_cast<uint16_t>(
+          (seed + palette_index * color_count + color_index) & 0x7FFF)));
+    }
+    group->AddPalette(palette);
+  }
+}
 
 // Test fixture for PaletteManager integration tests
 class PaletteManagerTest : public ::testing::Test {
@@ -280,6 +324,136 @@ TEST_F(PaletteManagerTest, SaveTransactionRollbackRestoresRetryState) {
 
   ASSERT_TRUE(manager.ResetColor("ow_main", 0, 0).ok());
   EXPECT_EQ(manager.GetColor("ow_main", 0, 0).snes(), 0x0000);
+}
+
+TEST_F(PaletteManagerTest, DungeonRenderEditsMapToManagedHudAndDungeonColors) {
+  Rom rom;
+  ASSERT_TRUE(rom.LoadFromData(std::vector<uint8_t>(0x100000, 0)).ok());
+  zelda3::GameData game_data(&rom);
+  SeedPaletteGroup(game_data.palette_groups.get_group("hud"), 1, 32, 0x0100);
+  SeedPaletteGroup(game_data.palette_groups.get_group("dungeon_main"), 2, 90,
+                   0x0200);
+
+  auto& manager = PaletteManager::Get();
+  manager.Initialize(&game_data);
+
+  gui::PaletteEditorWidget widget;
+  widget.Initialize(&game_data);
+  widget.SetDungeonRenderPaletteMode(true);
+  widget.SetCurrentPaletteId(1);
+  int callback_count = 0;
+  int callback_palette = -1;
+  widget.SetOnPaletteChanged([&](int palette_id) {
+    ++callback_count;
+    callback_palette = palette_id;
+  });
+
+  constexpr int kHudDisplayIndex = 17;
+  constexpr int kDungeonDisplayIndex = 99;
+  constexpr int kDungeonColorIndex = 62;
+  const SnesColor original_dungeon_color =
+      manager.GetColor("dungeon_main", 1, kDungeonColorIndex);
+  const SnesColor new_hud_color(0x001F);
+  const SnesColor new_dungeon_color(0x7C00);
+
+  ASSERT_TRUE(
+      widget.ApplyDungeonRenderColorEdit(kHudDisplayIndex, new_hud_color).ok());
+  ASSERT_TRUE(
+      widget
+          .ApplyDungeonRenderColorEdit(kDungeonDisplayIndex, new_dungeon_color)
+          .ok());
+
+  EXPECT_TRUE(manager.IsColorModified("hud", 0, kHudDisplayIndex));
+  EXPECT_TRUE(manager.IsColorModified("dungeon_main", 1, kDungeonColorIndex));
+  EXPECT_EQ(manager.GetColor("hud", 0, kHudDisplayIndex).snes(),
+            new_hud_color.snes());
+  EXPECT_EQ(manager.GetColor("dungeon_main", 1, kDungeonColorIndex).snes(),
+            new_dungeon_color.snes());
+  EXPECT_EQ(callback_count, 2);
+  EXPECT_EQ(callback_palette, 1);
+
+  std::array<uint16_t, 256> cgram{};
+  const auto& dungeon_palette =
+      game_data.palette_groups.dungeon_main.palette_ref(1);
+  const auto& hud_palette = game_data.palette_groups.hud.palette_ref(0);
+  zelda3::LoadDungeonRenderPaletteToCgram(cgram, dungeon_palette, &hud_palette);
+  EXPECT_EQ(cgram[kHudDisplayIndex], new_hud_color.snes());
+  EXPECT_EQ(cgram[kDungeonDisplayIndex], new_dungeon_color.snes());
+
+  ASSERT_TRUE(
+      widget.ApplyDungeonRenderColorEdit(kDungeonDisplayIndex, std::nullopt)
+          .ok());
+  EXPECT_EQ(manager.GetColor("dungeon_main", 1, kDungeonColorIndex).snes(),
+            original_dungeon_color.snes());
+  EXPECT_EQ(callback_count, 3);
+
+  constexpr int kReservedRowStart = 96;
+  const absl::Status reserved_status =
+      widget.ApplyDungeonRenderColorEdit(kReservedRowStart, new_dungeon_color);
+  EXPECT_FALSE(reserved_status.ok());
+  EXPECT_EQ(reserved_status.code(), absl::StatusCode::kInvalidArgument);
+  EXPECT_EQ(callback_count, 3);
+}
+
+TEST_F(PaletteManagerTest, DungeonRenderEditPersistsThroughDungeonEditorSave) {
+  Rom rom;
+  ASSERT_TRUE(rom.LoadFromData(std::vector<uint8_t>(0x100000, 0)).ok());
+  zelda3::GameData game_data(&rom);
+  SeedPaletteGroup(game_data.palette_groups.get_group("dungeon_main"), 2, 90,
+                   0x0200);
+
+  auto& manager = PaletteManager::Get();
+  manager.Initialize(&game_data);
+
+  gui::PaletteEditorWidget widget;
+  widget.Initialize(&game_data);
+  widget.SetDungeonRenderPaletteMode(true);
+  widget.SetCurrentPaletteId(1);
+
+  constexpr int kDungeonDisplayIndex = 99;
+  constexpr int kDungeonColorIndex = 62;
+  const SnesColor edited_color(0x1234);
+  const uint32_t color_address =
+      GetPaletteAddress("dungeon_main", 1, kDungeonColorIndex);
+  ASSERT_TRUE(rom.ReadWord(color_address - 2).ok());
+  ASSERT_TRUE(rom.ReadWord(color_address + 2).ok());
+  const uint16_t previous_color = *rom.ReadWord(color_address - 2);
+  const uint16_t next_color = *rom.ReadWord(color_address + 2);
+
+  ASSERT_TRUE(
+      widget.ApplyDungeonRenderColorEdit(kDungeonDisplayIndex, edited_color)
+          .ok());
+  ASSERT_TRUE(manager.HasUnsavedChanges());
+  ASSERT_TRUE(manager.IsColorModified("dungeon_main", 1, kDungeonColorIndex));
+
+  DungeonSaveFlagsGuard flags_guard;
+  ConfigurePaletteOnlyDungeonSave();
+  auto dungeon_editor = std::make_unique<editor::DungeonEditorV2>(&rom);
+  editor::EditorDependencies dependencies;
+  dependencies.rom = &rom;
+  dependencies.game_data = &game_data;
+  dungeon_editor->SetDependencies(dependencies);
+  dungeon_editor->SetGameData(&game_data);
+
+  const absl::Status save_status = dungeon_editor->Save();
+  ASSERT_TRUE(save_status.ok()) << save_status.message();
+
+  ASSERT_TRUE(rom.ReadWord(color_address).ok());
+  EXPECT_EQ(*rom.ReadWord(color_address), edited_color.snes());
+  EXPECT_EQ(*rom.ReadWord(color_address - 2), previous_color);
+  EXPECT_EQ(*rom.ReadWord(color_address + 2), next_color);
+
+  PaletteGroupMap reloaded_groups;
+  const absl::Status reload_status =
+      LoadAllPalettes(rom.vector(), reloaded_groups);
+  ASSERT_TRUE(reload_status.ok()) << reload_status.message();
+  ASSERT_GT(reloaded_groups.dungeon_main.size(), 1u);
+  ASSERT_GT(reloaded_groups.dungeon_main.palette_ref(1).size(),
+            static_cast<size_t>(kDungeonColorIndex));
+  EXPECT_EQ(
+      reloaded_groups.dungeon_main.palette_ref(1)[kDungeonColorIndex].snes(),
+      edited_color.snes());
+  EXPECT_FALSE(manager.HasUnsavedChanges());
 }
 
 TEST_F(PaletteManagerTest, DiscardGroupWithoutInitializationIsNoOp) {

--- a/test/integration/palette_manager_test.cc
+++ b/test/integration/palette_manager_test.cc
@@ -7,6 +7,7 @@
 #include <optional>
 
 #include "app/editor/dungeon/dungeon_editor_v2.h"
+#include "app/editor/palette/palette_editor.h"
 #include "app/gfx/types/snes_color.h"
 #include "app/gfx/types/snes_palette.h"
 #include "app/gui/widgets/palette_editor_widget.h"
@@ -395,7 +396,8 @@ TEST_F(PaletteManagerTest, DungeonRenderEditsMapToManagedHudAndDungeonColors) {
   EXPECT_EQ(callback_count, 3);
 }
 
-TEST_F(PaletteManagerTest, DungeonRenderEditPersistsThroughDungeonEditorSave) {
+TEST_F(PaletteManagerTest,
+       DungeonRenderEditSurvivesPaletteEditorLoadAndPersistsThroughSave) {
   Rom rom;
   ASSERT_TRUE(rom.LoadFromData(std::vector<uint8_t>(0x100000, 0)).ok());
   zelda3::GameData game_data(&rom);
@@ -423,6 +425,13 @@ TEST_F(PaletteManagerTest, DungeonRenderEditPersistsThroughDungeonEditorSave) {
   ASSERT_TRUE(
       widget.ApplyDungeonRenderColorEdit(kDungeonDisplayIndex, edited_color)
           .ok());
+  ASSERT_TRUE(manager.HasUnsavedChanges());
+  ASSERT_TRUE(manager.IsColorModified("dungeon_main", 1, kDungeonColorIndex));
+
+  editor::PaletteEditor palette_editor(&rom);
+  palette_editor.SetGameData(&game_data);
+  const absl::Status palette_load_status = palette_editor.Load();
+  ASSERT_TRUE(palette_load_status.ok()) << palette_load_status.message();
   ASSERT_TRUE(manager.HasUnsavedChanges());
   ASSERT_TRUE(manager.IsColorModified("dungeon_main", 1, kDungeonColorIndex));
 


### PR DESCRIPTION
## Summary

- route dungeon render-palette picker, drag/drop, and reset edits through `PaletteManager`
- preserve pending palette dirty state when another editor lazily loads the same `GameData`
- fail closed when a stale dungeon widget or dungeon save is bound to a different ROM session
- keep rendered CGRAM previews synchronized and report the real saved-color count

## Root cause

The dungeon palette panel mutated `GameData` directly, while `DungeonEditorV2::Save()` only persisted colors tracked as dirty by `PaletteManager`. The edit therefore looked correct in the preview but could be silently skipped on Save/reopen. A second same-session editor load also reinitialized the singleton and cleared dirty tracking.

## User impact

Dungeon HUD and dungeon-main color edits now participate in the normal transactional save path and survive ROM readback. Stale cross-session operations return a failed precondition instead of mutating or saving the wrong ROM.

This is an incremental safety fix, not per-session `PaletteManager` architecture: rebinding the singleton to a different `GameData` still replaces the previous session's tracking.

## Verification

- `PaletteManagerTest.Dungeon*`: 4/4 passed
- `PaletteManagerTest.*`: 30/30 passed
- Debug integration target: 970/970 build steps completed
- pre-push validation: passed in 119s (unit target build, formatting, change-aware checks)
- `git diff --check origin/master...HEAD`: passed
