### PR TITLE
fix(dungeon): include palette writes in save preflight

### DIFF
--- a/src/app/editor/dungeon/dungeon_editor_v2_persistence.cc
+++ b/src/app/editor/dungeon/dungeon_editor_v2_persistence.cc
@@ -566,6 +566,12 @@ std::vector<std::pair<uint32_t, uint32_t>> DungeonEditorV2::CollectWriteRanges()
   const auto& flags = core::FeatureFlags::get().dungeon;
   const auto& rom_data = rom_->vector();
 
+  auto& palette_manager = gfx::PaletteManager::Get();
+  if (flags.kSavePalettes && palette_manager.IsManaging(game_data_)) {
+    auto palette_ranges = palette_manager.GetModifiedColorWriteRanges();
+    ranges.insert(ranges.end(), palette_ranges.begin(), palette_ranges.end());
+  }
+
   if (flags.kSaveEntrances) {
     auto entrance_ranges =
         zelda3::CollectDirtyRegularDungeonEntranceWriteRanges(entrances_);

--- a/src/app/gfx/util/palette_manager.cc
+++ b/src/app/gfx/util/palette_manager.cc
@@ -1,5 +1,6 @@
 #include "palette_manager.h"
 
+#include <algorithm>
 #include <chrono>
 
 #include "absl/strings/str_format.h"
@@ -264,6 +265,34 @@ size_t PaletteManager::GetModifiedColorCount() const {
     }
   }
   return count;
+}
+
+std::vector<std::pair<uint32_t, uint32_t>>
+PaletteManager::GetModifiedColorWriteRanges() const {
+  std::vector<std::pair<uint32_t, uint32_t>> ranges;
+  ranges.reserve(GetModifiedColorCount());
+
+  for (const auto& [group_name, palette_map] : modified_colors_) {
+    for (const auto& [palette_index, color_indices] : palette_map) {
+      for (int color_index : color_indices) {
+        const uint32_t begin =
+            GetPaletteAddress(group_name, palette_index, color_index);
+        ranges.emplace_back(begin, begin + 2u);
+      }
+    }
+  }
+
+  std::sort(ranges.begin(), ranges.end());
+  std::vector<std::pair<uint32_t, uint32_t>> coalesced;
+  coalesced.reserve(ranges.size());
+  for (const auto& range : ranges) {
+    if (coalesced.empty() || coalesced.back().second < range.first) {
+      coalesced.push_back(range);
+      continue;
+    }
+    coalesced.back().second = std::max(coalesced.back().second, range.second);
+  }
+  return coalesced;
 }
 
 // ========== Persistence ==========

--- a/src/app/gfx/util/palette_manager.h
+++ b/src/app/gfx/util/palette_manager.h
@@ -9,6 +9,7 @@
 #include <string>
 #include <unordered_map>
 #include <unordered_set>
+#include <utility>
 #include <vector>
 
 #include "absl/status/status.h"
