### PR TITLE
fix(cli): make dungeon room-property writes transactional

### DIFF
--- a/docs/internal/agents/rom-safety-guardrails.md
+++ b/docs/internal/agents/rom-safety-guardrails.md
@@ -20,10 +20,10 @@ This repo is used to edit ROM hacks (including Oracle of Secrets). Treat ROM wri
   completes; failure returns before the ROM target is replaced. A new target
   has no previous bytes to back up. A completed required backup is retained if
   the later target write fails, so recovery bytes remain available.
-- `dungeon-place-sprite`, `dungeon-remove-sprite`, `dungeon-place-object`, and
-  `dungeon-set-collision-tile` wrap their serializer, required backup, and disk
-  commit in `ScopedRomTransaction`. Any failure restores the caller's ROM
-  bytes, filename, size, and dirty state.
+- `dungeon-place-sprite`, `dungeon-remove-sprite`, `dungeon-place-object`,
+  `dungeon-set-collision-tile`, and `dungeon-set-room-property` wrap their
+  serializer, required backup, and disk commit in `ScopedRomTransaction`. Any
+  failure restores the caller's ROM bytes, filename, size, and dirty state.
 - Other CLI writers that still set only `backup=true` remain best-effort and
   must be audited before opting into the strict transaction path.
 

--- a/src/cli/handlers/game/dungeon_commands.cc
+++ b/src/cli/handlers/game/dungeon_commands.cc
@@ -11,6 +11,7 @@
 #include "cli/util/hex_util.h"
 #include "rom/rom.h"
 #include "rom/snes.h"
+#include "rom/transaction.h"
 #include "util/macro.h"
 #include "zelda3/dungeon/custom_collision.h"
 #include "zelda3/dungeon/dungeon_editor_system.h"
