### PR TITLE
Fix dungeon graphics palette slot mapping

### DIFF
--- a/src/zelda3/dungeon/room.cc
+++ b/src/zelda3/dungeon/room.cc
@@ -901,22 +901,25 @@ void Room::CopyRoomGraphicsToBuffer() {
   //
   // For background graphics sets, the game selects Left/Right based on the
   // active main graphics group ($0AA1) and the slot index ($0F).
-  // For UW groups (< $20), slots 4-7 use Right; for OW groups (>= $20), the
-  // Right slots are {2,3,4,7}. We mirror this by shifting non-zero pixels by
-  // +8 when copying those background blocks into current_gfx16_.
+  // InitializeTilesets starts $0F at 7 for destination block 0 and decrements
+  // it through destination block 7, so the runtime slot is 7 - block. For UW
+  // groups (< $20), runtime slots 4-7 use Right; for OW groups (>= $20), the
+  // Right runtime slots are {2,3,4,7}.
   const uint8_t active_main_blockset =
       resolved_main_blockset_ != 0xFF
           ? resolved_main_blockset_
           : (render_entrance_blockset_ != 0xFF ? render_entrance_blockset_
                                                : blockset_);
-  auto is_right_palette_background_slot = [&](int slot) -> bool {
-    if (slot < 0 || slot >= 8) {
+  auto is_right_palette_background_slot = [&](int block) -> bool {
+    if (block < 0 || block >= 8) {
       return false;
     }
+    const int runtime_slot = 7 - block;
     if (active_main_blockset < 0x20) {
-      return slot >= 4;
+      return runtime_slot >= 4;
     }
-    return (slot == 2 || slot == 3 || slot == 4 || slot == 7);
+    return (runtime_slot == 2 || runtime_slot == 3 || runtime_slot == 4 ||
+            runtime_slot == 7);
   };
 
   // Process each of the 16 graphics blocks

--- a/test/fixtures/visual/dungeon/README.md
+++ b/test/fixtures/visual/dungeon/README.md
@@ -18,6 +18,8 @@ They are correctness references, not recordings of yaze's current renderer.
   underworld module.
 - Mesen source screenshot: 256x224; crop `(x=32, y=80, w=48, h=64)`.
 - Corresponding yaze 512x512 room crop: `(x=160, y=353, w=48, h=64)`.
+- Carpet diagnostic pixel: Mesen `(x=128, y=64)` is RGB `(107, 33, 33)`;
+  the corresponding yaze room pixel is `(x=256, y=337)`.
 - Fixture SHA-256:
   `8cc0cd0c1a79a86023cd4823340e3129c378f2d478e74297b62a6b20edbc020d`.
 
@@ -26,9 +28,9 @@ pixel-exact between Mesen and yaze. The test uses exact RGBA comparison: there
 is no GPU rasterization or antialiasing in either path, so a tolerance would
 hide real renderer drift. The test skips when no ROM is configured, the first
 1 MiB is not the canonical US ROM, or the build has no libpng-backed visual
-diff support. Larger Sanctuary floor/background regions currently expose
-palette differences and are deliberately not treated as passing parity
-evidence.
+diff support. The separately asserted carpet pixel catches reversed SNES
+3bpp-to-4bpp Left/Right expansion without broadening the committed image
+fixture.
 
 ## Updating a baseline
 

--- a/test/integration/zelda3/dungeon_room_regression_fixtures_test.cc
+++ b/test/integration/zelda3/dungeon_room_regression_fixtures_test.cc
@@ -78,6 +78,13 @@ constexpr int kRoom012YazeRoiX = 160;
 constexpr int kRoom012YazeRoiY = 353;
 constexpr int kRoom012RoiWidth = 48;
 constexpr int kRoom012RoiHeight = 64;
+constexpr int kRoom012MesenCarpetX = 128;
+constexpr int kRoom012MesenCarpetY = 64;
+constexpr int kRoom012YazeCarpetX = 256;
+constexpr int kRoom012YazeCarpetY = 337;
+constexpr uint8_t kRoom012CarpetR = 107;
+constexpr uint8_t kRoom012CarpetG = 33;
+constexpr uint8_t kRoom012CarpetB = 33;
 
 ::yaze::test::Screenshot CaptureRgbaRegion(const gfx::Bitmap& bitmap, int x,
                                            int y, int width, int height) {
@@ -402,6 +409,49 @@ TEST_F(DungeonRoomRegressionFixturesTest,
   EXPECT_EQ(result.total_pixels, kRoom012RoiWidth * kRoom012RoiHeight);
   EXPECT_TRUE(actual.data == expected.data)
       << "Mesen and yaze ROI RGBA bytes must match exactly.";
+#endif
+}
+
+TEST_F(DungeonRoomRegressionFixturesTest,
+       Room012CarpetPixelMatchesIndependentMesenBaseline) {
+#if !defined(YAZE_HAS_VISUAL_DIFF_ENGINE)
+  GTEST_SKIP() << "libpng-backed VisualDiffEngine is unavailable.";
+#else
+  SCOPED_TRACE(::testing::Message()
+               << "Mesen carpet pixel (" << kRoom012MesenCarpetX << ","
+               << kRoom012MesenCarpetY << ")");
+  if (rom_.size() < kCanonicalUsRomSize) {
+    GTEST_SKIP() << "Mesen baseline requires the canonical US ROM data.";
+  }
+  const std::string base_sha1 =
+      util::ComputeSha1Hex(rom_.data(), kCanonicalUsRomSize);
+  if (base_sha1 != kCanonicalUsRomSha1) {
+    GTEST_SKIP() << "Mesen baseline was captured from US ROM SHA-1 "
+                 << kCanonicalUsRomSha1 << "; loaded ROM begins with "
+                 << base_sha1 << ".";
+  }
+
+  Room room = LoadRoomFromRom(&rom_, 0x012);
+  room.SetGameData(&game_data_);
+  room.LoadSprites();
+  room.LoadRoomGraphics();
+  room.RenderRoomGraphics();
+
+  RoomLayerManager layer_manager;
+  const auto& composite = room.GetCompositeBitmap(layer_manager);
+  ASSERT_TRUE(composite.is_active());
+  ASSERT_NE(composite.surface(), nullptr);
+  ASSERT_GT(composite.width(), kRoom012YazeCarpetX);
+  ASSERT_GT(composite.height(), kRoom012YazeCarpetY);
+
+  const auto actual = CaptureRgbaRegion(composite, kRoom012YazeCarpetX,
+                                        kRoom012YazeCarpetY, 1, 1);
+  ASSERT_TRUE(actual.IsValid());
+  ASSERT_EQ(actual.data.size(), 4u);
+  EXPECT_EQ(actual.data[0], kRoom012CarpetR);
+  EXPECT_EQ(actual.data[1], kRoom012CarpetG);
+  EXPECT_EQ(actual.data[2], kRoom012CarpetB);
+  EXPECT_EQ(actual.data[3], 0xFF);
 #endif
 }
 

--- a/test/unit/zelda3/dungeon/custom_object_room_render_test.cc
+++ b/test/unit/zelda3/dungeon/custom_object_room_render_test.cc
@@ -23,6 +23,10 @@
 namespace yaze::zelda3::test {
 namespace {
 
+// The seeded source pixel is 1. Palette 2 contributes 32, and room 0's
+// underworld destination block uses right-palette expansion (+8).
+constexpr uint8_t kPaletteTwoRightSlotPixel = 41;
+
 class CustomObjectRoomRenderTest : public ::testing::Test {
  protected:
   void SetUp() override {
@@ -166,7 +170,7 @@ TEST_F(CustomObjectRoomRenderTest,
 
   const int pixel_index = PixelIndex(bitmap, /*x=*/3 * 8, /*y=*/4 * 8);
   ASSERT_LT(pixel_index, static_cast<int>(bitmap.size()));
-  EXPECT_EQ(bitmap.data()[pixel_index], 33)
+  EXPECT_EQ(bitmap.data()[pixel_index], kPaletteTwoRightSlotPixel)
       << "Custom object should draw visible pixels onto the room canvas";
   EXPECT_EQ(room.object_bg1_buffer().coverage_data()[pixel_index], 1);
 }
@@ -209,7 +213,7 @@ TEST_F(CustomObjectRoomRenderTest,
 
   const int pixel_index = PixelIndex(bitmap, /*x=*/6 * 8, /*y=*/7 * 8);
   ASSERT_LT(pixel_index, static_cast<int>(bitmap.size()));
-  EXPECT_EQ(bitmap.data()[pixel_index], 33)
+  EXPECT_EQ(bitmap.data()[pixel_index], kPaletteTwoRightSlotPixel)
       << "Corner alias object should render from its mapped custom bin";
   EXPECT_EQ(room.object_bg1_buffer().coverage_data()[pixel_index], 1);
 }
@@ -231,7 +235,7 @@ TEST_F(CustomObjectRoomRenderTest,
 
   const int pixel_index = PixelIndex(bitmap, /*x=*/6 * 8, /*y=*/7 * 8);
   ASSERT_LT(pixel_index, static_cast<int>(bitmap.size()));
-  EXPECT_NE(bitmap.data()[pixel_index], 33)
+  EXPECT_NE(bitmap.data()[pixel_index], kPaletteTwoRightSlotPixel)
       << "Vanilla wall corners should not be hijacked by track alias files in "
          "rooms without 0x31";
 }
@@ -318,12 +322,12 @@ TEST_F(CustomObjectRoomRenderTest,
   ASSERT_LT(primary_index, static_cast<int>(bg1_bitmap.size()));
   ASSERT_LT(overlay_index, static_cast<int>(bg1_bitmap.size()));
 
-  EXPECT_EQ(bg1_bitmap.data()[primary_index], 33)
+  EXPECT_EQ(bg1_bitmap.data()[primary_index], kPaletteTwoRightSlotPixel)
       << "Primary room-object list should render through the BG1 object buffer";
   EXPECT_EQ(bg2_bitmap.data()[primary_index], 255)
       << "Primary room-object list should not land in the BG2 overlay buffer";
 
-  EXPECT_EQ(bg2_bitmap.data()[overlay_index], 33)
+  EXPECT_EQ(bg2_bitmap.data()[overlay_index], kPaletteTwoRightSlotPixel)
       << "BG2 overlay list should render through the BG2 object buffer";
 }
 

--- a/test/unit/zelda3/dungeon/room_graphics_palette_test.cc
+++ b/test/unit/zelda3/dungeon/room_graphics_palette_test.cc
@@ -14,13 +14,13 @@ namespace yaze::zelda3::test {
 
 // USDASM grounding:
 // - bank_00.asm LoadBackgroundGraphics chooses Expand3bppToVRAM_RightPalette for
-//   underworld (UW) background slots $0F >= 4 (i.e. the second half of the 8
-//   background sheets in the set). Right-palette expansion sets bit3 for any
-//   non-zero pixel, shifting values 1-7 to 9-15.
+//   underworld (UW) runtime slots $0F >= 4. InitializeTilesets loads destination
+//   blocks 0..7 while counting $0F down from 7..0. Right-palette expansion sets
+//   bit3 for any non-zero pixel, shifting values 1-7 to 9-15.
 //
 // In yaze we store sheets as 8BPP linear indices (one byte per pixel). To
 // mirror the runtime expansion, we apply the +8 shift when copying UW
-// background blocks 4-7 into the room's graphics buffer.
+// destination blocks 0-3 into the room's graphics buffer.
 TEST(RoomGraphicsPaletteTest,
      CopyRoomGraphicsToBuffer_ShiftsRightPaletteBlocks) {
   auto rom = std::make_unique<Rom>();
@@ -55,20 +55,20 @@ TEST(RoomGraphicsPaletteTest,
 
   const auto& gfx = room.get_gfx_buffer();
 
-  // Block 3 (UW background slot < 4): left palette (no shift).
+  // Destination block 3 is runtime slot 4: right palette shift.
   EXPECT_EQ(gfx[3 * 4096 + 0], 0);
-  EXPECT_EQ(gfx[3 * 4096 + 1], 1);
-  EXPECT_EQ(gfx[3 * 4096 + 2], 7);
+  EXPECT_EQ(gfx[3 * 4096 + 1], 9);
+  EXPECT_EQ(gfx[3 * 4096 + 2], 15);
 
-  // Block 4 (UW background slot >= 4): right palette shift (+8 for non-zero).
+  // Destination block 4 is runtime slot 3: left palette (no shift).
   EXPECT_EQ(gfx[4 * 4096 + 0], 0);
-  EXPECT_EQ(gfx[4 * 4096 + 1], 9);
-  EXPECT_EQ(gfx[4 * 4096 + 2], 15);
+  EXPECT_EQ(gfx[4 * 4096 + 1], 1);
+  EXPECT_EQ(gfx[4 * 4096 + 2], 7);
 
-  // Block 5 also shifted.
+  // Destination block 5 is runtime slot 2 and is also unshifted for UW.
   EXPECT_EQ(gfx[5 * 4096 + 0], 0);
-  EXPECT_EQ(gfx[5 * 4096 + 1], 9);
-  EXPECT_EQ(gfx[5 * 4096 + 2], 15);
+  EXPECT_EQ(gfx[5 * 4096 + 1], 1);
+  EXPECT_EQ(gfx[5 * 4096 + 2], 7);
 
   // Sprite blocks should NOT be shifted by this UW background rule.
   EXPECT_EQ(gfx[8 * 4096 + 0], 0);
@@ -101,15 +101,16 @@ TEST(RoomGraphicsPaletteTest,
 
   const auto& gfx = room.get_gfx_buffer();
 
-  // OW main groups ($0AA1 >= $20) use right palette for slots 2, 3, 4, and 7.
-  EXPECT_EQ(gfx[2 * 4096 + 1], 9);
+  // OW runtime slots 2, 3, 4, and 7 map to destination blocks 5, 4, 3, and 0.
+  EXPECT_EQ(gfx[0 * 4096 + 1], 9);
   EXPECT_EQ(gfx[3 * 4096 + 1], 9);
   EXPECT_EQ(gfx[4 * 4096 + 1], 9);
-  EXPECT_EQ(gfx[7 * 4096 + 1], 9);
+  EXPECT_EQ(gfx[5 * 4096 + 1], 9);
 
   EXPECT_EQ(gfx[1 * 4096 + 1], 1);
-  EXPECT_EQ(gfx[5 * 4096 + 1], 1);
+  EXPECT_EQ(gfx[2 * 4096 + 1], 1);
   EXPECT_EQ(gfx[6 * 4096 + 1], 1);
+  EXPECT_EQ(gfx[7 * 4096 + 1], 1);
   EXPECT_EQ(gfx[8 * 4096 + 1], 1);
 }
 


### PR DESCRIPTION
## Summary
- map destination graphics blocks back to the SNES runtime `$0F` slot before selecting Left/Right 3bpp expansion
- update underworld and overworld slot-mapping unit coverage
- add a Sanctuary carpet-pixel regression from the independent Mesen baseline while preserving the existing wall ROI assertion

## Root cause
`InitializeTilesets` loads destination blocks 0 through 7 while `$0F` counts down from 7 through 0. The editor treated the destination block as the runtime slot, reversing which background blocks received the high-palette expansion bit.

## Verification
- `cmake --build --preset mac-ai --target yaze_test_unit`
- `build/presets/mac-ai/bin/Debug/yaze_test_unit --gtest_filter='RoomGraphicsPaletteTest.*' --gtest_color=no` (7 passed)
- `cmake --build --preset mac-ai --target yaze_test_integration`
- `YAZE_TEST_ROM_VANILLA='<canonical US ROM>' build/presets/mac-ai/bin/Debug/yaze_test_integration --gtest_filter='DungeonRoomRegressionFixturesTest.Room012WallRoiMatchesIndependentMesenBaseline:DungeonRoomRegressionFixturesTest.Room012CarpetPixelMatchesIndependentMesenBaseline' --gtest_color=no` (2 passed)
- `YAZE_PREPUSH_BUILD_DIR=build/presets/mac-ai scripts/pre-push.sh`
