### PR TITLE
fix(cli): preflight manifest-backed dungeon object writes

### DIFF
--- a/docs/public/reference/z3ed-command-reference.md
+++ b/docs/public/reference/z3ed-command-reference.md
@@ -165,7 +165,10 @@ These commands operate directly on ROM data (no GUI required).
 execute the same immutable capacity preflight. In-place edits can proceed
 without a manifest, but a shared or growing object stream fails closed unless
 an explicit manifest defines `dungeon_stream_regions.objects` with the
-`copy_on_write` strategy and allocator-owned space.
+`copy_on_write` strategy and allocator-owned space. The manifest remains an
+ownership guard: protected current-stream, allocation, object-pointer, or
+door-pointer writes are rejected before either dry-run or write can mutate ROM
+bytes.
 
 Example:
 ```bash

--- a/docs/public/reference/z3ed-command-reference.md
+++ b/docs/public/reference/z3ed-command-reference.md
@@ -157,8 +157,15 @@ These commands operate directly on ROM data (no GUI required).
 - `dungeon-list-chests --room <hex>`
 - `dungeon-get-entrance --entrance <hex> [--spawn]`
 - `dungeon-export-room --room <hex> --output <file>`
+- `dungeon-place-object --room <hex> --id <hex> --x <int> --y <int> [--size <int>] [--layer <0|1|2>] [--manifest <path>] [--write]`
 - `dungeon-get-room-tiles --room <hex>` *(stubbed)*
 - `dungeon-set-room-property --room <hex> --property <name> --value <value>` *(stubbed)*
+
+`dungeon-place-object` is a dry-run unless `--write` is supplied. Both modes
+execute the same immutable capacity preflight. In-place edits can proceed
+without a manifest, but a shared or growing object stream fails closed unless
+an explicit manifest defines `dungeon_stream_regions.objects` with the
+`copy_on_write` strategy and allocator-owned space.
 
 Example:
 ```bash

--- a/src/cli/handlers/game/dungeon_edit_commands.cc
+++ b/src/cli/handlers/game/dungeon_edit_commands.cc
@@ -1,12 +1,17 @@
 #include "cli/handlers/game/dungeon_edit_commands.h"
 
+#include <optional>
+
 #include "absl/strings/numbers.h"
 #include "absl/strings/str_format.h"
 #include "absl/strings/str_split.h"
 #include "cli/util/hex_util.h"
+#include "core/dungeon_stream_layout_adapter.h"
+#include "core/hack_manifest.h"
 #include "rom/rom.h"
 #include "rom/snes.h"
 #include "util/macro.h"
+#include "zelda3/dungeon/dungeon_stream_allocator.h"
 #include "zelda3/dungeon/room.h"
 #include "zelda3/dungeon/room_object.h"
 #include "zelda3/dungeon/track_collision_generator.h"
@@ -82,6 +87,51 @@ absl::Status SaveRomWithBackup(Rom* rom,
 
   formatter.AddField("save_status", "saved");
   return absl::OkStatus();
+}
+
+absl::StatusOr<std::optional<zelda3::DungeonStreamLayout>>
+LoadObjectCopyOnWriteLayout(const resources::ArgumentParser& parser) {
+  const auto manifest_path = parser.GetString("manifest");
+  if (!manifest_path.has_value()) {
+    return std::nullopt;
+  }
+
+  core::HackManifest manifest;
+  RETURN_IF_ERROR(manifest.LoadFromFile(*manifest_path));
+  const core::DungeonStreamLayout* manifest_layout =
+      manifest.GetDungeonStreamLayout(core::DungeonStreamType::kObjects);
+  if (manifest_layout == nullptr) {
+    return absl::FailedPreconditionError(
+        "Manifest does not define dungeon_stream_regions.objects");
+  }
+  if (manifest_layout->strategy != core::DungeonWriteStrategy::kCopyOnWrite) {
+    return absl::FailedPreconditionError(
+        "dungeon_stream_regions.objects must use copy_on_write");
+  }
+
+  zelda3::DungeonStreamLayout allocator_layout;
+  ASSIGN_OR_RETURN(allocator_layout,
+                   core::ToDungeonStreamAllocatorLayout(
+                       core::DungeonStreamType::kObjects, *manifest_layout));
+  return std::optional<zelda3::DungeonStreamLayout>(
+      std::move(allocator_layout));
+}
+
+absl::Status PreflightObjectSave(
+    const Rom& source_rom, int room_id, const zelda3::RoomObject& object,
+    const zelda3::DungeonStreamLayout* allocator_layout) {
+  // Exercise the exact Room::SaveObjects path against an isolated snapshot so
+  // dry-run capacity and allocator outcomes match --write without mutating the
+  // caller's ROM.
+  Rom scratch_rom;
+  Rom::LoadOptions options;
+  options.strip_header = false;
+  options.load_resource_labels = false;
+  RETURN_IF_ERROR(scratch_rom.LoadFromData(source_rom.vector(), options));
+
+  zelda3::Room scratch_room = zelda3::LoadRoomFromRom(&scratch_rom, room_id);
+  RETURN_IF_ERROR(scratch_room.AddObject(object));
+  return scratch_room.SaveObjects(allocator_layout);
 }
 
 }  // namespace
@@ -393,6 +443,11 @@ absl::Status DungeonPlaceObjectCommandHandler::Execute(
     return absl::InvalidArgumentError("Size must be 0-255");
   }
 
+  std::optional<zelda3::DungeonStreamLayout> allocator_layout;
+  ASSIGN_OR_RETURN(allocator_layout, LoadObjectCopyOnWriteLayout(parser));
+  const zelda3::DungeonStreamLayout* layout =
+      allocator_layout.has_value() ? &*allocator_layout : nullptr;
+
   // Load room with full objects
   zelda3::Room room = zelda3::LoadRoomFromRom(rom, room_id);
 
