### PR TITLE
fix(cli): make dungeon writes transactional

### DIFF
--- a/docs/internal/agents/rom-safety-guardrails.md
+++ b/docs/internal/agents/rom-safety-guardrails.md
@@ -14,9 +14,12 @@ This repo is used to edit ROM hacks (including Oracle of Secrets). Treat ROM wri
 ## CLI Save Transaction Contract
 
 - `Rom::SaveSettings::backup` keeps its legacy best-effort behavior.
-- Safety-critical CLI writes can set `require_backup=true`. A required backup
-  is copied to a same-directory temporary path and renamed into place only
-  after the copy completes; failure returns before the ROM target is replaced.
+- Safety-critical CLI writes can set `require_backup=true`. If the save target
+  already exists, that target (including a Save As destination) is copied to a
+  same-directory temporary path and renamed into place only after the copy
+  completes; failure returns before the ROM target is replaced. A new target
+  has no previous bytes to back up. A completed required backup is retained if
+  the later target write fails, so recovery bytes remain available.
 - `dungeon-place-sprite`, `dungeon-remove-sprite`, `dungeon-place-object`, and
   `dungeon-set-collision-tile` wrap their serializer, required backup, and disk
   commit in `ScopedRomTransaction`. Any failure restores the caller's ROM

--- a/docs/internal/agents/rom-safety-guardrails.md
+++ b/docs/internal/agents/rom-safety-guardrails.md
@@ -11,6 +11,19 @@ This repo is used to edit ROM hacks (including Oracle of Secrets). Treat ROM wri
   - Project setting: `workspace_settings.backup_on_save=true`
   - Backups are managed via `RomFileManager` retention/daily keep.
 
+## CLI Save Transaction Contract
+
+- `Rom::SaveSettings::backup` keeps its legacy best-effort behavior.
+- Safety-critical CLI writes can set `require_backup=true`. A required backup
+  is copied to a same-directory temporary path and renamed into place only
+  after the copy completes; failure returns before the ROM target is replaced.
+- `dungeon-place-sprite`, `dungeon-remove-sprite`, `dungeon-place-object`, and
+  `dungeon-set-collision-tile` wrap their serializer, required backup, and disk
+  commit in `ScopedRomTransaction`. Any failure restores the caller's ROM
+  bytes, filename, size, and dirty state.
+- Other CLI writers that still set only `backup=true` remain best-effort and
+  must be audited before opting into the strict transaction path.
+
 ## Save-Time Write Fences (C++)
 
 Yaze supports a strict allow-list for save-time writes:

--- a/src/cli/handlers/game/dungeon_edit_commands.cc
+++ b/src/cli/handlers/game/dungeon_edit_commands.cc
@@ -15,6 +15,7 @@
 #include "core/project.h"
 #include "rom/rom.h"
 #include "rom/snes.h"
+#include "rom/transaction.h"
 #include "util/macro.h"
 #include "zelda3/dungeon/dungeon_stream_allocator.h"
 #include "zelda3/dungeon/room.h"