@@ -186,6 +187,12 @@ class PaletteManager {
    * @brief Get count of modified colors across all groups
    */
   size_t GetModifiedColorCount() const;
+
+  /**
+   * @brief Get exact, coalesced half-open ROM ranges for modified colors
+   */
+  std::vector<std::pair<uint32_t, uint32_t>> GetModifiedColorWriteRanges()
+      const;
 
   // ========== Persistence ==========
 

--- a/test/integration/palette_manager_test.cc
+++ b/test/integration/palette_manager_test.cc
@@ -2,9 +2,12 @@
 
 #include <gtest/gtest.h>
 
+#include <algorithm>
 #include <array>
 #include <memory>
 #include <optional>
+#include <utility>
+#include <vector>
 
 #include "app/editor/dungeon/dungeon_editor_v2.h"
 #include "app/editor/palette/palette_editor.h"
@@ -394,6 +397,107 @@ TEST_F(PaletteManagerTest, DungeonRenderEditsMapToManagedHudAndDungeonColors) {
   EXPECT_FALSE(reserved_status.ok());
   EXPECT_EQ(reserved_status.code(), absl::StatusCode::kInvalidArgument);
   EXPECT_EQ(callback_count, 3);
+}
+
+TEST_F(PaletteManagerTest,
+       DungeonWriteRangesMapHudAndDungeonColorsExactlyAndCoalesce) {
+  Rom rom;
+  ASSERT_TRUE(rom.LoadFromData(std::vector<uint8_t>(0x100000, 0)).ok());
+  zelda3::GameData game_data(&rom);
+  SeedPaletteGroup(game_data.palette_groups.get_group("hud"), 1, 32, 0x0100);
+  SeedPaletteGroup(game_data.palette_groups.get_group("dungeon_main"), 2, 90,
+                   0x0200);
+
+  auto& manager = PaletteManager::Get();
+  manager.Initialize(&game_data);
+  ASSERT_TRUE(manager.SetColor("dungeon_main", 1, 64, SnesColor(0x001F)).ok());
+  ASSERT_TRUE(manager.SetColor("hud", 0, 5, SnesColor(0x03E0)).ok());
+  ASSERT_TRUE(manager.SetColor("dungeon_main", 1, 62, SnesColor(0x7C00)).ok());
+  ASSERT_TRUE(manager.SetColor("hud", 0, 4, SnesColor(0x7FFF)).ok());
+
+  const uint32_t hud_begin = GetPaletteAddress("hud", 0, 4);
+  const uint32_t dungeon_begin = GetPaletteAddress("dungeon_main", 1, 62);
+  const uint32_t later_dungeon_color = GetPaletteAddress("dungeon_main", 1, 64);
+  std::vector<std::pair<uint32_t, uint32_t>> expected = {
+      {hud_begin, hud_begin + 4},
+      {dungeon_begin, dungeon_begin + 2},
+      {later_dungeon_color, later_dungeon_color + 2}};
+  std::sort(expected.begin(), expected.end());
+
+  EXPECT_EQ(manager.GetModifiedColorWriteRanges(), expected);
+  EXPECT_EQ(manager.GetModifiedColorWriteRanges(), expected);
+
+  DungeonSaveFlagsGuard flags_guard;
+  ConfigurePaletteOnlyDungeonSave();
+  editor::DungeonEditorV2 dungeon_editor(&rom);
+  editor::EditorDependencies dependencies;
+  dependencies.rom = &rom;
+  dependencies.game_data = &game_data;
+  dungeon_editor.SetDependencies(dependencies);
+  dungeon_editor.SetGameData(&game_data);
+  EXPECT_EQ(dungeon_editor.CollectWriteRanges(), expected);
+}
+
+TEST_F(PaletteManagerTest,
+       DungeonWriteRangesOmitPalettesWhenPaletteSavingIsDisabled) {
+  Rom rom;
+  ASSERT_TRUE(rom.LoadFromData(std::vector<uint8_t>(0x100000, 0)).ok());
+  zelda3::GameData game_data(&rom);
+  SeedPaletteGroup(game_data.palette_groups.get_group("dungeon_main"), 1, 90,
+                   0x0200);
+
+  auto& manager = PaletteManager::Get();
+  manager.Initialize(&game_data);
+  ASSERT_TRUE(manager.SetColor("dungeon_main", 0, 10, SnesColor(0x7C00)).ok());
+  ASSERT_FALSE(manager.GetModifiedColorWriteRanges().empty());
+
+  DungeonSaveFlagsGuard flags_guard;
+  ConfigurePaletteOnlyDungeonSave();
+  core::FeatureFlags::get().dungeon.kSavePalettes = false;
+  editor::DungeonEditorV2 dungeon_editor(&rom);
+  dungeon_editor.SetGameData(&game_data);
+  EXPECT_TRUE(dungeon_editor.CollectWriteRanges().empty());
+}
+
+TEST_F(PaletteManagerTest,
+       DungeonWriteRangesOmitPalettesManagedForDifferentRomSession) {
+  Rom first_rom;
+  Rom second_rom;
+  ASSERT_TRUE(first_rom.LoadFromData(std::vector<uint8_t>(0x100000, 0)).ok());
+  ASSERT_TRUE(second_rom.LoadFromData(std::vector<uint8_t>(0x100000, 0)).ok());
+  zelda3::GameData first_game_data(&first_rom);
+  zelda3::GameData second_game_data(&second_rom);
+  SeedPaletteGroup(second_game_data.palette_groups.get_group("dungeon_main"), 1,
+                   90, 0x0200);
+
+  auto& manager = PaletteManager::Get();
+  manager.Initialize(&second_game_data);
+  ASSERT_TRUE(manager.SetColor("dungeon_main", 0, 10, SnesColor(0x7C00)).ok());
+  ASSERT_FALSE(manager.GetModifiedColorWriteRanges().empty());
+
+  DungeonSaveFlagsGuard flags_guard;
+  ConfigurePaletteOnlyDungeonSave();
+  editor::DungeonEditorV2 dungeon_editor(&first_rom);
+  dungeon_editor.SetGameData(&first_game_data);
+  EXPECT_TRUE(dungeon_editor.CollectWriteRanges().empty());
+}
+
+TEST_F(PaletteManagerTest, DungeonWriteRangesAreEmptyWithoutDirtyColors) {
+  Rom rom;
+  ASSERT_TRUE(rom.LoadFromData(std::vector<uint8_t>(0x100000, 0)).ok());
+  zelda3::GameData game_data(&rom);
+  SeedPaletteGroup(game_data.palette_groups.get_group("dungeon_main"), 1, 90,
+                   0x0200);
+
+  auto& manager = PaletteManager::Get();
+  manager.Initialize(&game_data);
+  EXPECT_TRUE(manager.GetModifiedColorWriteRanges().empty());
+
+  DungeonSaveFlagsGuard flags_guard;
+  ConfigurePaletteOnlyDungeonSave();
+  editor::DungeonEditorV2 dungeon_editor(&rom);
+  dungeon_editor.SetGameData(&game_data);
+  EXPECT_TRUE(dungeon_editor.CollectWriteRanges().empty());
 }
 
 TEST_F(PaletteManagerTest,


### PR DESCRIPTION
## Summary

- expose deterministic, coalesced half-open ROM ranges for every color currently dirty in `PaletteManager`
- include those ranges in `DungeonEditorV2::CollectWriteRanges()` when palette saving is enabled
- omit palette ranges when the manager is unbound or belongs to another ROM session

## Why

The dungeon save path writes all dirty palette groups through `PaletteManager::SaveAllToRom()`, but its manifest/write-conflict preflight previously reported only room and auxiliary dungeon data. A protected palette address could therefore be missing from conflict prediction even though the save would write it.

## User impact

Palette-only dungeon edits now participate in the same project manifest conflict surface as other ROM writes. Adjacent dirty colors are coalesced while gaps and distinct palette regions remain exact.

## Stack

- #111 (`codex/dungeon-palette-persistence`) is merged.
- This PR is rebased onto the resulting `master` tree.

## Verification

- `PaletteManagerTest.DungeonWriteRanges*`: 4/4 passed
- `PaletteManagerTest.*`: 34/34 passed
- `DungeonEditorV2RomSafetyTest.CollectWriteRanges*`: 6/6 passed
- integration and unit targets built successfully
- pre-push validation: passed
- strict audit: no blocking findings

## Follow-up

A generic `EditorManager::SaveRom()` manifest-conflict fallback test exists for other write types; a palette-specific end-to-end variant would add another integration layer but is not required for this focused range-generation change.

