### PR TITLE
fix(rom): back up the legacy Save As destination

### DIFF
--- a/docs/internal/agents/rom-safety-guardrails.md
+++ b/docs/internal/agents/rom-safety-guardrails.md
@@ -13,7 +13,9 @@ This repo is used to edit ROM hacks (including Oracle of Secrets). Treat ROM wri
 
 ## CLI Save Transaction Contract
 
-- `Rom::SaveSettings::backup` keeps its legacy best-effort behavior.
+- `Rom::SaveSettings::backup` is best-effort: an existing save destination is
+  copied before replacement, a new destination has no prior bytes to back up,
+  and backup failure is logged without blocking the save.
 - Safety-critical CLI writes can set `require_backup=true`. If the save target
   already exists, that target (including a Save As destination) is copied to a
   same-directory temporary path and renamed into place only after the copy

--- a/src/rom/rom.cc
+++ b/src/rom/rom.cc
@@ -378,9 +378,9 @@ absl::Status Rom::SaveToFile(const SaveSettings& settings) {
     filename = filename_;
   }
 
-  // Strict mode must reason about the actual destination, including the
+  // Backup modes must reason about the actual destination, including the
   // timestamped path selected by save_new.
-  if (settings.require_backup && settings.save_new) {
+  if (settings.save_new) {
     auto now = std::chrono::system_clock::now();
     auto now_c = std::chrono::system_clock::to_time_t(now);
     auto filename_no_ext = filename.substr(0, filename.find_last_of("."));
@@ -408,25 +408,22 @@ absl::Status Rom::SaveToFile(const SaveSettings& settings) {
       RETURN_IF_ERROR(CreateRequiredBackup(target_path, backup_filename));
     }
   } else if (settings.backup) {
-    auto now = std::chrono::system_clock::now();
-    auto now_c = std::chrono::system_clock::to_time_t(now);
-    std::string backup_filename =
-        absl::StrCat(filename, "_backup_", MakeSafeTimestamp(now_c));
-
     try {
-      std::filesystem::copy(filename_, backup_filename,
-                            std::filesystem::copy_options::overwrite_existing);
+      const std::filesystem::path target_path(filename);
+      // Best-effort backups protect the file about to be replaced. A new
+      // destination has no previous bytes to preserve.
+      if (std::filesystem::exists(target_path)) {
+        auto now = std::chrono::system_clock::now();
+        auto now_c = std::chrono::system_clock::to_time_t(now);
+        std::string backup_filename =
+            absl::StrCat(filename, "_backup_", MakeSafeTimestamp(now_c));
+        std::filesystem::copy(
+            target_path, backup_filename,
+            std::filesystem::copy_options::overwrite_existing);
+      }
     } catch (const std::filesystem::filesystem_error& e) {
       LOG_WARN("Rom", "Could not create backup: %s", e.what());
     }
-  }
-
-  if (settings.save_new && !settings.require_backup) {
-    auto now = std::chrono::system_clock::now();
-    auto now_c = std::chrono::system_clock::to_time_t(now);
-    auto filename_no_ext = filename.substr(0, filename.find_last_of("."));
-    filename =
-        absl::StrCat(filename_no_ext, "_", MakeSafeTimestamp(now_c), ".sfc");
   }
 
   // Save stability: write to a temp file in the same directory and rename into

--- a/src/rom/rom.h
+++ b/src/rom/rom.h
@@ -31,10 +31,10 @@ class Rom {
     bool backup = false;
     bool save_new = false;
     std::string filename;
-    // Unlike the legacy best-effort `backup` flag, back up an existing save
-    // target and fail before replacing it if that backup cannot be created.
-    // A new target has no previous bytes to protect. This implies backup
-    // creation when `backup` is false.
+    // Require a successful backup of an existing save target before replacing
+    // it. Unlike the legacy best-effort `backup` flag, backup failure aborts
+    // the save. A new target has no previous bytes to protect. This implies
+    // backup creation when `backup` is false.
     bool require_backup = false;
   };
 

--- a/test/unit/rom/rom_test.cc
+++ b/test/unit/rom/rom_test.cc
@@ -17,6 +17,10 @@
 #include "test_utils.h"
 #include "testing.h"
 
+#if !defined(_WIN32)
+#include <unistd.h>
+#endif
+
 namespace yaze {
 namespace test {
 
@@ -78,6 +82,21 @@ int CountFilesWithPrefix(const std::filesystem::path& directory,
     }
   }
   return count;
+}
+
+std::vector<std::filesystem::path> FindFilesWithPrefix(
+    const std::filesystem::path& directory, const std::string& prefix) {
+  std::vector<std::filesystem::path> matches;
+  std::error_code ec;
+  for (const auto& entry : std::filesystem::directory_iterator(directory, ec)) {
+    if (ec) {
+      break;
+    }
+    if (entry.path().filename().string().rfind(prefix, 0) == 0) {
+      matches.push_back(entry.path());
+    }
+  }
+  return matches;
 }
 
 class RomTest : public ::testing::Test {
@@ -316,16 +335,38 @@ TEST_F(RomTest, SaveTruncatesExistingFile) {
   EXPECT_EQ(file_bytes[0], 0xEE);
 }
 
-TEST_F(RomTest, BestEffortBackupFailureStillSaves) {
+TEST_F(RomTest, BestEffortBackupProtectsExistingSaveAsTarget) {
   ScopedTempDirectory temp;
+  const auto source = temp.path() / "source.sfc";
   const auto target = temp.path() / "target.sfc";
-  const auto missing_source = temp.path() / "missing-source.sfc";
-  const std::vector<uint8_t> disk_before = {0xAA, 0xBB, 0xCC};
-  WriteFileBytes(target, disk_before);
+  const std::vector<uint8_t> source_bytes = {0x10, 0x20, 0x30};
+  const std::vector<uint8_t> target_before = {0xAA, 0xBB, 0xCC};
+  WriteFileBytes(source, source_bytes);
+  WriteFileBytes(target, target_before);
 
   EXPECT_OK(rom_.LoadFromData(kMockRomData));
-  EXPECT_OK(rom_.WriteByte(0, 0xEE));
-  rom_.set_filename(missing_source.string());
+  rom_.set_filename(source.string());
+
+  Rom::SaveSettings settings;
+  settings.backup = true;
+  settings.filename = target.string();
+  EXPECT_OK(rom_.SaveToFile(settings));
+
+  EXPECT_EQ(ReadFileBytes(target), rom_.vector());
+  const auto backups = FindFilesWithPrefix(temp.path(), "target.sfc_backup_");
+  ASSERT_EQ(backups.size(), 1);
+  EXPECT_EQ(ReadFileBytes(backups.front()), target_before);
+  EXPECT_EQ(CountFilesWithPrefix(temp.path(), "source.sfc_backup_"), 0);
+}
+
+TEST_F(RomTest, BestEffortBackupSkipsMissingSaveAsTarget) {
+  ScopedTempDirectory temp;
+  const auto source = temp.path() / "source.sfc";
+  const auto target = temp.path() / "target.sfc";
+  WriteFileBytes(source, {0x10, 0x20, 0x30});
+
+  EXPECT_OK(rom_.LoadFromData(kMockRomData));
+  rom_.set_filename(source.string());
 
   Rom::SaveSettings settings;
   settings.backup = true;
@@ -334,6 +375,75 @@ TEST_F(RomTest, BestEffortBackupFailureStillSaves) {
 
   EXPECT_EQ(ReadFileBytes(target), rom_.vector());
   EXPECT_EQ(CountFilesWithPrefix(temp.path(), "target.sfc_backup_"), 0);
+  EXPECT_EQ(CountFilesWithPrefix(temp.path(), "source.sfc_backup_"), 0);
+}
+
+TEST_F(RomTest, BestEffortBackupSameTargetCreatesBackup) {
+  ScopedTempDirectory temp;
+  const auto target = temp.path() / "target.sfc";
+  const std::vector<uint8_t> target_before = {0xAA, 0xBB, 0xCC};
+  WriteFileBytes(target, target_before);
+
+  EXPECT_OK(rom_.LoadFromData(kMockRomData));
+  rom_.set_filename(target.string());
+
+  Rom::SaveSettings settings;
+  settings.backup = true;
+  EXPECT_OK(rom_.SaveToFile(settings));
+
+  EXPECT_EQ(ReadFileBytes(target), rom_.vector());
+  const auto backups = FindFilesWithPrefix(temp.path(), "target.sfc_backup_");
+  ASSERT_EQ(backups.size(), 1);
+  EXPECT_EQ(ReadFileBytes(backups.front()), target_before);
+}
+
+TEST_F(RomTest, BestEffortBackupSaveNewSkipsUnreplacedBaseTarget) {
+  ScopedTempDirectory temp;
+  const auto base_target = temp.path() / "target.sfc";
+  const std::vector<uint8_t> target_before = {0xAA, 0xBB, 0xCC};
+  WriteFileBytes(base_target, target_before);
+
+  EXPECT_OK(rom_.LoadFromData(kMockRomData));
+
+  Rom::SaveSettings settings;
+  settings.backup = true;
+  settings.save_new = true;
+  settings.filename = base_target.string();
+  EXPECT_OK(rom_.SaveToFile(settings));
+
+  EXPECT_EQ(ReadFileBytes(base_target), target_before);
+  EXPECT_EQ(CountFilesWithPrefix(temp.path(), "target.sfc_backup_"), 0);
+  const auto saved_files = FindFilesWithPrefix(temp.path(), "target_");
+  ASSERT_EQ(saved_files.size(), 1);
+  EXPECT_EQ(ReadFileBytes(saved_files.front()), rom_.vector());
+}
+
+TEST_F(RomTest, BestEffortBackupFailureStillSaves) {
+#if defined(_WIN32)
+  GTEST_SKIP() << "A portable best-effort backup failure needs POSIX "
+                  "component-length semantics";
+#else
+  ScopedTempDirectory temp;
+  const long name_max = pathconf(temp.path().c_str(), _PC_NAME_MAX);
+  if (name_max < 64) {
+    GTEST_SKIP() << "Could not determine a usable component-length limit";
+  }
+  // The target and its .tmp sibling fit within the filesystem's component
+  // limit, while the timestamped backup name does not.
+  const auto target =
+      temp.path() / std::string(static_cast<size_t>(name_max) - 5, 't');
+  WriteFileBytes(target, {0xAA, 0xBB, 0xCC});
+
+  EXPECT_OK(rom_.LoadFromData(kMockRomData));
+  rom_.set_filename(target.string());
+
+  Rom::SaveSettings settings;
+  settings.backup = true;
+  EXPECT_OK(rom_.SaveToFile(settings));
+
+  EXPECT_EQ(ReadFileBytes(target), rom_.vector());
+  EXPECT_EQ(CountFilesWithPrefix(temp.path(), target.filename().string()), 1);
+#endif
 }
 
 TEST_F(RomTest, RequiredBackupFailureRollsBackTransactionAndLeavesNoArtifacts) {
@@ -386,12 +496,7 @@ TEST_F(RomTest, RequiredBackupProtectsExistingSaveAsTarget) {
   EXPECT_OK(rom_.SaveToFile(settings));
 
   EXPECT_EQ(ReadFileBytes(target), rom_.vector());
-  std::vector<std::filesystem::path> backups;
-  for (const auto& entry : std::filesystem::directory_iterator(temp.path())) {
-    if (entry.path().filename().string().rfind("target.sfc_backup_", 0) == 0) {
-      backups.push_back(entry.path());
-    }
-  }
+  const auto backups = FindFilesWithPrefix(temp.path(), "target.sfc_backup_");
   ASSERT_EQ(backups.size(), 1);
   EXPECT_EQ(ReadFileBytes(backups.front()), target_before);
   EXPECT_EQ(CountFilesWithPrefix(temp.path(), "source.sfc_backup_"), 0);


### PR DESCRIPTION
## Summary

- make legacy best-effort `backup=true` protect the existing destination actually being replaced, not the ROM's original load path
- resolve `save_new` before either backup mode so backups reason about the final target
- skip misleading backups for missing/new destinations
- preserve same-target behavior and the legacy rule that backup failure is logged but does not block the save

## Compatibility audit

Active `backup=true` callers were inventoried. `yaze_save_rom` is the only caller that can supply a different destination, where target protection is the intended behavior. The overworld and track-collision handlers use the loaded filename, so their same-target behavior is unchanged. No active caller intentionally needs source-A bytes in a destination-B backup.

## Verification

- clean exact-head `yaze_test_unit` build
- `RomTest.BestEffortBackup*:RomTest.RequiredBackup*`: **7/7 passed**
- `RomTest.*-RomTest.LoadFromFile`: **32/32 passed**
- `YAZE_PREPUSH_BUILD_DIR=build/legacy-mac-ai scripts/pre-push.sh`
- independent strict review: no blockers
- `git show --check`

Fixes #125