@@ -83,7 +84,7 @@ absl::Status ValidateSpriteCoord(int value, char axis) {
 absl::Status SaveRomWithBackup(Rom* rom,
                                resources::OutputFormatter& formatter) {
   Rom::SaveSettings save_settings;
-  save_settings.backup = true;
+  save_settings.require_backup = true;
   auto disk_status = rom->SaveToFile(save_settings);
   if (!disk_status.ok()) {
     formatter.AddField("save_error", std::string(disk_status.message()));
@@ -91,6 +92,24 @@ absl::Status SaveRomWithBackup(Rom* rom,
   }
 
   formatter.AddField("save_status", "saved");
+  return absl::OkStatus();
+}
+
+template <typename Mutation>
+absl::Status MutateAndSaveRomWithBackup(Rom* rom,
+                                        resources::OutputFormatter& formatter,
+                                        Mutation&& mutation) {
+  ScopedRomTransaction transaction(*rom);
+
+  auto write_status = std::forward<Mutation>(mutation)();
+  if (!write_status.ok()) {
+    formatter.AddField("write_error", std::string(write_status.message()));
+    return write_status;
+  }
+  formatter.AddField("write_status", "success");
+
+  RETURN_IF_ERROR(SaveRomWithBackup(rom, formatter));
+  transaction.Commit();
   return absl::OkStatus();
 }
 
@@ -315,18 +334,11 @@ absl::Status DungeonPlaceSpriteCommandHandler::Execute(
   formatter.AddField("mode", do_write ? "write" : "dry-run");
 
   if (do_write) {
-    auto save_status = room.SaveSprites();
+    auto save_status = MutateAndSaveRomWithBackup(
+        rom, formatter, [&room]() { return room.SaveSprites(); });
     if (!save_status.ok()) {
-      formatter.AddField("write_error", std::string(save_status.message()));
       formatter.EndObject();
       return save_status;
-    }
-    formatter.AddField("write_status", "success");
-
-    auto disk_status = SaveRomWithBackup(rom, formatter);
-    if (!disk_status.ok()) {
-      formatter.EndObject();
-      return disk_status;
     }
   }
 
@@ -440,18 +452,11 @@ absl::Status DungeonRemoveSpriteCommandHandler::Execute(
   formatter.AddField("mode", do_write ? "write" : "dry-run");
 
   if (do_write) {
-    auto save_status = room.SaveSprites();
+    auto save_status = MutateAndSaveRomWithBackup(
+        rom, formatter, [&room]() { return room.SaveSprites(); });
     if (!save_status.ok()) {
-      formatter.AddField("write_error", std::string(save_status.message()));
       formatter.EndObject();
       return save_status;
-    }
-    formatter.AddField("write_status", "success");
-
-    auto disk_status = SaveRomWithBackup(rom, formatter);
-    if (!disk_status.ok()) {
-      formatter.EndObject();
-      return disk_status;
     }
   }
 
@@ -593,18 +598,11 @@ absl::Status DungeonPlaceObjectCommandHandler::Execute(
   formatter.AddField("preflight_status", "success");
 
   if (do_write) {
-    auto save_status = room.SaveObjects(layout);
+    auto save_status = MutateAndSaveRomWithBackup(
+        rom, formatter, [&room, layout]() { return room.SaveObjects(layout); });
     if (!save_status.ok()) {
-      formatter.AddField("write_error", std::string(save_status.message()));
       formatter.EndObject();
       return save_status;
-    }
-    formatter.AddField("write_status", "success");
-
-    auto disk_status = SaveRomWithBackup(rom, formatter);
-    if (!disk_status.ok()) {
-      formatter.EndObject();
-      return disk_status;
     }
   }
 
@@ -712,20 +710,15 @@ absl::Status DungeonSetCollisionTileCommandHandler::Execute(
   formatter.EndArray();
 
   if (do_write) {
-    // Flush collision changes to ROM
-    std::array<zelda3::Room, 1> rooms_arr = {std::move(room)};
-    auto save_status = zelda3::SaveAllCollision(rom, absl::MakeSpan(rooms_arr));
+    auto save_status =
+        MutateAndSaveRomWithBackup(rom, formatter, [&rom, &room]() mutable {
+          // Flush collision changes to ROM.
+          std::array<zelda3::Room, 1> rooms_arr = {std::move(room)};
+          return zelda3::SaveAllCollision(rom, absl::MakeSpan(rooms_arr));
+        });
     if (!save_status.ok()) {
-      formatter.AddField("write_error", std::string(save_status.message()));
       formatter.EndObject();
       return save_status;
-    }
-    formatter.AddField("write_status", "success");
-
-    auto disk_status = SaveRomWithBackup(rom, formatter);
-    if (!disk_status.ok()) {
-      formatter.EndObject();
-      return disk_status;
     }
   }
 

--- a/src/rom/rom.cc
+++ b/src/rom/rom.cc
@@ -94,6 +94,64 @@ std::string MakeSafeTimestamp(std::time_t now_c) {
   return timestamp;
 }
 
+absl::StatusOr<std::filesystem::path> GetAvailableBackupPath(
+    const std::filesystem::path& requested_path) {
+  std::filesystem::path candidate = requested_path;
+  for (int suffix = 1; suffix <= 1000; ++suffix) {
+    std::error_code exists_ec;
+    const bool exists = std::filesystem::exists(candidate, exists_ec);
+    if (exists_ec) {
+      return absl::InternalError(absl::StrCat(
+          "Could not inspect required ROM backup path: ", candidate.string(),
+          ": ", exists_ec.message()));
+    }
+    if (!exists) {
+      return candidate;
+    }
+    candidate = requested_path.string() + "_" + std::to_string(suffix);
+  }
+
+  return absl::ResourceExhaustedError(
+      "Could not allocate a unique required ROM backup path");
+}
+
+absl::Status CreateRequiredBackup(
+    const std::filesystem::path& source_path,
+    const std::filesystem::path& requested_backup_path) {
+  auto backup_path_or = GetAvailableBackupPath(requested_backup_path);
+  if (!backup_path_or.ok()) {
+    return backup_path_or.status();
+  }
+
+  const std::filesystem::path backup_path = *backup_path_or;
+  std::filesystem::path temp_path = backup_path;
+  temp_path += ".tmp";
+
+  std::error_code copy_ec;
+  const bool copied = std::filesystem::copy_file(
+      source_path, temp_path, std::filesystem::copy_options::none, copy_ec);
+  if (!copied || copy_ec) {
+    std::error_code cleanup_ec;
+    std::filesystem::remove(temp_path, cleanup_ec);
+    return absl::FailedPreconditionError(absl::StrCat(
+        "Could not create required ROM backup: ", source_path.string(), " -> ",
+        backup_path.string(), ": ",
+        copy_ec ? copy_ec.message() : "copy did not complete"));
+  }
+
+  std::error_code rename_ec;
+  std::filesystem::rename(temp_path, backup_path, rename_ec);
+  if (rename_ec) {
+    std::error_code cleanup_ec;
+    std::filesystem::remove(temp_path, cleanup_ec);
+    return absl::FailedPreconditionError(absl::StrCat(
+        "Could not finalize required ROM backup: ", backup_path.string(), ": ",
+        rename_ec.message()));
+  }
+
+  return absl::OkStatus();
+}
+
 #ifdef __EMSCRIPTEN__
 inline void MaybeBroadcastChange(uint32_t offset,
                                  const std::vector<uint8_t>& old_bytes,
@@ -306,17 +364,22 @@ absl::Status Rom::SaveToFile(const SaveSettings& settings) {
     filename = filename_;
   }
 
-  if (settings.backup) {
+  if (settings.backup || settings.require_backup) {
     auto now = std::chrono::system_clock::now();
     auto now_c = std::chrono::system_clock::to_time_t(now);
     std::string backup_filename =
         absl::StrCat(filename, "_backup_", MakeSafeTimestamp(now_c));
 
-    try {
-      std::filesystem::copy(filename_, backup_filename,
-                            std::filesystem::copy_options::overwrite_existing);
-    } catch (const std::filesystem::filesystem_error& e) {
-      LOG_WARN("Rom", "Could not create backup: %s", e.what());
+    if (settings.require_backup) {
+      RETURN_IF_ERROR(CreateRequiredBackup(filename_, backup_filename));
+    } else {
+      try {
+        std::filesystem::copy(
+            filename_, backup_filename,
+            std::filesystem::copy_options::overwrite_existing);
+      } catch (const std::filesystem::filesystem_error& e) {
+        LOG_WARN("Rom", "Could not create backup: %s", e.what());
+      }
     }
   }
 

--- a/src/rom/rom.cc
+++ b/src/rom/rom.cc
@@ -11,6 +11,7 @@
 #include <iostream>
 #include <new>
 #include <string>
+#include <system_error>
 #include <vector>
 
 #include "absl/status/status.h"
@@ -115,6 +116,11 @@ absl::StatusOr<std::filesystem::path> GetAvailableBackupPath(
       "Could not allocate a unique required ROM backup path");
 }
 
+#if !defined(__EMSCRIPTEN__)
+void BestEffortFsyncFile(const std::filesystem::path& path);
+void BestEffortFsyncParentDir(const std::filesystem::path& file_path);
+#endif
+
 absl::Status CreateRequiredBackup(
     const std::filesystem::path& source_path,
     const std::filesystem::path& requested_backup_path) {
@@ -139,6 +145,10 @@ absl::Status CreateRequiredBackup(
         copy_ec ? copy_ec.message() : "copy did not complete"));
   }
 
+#if !defined(__EMSCRIPTEN__)
+  BestEffortFsyncFile(temp_path);
+#endif
+
   std::error_code rename_ec;
   std::filesystem::rename(temp_path, backup_path, rename_ec);
   if (rename_ec) {
@@ -148,6 +158,10 @@ absl::Status CreateRequiredBackup(
         "Could not finalize required ROM backup: ", backup_path.string(), ": ",
         rename_ec.message()));
   }
+
+#if !defined(__EMSCRIPTEN__)
+  BestEffortFsyncParentDir(backup_path);
+#endif
 
   return absl::OkStatus();
 }
@@ -364,26 +378,50 @@ absl::Status Rom::SaveToFile(const SaveSettings& settings) {
     filename = filename_;
   }
 
-  if (settings.backup || settings.require_backup) {
+  // Strict mode must reason about the actual destination, including the
+  // timestamped path selected by save_new.
+  if (settings.require_backup && settings.save_new) {
+    auto now = std::chrono::system_clock::now();
+    auto now_c = std::chrono::system_clock::to_time_t(now);
+    auto filename_no_ext = filename.substr(0, filename.find_last_of("."));
+    filename =
+        absl::StrCat(filename_no_ext, "_", MakeSafeTimestamp(now_c), ".sfc");
+  }
+
+  if (settings.require_backup) {
+    const std::filesystem::path target_path(filename);
+    std::error_code exists_ec;
+    const bool target_exists = std::filesystem::exists(target_path, exists_ec);
+    if (exists_ec) {
+      return absl::FailedPreconditionError(absl::StrCat(
+          "Could not inspect required ROM backup target: ", filename, ": ",
+          exists_ec.message()));
+    }
+
+    // A strict backup protects the file that is about to be replaced, not the
+    // ROM's original load path. A new target has no previous bytes to protect.
+    if (target_exists) {
+      auto now = std::chrono::system_clock::now();
+      auto now_c = std::chrono::system_clock::to_time_t(now);
+      std::string backup_filename =
+          absl::StrCat(filename, "_backup_", MakeSafeTimestamp(now_c));
+      RETURN_IF_ERROR(CreateRequiredBackup(target_path, backup_filename));
+    }
+  } else if (settings.backup) {
     auto now = std::chrono::system_clock::now();
     auto now_c = std::chrono::system_clock::to_time_t(now);
     std::string backup_filename =
         absl::StrCat(filename, "_backup_", MakeSafeTimestamp(now_c));
 
-    if (settings.require_backup) {
-      RETURN_IF_ERROR(CreateRequiredBackup(filename_, backup_filename));
-    } else {
-      try {
-        std::filesystem::copy(
-            filename_, backup_filename,
-            std::filesystem::copy_options::overwrite_existing);
-      } catch (const std::filesystem::filesystem_error& e) {
-        LOG_WARN("Rom", "Could not create backup: %s", e.what());
-      }
+    try {
+      std::filesystem::copy(filename_, backup_filename,
+                            std::filesystem::copy_options::overwrite_existing);
+    } catch (const std::filesystem::filesystem_error& e) {
+      LOG_WARN("Rom", "Could not create backup: %s", e.what());
     }
   }
 
-  if (settings.save_new) {
+  if (settings.save_new && !settings.require_backup) {
     auto now = std::chrono::system_clock::now();
     auto now_c = std::chrono::system_clock::to_time_t(now);
     auto filename_no_ext = filename.substr(0, filename.find_last_of("."));
@@ -423,13 +461,17 @@ absl::Status Rom::SaveToFile(const SaveSettings& settings) {
   std::error_code rename_ec;
   std::filesystem::rename(temp_path, target_path, rename_ec);
 #if defined(_WIN32)
-  // Windows may fail rename when the destination exists; fall back to remove +
-  // rename (non-atomic but still avoids partial/truncated writes).
-  if (rename_ec && std::filesystem::exists(target_path)) {
-    std::error_code rm_target_ec;
-    std::filesystem::remove(target_path, rm_target_ec);
-    rename_ec.clear();
-    std::filesystem::rename(temp_path, target_path, rename_ec);
+  // Windows may reject std::filesystem::rename when the destination exists.
+  // Replace it without deleting the original first, so a failed replacement
+  // does not leave the target missing.
+  if (rename_ec) {
+    if (MoveFileExW(temp_path.wstring().c_str(), target_path.wstring().c_str(),
+                    MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH)) {
+      rename_ec.clear();
+    } else {
+      rename_ec = std::error_code(static_cast<int>(GetLastError()),
+                                  std::system_category());
+    }
   }
 #endif
   if (rename_ec) {

--- a/src/rom/rom.h
+++ b/src/rom/rom.h
@@ -31,22 +31,28 @@ class Rom {
     bool backup = false;
     bool save_new = false;
     std::string filename;
+    // Unlike the legacy best-effort `backup` flag, fail before replacing the
+    // target when a complete backup cannot be created. This also implies
+    // backup creation when `backup` is false.
+    bool require_backup = false;
   };
 
   struct LoadOptions {
     bool strip_header = true;
     bool load_resource_labels = true;
-    
+
     static LoadOptions Defaults() { return LoadOptions{}; }
   };
 
   Rom() = default;
   ~Rom() = default;
 
-  absl::Status LoadFromFile(const std::string& filename,
-                            const LoadOptions& options = LoadOptions::Defaults());
-  absl::Status LoadFromData(const std::vector<uint8_t>& data,
-                            const LoadOptions& options = LoadOptions::Defaults());
+  absl::Status LoadFromFile(
+      const std::string& filename,
+      const LoadOptions& options = LoadOptions::Defaults());
+  absl::Status LoadFromData(
+      const std::vector<uint8_t>& data,
+      const LoadOptions& options = LoadOptions::Defaults());
 
   absl::Status SaveToFile(const SaveSettings& settings);
 
@@ -66,9 +72,11 @@ class Rom {
   absl::StatusOr<uint32_t> ReadLong(int offset) const;
   absl::StatusOr<std::vector<uint8_t>> ReadByteVector(uint32_t offset,
                                                       uint32_t length) const;
-  absl::StatusOr<gfx::Tile16> ReadTile16(uint32_t tile16_id, uint32_t tile16_ptr);
+  absl::StatusOr<gfx::Tile16> ReadTile16(uint32_t tile16_id,
+                                         uint32_t tile16_ptr);
 
-  absl::Status WriteTile16(int tile16_id, uint32_t tile16_ptr, const gfx::Tile16& tile);
+  absl::Status WriteTile16(int tile16_id, uint32_t tile16_ptr,
+                           const gfx::Tile16& tile);
   absl::Status WriteByte(int addr, uint8_t value);
   absl::Status WriteWord(int addr, uint16_t value);
   absl::Status WriteShort(int addr, uint16_t value);
@@ -109,15 +117,18 @@ class Rom {
   absl::Status ReadHelper(T& var, int address) {
     if constexpr (std::is_same_v<T, uint8_t>) {
       auto result = ReadByte(address);
-      if (!result.ok()) return result.status();
+      if (!result.ok())
+        return result.status();
       var = *result;
     } else if constexpr (std::is_same_v<T, uint16_t>) {
       auto result = ReadWord(address);
-      if (!result.ok()) return result.status();
+      if (!result.ok())
+        return result.status();
       var = *result;
     } else if constexpr (std::is_same_v<T, std::vector<uint8_t>>) {
       auto result = ReadByteVector(address, var.size());
-      if (!result.ok()) return result.status();
+      if (!result.ok())
+        return result.status();
       var = *result;
     }
     return absl::OkStatus();
@@ -133,7 +144,7 @@ class Rom {
   bool dirty() const { return dirty_; }
   void set_dirty(bool dirty) { dirty_ = dirty; }
   void ClearDirty() { dirty_ = false; }
-  
+
   auto title() const { return title_; }
   auto size() const { return size_; }
   auto data() const { return rom_data_.data(); }

--- a/src/rom/rom.h
+++ b/src/rom/rom.h
@@ -31,9 +31,10 @@ class Rom {
     bool backup = false;
     bool save_new = false;
     std::string filename;
-    // Unlike the legacy best-effort `backup` flag, fail before replacing the
-    // target when a complete backup cannot be created. This also implies
-    // backup creation when `backup` is false.
+    // Unlike the legacy best-effort `backup` flag, back up an existing save
+    // target and fail before replacing it if that backup cannot be created.
+    // A new target has no previous bytes to protect. This implies backup
+    // creation when `backup` is false.
     bool require_backup = false;
   };
 

--- a/test/unit/cli/dungeon_edit_commands_test.cc
+++ b/test/unit/cli/dungeon_edit_commands_test.cc
@@ -23,6 +23,10 @@
 #include "zelda3/dungeon/room.h"
 #include "zelda3/dungeon/room_object.h"
 
+#if !defined(_WIN32)
+#include <unistd.h>
+#endif
+
 namespace yaze::cli {
 namespace {
 
@@ -69,6 +73,7 @@ int CountBackupArtifacts(const std::filesystem::path& rom_path) {
 void CleanupRomArtifacts(const std::filesystem::path& rom_path) {
   std::error_code ec;
   std::filesystem::remove(rom_path, ec);
+  std::filesystem::remove_all(rom_path.string() + ".tmp", ec);
 
   const auto parent = rom_path.parent_path();
   const std::string prefix = rom_path.filename().string() + "_backup_";
@@ -232,6 +237,18 @@ void WriteSpriteStream(Rom* rom, int pc_addr, uint8_t sort_mode,
   ASSERT_TRUE(rom->WriteVector(pc_addr, std::move(bytes)).ok());
 }
 
+std::vector<uint8_t> EncodeSpritePayload(int count, uint8_t id_base = 0x10) {
+  std::vector<uint8_t> payload;
+  payload.reserve(count * 3 + 1);
+  for (int i = 0; i < count; ++i) {
+    payload.push_back(0x0A + (i & 0x07));
+    payload.push_back(0x0B + (i & 0x07));
+    payload.push_back(id_base + i);
+  }
+  payload.push_back(0xFF);
+  return payload;
+}
+
 TEST(DungeonEditCommandsTest, PlaceSpriteRejectsInvalidX) {
   handlers::DungeonPlaceSpriteCommandHandler handler;
   std::string output;
@@ -393,6 +410,69 @@ TEST(DungeonEditCommandsTest,
 }
 
 TEST(DungeonEditCommandsTest,
+     PlaceSpriteRequiredBackupFailureRollsBackCallerRom) {
+#if defined(_WIN32)
+  GTEST_SKIP() << "NAME_MAX backup failure fixture is POSIX-only";
+#else
+  Rom rom;
+  ASSERT_TRUE(rom.LoadFromData(std::vector<uint8_t>(0x200000, 0x00)).ok());
+
+  rom.mutable_data()[zelda3::kRoomsSpritePointer] = 0x00;
+  rom.mutable_data()[zelda3::kRoomsSpritePointer + 1] = 0x80;
+  const int table_pc = SnesToPc(0x098000);
+  for (int room_id = 0; room_id < zelda3::kNumberOfRooms; ++room_id) {
+    SetRoomSpritePointer(&rom, table_pc, room_id, zelda3::kSpritesData + 0x20);
+  }
+  SetRoomSpritePointer(&rom, table_pc, 0, zelda3::kSpritesData);
+  WriteSpriteStream(&rom, zelda3::kSpritesData, 0x00, EncodeSpritePayload(0));
+  WriteSpriteStream(&rom, zelda3::kSpritesData + 0x20, 0x00,
+                    EncodeSpritePayload(0));
+
+  const auto parent = std::filesystem::temp_directory_path();
+  const long name_max = pathconf(parent.c_str(), _PC_NAME_MAX);
+  if (name_max < 128) {
+    GTEST_SKIP() << "Filesystem does not expose a usable NAME_MAX";
+  }
+  const auto nonce =
+      std::chrono::steady_clock::now().time_since_epoch().count();
+  std::string filename = "yaze_required_backup_" + std::to_string(nonce);
+  const size_t target_length = static_cast<size_t>(name_max) - 4;
+  ASSERT_LT(filename.size(), target_length);
+  filename.append(target_length - filename.size(), 'r');
+
+  ScopedRomArtifactsCleanup cleanup(parent / filename);
+  WriteRomFile(rom, cleanup.rom_path);
+  rom.set_filename(cleanup.rom_path.string());
+  rom.set_dirty(false);
+
+  const std::vector<uint8_t> before = rom.vector();
+  const std::vector<uint8_t> disk_before = ReadFile(cleanup.rom_path);
+  const int pointer_before = ReadRoomSpritePointerPc(rom, table_pc, 0);
+  const bool dirty_before = rom.dirty();
+  const std::string filename_before = rom.filename();
+
+  handlers::DungeonPlaceSpriteCommandHandler handler;
+  std::string output;
+  const absl::Status status =
+      handler.Run({"--room=0x00", "--id=0xA3", "--x=16", "--y=21",
+                   "--subtype=4", "--write", "--format=json"},
+                  &rom, &output);
+
+  EXPECT_FALSE(status.ok());
+  EXPECT_THAT(std::string(status.message()), HasSubstr("required ROM backup"));
+  EXPECT_THAT(output, HasSubstr("\"write_status\": \"success\""));
+  EXPECT_THAT(output, HasSubstr("\"save_error\""));
+  EXPECT_EQ(rom.vector(), before);
+  EXPECT_EQ(rom.dirty(), dirty_before);
+  EXPECT_EQ(rom.filename(), filename_before);
+  EXPECT_EQ(ReadRoomSpritePointerPc(rom, table_pc, 0), pointer_before);
+  EXPECT_EQ(ReadFile(cleanup.rom_path), disk_before);
+  EXPECT_FALSE(std::filesystem::exists(cleanup.rom_path.string() + ".tmp"));
+  EXPECT_EQ(CountBackupArtifacts(cleanup.rom_path), 0);
+#endif
+}
+
+TEST(DungeonEditCommandsTest,
      PlaceObjectDryRunMatchesManifestlessWriteFailure) {
   Rom rom;
   InitializeTightObjectRom(&rom);
@@ -493,6 +573,48 @@ TEST(DungeonEditCommandsTest,
   zelda3::Room untouched = zelda3::LoadRoomFromRom(&reopened, 1);
   EXPECT_TRUE(untouched.GetTileObjects().empty());
   EXPECT_EQ(ReadRoomObjectPointerPc(reopened, 1), kObjectDataPc + 10);
+}
+
+TEST(DungeonEditCommandsTest,
+     PlaceObjectDiskSaveFailureRollsBackCowPlanAndCallerRom) {
+  Rom rom;
+  InitializeTightObjectRom(&rom);
+  ScopedRomArtifactsCleanup cleanup(MakeUniqueTempRomPath());
+  ScopedFileCleanup manifest_cleanup(cleanup.rom_path.string() +
+                                     ".manifest.json");
+  WriteRomFile(rom, cleanup.rom_path);
+  WriteObjectCowManifest(manifest_cleanup.file_path);
+  rom.set_filename(cleanup.rom_path.string());
+  rom.set_dirty(false);
+  ASSERT_TRUE(
+      std::filesystem::create_directory(cleanup.rom_path.string() + ".tmp"));
+
+  const std::vector<uint8_t> before = rom.vector();
+  const std::vector<uint8_t> disk_before = ReadFile(cleanup.rom_path);
+  const int pointer_before = ReadRoomObjectPointerPc(rom, 0);
+  const bool dirty_before = rom.dirty();
+  const std::string filename_before = rom.filename();
+
+  handlers::DungeonPlaceObjectCommandHandler handler;
+  std::string output;
+  const absl::Status status = handler.Run(
+      {"--room=0x00", "--id=0x0031", "--x=1", "--y=2", "--size=6",
+       absl::StrFormat("--manifest=%s", manifest_cleanup.file_path.string()),
+       "--write", "--format=json"},
+      &rom, &output);
+
+  EXPECT_TRUE(absl::IsInternal(status)) << status;
+  EXPECT_THAT(std::string(status.message()),
+              HasSubstr("Could not open temp ROM file for writing"));
+  EXPECT_THAT(output, HasSubstr("\"preflight_status\": \"success\""));
+  EXPECT_THAT(output, HasSubstr("\"write_status\": \"success\""));
+  EXPECT_THAT(output, HasSubstr("\"save_error\""));
+  EXPECT_EQ(rom.vector(), before);
+  EXPECT_EQ(rom.dirty(), dirty_before);
+  EXPECT_EQ(rom.filename(), filename_before);
+  EXPECT_EQ(ReadRoomObjectPointerPc(rom, 0), pointer_before);
+  EXPECT_EQ(ReadFile(cleanup.rom_path), disk_before);
+  EXPECT_EQ(CountBackupArtifacts(cleanup.rom_path), 1);
 }
 
 TEST(DungeonEditCommandsTest,

--- a/test/unit/rom/rom_test.cc
+++ b/test/unit/rom/rom_test.cc
@@ -339,12 +339,9 @@ TEST_F(RomTest, BestEffortBackupFailureStillSaves) {
 TEST_F(RomTest, RequiredBackupFailureRollsBackTransactionAndLeavesNoArtifacts) {
   ScopedTempDirectory temp;
   const auto target = temp.path() / "target.sfc";
-  const auto missing_source = temp.path() / "missing-source.sfc";
-  const std::vector<uint8_t> disk_before = {0xAA, 0xBB, 0xCC};
-  WriteFileBytes(target, disk_before);
+  ASSERT_TRUE(std::filesystem::create_directory(target));
 
   EXPECT_OK(rom_.LoadFromData(kMockRomData));
-  rom_.set_filename(missing_source.string());
   const auto rom_before = rom_.vector();
   const bool dirty_before = rom_.dirty();
   const std::string filename_before = rom_.filename();
@@ -366,9 +363,38 @@ TEST_F(RomTest, RequiredBackupFailureRollsBackTransactionAndLeavesNoArtifacts) {
   EXPECT_EQ(rom_.vector(), rom_before);
   EXPECT_EQ(rom_.dirty(), dirty_before);
   EXPECT_EQ(rom_.filename(), filename_before);
-  EXPECT_EQ(ReadFileBytes(target), disk_before);
+  EXPECT_TRUE(std::filesystem::is_directory(target));
   EXPECT_FALSE(std::filesystem::exists(target.string() + ".tmp"));
   EXPECT_EQ(CountFilesWithPrefix(temp.path(), "target.sfc_backup_"), 0);
+}
+
+TEST_F(RomTest, RequiredBackupProtectsExistingSaveAsTarget) {
+  ScopedTempDirectory temp;
+  const auto source = temp.path() / "source.sfc";
+  const auto target = temp.path() / "target.sfc";
+  const std::vector<uint8_t> source_bytes = {0x10, 0x20, 0x30};
+  const std::vector<uint8_t> target_before = {0xAA, 0xBB, 0xCC};
+  WriteFileBytes(source, source_bytes);
+  WriteFileBytes(target, target_before);
+
+  EXPECT_OK(rom_.LoadFromData(kMockRomData));
+  rom_.set_filename(source.string());
+
+  Rom::SaveSettings settings;
+  settings.require_backup = true;
+  settings.filename = target.string();
+  EXPECT_OK(rom_.SaveToFile(settings));
+
+  EXPECT_EQ(ReadFileBytes(target), rom_.vector());
+  std::vector<std::filesystem::path> backups;
+  for (const auto& entry : std::filesystem::directory_iterator(temp.path())) {
+    if (entry.path().filename().string().rfind("target.sfc_backup_", 0) == 0) {
+      backups.push_back(entry.path());
+    }
+  }
+  ASSERT_EQ(backups.size(), 1);
+  EXPECT_EQ(ReadFileBytes(backups.front()), target_before);
+  EXPECT_EQ(CountFilesWithPrefix(temp.path(), "source.sfc_backup_"), 0);
 }
 
 TEST_F(RomTest, TransactionRollbackRestoresOriginals) {

--- a/test/unit/rom/rom_test.cc
+++ b/test/unit/rom/rom_test.cc
@@ -3,10 +3,12 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include <chrono>
 #include <filesystem>
 #include <fstream>
 #include <iterator>
 #include <string>
+#include <vector>
 
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
@@ -26,6 +28,57 @@ const static std::vector<uint8_t> kMockRomData = {
     0x0B, 0x0C, 0x0D, 0x0E, 0x0F, 0x10, 0x11, 0x12, 0x13, 0x14, 0x15,
     0x16, 0x17, 0x18, 0x19, 0x1A, 0x1B, 0x1C, 0x1D, 0x1E, 0x1F,
 };
+
+class ScopedTempDirectory {
+ public:
+  ScopedTempDirectory() {
+    const auto nonce =
+        std::chrono::steady_clock::now().time_since_epoch().count();
+    path_ = std::filesystem::temp_directory_path() /
+            ("yaze_rom_save_test_" + std::to_string(nonce));
+    std::filesystem::create_directories(path_);
+  }
+
+  ~ScopedTempDirectory() {
+    std::error_code ec;
+    std::filesystem::remove_all(path_, ec);
+  }
+
+  const std::filesystem::path& path() const { return path_; }
+
+ private:
+  std::filesystem::path path_;
+};
+
+std::vector<uint8_t> ReadFileBytes(const std::filesystem::path& path) {
+  std::ifstream input(path, std::ios::binary);
+  return std::vector<uint8_t>(std::istreambuf_iterator<char>(input),
+                              std::istreambuf_iterator<char>());
+}
+
+void WriteFileBytes(const std::filesystem::path& path,
+                    const std::vector<uint8_t>& bytes) {
+  std::ofstream output(path, std::ios::binary | std::ios::trunc);
+  ASSERT_TRUE(output.is_open());
+  output.write(reinterpret_cast<const char*>(bytes.data()),
+               static_cast<std::streamsize>(bytes.size()));
+  ASSERT_TRUE(output.good());
+}
+
+int CountFilesWithPrefix(const std::filesystem::path& directory,
+                         const std::string& prefix) {
+  std::error_code ec;
+  int count = 0;
+  for (const auto& entry : std::filesystem::directory_iterator(directory, ec)) {
+    if (ec) {
+      return count;
+    }
+    if (entry.path().filename().string().rfind(prefix, 0) == 0) {
+      ++count;
+    }
+  }
+  return count;
+}
 
 class RomTest : public ::testing::Test {
  protected:
@@ -261,6 +314,61 @@ TEST_F(RomTest, SaveTruncatesExistingFile) {
   EXPECT_EQ(file_bytes.size(), kMockRomData.size());
   ASSERT_FALSE(file_bytes.empty());
   EXPECT_EQ(file_bytes[0], 0xEE);
+}
+
+TEST_F(RomTest, BestEffortBackupFailureStillSaves) {
+  ScopedTempDirectory temp;
+  const auto target = temp.path() / "target.sfc";
+  const auto missing_source = temp.path() / "missing-source.sfc";
+  const std::vector<uint8_t> disk_before = {0xAA, 0xBB, 0xCC};
+  WriteFileBytes(target, disk_before);
+
+  EXPECT_OK(rom_.LoadFromData(kMockRomData));
+  EXPECT_OK(rom_.WriteByte(0, 0xEE));
+  rom_.set_filename(missing_source.string());
+
+  Rom::SaveSettings settings;
+  settings.backup = true;
+  settings.filename = target.string();
+  EXPECT_OK(rom_.SaveToFile(settings));
+
+  EXPECT_EQ(ReadFileBytes(target), rom_.vector());
+  EXPECT_EQ(CountFilesWithPrefix(temp.path(), "target.sfc_backup_"), 0);
+}
+
+TEST_F(RomTest, RequiredBackupFailureRollsBackTransactionAndLeavesNoArtifacts) {
+  ScopedTempDirectory temp;
+  const auto target = temp.path() / "target.sfc";
+  const auto missing_source = temp.path() / "missing-source.sfc";
+  const std::vector<uint8_t> disk_before = {0xAA, 0xBB, 0xCC};
+  WriteFileBytes(target, disk_before);
+
+  EXPECT_OK(rom_.LoadFromData(kMockRomData));
+  rom_.set_filename(missing_source.string());
+  const auto rom_before = rom_.vector();
+  const bool dirty_before = rom_.dirty();
+  const std::string filename_before = rom_.filename();
+
+  {
+    ScopedRomTransaction transaction(rom_);
+    EXPECT_OK(rom_.WriteByte(0, 0xEE));
+
+    Rom::SaveSettings settings;
+    settings.require_backup = true;
+    settings.filename = target.string();
+    const absl::Status status = rom_.SaveToFile(settings);
+
+    EXPECT_TRUE(absl::IsFailedPrecondition(status)) << status;
+    EXPECT_THAT(std::string(status.message()),
+                ::testing::HasSubstr("Could not create required ROM backup"));
+  }
+
+  EXPECT_EQ(rom_.vector(), rom_before);
+  EXPECT_EQ(rom_.dirty(), dirty_before);
+  EXPECT_EQ(rom_.filename(), filename_before);
+  EXPECT_EQ(ReadFileBytes(target), disk_before);
+  EXPECT_FALSE(std::filesystem::exists(target.string() + ".tmp"));
+  EXPECT_EQ(CountFilesWithPrefix(temp.path(), "target.sfc_backup_"), 0);
 }
 
 TEST_F(RomTest, TransactionRollbackRestoresOriginals) {


### PR DESCRIPTION
## Summary

- add an explicit `Rom::SaveSettings::require_backup` mode while preserving legacy best-effort `backup=true`
- back up the actual existing save target (including Save As destinations), not the originally loaded source
- create required backups through a unique same-directory temporary file, best-effort durability sync, and rename only after the copy completes
- wrap dungeon sprite/object/collision serialization plus backup and disk commit in `ScopedRomTransaction`
- restore caller ROM bytes, size, filename, dirty state, and stream pointers on serializer, backup, or target-write failure
- replace the Windows remove-then-rename fallback with `MoveFileExW(..., MOVEFILE_REPLACE_EXISTING)` so a failed replacement does not first delete the target

## Root cause

The dungeon edit handlers mutated their reusable in-memory `Rom` before calling the atomic disk save. A disk failure preserved the target file but left the caller's bytes and pointers mutated. Separately, `backup=true` logged and continued when backup creation failed, even for safety-critical writes.

## Commands covered

- `dungeon-place-sprite`
- `dungeon-remove-sprite`
- `dungeon-place-object`
- `dungeon-set-collision-tile`

Other CLI callers that use only `backup=true` intentionally remain best-effort pending their own transaction audit.

## Verification

- `cmake --build --preset mac-ai --target yaze_test_unit --parallel 8`
- focused ROM and dungeon edit suites: **44/44 passed**
- object COW mutation followed by target temp-write failure restores memory, filename, dirty state, pointer, and disk bytes
- deterministic required-backup failure restores a second handler and leaves no temp/backup artifact
- Save As regression proves an existing destination's original bytes, rather than the loaded source, are stored in the required backup
- existing successful object COW write still creates one backup and reopens correctly
- `YAZE_PREPUSH_BUILD_DIR=build/presets/mac-ai scripts/pre-push.sh`
- pre-commit formatting and release/version checks passed

Test note: the broader local filter also selected the pre-existing environment-sensitive `RomTest.LoadFromFile`; it found the available 1 MiB local vanilla fixture while that test expects 2 MiB. The task-focused filter excludes only that unrelated fixture check.

Fixes #123