@@ -596,37 +597,47 @@ absl::Status DungeonSetRoomPropertyCommandHandler::Execute(
   formatter.AddField("property", property);
   formatter.AddField("value", value);
 
-  // Use existing dungeon system
-  zelda3::DungeonEditorSystem dungeon_editor(rom);
-  auto room_or = dungeon_editor.GetRoom(room_id);
-  if (!room_or.ok()) {
+  if (room_id < 0 || room_id >= zelda3::kNumberOfRooms) {
+    const absl::Status room_status =
+        absl::InvalidArgumentError("Invalid room ID");
     formatter.AddField("status", "error");
-    formatter.AddField("error", room_or.status().ToString());
+    formatter.AddField("error", room_status.ToString());
     formatter.EndObject();
-    return room_or.status();
+    return room_status;
   }
-
-  auto& room = room_or.value();
 
   int parsed_value = 0;
   if (!ParseHexString(value, &parsed_value)) {
-    return absl::InvalidArgumentError(absl::StrFormat(
-        "Invalid value format: %s (expected integer/hex)", value));
+    const absl::Status value_status =
+        absl::InvalidArgumentError(absl::StrFormat(
+            "Invalid value format: %s (expected integer/hex)", value));
+    formatter.AddField("status", "error");
+    formatter.AddField("error", std::string(value_status.message()));
+    formatter.EndObject();
+    return value_status;
   }
 
   const std::string prop = absl::AsciiStrToLower(property);
+  if (prop == "layout" || prop == "layout_id" || prop == "floor1" ||
+      prop == "floor2") {
+    const absl::Status property_status = absl::UnimplementedError(
+        absl::StrFormat("Property %s is stored in the dungeon object-stream "
+                        "header; persistence is not implemented",
+                        property));
+    formatter.AddField("status", "error");
+    formatter.AddField("error", std::string(property_status.message()));
+    formatter.EndObject();
+    return property_status;
+  }
+
+  zelda3::Room room = zelda3::LoadRoomHeaderFromRom(rom, room_id);
+  ScopedRomTransaction transaction(*rom);
   if (prop == "palette") {
     room.SetPalette(static_cast<uint8_t>(parsed_value & 0xFF));
   } else if (prop == "blockset") {
     room.SetBlockset(static_cast<uint8_t>(parsed_value & 0xFF));
   } else if (prop == "spriteset") {
     room.SetSpriteset(static_cast<uint8_t>(parsed_value & 0xFF));
-  } else if (prop == "layout" || prop == "layout_id") {
-    room.SetLayoutId(static_cast<uint8_t>(parsed_value & 0xFF));
-  } else if (prop == "floor1") {
-    room.set_floor1(static_cast<uint8_t>(parsed_value & 0xFF));
-  } else if (prop == "floor2") {
-    room.set_floor2(static_cast<uint8_t>(parsed_value & 0xFF));
   } else if (prop == "effect") {
     room.SetEffect(static_cast<zelda3::EffectKey>(parsed_value & 0xFF));
   } else if (prop == "tag1") {
@@ -636,21 +647,39 @@ absl::Status DungeonSetRoomPropertyCommandHandler::Execute(
   } else if (prop == "holewarp") {
     room.SetHolewarp(static_cast<uint8_t>(parsed_value & 0xFF));
   } else {
-    return absl::InvalidArgumentError(
+    const absl::Status property_status = absl::InvalidArgumentError(
         absl::StrFormat("Unsupported property: %s", property));
+    formatter.AddField("status", "error");
+    formatter.AddField("error", std::string(property_status.message()));
+    formatter.EndObject();
+    return property_status;
   }
 
-  RETURN_IF_ERROR(room.SaveRoomHeader());
+  const absl::Status write_status = room.SaveRoomHeader();
+  if (!write_status.ok()) {
+    formatter.AddField("status", "error");
+    formatter.AddField("write_error", std::string(write_status.message()));
+    formatter.EndObject();
+    return write_status;
+  }
 
-  formatter.AddField("status", "success");
   if (parser.HasFlag("mock-rom")) {
+    transaction.Commit();
     formatter.AddField("save_status", "mock-rom-skipped");
   } else {
     Rom::SaveSettings save_settings;
-    save_settings.backup = true;
-    RETURN_IF_ERROR(rom->SaveToFile(save_settings));
+    save_settings.require_backup = true;
+    const absl::Status save_status = rom->SaveToFile(save_settings);
+    if (!save_status.ok()) {
+      formatter.AddField("status", "error");
+      formatter.AddField("save_error", std::string(save_status.message()));
+      formatter.EndObject();
+      return save_status;
+    }
+    transaction.Commit();
     formatter.AddField("save_status", "saved");
   }
+  formatter.AddField("status", "success");
   formatter.EndObject();
 
   return absl::OkStatus();

--- a/src/zelda3/dungeon/room.cc
+++ b/src/zelda3/dungeon/room.cc
@@ -2214,7 +2214,8 @@ absl::Status Room::SaveRoomHeader() {
       IsLight() || is_dark_ || bg2() == background2::DarkRoom;
   uint8_t byte0 = static_cast<uint8_t>(
       (layer2_mode_for_save << 5) |
-      ((static_cast<uint8_t>(collision()) & 0x07) << 2) | (dark_room ? 1 : 0));
+      ((static_cast<uint8_t>(collision()) & 0x07) << 2) |
+      (rom_data[header_location] & 0x02) | (dark_room ? 1 : 0));
   // Preserve the full palette set ID byte (USDASM LoadRoomHeader uses 8-bit).
   uint8_t byte1 = palette_;
   // Byte 7 stores the pit target layer in bits 0-1 followed by the first
@@ -2222,6 +2223,8 @@ absl::Status Room::SaveRoomHeader() {
   uint8_t byte7 =
       (pits_.target_layer & 0x03) | ((staircase_plane(0) & 0x03) << 2) |
       ((staircase_plane(1) & 0x03) << 4) | ((staircase_plane(2) & 0x03) << 6);
+  const uint8_t byte8 = static_cast<uint8_t>(
+      (rom_data[header_location + 8] & 0xFC) | (staircase_plane(3) & 0x03));
 
   RETURN_IF_ERROR(rom_->WriteByte(header_location + 0, byte0));
   RETURN_IF_ERROR(rom_->WriteByte(header_location + 1, byte1));
@@ -2234,7 +2237,7 @@ absl::Status Room::SaveRoomHeader() {
   RETURN_IF_ERROR(
       rom_->WriteByte(header_location + 6, static_cast<uint8_t>(tag2())));
   RETURN_IF_ERROR(rom_->WriteByte(header_location + 7, byte7));
-  RETURN_IF_ERROR(rom_->WriteByte(header_location + 8, staircase_plane(3)));
+  RETURN_IF_ERROR(rom_->WriteByte(header_location + 8, byte8));
   RETURN_IF_ERROR(rom_->WriteByte(header_location + 9, holewarp_));
   RETURN_IF_ERROR(rom_->WriteByte(header_location + 10, staircase_room(0)));
   RETURN_IF_ERROR(rom_->WriteByte(header_location + 11, staircase_room(1)));

--- a/test/unit/cli/dungeon_edit_commands_test.cc
+++ b/test/unit/cli/dungeon_edit_commands_test.cc
@@ -1,6 +1,7 @@
 #include "cli/handlers/game/dungeon_edit_commands.h"
 #include "cli/handlers/game/dungeon_commands.h"
 
+#include <array>
 #include <chrono>
 #include <cstdint>
 #include <filesystem>
@@ -13,6 +14,7 @@
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
+#include <nlohmann/json.hpp>
 
 #include "absl/status/status.h"
 #include "absl/strings/str_format.h"
@@ -37,6 +39,13 @@ constexpr int kObjectDataPc = 0x060000;
 constexpr int kObjectAllocationPc = 0x060100;
 constexpr int kObjectDataEndPc = 0x060200;
 constexpr int kSyntheticPotTerminatorPc = 0x00F000;
+constexpr int kRoomHeaderPointerTablePc = 0x020000;
+constexpr int kRoomHeaderDataPc = 0x021000;
+constexpr std::array<uint8_t, 14> kRoomHeaderSentinel = {
+    0xAF, 0x11, 0x22, 0x33, 0x04, 0x05, 0x06,
+    0xE4, 0xCF, 0x77, 0x88, 0x99, 0xAA, 0xBB,
+};
+constexpr uint16_t kRoomMessageSentinel = 0xDDCC;
 
 void ExpectInvalidArgument(const absl::Status& status,
                            const std::string& message_fragment) {
@@ -52,22 +61,27 @@ std::filesystem::path MakeUniqueTempRomPath() {
           ".sfc");
 }
 
-int CountBackupArtifacts(const std::filesystem::path& rom_path) {
+std::vector<std::filesystem::path> FindBackupArtifacts(
+    const std::filesystem::path& rom_path) {
   std::error_code ec;
   const auto parent = rom_path.parent_path();
   const std::string prefix = rom_path.filename().string() + "_backup_";
 
-  int count = 0;
+  std::vector<std::filesystem::path> backups;
   for (const auto& entry : std::filesystem::directory_iterator(parent, ec)) {
     if (ec || !entry.is_regular_file()) {
       continue;
     }
     const std::string filename = entry.path().filename().string();
     if (filename.rfind(prefix, 0) == 0) {
-      ++count;
+      backups.push_back(entry.path());
     }
   }
-  return count;
+  return backups;
+}
+
+int CountBackupArtifacts(const std::filesystem::path& rom_path) {
+  return static_cast<int>(FindBackupArtifacts(rom_path).size());
 }
 
 void CleanupRomArtifacts(const std::filesystem::path& rom_path) {
@@ -125,6 +139,28 @@ void WriteLong(Rom* rom, int address, uint32_t value) {
   rom->mutable_data()[address] = value & 0xFF;
   rom->mutable_data()[address + 1] = (value >> 8) & 0xFF;
   rom->mutable_data()[address + 2] = (value >> 16) & 0xFF;
+}
+
+void InitializeRoomHeaderRom(Rom* rom) {
+  ASSERT_TRUE(rom->LoadFromData(std::vector<uint8_t>(0x100000, 0x00)).ok());
+
+  const uint32_t table_snes = PcToSnes(kRoomHeaderPointerTablePc);
+  const uint32_t header_snes = PcToSnes(kRoomHeaderDataPc);
+  WriteLong(rom, zelda3::kRoomHeaderPointer, table_snes);
+  rom->mutable_data()[zelda3::kRoomHeaderPointerBank] =
+      (header_snes >> 16) & 0xFF;
+  for (int room_id = 0; room_id < zelda3::kNumberOfRooms; ++room_id) {
+    const int pointer = kRoomHeaderPointerTablePc + room_id * 2;
+    rom->mutable_data()[pointer] = header_snes & 0xFF;
+    rom->mutable_data()[pointer + 1] = (header_snes >> 8) & 0xFF;
+  }
+  for (size_t index = 0; index < kRoomHeaderSentinel.size(); ++index) {
+    rom->mutable_data()[kRoomHeaderDataPc + index] = kRoomHeaderSentinel[index];
+  }
+  rom->mutable_data()[zelda3::kMessagesIdDungeon] = kRoomMessageSentinel & 0xFF;
+  rom->mutable_data()[zelda3::kMessagesIdDungeon + 1] =
+      (kRoomMessageSentinel >> 8) & 0xFF;
+  rom->set_dirty(false);
 }
 
 void SetRoomObjectPointer(Rom* rom, int room_id, int pc_addr) {
@@ -349,6 +385,267 @@ TEST(DungeonEditCommandsTest, SetCollisionTileRejectsMalformedTileTuple) {
       &output);
 
   ExpectInvalidArgument(status, "Invalid tile spec");
+}
+
+TEST(DungeonEditCommandsTest,
+     SetRoomPropertyRejectsMalformedValueWithStructuredError) {
+  Rom rom;
+  InitializeRoomHeaderRom(&rom);
+  const std::vector<uint8_t> before = rom.vector();
+
+  handlers::DungeonSetRoomPropertyCommandHandler handler;
+  std::string output;
+  const absl::Status status =
+      handler.Run({"--mock-rom", "--room=0x00", "--property=palette",
+                   "--value=nope", "--format=json"},
+                  &rom, &output);
+
+  ExpectInvalidArgument(status, "Invalid value format");
+  const auto report = nlohmann::json::parse(output);
+  const auto& result = report.at("Dungeon Room Property Set");
+  EXPECT_EQ(result.at("status"), "error");
+  EXPECT_THAT(result.at("error").get<std::string>(),
+              HasSubstr("Invalid value format"));
+  EXPECT_EQ(rom.vector(), before);
+  EXPECT_FALSE(rom.dirty());
+}
+
+TEST(DungeonEditCommandsTest,
+     SetRoomPropertyRejectsUnsupportedPropertyWithStructuredError) {
+  Rom rom;
+  InitializeRoomHeaderRom(&rom);
+  const std::vector<uint8_t> before = rom.vector();
+
+  handlers::DungeonSetRoomPropertyCommandHandler handler;
+  std::string output;
+  const absl::Status status =
+      handler.Run({"--mock-rom", "--room=0x00", "--property=unknown",
+                   "--value=0x01", "--format=json"},
+                  &rom, &output);
+
+  ExpectInvalidArgument(status, "Unsupported property");
+  const auto report = nlohmann::json::parse(output);
+  const auto& result = report.at("Dungeon Room Property Set");
+  EXPECT_EQ(result.at("status"), "error");
+  EXPECT_THAT(result.at("error").get<std::string>(),
+              HasSubstr("Unsupported property"));
+  EXPECT_EQ(rom.vector(), before);
+  EXPECT_FALSE(rom.dirty());
+}
+
+TEST(DungeonEditCommandsTest,
+     SetRoomPropertyRejectsOutOfRangeRoomIdWithoutMutation) {
+  Rom rom;
+  InitializeRoomHeaderRom(&rom);
+  const std::vector<uint8_t> before = rom.vector();
+
+  handlers::DungeonSetRoomPropertyCommandHandler handler;
+  std::string output;
+  const absl::Status status =
+      handler.Run({"--mock-rom", "--room=0x128", "--property=palette",
+                   "--value=0x01", "--format=json"},
+                  &rom, &output);
+
+  ExpectInvalidArgument(status, "Invalid room ID");
+  const auto report = nlohmann::json::parse(output);
+  const auto& result = report.at("Dungeon Room Property Set");
+  EXPECT_EQ(result.at("status"), "error");
+  EXPECT_THAT(result.at("error").get<std::string>(),
+              HasSubstr("Invalid room ID"));
+  EXPECT_EQ(rom.vector(), before);
+  EXPECT_FALSE(rom.dirty());
+}
+
+TEST(DungeonEditCommandsTest, SetRoomPropertyMockRomCommitsSerializedHeader) {
+  Rom rom;
+  InitializeRoomHeaderRom(&rom);
+
+  handlers::DungeonSetRoomPropertyCommandHandler handler;
+  std::string output;
+  const absl::Status status =
+      handler.Run({"--mock-rom", "--room=0x00", "--property=palette",
+                   "--value=0x02", "--format=json"},
+                  &rom, &output);
+
+  ASSERT_TRUE(status.ok()) << status;
+  EXPECT_EQ(rom.data()[kRoomHeaderDataPc + 1], 0x02);
+  EXPECT_TRUE(rom.dirty());
+  EXPECT_THAT(output, HasSubstr("\"save_status\": \"mock-rom-skipped\""));
+}
+
+TEST(DungeonEditCommandsTest,
+     SetRoomPropertyRejectsUnimplementedObjectStreamPropertiesWithoutMutation) {
+  for (const std::string property :
+       {"layout", "layout_id", "floor1", "floor2"}) {
+    SCOPED_TRACE(property);
+    Rom rom;
+    InitializeRoomHeaderRom(&rom);
+    ScopedRomArtifactsCleanup cleanup(MakeUniqueTempRomPath());
+    WriteRomFile(rom, cleanup.rom_path);
+    rom.set_filename(cleanup.rom_path.string());
+    rom.set_dirty(false);
+
+    const std::vector<uint8_t> before = rom.vector();
+    const std::vector<uint8_t> disk_before = ReadFile(cleanup.rom_path);
+    const std::string filename_before = rom.filename();
+
+    handlers::DungeonSetRoomPropertyCommandHandler handler;
+    std::string output;
+    const absl::Status status =
+        handler.Run({"--room=0x00", "--property=" + property, "--value=0x02",
+                     "--format=json"},
+                    &rom, &output);
+
+    EXPECT_TRUE(absl::IsUnimplemented(status)) << status;
+    EXPECT_THAT(std::string(status.message()),
+                HasSubstr("object-stream header"));
+    EXPECT_THAT(std::string(status.message()),
+                HasSubstr("persistence is not implemented"));
+    EXPECT_THAT(output, HasSubstr("\"status\": \"error\""));
+    EXPECT_THAT(output, HasSubstr("\"error\""));
+    EXPECT_EQ(rom.vector(), before);
+    EXPECT_FALSE(rom.dirty());
+    EXPECT_EQ(rom.filename(), filename_before);
+    EXPECT_EQ(ReadFile(cleanup.rom_path), disk_before);
+    EXPECT_EQ(CountBackupArtifacts(cleanup.rom_path), 0);
+  }
+}
+
+TEST(DungeonEditCommandsTest,
+     SetRoomPropertyRequiredBackupFailureRollsBackCallerRom) {
+#if defined(_WIN32)
+  GTEST_SKIP() << "NAME_MAX backup failure fixture is POSIX-only";
+#else
+  Rom rom;
+  InitializeRoomHeaderRom(&rom);
+
+  const auto parent = std::filesystem::temp_directory_path();
+  const long name_max = pathconf(parent.c_str(), _PC_NAME_MAX);
+  if (name_max < 128) {
+    GTEST_SKIP() << "Filesystem does not expose a usable NAME_MAX";
+  }
+  const auto nonce =
+      std::chrono::steady_clock::now().time_since_epoch().count();
+  std::string filename = "yaze_room_property_backup_" + std::to_string(nonce);
+  const size_t target_length = static_cast<size_t>(name_max) - 4;
+  ASSERT_LT(filename.size(), target_length);
+  filename.append(target_length - filename.size(), 'r');
+
+  ScopedRomArtifactsCleanup cleanup(parent / filename);
+  WriteRomFile(rom, cleanup.rom_path);
+  rom.set_filename(cleanup.rom_path.string());
+  rom.set_dirty(false);
+
+  const std::vector<uint8_t> before = rom.vector();
+  const std::vector<uint8_t> disk_before = ReadFile(cleanup.rom_path);
+  const size_t size_before = rom.size();
+  const bool dirty_before = rom.dirty();
+  const std::string filename_before = rom.filename();
+
+  handlers::DungeonSetRoomPropertyCommandHandler handler;
+  std::string output;
+  const absl::Status status = handler.Run(
+      {"--room=0x00", "--property=palette", "--value=0x02", "--format=json"},
+      &rom, &output);
+
+  EXPECT_FALSE(status.ok());
+  EXPECT_THAT(std::string(status.message()), HasSubstr("required ROM backup"));
+  EXPECT_THAT(output, HasSubstr("\"status\": \"error\""));
+  EXPECT_THAT(output, HasSubstr("\"save_error\""));
+  EXPECT_EQ(rom.vector(), before);
+  EXPECT_EQ(rom.size(), size_before);
+  EXPECT_EQ(rom.dirty(), dirty_before);
+  EXPECT_EQ(rom.filename(), filename_before);
+  EXPECT_EQ(ReadFile(cleanup.rom_path), disk_before);
+  EXPECT_FALSE(std::filesystem::exists(cleanup.rom_path.string() + ".tmp"));
+  EXPECT_EQ(CountBackupArtifacts(cleanup.rom_path), 0);
+#endif
+}
+
+TEST(DungeonEditCommandsTest,
+     SetRoomPropertyDiskSaveFailureRollsBackCallerRom) {
+  Rom rom;
+  InitializeRoomHeaderRom(&rom);
+  ScopedRomArtifactsCleanup cleanup(MakeUniqueTempRomPath());
+  WriteRomFile(rom, cleanup.rom_path);
+  rom.set_filename(cleanup.rom_path.string());
+  rom.set_dirty(false);
+  ASSERT_TRUE(
+      std::filesystem::create_directory(cleanup.rom_path.string() + ".tmp"));
+
+  const std::vector<uint8_t> before = rom.vector();
+  const std::vector<uint8_t> disk_before = ReadFile(cleanup.rom_path);
+  const size_t size_before = rom.size();
+  const bool dirty_before = rom.dirty();
+  const std::string filename_before = rom.filename();
+
+  handlers::DungeonSetRoomPropertyCommandHandler handler;
+  std::string output;
+  const absl::Status status = handler.Run(
+      {"--room=0x00", "--property=palette", "--value=0x02", "--format=json"},
+      &rom, &output);
+
+  EXPECT_TRUE(absl::IsInternal(status)) << status;
+  EXPECT_THAT(std::string(status.message()),
+              HasSubstr("Could not open temp ROM file for writing"));
+  EXPECT_THAT(output, HasSubstr("\"status\": \"error\""));
+  EXPECT_THAT(output, HasSubstr("\"save_error\""));
+  EXPECT_EQ(rom.vector(), before);
+  EXPECT_EQ(rom.size(), size_before);
+  EXPECT_EQ(rom.dirty(), dirty_before);
+  EXPECT_EQ(rom.filename(), filename_before);
+  EXPECT_EQ(ReadFile(cleanup.rom_path), disk_before);
+  const auto backups = FindBackupArtifacts(cleanup.rom_path);
+  ASSERT_EQ(backups.size(), 1u);
+  EXPECT_EQ(ReadFile(backups.front()), disk_before);
+}
+
+TEST(DungeonEditCommandsTest, SetRoomPropertySavesBackupAndReopens) {
+  Rom rom;
+  InitializeRoomHeaderRom(&rom);
+  ScopedRomArtifactsCleanup cleanup(MakeUniqueTempRomPath());
+  WriteRomFile(rom, cleanup.rom_path);
+  rom.set_filename(cleanup.rom_path.string());
+  const std::vector<uint8_t> disk_before = ReadFile(cleanup.rom_path);
+
+  handlers::DungeonSetRoomPropertyCommandHandler handler;
+  std::string output;
+  const absl::Status status = handler.Run(
+      {"--room=0x00", "--property=palette", "--value=0x02", "--format=json"},
+      &rom, &output);
+
+  ASSERT_TRUE(status.ok()) << status;
+  EXPECT_THAT(output, HasSubstr("\"save_status\": \"saved\""));
+  std::vector<uint8_t> expected = disk_before;
+  expected[kRoomHeaderDataPc + 1] = 0x02;
+  EXPECT_EQ(rom.vector(), expected);
+  EXPECT_EQ(ReadFile(cleanup.rom_path), expected);
+  EXPECT_FALSE(rom.dirty());
+  const auto backups = FindBackupArtifacts(cleanup.rom_path);
+  ASSERT_EQ(backups.size(), 1u);
+  EXPECT_EQ(ReadFile(backups.front()), disk_before);
+
+  Rom reopened;
+  ASSERT_TRUE(reopened.LoadFromFile(cleanup.rom_path.string()).ok());
+  const zelda3::Room room = zelda3::LoadRoomHeaderFromRom(&reopened, 0);
+  EXPECT_EQ(room.bg2(), background2::DarkRoom);
+  EXPECT_EQ(room.collision(), static_cast<zelda3::CollisionKey>(3));
+  EXPECT_EQ(room.palette(), 0x02);
+  EXPECT_EQ(room.blockset(), 0x22);
+  EXPECT_EQ(room.spriteset(), 0x33);
+  EXPECT_EQ(room.effect(), static_cast<zelda3::EffectKey>(0x04));
+  EXPECT_EQ(room.tag1(), static_cast<zelda3::TagKey>(0x05));
+  EXPECT_EQ(room.tag2(), static_cast<zelda3::TagKey>(0x06));
+  EXPECT_EQ(room.staircase_plane(0), 0x01);
+  EXPECT_EQ(room.staircase_plane(1), 0x02);
+  EXPECT_EQ(room.staircase_plane(2), 0x03);
+  EXPECT_EQ(room.staircase_plane(3), 0x03);
+  EXPECT_EQ(room.holewarp(), 0x77);
+  EXPECT_EQ(room.staircase_room(0), 0x88);
+  EXPECT_EQ(room.staircase_room(1), 0x99);
+  EXPECT_EQ(room.staircase_room(2), 0xAA);
+  EXPECT_EQ(room.staircase_room(3), 0xBB);
+  EXPECT_EQ(room.message_id(), kRoomMessageSentinel);
 }
 
 TEST(DungeonEditCommandsTest,

--- a/test/unit/zelda3/dungeon/room_header_palette_test.cc
+++ b/test/unit/zelda3/dungeon/room_header_palette_test.cc
@@ -120,5 +120,19 @@ TEST(RoomHeaderPaletteTest,
   EXPECT_EQ(rom.vector(), before);
 }
 
+TEST(RoomHeaderPaletteTest, ReservedHeaderBitsRoundTripExactly) {
+  constexpr uint8_t byte0 = static_cast<uint8_t>((5 << 5) | (3 << 2) | 0x03);
+  Rom rom;
+  auto data = BuildHeaderRomData(byte0, /*palette_id=*/0x00);
+  data.dummy_rom[data.header_pc + 8] = 0xFE;
+  ASSERT_TRUE(rom.LoadFromData(data.dummy_rom).ok());
+
+  Room room = LoadRoomHeaderFromRom(&rom, kTestRoomId);
+  const std::vector<uint8_t> before = rom.vector();
+
+  ASSERT_TRUE(room.SaveRoomHeader().ok());
+  EXPECT_EQ(rom.vector(), before);
+}
+
 }  // namespace
 }  // namespace yaze::zelda3::test


### PR DESCRIPTION
## Summary

- wrap `dungeon-set-room-property` serialization, required backup, and disk replacement in `ScopedRomTransaction`
- load the existing room header before mutation so unrelated fields are not reset
- preserve room-header byte 0 bit 1 and byte 8 upper bits during normal header round-trips
- return closed, parseable structured errors on invalid values and unsupported properties
- fail `layout` / `floor1` / `floor2` closed until their object-stream-header persistence contract lands in #129

## Safety contract

- serializer, required-backup, and target-write failures restore caller bytes, size, filename, and dirty state
- a later target-write failure retains the completed recovery backup
- successful real writes create a destination backup and reopen with only the requested property changed
- `--mock-rom` commits the serialized in-memory edit without disk access

## Verification

- `cmake --build --preset mac-ai --target yaze_test_unit --parallel 8`
- focused room-property/header suite: **15/15 passed**
- disposable vanilla room `0x03` write changed only the requested palette byte; unrelated header byte 8 remained intact
- `YAZE_PREPUSH_BUILD_DIR=build/presets/mac-ai scripts/pre-push.sh`
- `git show --check`

Fixes #126
Follow-up: #129