@@ -418,6 +473,12 @@ absl::Status DungeonPlaceObjectCommandHandler::Execute(
   formatter.AddField("size", size);
   formatter.AddField("layer", layer);
   formatter.AddField("objects_before", count_before);
+  if (const auto manifest_path = parser.GetString("manifest");
+      manifest_path.has_value()) {
+    formatter.AddField("manifest", *manifest_path);
+  }
+  formatter.AddField("allocator_capability",
+                     layout != nullptr ? "copy_on_write" : "none");
 
   // Add the object
   auto add_status = room.AddObject(obj);
@@ -431,8 +492,18 @@ absl::Status DungeonPlaceObjectCommandHandler::Execute(
                      static_cast<int>(room.GetTileObjects().size()));
   formatter.AddField("mode", do_write ? "write" : "dry-run");
 
+  const auto preflight_status = PreflightObjectSave(*rom, room_id, obj, layout);
+  if (!preflight_status.ok()) {
+    formatter.AddField("preflight_status", "failed");
+    formatter.AddField("preflight_error",
+                       std::string(preflight_status.message()));
+    formatter.EndObject();
+    return preflight_status;
+  }
+  formatter.AddField("preflight_status", "success");
+
   if (do_write) {
-    auto save_status = room.SaveObjects();
+    auto save_status = room.SaveObjects(layout);
     if (!save_status.ok()) {
       formatter.AddField("write_error", std::string(save_status.message()));
       formatter.EndObject();

--- a/src/cli/handlers/game/dungeon_edit_commands.cc
+++ b/src/cli/handlers/game/dungeon_edit_commands.cc
@@ -1,6 +1,10 @@
 #include "cli/handlers/game/dungeon_edit_commands.h"
 
+#include <cstdint>
+#include <limits>
 #include <optional>
+#include <utility>
+#include <vector>
 
 #include "absl/strings/numbers.h"
 #include "absl/strings/str_format.h"
@@ -8,6 +12,7 @@
 #include "cli/util/hex_util.h"
 #include "core/dungeon_stream_layout_adapter.h"
 #include "core/hack_manifest.h"
+#include "core/project.h"
 #include "rom/rom.h"
 #include "rom/snes.h"
 #include "util/macro.h"
@@ -89,17 +94,27 @@ absl::Status SaveRomWithBackup(Rom* rom,
   return absl::OkStatus();
 }
 
-absl::StatusOr<std::optional<zelda3::DungeonStreamLayout>>
-LoadObjectCopyOnWriteLayout(const resources::ArgumentParser& parser) {
+struct ObjectSaveManifestContext {
+  core::HackManifest manifest;
+  zelda3::DungeonStreamLayout allocator_layout;
+  // A standalone --manifest is a safety capability, not permission to ignore
+  // ownership. Unlike a project, the CLI has no separate policy setting, so
+  // protected writes are always blocked.
+  project::RomWritePolicy write_policy = project::RomWritePolicy::kBlock;
+};
+
+absl::StatusOr<std::optional<ObjectSaveManifestContext>>
+LoadObjectSaveManifestContext(const resources::ArgumentParser& parser) {
   const auto manifest_path = parser.GetString("manifest");
   if (!manifest_path.has_value()) {
     return std::nullopt;
   }
 
-  core::HackManifest manifest;
-  RETURN_IF_ERROR(manifest.LoadFromFile(*manifest_path));
+  ObjectSaveManifestContext context;
+  RETURN_IF_ERROR(context.manifest.LoadFromFile(*manifest_path));
   const core::DungeonStreamLayout* manifest_layout =
-      manifest.GetDungeonStreamLayout(core::DungeonStreamType::kObjects);
+      context.manifest.GetDungeonStreamLayout(
+          core::DungeonStreamType::kObjects);
   if (manifest_layout == nullptr) {
     return absl::FailedPreconditionError(
         "Manifest does not define dungeon_stream_regions.objects");
@@ -109,17 +124,86 @@ LoadObjectCopyOnWriteLayout(const resources::ArgumentParser& parser) {
         "dungeon_stream_regions.objects must use copy_on_write");
   }
 
-  zelda3::DungeonStreamLayout allocator_layout;
-  ASSIGN_OR_RETURN(allocator_layout,
+  ASSIGN_OR_RETURN(context.allocator_layout,
                    core::ToDungeonStreamAllocatorLayout(
                        core::DungeonStreamType::kObjects, *manifest_layout));
-  return std::optional<zelda3::DungeonStreamLayout>(
-      std::move(allocator_layout));
+  return std::optional<ObjectSaveManifestContext>(std::move(context));
+}
+
+absl::Status ValidateObjectSaveManifestConflicts(
+    const Rom& source_rom, int room_id, const zelda3::Room& pending_room,
+    const ObjectSaveManifestContext& context) {
+  std::vector<std::pair<uint32_t, uint32_t>> ranges;
+
+  // Match DungeonEditorV2's conservative object-save prediction: validate the
+  // selected in-place stream, the door pointer, every possible COW allocation,
+  // and the selected object-pointer slot before exercising either save path.
+  uint32_t object_pointer_table_snes = 0;
+  ASSIGN_OR_RETURN(object_pointer_table_snes,
+                   source_rom.ReadLong(zelda3::kRoomObjectPointer));
+  const uint32_t object_pointer_table_pc = SnesToPc(object_pointer_table_snes);
+  const uint64_t current_pointer_slot =
+      static_cast<uint64_t>(object_pointer_table_pc) +
+      static_cast<uint64_t>(room_id) * 3u;
+  if (current_pointer_slot + 3u > source_rom.size()) {
+    return absl::OutOfRangeError(
+        "Selected object pointer slot is outside the ROM");
+  }
+
+  uint32_t current_stream_snes = 0;
+  ASSIGN_OR_RETURN(current_stream_snes,
+                   source_rom.ReadLong(static_cast<int>(current_pointer_slot)));
+  const uint32_t current_stream_pc = SnesToPc(current_stream_snes);
+  const uint64_t current_stream_end = static_cast<uint64_t>(current_stream_pc) +
+                                      pending_room.EncodeObjects().size() + 2u;
+  if (current_stream_end > std::numeric_limits<uint32_t>::max()) {
+    return absl::OutOfRangeError("Selected object write range overflows");
+  }
+  ranges.emplace_back(current_stream_pc,
+                      static_cast<uint32_t>(current_stream_end));
+
+  const uint64_t door_pointer_slot =
+      static_cast<uint64_t>(zelda3::kDoorPointers) +
+      static_cast<uint64_t>(room_id) * 3u;
+  if (door_pointer_slot + 3u > std::numeric_limits<uint32_t>::max()) {
+    return absl::OutOfRangeError("Selected door pointer range overflows");
+  }
+  ranges.emplace_back(static_cast<uint32_t>(door_pointer_slot),
+                      static_cast<uint32_t>(door_pointer_slot + 3u));
+
+  for (const auto& range : context.allocator_layout.allocation_ranges) {
+    ranges.emplace_back(range.begin, range.end);
+  }
+  const uint32_t pointer_width = context.allocator_layout.pointer_encoding ==
+                                         zelda3::DungeonPointerEncoding::kLong24
+                                     ? 3u
+                                     : 2u;
+  const uint64_t cow_pointer_slot =
+      static_cast<uint64_t>(context.allocator_layout.pointer_table_pc) +
+      static_cast<uint64_t>(room_id) * pointer_width;
+  if (cow_pointer_slot + pointer_width > std::numeric_limits<uint32_t>::max()) {
+    return absl::OutOfRangeError("Selected COW pointer range overflows");
+  }
+  ranges.emplace_back(static_cast<uint32_t>(cow_pointer_slot),
+                      static_cast<uint32_t>(cow_pointer_slot + pointer_width));
+
+  const auto conflicts = context.manifest.AnalyzePcWriteRanges(ranges);
+  if (conflicts.empty() ||
+      context.write_policy != project::RomWritePolicy::kBlock) {
+    return absl::OkStatus();
+  }
+  return absl::PermissionDeniedError("Write conflict with Hack Manifest");
 }
 
 absl::Status PreflightObjectSave(
     const Rom& source_rom, int room_id, const zelda3::RoomObject& object,
-    const zelda3::DungeonStreamLayout* allocator_layout) {
+    const zelda3::Room& pending_room,
+    const ObjectSaveManifestContext* manifest_context) {
+  if (manifest_context != nullptr) {
+    RETURN_IF_ERROR(ValidateObjectSaveManifestConflicts(
+        source_rom, room_id, pending_room, *manifest_context));
+  }
+
   // Exercise the exact Room::SaveObjects path against an isolated snapshot so
   // dry-run capacity and allocator outcomes match --write without mutating the
   // caller's ROM.
@@ -131,7 +215,9 @@ absl::Status PreflightObjectSave(
 
   zelda3::Room scratch_room = zelda3::LoadRoomFromRom(&scratch_rom, room_id);
   RETURN_IF_ERROR(scratch_room.AddObject(object));
-  return scratch_room.SaveObjects(allocator_layout);
+  return scratch_room.SaveObjects(manifest_context != nullptr
+                                      ? &manifest_context->allocator_layout
+                                      : nullptr);
 }
 
 }  // namespace
@@ -443,10 +529,11 @@ absl::Status DungeonPlaceObjectCommandHandler::Execute(
     return absl::InvalidArgumentError("Size must be 0-255");
   }
 
-  std::optional<zelda3::DungeonStreamLayout> allocator_layout;
-  ASSIGN_OR_RETURN(allocator_layout, LoadObjectCopyOnWriteLayout(parser));
+  std::optional<ObjectSaveManifestContext> manifest_context;
+  ASSIGN_OR_RETURN(manifest_context, LoadObjectSaveManifestContext(parser));
   const zelda3::DungeonStreamLayout* layout =
-      allocator_layout.has_value() ? &*allocator_layout : nullptr;
+      manifest_context.has_value() ? &manifest_context->allocator_layout
+                                   : nullptr;
 
   // Load room with full objects
   zelda3::Room room = zelda3::LoadRoomFromRom(rom, room_id);
@@ -476,6 +563,7 @@ absl::Status DungeonPlaceObjectCommandHandler::Execute(
   if (const auto manifest_path = parser.GetString("manifest");
       manifest_path.has_value()) {
     formatter.AddField("manifest", *manifest_path);
+    formatter.AddField("manifest_write_policy", "block");
   }
   formatter.AddField("allocator_capability",
                      layout != nullptr ? "copy_on_write" : "none");
@@ -492,7 +580,9 @@ absl::Status DungeonPlaceObjectCommandHandler::Execute(
                      static_cast<int>(room.GetTileObjects().size()));
   formatter.AddField("mode", do_write ? "write" : "dry-run");
 
-  const auto preflight_status = PreflightObjectSave(*rom, room_id, obj, layout);
+  const auto preflight_status = PreflightObjectSave(
+      *rom, room_id, obj, room,
+      manifest_context.has_value() ? &*manifest_context : nullptr);
   if (!preflight_status.ok()) {
     formatter.AddField("preflight_status", "failed");
     formatter.AddField("preflight_error",

--- a/src/cli/handlers/game/dungeon_edit_commands.h
+++ b/src/cli/handlers/game/dungeon_edit_commands.h
@@ -71,6 +71,7 @@ class DungeonPlaceObjectCommandHandler : public resources::CommandHandler {
   std::string GetUsage() const override {
     return "dungeon-place-object --room <hex> --id <hex> --x <int> --y <int> "
            "[--size <int>] [--layer <0|1|2>] "
+           "[--manifest <path>] "
            "[--write] [--format <json|text>]";
   }
 
@@ -88,12 +89,9 @@ class DungeonPlaceObjectCommandHandler : public resources::CommandHandler {
  * Supports setting one or more tiles. Dry-run by default.
  * Use --write to commit + save ROM.
  */
-class DungeonSetCollisionTileCommandHandler
-    : public resources::CommandHandler {
+class DungeonSetCollisionTileCommandHandler : public resources::CommandHandler {
  public:
-  std::string GetName() const override {
-    return "dungeon-set-collision-tile";
-  }
+  std::string GetName() const override { return "dungeon-set-collision-tile"; }
   std::string GetDescription() const {
     return "Set custom collision tiles in a dungeon room";
   }

--- a/src/cli/service/command_registry.cc
+++ b/src/cli/service/command_registry.cc
@@ -138,12 +138,14 @@ void CommandRegistry::RegisterHandlers(
             "--rom=/tmp/oos-work.sfc --format=json"};
       } else if (name == "dungeon-place-object") {
         metadata.description =
-            "Place a dungeon object (tracks, rails, doors, etc.)";
+            "Place a dungeon object with immutable capacity/COW preflight "
+            "(dry-run by default)";
         metadata.examples = {
             "z3ed dungeon-place-object --room=0x98 --id=0x0031 --x=20 --y=20 "
             "--size=4 --rom=/tmp/oos-work.sfc --format=json",
             "z3ed dungeon-place-object --room=0x98 --id=0x0031 --x=20 --y=20 "
-            "--size=4 --write --rom=/tmp/oos-work.sfc --format=json"};
+            "--size=4 --manifest=hack_manifest.json --write "
+            "--rom=/tmp/oos-work.sfc --format=json"};
       } else if (name == "dungeon-oracle-preflight") {
         metadata.description =
             "Oracle ROM safety preflight: water-fill region/table, collision "

--- a/test/integration/zelda3/dungeon_pot_repack_oos_integration_test.cc
+++ b/test/integration/zelda3/dungeon_pot_repack_oos_integration_test.cc
@@ -29,6 +29,7 @@
 #include "absl/status/statusor.h"
 #include "absl/strings/str_format.h"
 #include "app/editor/dungeon/dungeon_editor_v2.h"
+#include "cli/handlers/game/dungeon_edit_commands.h"
 #include "core/dungeon_stream_layout_adapter.h"
 #include "core/features.h"
 #include "core/hack_manifest.h"
@@ -186,6 +187,22 @@ std::vector<uint8_t> ReadFile(const std::filesystem::path& path) {
   }
   return std::vector<uint8_t>(std::istreambuf_iterator<char>(file),
                               std::istreambuf_iterator<char>());
+}
+
+int CountBackupArtifacts(const std::filesystem::path& rom_path) {
+  std::error_code error;
+  const std::string prefix = rom_path.filename().string() + "_backup_";
+  int count = 0;
+  for (const auto& entry :
+       std::filesystem::directory_iterator(rom_path.parent_path(), error)) {
+    if (error || !entry.is_regular_file()) {
+      continue;
+    }
+    if (entry.path().filename().string().rfind(prefix, 0) == 0) {
+      ++count;
+    }
+  }
+  return count;
 }
 
 std::vector<uint8_t> EncodePotItems(const std::vector<PotItem>& items) {
@@ -571,6 +588,99 @@ class DungeonPotRepackOosIntegrationTest : public ::testing::Test {
   project::YazeProject project_;
   DungeonStreamLayout layout_;
 };
+
+TEST_F(DungeonPotRepackOosIntegrationTest,
+       DungeonPlaceObjectCliCowDryRunWriteAndReadback) {
+  constexpr int kRoomId = 0xA8;
+  constexpr int kObjectId = 0x0031;
+  constexpr int kX = 60;
+  constexpr int kY = 60;
+  constexpr int kSize = 6;
+
+  auto object_layout =
+      LoadManifestLayout(project_, core::DungeonStreamType::kObjects,
+                         core::DungeonWriteStrategy::kCopyOnWrite);
+  ASSERT_TRUE(object_layout.ok()) << object_layout.status().message();
+
+  Rom rom;
+  ASSERT_TRUE(rom.LoadFromFile(temp_rom_path_.string()).ok());
+  auto before_inventory = InventoryDungeonStreams(rom, *object_layout);
+  ASSERT_TRUE(before_inventory.ok()) << before_inventory.status().message();
+  ASSERT_TRUE(before_inventory->ok())
+      << "Oracle object inventory contains stream issues";
+  const DungeonStreamRecord* before_record =
+      FindRoomRecord(*before_inventory, kRoomId);
+  ASSERT_NE(before_record, nullptr);
+
+  Room before_room = LoadRoomFromRom(&rom, kRoomId);
+  const size_t object_count_before = before_room.GetTileObjects().size();
+  const auto matching_object_count = [](const Room& room) {
+    return std::count_if(room.GetTileObjects().begin(),
+                         room.GetTileObjects().end(),
+                         [](const RoomObject& object) {
+                           return object.id_ == kObjectId && object.x() == kX &&
+                                  object.y() == kY && object.size() == kSize &&
+                                  object.GetLayerValue() == 0;
+                         });
+  };
+  const int matching_before = matching_object_count(before_room);
+  const std::vector<uint8_t> bytes_before = rom.vector();
+  auto disk_sha_before = ComputeSha256(temp_rom_path_.string());
+  ASSERT_TRUE(disk_sha_before.ok()) << disk_sha_before.status().message();
+  ASSERT_EQ(CountBackupArtifacts(temp_rom_path_), 0);
+
+  ::yaze::cli::handlers::DungeonPlaceObjectCommandHandler handler;
+  const std::vector<std::string> args = {
+      "--room=0xA8",  "--id=0x0031",
+      "--x=60",       "--y=60",
+      "--size=6",     absl::StrFormat("--manifest=%s", source_manifest_path_),
+      "--format=json"};
+
+  std::string dry_output;
+  const absl::Status dry_status = handler.Run(args, &rom, &dry_output);
+  ASSERT_TRUE(dry_status.ok()) << dry_status.message();
+  EXPECT_NE(dry_output.find("\"mode\": \"dry-run\""), std::string::npos);
+  EXPECT_NE(dry_output.find("\"preflight_status\": \"success\""),
+            std::string::npos);
+  EXPECT_NE(dry_output.find("\"allocator_capability\": \"copy_on_write\""),
+            std::string::npos);
+  EXPECT_EQ(rom.vector(), bytes_before);
+  auto disk_sha_after_dry = ComputeSha256(temp_rom_path_.string());
+  ASSERT_TRUE(disk_sha_after_dry.ok()) << disk_sha_after_dry.status().message();
+  EXPECT_EQ(*disk_sha_after_dry, *disk_sha_before);
+  EXPECT_EQ(CountBackupArtifacts(temp_rom_path_), 0);
+
+  std::vector<std::string> write_args = args;
+  write_args.push_back("--write");
+  std::string write_output;
+  const absl::Status write_status =
+      handler.Run(write_args, &rom, &write_output);
+  ASSERT_TRUE(write_status.ok()) << write_status.message();
+  EXPECT_NE(write_output.find("\"preflight_status\": \"success\""),
+            std::string::npos);
+  EXPECT_NE(write_output.find("\"write_status\": \"success\""),
+            std::string::npos);
+  EXPECT_NE(write_output.find("\"save_status\": \"saved\""), std::string::npos);
+  EXPECT_NE(rom.vector(), bytes_before);
+  EXPECT_EQ(CountBackupArtifacts(temp_rom_path_), 1);
+
+  Rom reopened;
+  ASSERT_TRUE(reopened.LoadFromFile(temp_rom_path_.string()).ok());
+  Room reopened_room = LoadRoomFromRom(&reopened, kRoomId);
+  EXPECT_EQ(reopened_room.GetTileObjects().size(), object_count_before + 1);
+  EXPECT_EQ(matching_object_count(reopened_room), matching_before + 1);
+
+  auto after_inventory = InventoryDungeonStreams(reopened, *object_layout);
+  ASSERT_TRUE(after_inventory.ok()) << after_inventory.status().message();
+  const DungeonStreamRecord* after_record =
+      FindRoomRecord(*after_inventory, kRoomId);
+  ASSERT_NE(after_record, nullptr);
+  EXPECT_NE(after_record->data_pc, before_record->data_pc);
+  EXPECT_TRUE(IsInsideAllocationRange(*object_layout, *after_record));
+  EXPECT_TRUE(InventoryPreservesUntouchedRooms(
+      *before_inventory, *after_inventory, *object_layout, kRoomId,
+      after_record->encoded_stream, /*preserve_untouched_addresses=*/true));
+}
 
 TEST_F(DungeonPotRepackOosIntegrationTest,
        SharedEmptyOwnerDetachesAndRoundTripsDeterministically) {

--- a/test/integration/zelda3/dungeon_pot_repack_oos_integration_test.cc
+++ b/test/integration/zelda3/dungeon_pot_repack_oos_integration_test.cc
@@ -636,6 +636,92 @@ TEST_F(DungeonPotRepackOosIntegrationTest,
       "--size=6",     absl::StrFormat("--manifest=%s", source_manifest_path_),
       "--format=json"};
 
+  // Add a test-local guard over the real object allocation arena and prove
+  // both CLI modes reject before touching the caller ROM or disk. The source
+  // Oracle manifest remains immutable and is checked again in TearDown().
+  ASSERT_FALSE(object_layout->allocation_ranges.empty());
+  const DungeonStreamPcRange protected_allocation =
+      object_layout->allocation_ranges.front();
+  const std::vector<uint8_t> source_manifest_bytes =
+      ReadFile(source_manifest_path_);
+  ASSERT_FALSE(source_manifest_bytes.empty());
+  Json protected_manifest = Json::parse(
+      std::string(source_manifest_bytes.begin(), source_manifest_bytes.end()));
+  auto& protected_section = protected_manifest["protected_regions"];
+  if (!protected_section.is_object()) {
+    protected_section = Json::object();
+  }
+  auto& protected_regions = protected_section["regions"];
+  if (!protected_regions.is_array()) {
+    protected_regions = Json::array();
+  }
+  protected_regions.push_back(
+      {{"start",
+        absl::StrFormat("0x%06X", PcToSnes(protected_allocation.begin))},
+       {"end", absl::StrFormat("0x%06X", PcToSnes(protected_allocation.end))},
+       {"size", protected_allocation.end - protected_allocation.begin},
+       {"hook_count", 1},
+       {"module", "ObjectAllocatorGuard"}});
+  protected_section["total_hooks"] =
+      protected_section.value("total_hooks", 0) + 1;
+  const std::filesystem::path protected_manifest_path =
+      temp_dir_ / "oos-object-protected-manifest.json";
+  {
+    std::ofstream output(protected_manifest_path, std::ios::trunc);
+    ASSERT_TRUE(output.is_open());
+    output << protected_manifest.dump(2);
+    ASSERT_TRUE(output.good());
+  }
+
+  Rom protected_rom;
+  ASSERT_TRUE(protected_rom.LoadFromFile(temp_rom_path_.string()).ok());
+  const std::vector<uint8_t> protected_rom_before = protected_rom.vector();
+  const auto protected_pointer_slot =
+      object_layout->pointer_table_pc + kRoomId * 3u;
+  auto protected_pointer_before =
+      protected_rom.ReadLong(protected_pointer_slot);
+  ASSERT_TRUE(protected_pointer_before.ok())
+      << protected_pointer_before.status().message();
+  std::vector<std::string> protected_args = args;
+  protected_args[5] =
+      absl::StrFormat("--manifest=%s", protected_manifest_path.string());
+
+  std::string protected_dry_output;
+  const absl::Status protected_dry_status =
+      handler.Run(protected_args, &protected_rom, &protected_dry_output);
+  EXPECT_EQ(protected_dry_status.code(), absl::StatusCode::kPermissionDenied)
+      << protected_dry_status;
+  EXPECT_NE(protected_dry_output.find("\"preflight_status\": \"failed\""),
+            std::string::npos);
+  EXPECT_EQ(protected_rom.vector(), protected_rom_before);
+  EXPECT_EQ(ReadFile(temp_rom_path_), bytes_before);
+  auto protected_sha_after_dry = ComputeSha256(temp_rom_path_.string());
+  ASSERT_TRUE(protected_sha_after_dry.ok())
+      << protected_sha_after_dry.status().message();
+  EXPECT_EQ(*protected_sha_after_dry, *disk_sha_before);
+  EXPECT_EQ(*protected_rom.ReadLong(protected_pointer_slot),
+            *protected_pointer_before);
+  EXPECT_EQ(CountBackupArtifacts(temp_rom_path_), 0);
+
+  protected_args.push_back("--write");
+  std::string protected_write_output;
+  const absl::Status protected_write_status =
+      handler.Run(protected_args, &protected_rom, &protected_write_output);
+  EXPECT_EQ(protected_write_status.code(), protected_dry_status.code())
+      << protected_write_status;
+  EXPECT_EQ(protected_write_status.message(), protected_dry_status.message());
+  EXPECT_NE(protected_write_output.find("\"preflight_status\": \"failed\""),
+            std::string::npos);
+  EXPECT_EQ(protected_rom.vector(), protected_rom_before);
+  EXPECT_EQ(ReadFile(temp_rom_path_), bytes_before);
+  auto protected_sha_after_write = ComputeSha256(temp_rom_path_.string());
+  ASSERT_TRUE(protected_sha_after_write.ok())
+      << protected_sha_after_write.status().message();
+  EXPECT_EQ(*protected_sha_after_write, *disk_sha_before);
+  EXPECT_EQ(*protected_rom.ReadLong(protected_pointer_slot),
+            *protected_pointer_before);
+  EXPECT_EQ(CountBackupArtifacts(temp_rom_path_), 0);
+
   std::string dry_output;
   const absl::Status dry_status = handler.Run(args, &rom, &dry_output);
   ASSERT_TRUE(dry_status.ok()) << dry_status.message();

--- a/test/unit/cli/dungeon_edit_commands_test.cc
+++ b/test/unit/cli/dungeon_edit_commands_test.cc
@@ -19,6 +19,7 @@
 #include "rom/rom.h"
 #include "rom/snes.h"
 #include "zelda3/dungeon/dungeon_rom_addresses.h"
+#include "zelda3/dungeon/oracle_rom_safety_preflight.h"
 #include "zelda3/dungeon/room.h"
 #include "zelda3/dungeon/room_object.h"
 
@@ -161,7 +162,27 @@ void InitializeTightObjectRom(Rom* rom) {
   rom->mutable_data()[kSyntheticPotTerminatorPc + 1] = 0xFF;
 }
 
-void WriteObjectCowManifest(const std::filesystem::path& path) {
+void WriteObjectCowManifest(const std::filesystem::path& path,
+                            bool protect_allocation = false) {
+  std::string protected_section;
+  if (protect_allocation) {
+    protected_section = absl::StrFormat(
+        R"json(,
+  "protected_regions": {
+    "total_hooks": 1,
+    "regions": [
+      {
+        "start": "0x%06X",
+        "end": "0x%06X",
+        "size": %d,
+        "hook_count": 1,
+        "module": "ObjectAllocatorGuard"
+      }
+    ]
+  })json",
+        PcToSnes(kObjectAllocationPc), PcToSnes(kObjectDataEndPc),
+        kObjectDataEndPc - kObjectAllocationPc);
+  }
   const std::string json = absl::StrFormat(
       R"json({
   "manifest_version": 3,
@@ -178,11 +199,11 @@ void WriteObjectCowManifest(const std::filesystem::path& path) {
         {"start": "0x%06X", "end": "0x%06X"}
       ]
     }
-  }
+  }%s
 })json",
       PcToSnes(kObjectPointerTablePc), PcToSnes(kObjectDataPc),
       PcToSnes(kObjectDataEndPc), PcToSnes(kObjectAllocationPc),
-      PcToSnes(kObjectDataEndPc));
+      PcToSnes(kObjectDataEndPc), protected_section);
   std::ofstream output(path, std::ios::trunc);
   ASSERT_TRUE(output.is_open());
   output << json;
@@ -472,6 +493,71 @@ TEST(DungeonEditCommandsTest,
   zelda3::Room untouched = zelda3::LoadRoomFromRom(&reopened, 1);
   EXPECT_TRUE(untouched.GetTileObjects().empty());
   EXPECT_EQ(ReadRoomObjectPointerPc(reopened, 1), kObjectDataPc + 10);
+}
+
+TEST(DungeonEditCommandsTest,
+     PlaceObjectProtectedCowRangeRejectsDryRunAndWriteBeforeMutation) {
+  Rom rom;
+  InitializeTightObjectRom(&rom);
+  ScopedRomArtifactsCleanup cleanup(MakeUniqueTempRomPath());
+  ScopedFileCleanup manifest_cleanup(cleanup.rom_path.string() +
+                                     ".manifest.json");
+  WriteRomFile(rom, cleanup.rom_path);
+  WriteObjectCowManifest(manifest_cleanup.file_path,
+                         /*protect_allocation=*/true);
+  rom.set_filename(cleanup.rom_path.string());
+
+  const std::vector<uint8_t> before = rom.vector();
+  const std::vector<uint8_t> disk_before = ReadFile(cleanup.rom_path);
+  auto disk_hash_before = zelda3::ComputeSha256(cleanup.rom_path.string());
+  ASSERT_TRUE(disk_hash_before.ok()) << disk_hash_before.status();
+  const int pointer_before = ReadRoomObjectPointerPc(rom, 0);
+  const bool dirty_before = rom.dirty();
+
+  handlers::DungeonPlaceObjectCommandHandler handler;
+  const std::vector<std::string> args = {
+      "--room=0x00",
+      "--id=0x0031",
+      "--x=1",
+      "--y=2",
+      "--size=6",
+      absl::StrFormat("--manifest=%s", manifest_cleanup.file_path.string()),
+      "--format=json"};
+
+  std::string dry_output;
+  const absl::Status dry_status = handler.Run(args, &rom, &dry_output);
+  EXPECT_EQ(dry_status.code(), absl::StatusCode::kPermissionDenied)
+      << dry_status;
+  EXPECT_EQ(dry_status.message(), "Write conflict with Hack Manifest");
+  EXPECT_THAT(dry_output, HasSubstr("\"mode\": \"dry-run\""));
+  EXPECT_THAT(dry_output, HasSubstr("\"manifest_write_policy\": \"block\""));
+  EXPECT_THAT(dry_output, HasSubstr("\"preflight_status\": \"failed\""));
+  EXPECT_EQ(rom.vector(), before);
+  EXPECT_EQ(rom.dirty(), dirty_before);
+  EXPECT_EQ(ReadFile(cleanup.rom_path), disk_before);
+  auto disk_hash_after_dry = zelda3::ComputeSha256(cleanup.rom_path.string());
+  ASSERT_TRUE(disk_hash_after_dry.ok()) << disk_hash_after_dry.status();
+  EXPECT_EQ(*disk_hash_after_dry, *disk_hash_before);
+  EXPECT_EQ(ReadRoomObjectPointerPc(rom, 0), pointer_before);
+  EXPECT_EQ(CountBackupArtifacts(cleanup.rom_path), 0);
+
+  std::vector<std::string> write_args = args;
+  write_args.push_back("--write");
+  std::string write_output;
+  const absl::Status write_status =
+      handler.Run(write_args, &rom, &write_output);
+  EXPECT_EQ(write_status.code(), dry_status.code()) << write_status;
+  EXPECT_EQ(write_status.message(), dry_status.message());
+  EXPECT_THAT(write_output, HasSubstr("\"mode\": \"write\""));
+  EXPECT_THAT(write_output, HasSubstr("\"preflight_status\": \"failed\""));
+  EXPECT_EQ(rom.vector(), before);
+  EXPECT_EQ(rom.dirty(), dirty_before);
+  EXPECT_EQ(ReadFile(cleanup.rom_path), disk_before);
+  auto disk_hash_after_write = zelda3::ComputeSha256(cleanup.rom_path.string());
+  ASSERT_TRUE(disk_hash_after_write.ok()) << disk_hash_after_write.status();
+  EXPECT_EQ(*disk_hash_after_write, *disk_hash_before);
+  EXPECT_EQ(ReadRoomObjectPointerPc(rom, 0), pointer_before);
+  EXPECT_EQ(CountBackupArtifacts(cleanup.rom_path), 0);
 }
 
 }  // namespace

--- a/test/unit/cli/dungeon_edit_commands_test.cc
+++ b/test/unit/cli/dungeon_edit_commands_test.cc
@@ -2,24 +2,36 @@
 #include "cli/handlers/game/dungeon_commands.h"
 
 #include <chrono>
+#include <cstdint>
 #include <filesystem>
 #include <fstream>
+#include <iterator>
 #include <string>
 #include <system_error>
+#include <utility>
 #include <vector>
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
 #include "absl/status/status.h"
+#include "absl/strings/str_format.h"
 #include "rom/rom.h"
 #include "rom/snes.h"
 #include "zelda3/dungeon/dungeon_rom_addresses.h"
+#include "zelda3/dungeon/room.h"
+#include "zelda3/dungeon/room_object.h"
 
 namespace yaze::cli {
 namespace {
 
 using ::testing::HasSubstr;
+
+constexpr int kObjectPointerTablePc = 0x070000;
+constexpr int kObjectDataPc = 0x060000;
+constexpr int kObjectAllocationPc = 0x060100;
+constexpr int kObjectDataEndPc = 0x060200;
+constexpr int kSyntheticPotTerminatorPc = 0x00F000;
 
 void ExpectInvalidArgument(const absl::Status& status,
                            const std::string& message_fragment) {
@@ -77,6 +89,105 @@ struct ScopedRomArtifactsCleanup {
 
   std::filesystem::path rom_path;
 };
+
+struct ScopedFileCleanup {
+  explicit ScopedFileCleanup(std::filesystem::path path)
+      : file_path(std::move(path)) {}
+  ~ScopedFileCleanup() {
+    std::error_code ec;
+    std::filesystem::remove(file_path, ec);
+  }
+
+  std::filesystem::path file_path;
+};
+
+std::vector<uint8_t> ReadFile(const std::filesystem::path& path) {
+  std::ifstream input(path, std::ios::binary);
+  return std::vector<uint8_t>(std::istreambuf_iterator<char>(input),
+                              std::istreambuf_iterator<char>());
+}
+
+void WriteRomFile(const Rom& rom, const std::filesystem::path& path) {
+  std::ofstream output(path, std::ios::binary | std::ios::trunc);
+  ASSERT_TRUE(output.is_open());
+  output.write(reinterpret_cast<const char*>(rom.data()),
+               static_cast<std::streamsize>(rom.size()));
+  ASSERT_TRUE(output.good());
+}
+
+void WriteLong(Rom* rom, int address, uint32_t value) {
+  rom->mutable_data()[address] = value & 0xFF;
+  rom->mutable_data()[address + 1] = (value >> 8) & 0xFF;
+  rom->mutable_data()[address + 2] = (value >> 16) & 0xFF;
+}
+
+void SetRoomObjectPointer(Rom* rom, int room_id, int pc_addr) {
+  WriteLong(rom, kObjectPointerTablePc + room_id * 3, PcToSnes(pc_addr));
+}
+
+int ReadRoomObjectPointerPc(const Rom& rom, int room_id) {
+  const int pointer = kObjectPointerTablePc + room_id * 3;
+  const uint32_t snes = rom.data()[pointer] |
+                        (static_cast<uint32_t>(rom.data()[pointer + 1]) << 8) |
+                        (static_cast<uint32_t>(rom.data()[pointer + 2]) << 16);
+  return SnesToPc(snes);
+}
+
+void WriteEmptyObjectStream(Rom* rom, int pc_addr) {
+  const std::vector<uint8_t> stream = {0x00, 0x00, 0xFF, 0xFF, 0xFF,
+                                       0xFF, 0xF0, 0xFF, 0xFF, 0xFF};
+  ASSERT_TRUE(rom->WriteVector(pc_addr, stream).ok());
+}
+
+void InitializeTightObjectRom(Rom* rom) {
+  ASSERT_TRUE(rom->LoadFromData(std::vector<uint8_t>(0x200000, 0x00)).ok());
+  WriteLong(rom, zelda3::kRoomObjectPointer, PcToSnes(kObjectPointerTablePc));
+  SetRoomObjectPointer(rom, 0, kObjectDataPc);
+  for (int room_id = 1; room_id < zelda3::kNumberOfRooms; ++room_id) {
+    SetRoomObjectPointer(rom, room_id, kObjectDataPc + 10);
+  }
+  WriteEmptyObjectStream(rom, kObjectDataPc);
+  WriteEmptyObjectStream(rom, kObjectDataPc + 10);
+
+  // Keep LoadRoomFromRom's unrelated pot-item scan bounded in the synthetic
+  // fixture so the object-stream assertions stay focused and deterministic.
+  const uint16_t pot_pointer = PcToSnes(kSyntheticPotTerminatorPc) & 0xFFFF;
+  for (int room_id = 0; room_id < zelda3::kNumberOfRooms; ++room_id) {
+    const int pointer = zelda3::kRoomItemsPointers + room_id * 2;
+    rom->mutable_data()[pointer] = pot_pointer & 0xFF;
+    rom->mutable_data()[pointer + 1] = (pot_pointer >> 8) & 0xFF;
+  }
+  rom->mutable_data()[kSyntheticPotTerminatorPc] = 0xFF;
+  rom->mutable_data()[kSyntheticPotTerminatorPc + 1] = 0xFF;
+}
+
+void WriteObjectCowManifest(const std::filesystem::path& path) {
+  const std::string json = absl::StrFormat(
+      R"json({
+  "manifest_version": 3,
+  "dungeon_stream_regions": {
+    "objects": {
+      "pointer_table": "0x%06X",
+      "pointer_count": 296,
+      "pointer_encoding": "long24",
+      "strategy": "copy_on_write",
+      "data_regions": [
+        {"start": "0x%06X", "end": "0x%06X"}
+      ],
+      "allocation_regions": [
+        {"start": "0x%06X", "end": "0x%06X"}
+      ]
+    }
+  }
+})json",
+      PcToSnes(kObjectPointerTablePc), PcToSnes(kObjectDataPc),
+      PcToSnes(kObjectDataEndPc), PcToSnes(kObjectAllocationPc),
+      PcToSnes(kObjectDataEndPc));
+  std::ofstream output(path, std::ios::trunc);
+  ASSERT_TRUE(output.is_open());
+  output << json;
+  ASSERT_TRUE(output.good());
+}
 
 void SetRoomSpritePointer(Rom* rom, int table_pc, int room_id, int pc_addr) {
   const uint32_t snes = PcToSnes(pc_addr);
@@ -258,6 +369,109 @@ TEST(DungeonEditCommandsTest,
   EXPECT_EQ(rom.vector(), before);
   EXPECT_EQ(ReadRoomSpritePointerPc(rom, table_pc, 0), zelda3::kSpritesData);
   EXPECT_EQ(CountBackupArtifacts(cleanup.rom_path), 0);
+}
+
+TEST(DungeonEditCommandsTest,
+     PlaceObjectDryRunMatchesManifestlessWriteFailure) {
+  Rom rom;
+  InitializeTightObjectRom(&rom);
+  ScopedRomArtifactsCleanup cleanup(MakeUniqueTempRomPath());
+  WriteRomFile(rom, cleanup.rom_path);
+  rom.set_filename(cleanup.rom_path.string());
+
+  const std::vector<uint8_t> before = rom.vector();
+  const std::vector<uint8_t> disk_before = ReadFile(cleanup.rom_path);
+  handlers::DungeonPlaceObjectCommandHandler handler;
+  const std::vector<std::string> args = {"--room=0x00", "--id=0x0031",
+                                         "--x=1",       "--y=2",
+                                         "--size=6",    "--format=json"};
+
+  std::string dry_output;
+  const absl::Status dry_status = handler.Run(args, &rom, &dry_output);
+  EXPECT_TRUE(absl::IsResourceExhausted(dry_status)) << dry_status;
+  EXPECT_THAT(dry_output, HasSubstr("\"mode\": \"dry-run\""));
+  EXPECT_THAT(dry_output, HasSubstr("\"preflight_status\": \"failed\""));
+  EXPECT_THAT(dry_output, HasSubstr("object data too large"));
+  EXPECT_EQ(rom.vector(), before);
+  EXPECT_EQ(ReadFile(cleanup.rom_path), disk_before);
+  EXPECT_EQ(ReadRoomObjectPointerPc(rom, 0), kObjectDataPc);
+  EXPECT_EQ(CountBackupArtifacts(cleanup.rom_path), 0);
+
+  std::vector<std::string> write_args = args;
+  write_args.push_back("--write");
+  std::string write_output;
+  const absl::Status write_status =
+      handler.Run(write_args, &rom, &write_output);
+  EXPECT_EQ(write_status.code(), dry_status.code());
+  EXPECT_EQ(write_status.message(), dry_status.message());
+  EXPECT_THAT(write_output, HasSubstr("\"mode\": \"write\""));
+  EXPECT_THAT(write_output, HasSubstr("\"preflight_status\": \"failed\""));
+  EXPECT_EQ(rom.vector(), before);
+  EXPECT_EQ(ReadFile(cleanup.rom_path), disk_before);
+  EXPECT_EQ(ReadRoomObjectPointerPc(rom, 0), kObjectDataPc);
+  EXPECT_EQ(CountBackupArtifacts(cleanup.rom_path), 0);
+}
+
+TEST(DungeonEditCommandsTest,
+     PlaceObjectManifestDryRunAndWriteRelocatesAndReopens) {
+  Rom rom;
+  InitializeTightObjectRom(&rom);
+  ScopedRomArtifactsCleanup cleanup(MakeUniqueTempRomPath());
+  ScopedFileCleanup manifest_cleanup(cleanup.rom_path.string() +
+                                     ".manifest.json");
+  WriteRomFile(rom, cleanup.rom_path);
+  WriteObjectCowManifest(manifest_cleanup.file_path);
+  rom.set_filename(cleanup.rom_path.string());
+
+  const std::vector<uint8_t> before = rom.vector();
+  const std::vector<uint8_t> disk_before = ReadFile(cleanup.rom_path);
+  handlers::DungeonPlaceObjectCommandHandler handler;
+  const std::vector<std::string> args = {
+      "--room=0x00",
+      "--id=0x0031",
+      "--x=1",
+      "--y=2",
+      "--size=6",
+      absl::StrFormat("--manifest=%s", manifest_cleanup.file_path.string()),
+      "--format=json"};
+
+  std::string dry_output;
+  const absl::Status dry_status = handler.Run(args, &rom, &dry_output);
+  ASSERT_TRUE(dry_status.ok()) << dry_status;
+  EXPECT_THAT(dry_output,
+              HasSubstr("\"allocator_capability\": \"copy_on_write\""));
+  EXPECT_THAT(dry_output, HasSubstr("\"preflight_status\": \"success\""));
+  EXPECT_EQ(rom.vector(), before);
+  EXPECT_EQ(ReadFile(cleanup.rom_path), disk_before);
+  EXPECT_EQ(ReadRoomObjectPointerPc(rom, 0), kObjectDataPc);
+  EXPECT_EQ(CountBackupArtifacts(cleanup.rom_path), 0);
+
+  std::vector<std::string> write_args = args;
+  write_args.push_back("--write");
+  std::string write_output;
+  const absl::Status write_status =
+      handler.Run(write_args, &rom, &write_output);
+  ASSERT_TRUE(write_status.ok()) << write_status;
+  EXPECT_THAT(write_output, HasSubstr("\"write_status\": \"success\""));
+  EXPECT_THAT(write_output, HasSubstr("\"save_status\": \"saved\""));
+  EXPECT_EQ(ReadRoomObjectPointerPc(rom, 0), kObjectAllocationPc);
+  EXPECT_EQ(CountBackupArtifacts(cleanup.rom_path), 1);
+
+  Rom reopened;
+  ASSERT_TRUE(reopened.LoadFromFile(cleanup.rom_path.string()).ok());
+  EXPECT_EQ(ReadRoomObjectPointerPc(reopened, 0), kObjectAllocationPc);
+  zelda3::Room room = zelda3::LoadRoomFromRom(&reopened, 0);
+  ASSERT_EQ(room.GetTileObjects().size(), 1u);
+  const zelda3::RoomObject& object = room.GetTileObjects().front();
+  EXPECT_EQ(object.id_, 0x0031);
+  EXPECT_EQ(object.x(), 1);
+  EXPECT_EQ(object.y(), 2);
+  EXPECT_EQ(object.size(), 6);
+  EXPECT_EQ(object.GetLayerValue(), 0);
+
+  zelda3::Room untouched = zelda3::LoadRoomFromRom(&reopened, 1);
+  EXPECT_TRUE(untouched.GetTileObjects().empty());
+  EXPECT_EQ(ReadRoomObjectPointerPc(reopened, 1), kObjectDataPc + 10);
 }
 
 }  // namespace


### PR DESCRIPTION
## Summary

- add explicit `--manifest` support to `dungeon-place-object`
- load and retain the object copy-on-write allocator layout plus manifest ownership policy
- reject protected current-stream, allocation, object-pointer, and door-pointer ranges before scratch or live writes
- run the exact `Room::SaveObjects()` path against an isolated ROM snapshot before both dry-run and write
- fail closed when an object stream cannot be saved in place, no explicit COW capability is available, or manifest ownership protects any possible object-save range
- document the capacity/COW and protected-region behavior

## Why

`dungeon-place-object` previously reported a successful dry-run for edits that later failed on write because the dry-run never exercised object serialization or capacity allocation. It also discarded the loaded manifest after adapting its allocator layout, so COW writes could bypass the manifest's protected-region ownership policy.

The immutable preflight now gives dry-run and write the same capacity/allocation outcome without modifying the caller ROM. A valid manifest can authorize deterministic copy-on-write relocation, while the CLI's fail-closed block policy rejects any predicted in-place, allocation, object-pointer, or door-pointer conflict before mutation.

## Validation

- `build/presets/mac-test/bin/Debug/yaze_test_unit --gtest_filter='DungeonEditCommandsTest.*' --gtest_brief=1` — 14/14 passed
- Oracle ROM-gated `DungeonPotRepackOosIntegrationTest.DungeonPlaceObjectCliCowDryRunWriteAndReadback` — 1/1 passed, including test-local protected-allocation rejection and real-manifest relocation/readback
- `YAZE_PREPUSH_BUILD_DIR=build/presets/mac-test scripts/pre-push.sh` — passed

Closes #121

