### PR TITLE
fix(cli): report dedicated dungeon spawn schema

### DIFF
--- a/docs/public/reference/z3ed-command-reference.md
+++ b/docs/public/reference/z3ed-command-reference.md
@@ -156,9 +156,15 @@ These commands operate directly on ROM data (no GUI required).
 - `dungeon-map --room <hex> [--layer <0|1|2>]` *(overlays Oracle custom collision tiles when present)*
 - `dungeon-list-chests --room <hex>`
 - `dungeon-get-entrance --entrance <hex> [--spawn]`
+- `entrance-info --entrance <hex> [--spawn]`
 - `dungeon-export-room --room <hex> --output <file>`
 - `dungeon-get-room-tiles --room <hex>` *(stubbed)*
 - `dungeon-set-room-property --room <hex> --property <name> --value <value>` *(stubbed)*
+
+When `--spawn` is set, the ID must be `0x00`-`0x06`. Both entrance commands
+report the dedicated spawn fields (`quadrant`, `overworld_door_tilemap`, and
+the linked regular `entrance_id`) and omit the regular-entrance-only `door`
+field.
 
 Example:
 ```bash

--- a/src/cli/handlers/game/dungeon_commands.cc
+++ b/src/cli/handlers/game/dungeon_commands.cc
@@ -15,6 +15,7 @@
 #include "zelda3/dungeon/custom_collision.h"
 #include "zelda3/dungeon/dungeon_editor_system.h"
 #include "zelda3/dungeon/dungeon_rom_addresses.h"
+#include "zelda3/dungeon/dungeon_spawn_point.h"
 #include "zelda3/dungeon/room.h"
 #include "zelda3/dungeon/room_entrance.h"
 #include "zelda3/dungeon/track_collision_generator.h"
@@ -67,6 +68,73 @@ absl::Status MaybeLoadSpriteRegistry(const resources::ArgumentParser& parser) {
 }
 
 }  // namespace
+
+absl::Status WriteDungeonSpawnPointReport(Rom* rom, int spawn_id,
+                                          resources::OutputFormatter& formatter,
+                                          std::string_view object_title) {
+  if (spawn_id < 0 || spawn_id >= zelda3::kNumDungeonSpawnPoints) {
+    return absl::InvalidArgumentError(absl::StrFormat(
+        "Dungeon spawn point ID %d out of range (0x00-0x06).", spawn_id));
+  }
+
+  auto spawn_or = zelda3::DungeonSpawnPoint::Load(*rom, spawn_id);
+  if (!spawn_or.ok()) {
+    return spawn_or.status();
+  }
+  const auto& spawn = spawn_or.value();
+
+  if (!object_title.empty()) {
+    formatter.BeginObject(std::string(object_title));
+  }
+
+  formatter.AddHexField("spawn_id", spawn_id, 2);
+  formatter.AddField("is_spawn_point", true);
+  formatter.AddHexField("room_id", spawn.room_id, 4);
+  formatter.AddHexField("dungeon_id", spawn.dungeon_id, 2);
+  formatter.AddHexField("quadrant", spawn.quadrant, 2);
+  formatter.AddHexField("overworld_door_tilemap", spawn.overworld_door_tilemap,
+                        4);
+  formatter.AddHexField("entrance_id", spawn.entrance_id, 4);
+
+  formatter.BeginObject("position");
+  formatter.AddField("x", static_cast<int>(spawn.x_coordinate));
+  formatter.AddField("y", static_cast<int>(spawn.y_coordinate));
+  formatter.EndObject();
+
+  formatter.BeginObject("camera");
+  formatter.AddField("horizontal_scroll",
+                     static_cast<int>(spawn.horizontal_scroll));
+  formatter.AddField("vertical_scroll",
+                     static_cast<int>(spawn.vertical_scroll));
+  formatter.AddField("trigger_x", static_cast<int>(spawn.camera_trigger_x));
+  formatter.AddField("trigger_y", static_cast<int>(spawn.camera_trigger_y));
+  formatter.EndObject();
+
+  formatter.BeginObject("properties");
+  formatter.AddHexField("main_gfx", spawn.main_gfx, 2);
+  formatter.AddHexField("floor", spawn.floor, 2);
+  formatter.AddHexField("layer", spawn.layer, 2);
+  formatter.AddHexField("camera_scroll_controller",
+                        spawn.camera_scroll_controller, 2);
+  formatter.AddHexField("song", spawn.song, 2);
+  formatter.EndObject();
+
+  formatter.BeginObject("camera_boundaries");
+  formatter.AddHexField("qn", spawn.camera_scroll_boundaries[0], 2);
+  formatter.AddHexField("fn", spawn.camera_scroll_boundaries[1], 2);
+  formatter.AddHexField("qs", spawn.camera_scroll_boundaries[2], 2);
+  formatter.AddHexField("fs", spawn.camera_scroll_boundaries[3], 2);
+  formatter.AddHexField("qw", spawn.camera_scroll_boundaries[4], 2);
+  formatter.AddHexField("fw", spawn.camera_scroll_boundaries[5], 2);
+  formatter.AddHexField("qe", spawn.camera_scroll_boundaries[6], 2);
+  formatter.AddHexField("fe", spawn.camera_scroll_boundaries[7], 2);
+  formatter.EndObject();
+
+  if (!object_title.empty()) {
+    formatter.EndObject();
+  }
+  return absl::OkStatus();
+}
 
 absl::Status DungeonListSpritesCommandHandler::Execute(
     Rom* rom, const resources::ArgumentParser& parser,
@@ -299,8 +367,11 @@ absl::Status DungeonGetEntranceCommandHandler::Execute(
         "Invalid entrance ID format. Must be hex.");
   }
 
-  zelda3::RoomEntrance entrance(rom, static_cast<uint8_t>(entrance_id),
-                                is_spawn_point);
+  if (is_spawn_point) {
+    return WriteDungeonSpawnPointReport(rom, entrance_id, formatter, "");
+  }
+
+  zelda3::RoomEntrance entrance(rom, static_cast<uint8_t>(entrance_id), false);
 
   formatter.AddField("entrance_id", absl::StrFormat("0x%02X", entrance_id));
   formatter.AddField("is_spawn_point", is_spawn_point);

--- a/src/cli/handlers/game/dungeon_commands.h
+++ b/src/cli/handlers/game/dungeon_commands.h
@@ -1,11 +1,19 @@
 #ifndef YAZE_SRC_CLI_HANDLERS_DUNGEON_COMMANDS_H_
 #define YAZE_SRC_CLI_HANDLERS_DUNGEON_COMMANDS_H_
 
+#include <string_view>
+
 #include "cli/service/resources/command_handler.h"
 
 namespace yaze {
 namespace cli {
 namespace handlers {
+
+// Writes the dedicated seven-record dungeon spawn schema. If object_title is
+// non-empty, the report is nested under an object with that name.
+absl::Status WriteDungeonSpawnPointReport(Rom* rom, int spawn_id,
+                                          resources::OutputFormatter& formatter,
+                                          std::string_view object_title);
 
 /**
  * @brief Command handler for listing sprites in a dungeon room

--- a/src/cli/handlers/game/dungeon_graph_commands.cc
+++ b/src/cli/handlers/game/dungeon_graph_commands.cc
@@ -9,6 +9,7 @@
 
 #include "absl/strings/numbers.h"
 #include "absl/strings/str_format.h"
+#include "cli/handlers/game/dungeon_commands.h"
 #include "cli/util/hex_util.h"
 #include "rom/rom.h"
 #include "zelda3/dungeon/room.h"
@@ -322,14 +323,18 @@ absl::Status EntranceInfoCommandHandler::Execute(
         "Invalid entrance ID format. Must be hex (e.g., 0x08).");
   }
 
+  if (is_spawn_point) {
+    return WriteDungeonSpawnPointReport(rom, entrance_id, formatter,
+                                        "entrance");
+  }
+
   // Validate entrance ID range
   if (entrance_id < 0 || entrance_id > 0x84) {
     return absl::InvalidArgumentError(absl::StrFormat(
         "Entrance ID 0x%02X out of range (0x00-0x84).", entrance_id));
   }
 
-  zelda3::RoomEntrance entrance(rom, static_cast<uint8_t>(entrance_id),
-                                is_spawn_point);
+  zelda3::RoomEntrance entrance(rom, static_cast<uint8_t>(entrance_id), false);
 
   formatter.BeginObject("entrance");
   formatter.AddField("entrance_id", absl::StrFormat("0x%02X", entrance_id));

--- a/src/cli/handlers/game/dungeon_group_commands.cc
+++ b/src/cli/handlers/game/dungeon_group_commands.cc
@@ -9,6 +9,7 @@
 #include "absl/strings/str_format.h"
 #include "cli/util/hex_util.h"
 #include "rom/rom.h"
+#include "zelda3/dungeon/dungeon_spawn_point.h"
 #include "zelda3/dungeon/room.h"
 #include "zelda3/dungeon/room_entrance.h"
 
@@ -21,47 +22,47 @@ using util::ParseHexString;
 namespace {
 
 // ROM addresses for dungeon tables
-constexpr int kEntranceDungeon = 0x1548B;      // Dungeon ID per entrance
-constexpr int kDungeonsStartRooms = 0x7939;    // Start room per dungeon
-constexpr int kDungeonsEndRooms = 0x792D;      // End room per dungeon (unused)
-constexpr int kDungeonsBossRooms = 0x10954;    // Boss room per dungeon
-constexpr int kNumberOfDungeons = 14;          // Vanilla dungeons
-constexpr int kNumberOfEntrances = 0x84;       // Total entrances
+constexpr int kEntranceDungeon = 0x1548B;    // Dungeon ID per entrance
+constexpr int kDungeonsStartRooms = 0x7939;  // Start room per dungeon
+constexpr int kDungeonsEndRooms = 0x792D;    // End room per dungeon (unused)
+constexpr int kDungeonsBossRooms = 0x10954;  // Boss room per dungeon
+constexpr int kNumberOfDungeons = 14;        // Vanilla dungeons
+constexpr int kNumberOfEntrances = 0x84;     // Total entrances
 
 // Dungeon names (vanilla + common custom slots)
 const std::vector<std::string> kDungeonNames = {
-    "Sewers",                    // 0x00
-    "Hyrule Castle",             // 0x01
-    "Eastern Palace",            // 0x02
-    "Desert Palace",             // 0x03
-    "Agahnim's Tower",           // 0x04
-    "Swamp Palace",              // 0x05
-    "Palace of Darkness",        // 0x06
-    "Misery Mire",               // 0x07
-    "Skull Woods",               // 0x08
-    "Ice Palace",                // 0x09
-    "Tower of Hera",             // 0x0A
-    "Thieves' Town",             // 0x0B
-    "Turtle Rock",               // 0x0C
-    "Ganon's Tower",             // 0x0D
-    "Custom Dungeon 0E",         // 0x0E
-    "Custom Dungeon 0F",         // 0x0F
-    "Custom Dungeon 10",         // 0x10
-    "Custom Dungeon 11",         // 0x11
-    "Custom Dungeon 12",         // 0x12
-    "Custom Dungeon 13",         // 0x13
-    "Custom Dungeon 14",         // 0x14 (Oracle custom)
-    "Custom Dungeon 15",         // 0x15
-    "Custom Dungeon 16",         // 0x16
-    "Custom Dungeon 17",         // 0x17
-    "Custom Dungeon 18",         // 0x18
-    "Custom Dungeon 19",         // 0x19
-    "Custom Dungeon 1A",         // 0x1A
-    "Custom Dungeon 1B",         // 0x1B
-    "Custom Dungeon 1C",         // 0x1C
-    "Custom Dungeon 1D",         // 0x1D
-    "Custom Dungeon 1E",         // 0x1E
-    "Custom Dungeon 1F",         // 0x1F
+    "Sewers",              // 0x00
+    "Hyrule Castle",       // 0x01
+    "Eastern Palace",      // 0x02
+    "Desert Palace",       // 0x03
+    "Agahnim's Tower",     // 0x04
+    "Swamp Palace",        // 0x05
+    "Palace of Darkness",  // 0x06
+    "Misery Mire",         // 0x07
+    "Skull Woods",         // 0x08
+    "Ice Palace",          // 0x09
+    "Tower of Hera",       // 0x0A
+    "Thieves' Town",       // 0x0B
+    "Turtle Rock",         // 0x0C
+    "Ganon's Tower",       // 0x0D
+    "Custom Dungeon 0E",   // 0x0E
+    "Custom Dungeon 0F",   // 0x0F
+    "Custom Dungeon 10",   // 0x10
+    "Custom Dungeon 11",   // 0x11
+    "Custom Dungeon 12",   // 0x12
+    "Custom Dungeon 13",   // 0x13
+    "Custom Dungeon 14",   // 0x14 (Oracle custom)
+    "Custom Dungeon 15",   // 0x15
+    "Custom Dungeon 16",   // 0x16
+    "Custom Dungeon 17",   // 0x17
+    "Custom Dungeon 18",   // 0x18
+    "Custom Dungeon 19",   // 0x19
+    "Custom Dungeon 1A",   // 0x1A
+    "Custom Dungeon 1B",   // 0x1B
+    "Custom Dungeon 1C",   // 0x1C
+    "Custom Dungeon 1D",   // 0x1D
+    "Custom Dungeon 1E",   // 0x1E
+    "Custom Dungeon 1F",   // 0x1F
 };
 
 struct DungeonInfo {
@@ -110,8 +111,8 @@ absl::Status DungeonGroupCommandHandler::Execute(
 
     // Read boss room (2 bytes per dungeon)
     uint16_t boss_room_addr = kDungeonsBossRooms + (i * 2);
-    info.boss_room = rom->data()[boss_room_addr] |
-                     (rom->data()[boss_room_addr + 1] << 8);
+    info.boss_room =
+        rom->data()[boss_room_addr] | (rom->data()[boss_room_addr + 1] << 8);
 
     // Boss room 0xFFFF means no boss
     if (info.boss_room == 0xFFFF) {
@@ -124,7 +125,8 @@ absl::Status DungeonGroupCommandHandler::Execute(
   // Scan entrances to find room->dungeon mappings
   std::map<int, int> room_to_dungeon;
   for (int entrance_id = 0; entrance_id < kNumberOfEntrances; ++entrance_id) {
-    zelda3::RoomEntrance entrance(rom, static_cast<uint8_t>(entrance_id), false);
+    zelda3::RoomEntrance entrance(rom, static_cast<uint8_t>(entrance_id),
+                                  false);
 
     int dungeon_id = entrance.dungeon_id_;
     int room_id = entrance.room_;
@@ -146,11 +148,16 @@ absl::Status DungeonGroupCommandHandler::Execute(
   }
 
   // Also scan spawn points for additional room mappings
-  for (int spawn_id = 0; spawn_id < 0x14; ++spawn_id) {
-    zelda3::RoomEntrance spawn(rom, static_cast<uint8_t>(spawn_id), true);
+  for (int spawn_id = 0; spawn_id < zelda3::kNumDungeonSpawnPoints;
+       ++spawn_id) {
+    auto spawn_or = zelda3::DungeonSpawnPoint::Load(*rom, spawn_id);
+    if (!spawn_or.ok()) {
+      return spawn_or.status();
+    }
+    const auto& spawn = spawn_or.value();
 
-    int dungeon_id = spawn.dungeon_id_;
-    int room_id = spawn.room_;
+    int dungeon_id = spawn.dungeon_id;
+    int room_id = spawn.room_id;
 
     room_to_dungeon[room_id] = dungeon_id;
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -189,6 +189,7 @@ if(YAZE_BUILD_TESTS)
     unit/cli/dungeon_object_validate_test.cc
     unit/cli/dungeon_collision_json_commands_test.cc
     unit/cli/dungeon_edit_commands_test.cc
+    unit/cli/dungeon_spawn_report_commands_test.cc
     unit/cli/dungeon_stream_plan_commands_test.cc
     unit/cli/editor_completion_command_handlers_test.cc
     unit/cli/dungeon_minecart_audit_test.cc
@@ -550,6 +551,7 @@ if(YAZE_BUILD_TESTS)
     unit/zelda3/resource_labels_test.cc
     unit/zelda3/sprite_render_preview_test.cc
     unit/zelda3/dungeon/dungeon_stream_allocator_test.cc
+    unit/cli/dungeon_spawn_report_commands_test.cc
     unit/cli/dungeon_stream_plan_commands_test.cc
     unit/cli/message_commands_policy_test.cc
   )

--- a/test/unit/cli/dungeon_spawn_report_commands_test.cc
+++ b/test/unit/cli/dungeon_spawn_report_commands_test.cc
@@ -1,0 +1,125 @@
+#include "cli/handlers/game/dungeon_commands.h"
+#include "cli/handlers/game/dungeon_graph_commands.h"
+
+#include <string>
+#include <vector>
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include <nlohmann/json.hpp>
+
+#include "absl/status/status.h"
+#include "rom/rom.h"
+#include "zelda3/dungeon/dungeon_spawn_point.h"
+
+namespace yaze::cli {
+namespace {
+
+using ::testing::HasSubstr;
+
+class DungeonSpawnReportCommandsTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    ASSERT_TRUE(rom_.LoadFromData(std::vector<uint8_t>(0x200000, 0x00)).ok());
+
+    auto spawn_or = zelda3::DungeonSpawnPoint::Load(rom_, kSpawnId);
+    ASSERT_TRUE(spawn_or.ok()) << spawn_or.status();
+    auto spawn = spawn_or.value();
+    spawn.room_id = 0x01AB;
+    spawn.camera_scroll_boundaries = {0x10, 0x11, 0x12, 0x13,
+                                      0x14, 0x15, 0x16, 0x17};
+    spawn.horizontal_scroll = 0x1234;
+    spawn.vertical_scroll = 0x2345;
+    spawn.y_coordinate = 0x3456;
+    spawn.x_coordinate = 0x4567;
+    spawn.camera_trigger_y = 0x5678;
+    spawn.camera_trigger_x = 0x6789;
+    spawn.main_gfx = 0x98;
+    spawn.floor = 0xA9;
+    spawn.dungeon_id = 0x1A;
+    spawn.layer = 0x02;
+    spawn.camera_scroll_controller = 0xBC;
+    spawn.quadrant = 0x21;
+    spawn.overworld_door_tilemap = 0xA5C3;
+    spawn.entrance_id = 0x0084;
+    spawn.song = 0xDE;
+    ASSERT_TRUE(spawn.Save(&rom_, kSpawnId).ok());
+  }
+
+  void ExpectDedicatedSpawnSchema(const nlohmann::json& report) {
+    EXPECT_EQ(report.at("spawn_id"), "0x06");
+    EXPECT_TRUE(report.at("is_spawn_point"));
+    EXPECT_EQ(report.at("room_id"), "0x01AB");
+    EXPECT_EQ(report.at("dungeon_id"), "0x1A");
+    EXPECT_EQ(report.at("quadrant"), "0x21");
+    EXPECT_EQ(report.at("overworld_door_tilemap"), "0xA5C3");
+    EXPECT_EQ(report.at("entrance_id"), "0x0084");
+    EXPECT_EQ(report.at("position").at("x"), 0x4567);
+    EXPECT_EQ(report.at("position").at("y"), 0x3456);
+    EXPECT_EQ(report.at("camera").at("horizontal_scroll"), 0x1234);
+    EXPECT_EQ(report.at("camera").at("vertical_scroll"), 0x2345);
+    EXPECT_EQ(report.at("camera").at("trigger_x"), 0x6789);
+    EXPECT_EQ(report.at("camera").at("trigger_y"), 0x5678);
+    EXPECT_EQ(report.at("properties").at("main_gfx"), "0x98");
+    EXPECT_EQ(report.at("properties").at("floor"), "0xA9");
+    EXPECT_EQ(report.at("properties").at("layer"), "0x02");
+    EXPECT_EQ(report.at("properties").at("camera_scroll_controller"), "0xBC");
+    EXPECT_EQ(report.at("properties").at("song"), "0xDE");
+    EXPECT_EQ(report.at("camera_boundaries").at("qn"), "0x10");
+    EXPECT_EQ(report.at("camera_boundaries").at("fe"), "0x17");
+    EXPECT_FALSE(report.contains("exit_id"));
+    EXPECT_FALSE(report.contains("door"));
+    EXPECT_FALSE(report.at("properties").contains("door"));
+  }
+
+  static constexpr int kSpawnId = 0x06;
+  Rom rom_;
+};
+
+TEST_F(DungeonSpawnReportCommandsTest,
+       DungeonGetEntranceReportsDedicatedSpawnSchema) {
+  handlers::DungeonGetEntranceCommandHandler handler;
+  std::string output;
+  const auto status = handler.Run(
+      {"--entrance=0x06", "--spawn", "--format=json"}, &rom_, &output);
+
+  ASSERT_TRUE(status.ok()) << status;
+  ExpectDedicatedSpawnSchema(nlohmann::json::parse(output));
+}
+
+TEST_F(DungeonSpawnReportCommandsTest,
+       EntranceInfoReportsDedicatedSpawnSchema) {
+  handlers::EntranceInfoCommandHandler handler;
+  std::string output;
+  const auto status = handler.Run(
+      {"--entrance=0x06", "--spawn", "--format=json"}, &rom_, &output);
+
+  ASSERT_TRUE(status.ok()) << status;
+  const auto json = nlohmann::json::parse(output);
+  ExpectDedicatedSpawnSchema(json.at("entrance"));
+}
+
+TEST_F(DungeonSpawnReportCommandsTest, DungeonGetEntranceRejectsSpawnIdSeven) {
+  handlers::DungeonGetEntranceCommandHandler handler;
+  std::string output;
+  const auto status = handler.Run(
+      {"--entrance=0x07", "--spawn", "--format=json"}, &rom_, &output);
+
+  EXPECT_EQ(status.code(), absl::StatusCode::kInvalidArgument);
+  EXPECT_THAT(std::string(status.message()), HasSubstr("0x00-0x06"));
+  EXPECT_NO_THROW(nlohmann::json::parse(output));
+}
+
+TEST_F(DungeonSpawnReportCommandsTest, EntranceInfoRejectsSpawnIdSeven) {
+  handlers::EntranceInfoCommandHandler handler;
+  std::string output;
+  const auto status = handler.Run(
+      {"--entrance=0x07", "--spawn", "--format=json"}, &rom_, &output);
+
+  EXPECT_EQ(status.code(), absl::StatusCode::kInvalidArgument);
+  EXPECT_THAT(std::string(status.message()), HasSubstr("0x00-0x06"));
+  EXPECT_NO_THROW(nlohmann::json::parse(output));
+}
+
+}  // namespace
+}  // namespace yaze::cli


### PR DESCRIPTION
## Summary
- validate `--spawn` IDs against the seven-record dungeon spawn table
- report dedicated `DungeonSpawnPoint` fields from both entrance CLI aliases, including quadrant, overworld door tilemap, and linked entrance ID
- scan exactly seven dedicated spawn records during dungeon-group discovery
- document the spawn-report contract and add focused JSON/range coverage

## Validation
- `cmake --build build/presets/mac-test --target yaze_test_quick_unit_core z3ed -j 8`
- `build/presets/mac-test/bin/Debug/yaze_test_quick_unit_core --gtest_filter='DungeonSpawnReportCommandsTest.*' --gtest_brief=1` (4/4 passed)
- `build/presets/mac-test/bin/Debug/yaze_test_quick_unit_core --gtest_brief=1` (151/151 passed)
- `YAZE_PREPUSH_BUILD_DIR=build/presets/mac-test git push -u origin codex/dungeon-spawn-cli-report` (pre-push passed)
- `build/presets/mac-test/bin/Debug/z3ed dungeon-get-entrance --mock-rom --entrance=0x06 --spawn --format=json`

## Merge state
#117 has landed. This draft is now retargeted directly to `master`; the full default-branch pull-request matrix was triggered after retargeting. Exact-head audit found no blocker. A dedicated behavioral test for the dungeon-group seven-record scan remains a non-blocking follow-up; the shared spawn schema and ID bounds are covered directly.

Closes #118

