### PR TITLE
fix(dungeon): persist layout and floor stream headers

### DIFF
--- a/docs/internal/agents/rom-safety-guardrails.md
+++ b/docs/internal/agents/rom-safety-guardrails.md
@@ -24,6 +24,10 @@ This repo is used to edit ROM hacks (including Oracle of Secrets). Treat ROM wri
   `dungeon-set-collision-tile`, and `dungeon-set-room-property` wrap their
   serializer, required backup, and disk commit in `ScopedRomTransaction`. Any
   failure restores the caller's ROM bytes, filename, size, and dirty state.
+- Dungeon `layout`, `floor1`, and `floor2` edits use a separate object-stream
+  header dirty mask. They preserve unrelated header bits and object payload,
+  save after any dirty object payload, and fail closed on shared streams unless
+  a `copy_on_write` object-stream manifest supplies allocator-owned space.
 - Other CLI writers that still set only `backup=true` remain best-effort and
   must be audited before opting into the strict transaction path.
 

--- a/docs/public/reference/z3ed-command-reference.md
+++ b/docs/public/reference/z3ed-command-reference.md
@@ -160,7 +160,7 @@ These commands operate directly on ROM data (no GUI required).
 - `dungeon-export-room --room <hex> --output <file>`
 - `dungeon-place-object --room <hex> --id <hex> --x <int> --y <int> [--size <int>] [--layer <0|1|2>] [--manifest <path>] [--write]`
 - `dungeon-get-room-tiles --room <hex>` *(stubbed)*
-- `dungeon-set-room-property --room <hex> --property <name> --value <value>` *(stubbed)*
+- `dungeon-set-room-property --room <hex> --property <name> --value <value> [--manifest <path>]`
 
 `dungeon-place-object` is a dry-run unless `--write` is supplied. Both modes
 execute the same immutable capacity preflight. In-place edits can proceed
@@ -170,6 +170,13 @@ an explicit manifest defines `dungeon_stream_regions.objects` with the
 ownership guard: protected current-stream, allocation, object-pointer, or
 door-pointer writes are rejected before either dry-run or write can mutate ROM
 bytes.
+
+`dungeon-set-room-property` accepts `layout`/`layout_id` values `0`-`7` and
+`floor1`/`floor2` values `0`-`15`. These properties are persisted in the
+two-byte object-stream header with per-field read/modify/write; unrelated bits
+and the object payload remain unchanged. A shared stream requires the same
+manifest-backed `copy_on_write` capability described above. Successful
+non-mock writes require a completed destination backup before replacement.
 
 When `--spawn` is set, the ID must be `0x00`-`0x06`. Both entrance commands
 report the dedicated spawn fields (`quadrant`, `overworld_door_tilemap`, and

--- a/src/app/editor/dungeon/dungeon_editor_v2_persistence.cc
+++ b/src/app/editor/dungeon/dungeon_editor_v2_persistence.cc
@@ -631,6 +631,11 @@ std::vector<std::pair<uint32_t, uint32_t>> DungeonEditorV2::CollectWriteRanges()
         yaze::SnesToPc(layout->pointer_table) +
         static_cast<uint32_t>(room_id) * pointer_width;
     ranges.emplace_back(pointer_slot, pointer_slot + pointer_width);
+    if (stream_type == core::DungeonStreamType::kObjects) {
+      const uint32_t door_slot =
+          zelda3::kDoorPointers + static_cast<uint32_t>(room_id) * 3u;
+      ranges.emplace_back(door_slot, door_slot + 3u);
+    }
   };
 
   // Oracle of Secrets: the water fill table lives in a reserved tail region.
@@ -743,6 +748,33 @@ std::vector<std::pair<uint32_t, uint32_t>> DungeonEditorV2::CollectWriteRanges()
       }
     }
 
+    if (flags.kSaveObjects && room.object_stream_header_dirty() &&
+        zelda3::kRoomObjectPointer + 2 < static_cast<int>(rom_data.size())) {
+      const uint32_t table_snes =
+          (static_cast<uint32_t>(rom_data[zelda3::kRoomObjectPointer + 2])
+           << 16) |
+          (static_cast<uint32_t>(rom_data[zelda3::kRoomObjectPointer + 1])
+           << 8) |
+          rom_data[zelda3::kRoomObjectPointer];
+      if ((table_snes & 0xFFFFu) >= 0x8000u) {
+        const int table_pc = yaze::SnesToPc(table_snes);
+        const int pointer_slot = table_pc + room_id * 3;
+        if (pointer_slot >= 0 &&
+            pointer_slot + 2 < static_cast<int>(rom_data.size())) {
+          const uint32_t stream_snes =
+              (static_cast<uint32_t>(rom_data[pointer_slot + 2]) << 16) |
+              (static_cast<uint32_t>(rom_data[pointer_slot + 1]) << 8) |
+              rom_data[pointer_slot];
+          if ((stream_snes & 0xFFFFu) >= 0x8000u) {
+            const uint32_t stream_pc = yaze::SnesToPc(stream_snes);
+            if (static_cast<uint64_t>(stream_pc) + 2u <= rom_data.size()) {
+              ranges.emplace_back(stream_pc, stream_pc + 2u);
+            }
+          }
+        }
+      }
+    }
+
     // Sprite stream (sort byte + encoded sprite records/terminator).
     if (flags.kSaveSprites && room.sprites_dirty() &&
         zelda3::kRoomsSpritePointer + 1 < static_cast<int>(rom_data.size())) {
@@ -766,9 +798,11 @@ std::vector<std::pair<uint32_t, uint32_t>> DungeonEditorV2::CollectWriteRanges()
       }
     }
 
-    append_declared_cow_ranges(core::DungeonStreamType::kObjects,
-                               flags.kSaveObjects && room.object_stream_dirty(),
-                               room_id);
+    append_declared_cow_ranges(
+        core::DungeonStreamType::kObjects,
+        flags.kSaveObjects &&
+            (room.object_stream_dirty() || room.object_stream_header_dirty()),
+        room_id);
     append_declared_cow_ranges(core::DungeonStreamType::kSprites,
                                flags.kSaveSprites && room.sprites_dirty(),
                                room_id);
@@ -938,7 +972,9 @@ absl::Status DungeonEditorV2::SaveRoomData(int room_id) {
 
     RETURN_IF_ERROR(load_cow_layout(
         core::DungeonStreamType::kObjects,
-        flags.kSaveObjects && room.object_stream_dirty(), &object_cow_layout));
+        flags.kSaveObjects &&
+            (room.object_stream_dirty() || room.object_stream_header_dirty()),
+        &object_cow_layout));
     RETURN_IF_ERROR(load_cow_layout(core::DungeonStreamType::kSprites,
                                     flags.kSaveSprites && room.sprites_dirty(),
                                     &sprite_cow_layout));
@@ -1004,6 +1040,33 @@ absl::Status DungeonEditorV2::SaveRoomData(int room_id) {
       }
     }
 
+    if (flags.kSaveObjects && room.object_stream_header_dirty() &&
+        zelda3::kRoomObjectPointer + 2 < static_cast<int>(rom_data.size())) {
+      const uint32_t table_snes =
+          (static_cast<uint32_t>(rom_data[zelda3::kRoomObjectPointer + 2])
+           << 16) |
+          (static_cast<uint32_t>(rom_data[zelda3::kRoomObjectPointer + 1])
+           << 8) |
+          rom_data[zelda3::kRoomObjectPointer];
+      if ((table_snes & 0xFFFFu) >= 0x8000u) {
+        const int table_pc = yaze::SnesToPc(table_snes);
+        const int pointer_slot = table_pc + room_id * 3;
+        if (pointer_slot >= 0 &&
+            pointer_slot + 2 < static_cast<int>(rom_data.size())) {
+          const uint32_t stream_snes =
+              (static_cast<uint32_t>(rom_data[pointer_slot + 2]) << 16) |
+              (static_cast<uint32_t>(rom_data[pointer_slot + 1]) << 8) |
+              rom_data[pointer_slot];
+          if ((stream_snes & 0xFFFFu) >= 0x8000u) {
+            const uint32_t stream_pc = yaze::SnesToPc(stream_snes);
+            if (static_cast<uint64_t>(stream_pc) + 2u <= rom_data.size()) {
+              ranges.emplace_back(stream_pc, stream_pc + 2u);
+            }
+          }
+        }
+      }
+    }
+
     // 3. Validate the current sprite stream for the in-place fast path.
     if (flags.kSaveSprites && room.sprites_dirty() &&
         zelda3::kRoomsSpritePointer + 1 < static_cast<int>(rom_data.size())) {
@@ -1043,6 +1106,11 @@ absl::Status DungeonEditorV2::SaveRoomData(int room_id) {
           layout.pointer_table_pc +
           static_cast<uint32_t>(room_id) * pointer_width;
       ranges.emplace_back(pointer_slot, pointer_slot + pointer_width);
+      if (layout.kind == zelda3::DungeonStreamKind::kObject) {
+        const uint32_t door_slot =
+            zelda3::kDoorPointers + static_cast<uint32_t>(room_id) * 3u;
+        ranges.emplace_back(door_slot, door_slot + 3u);
+      }
     };
     if (object_cow_layout.has_value()) {
       append_cow_ranges(*object_cow_layout);
@@ -1064,6 +1132,17 @@ absl::Status DungeonEditorV2::SaveRoomData(int room_id) {
         object_cow_layout.has_value() ? &*object_cow_layout : nullptr);
     if (!status.ok()) {
       LOG_ERROR("DungeonEditorV2", "Failed to save room objects: %s",
+                status.message().data());
+      return status;
+    }
+  }
+
+  if (flags.kSaveObjects && room.object_stream_header_dirty()) {
+    auto status = room.SaveObjectStreamHeader(
+        object_cow_layout.has_value() ? &*object_cow_layout : nullptr);
+    if (!status.ok()) {
+      LOG_ERROR("DungeonEditorV2",
+                "Failed to save room object-stream header: %s",
                 status.message().data());
       return status;
     }

--- a/src/cli/handlers/game/dungeon_commands.cc
+++ b/src/cli/handlers/game/dungeon_commands.cc
@@ -2,13 +2,18 @@
 
 #include <algorithm>
 #include <fstream>
+#include <limits>
+#include <optional>
 #include <sstream>
+#include <vector>
 
 #include "absl/strings/ascii.h"
 #include "absl/strings/str_cat.h"
 #include "absl/strings/str_format.h"
 #include "absl/strings/str_split.h"
 #include "cli/util/hex_util.h"
+#include "core/dungeon_stream_layout_adapter.h"
+#include "core/hack_manifest.h"
 #include "rom/rom.h"
 #include "rom/snes.h"
 #include "rom/transaction.h"
@@ -36,6 +41,87 @@ constexpr uint8_t kStopTileMax = 0xBA;
 
 bool IsStopTile(uint8_t v) {
   return v >= kStopTileMin && v <= kStopTileMax;
+}
+
+struct RoomPropertyManifestContext {
+  core::HackManifest manifest;
+  zelda3::DungeonStreamLayout allocator_layout;
+};
+
+absl::StatusOr<std::optional<RoomPropertyManifestContext>>
+LoadRoomPropertyManifestContext(const resources::ArgumentParser& parser) {
+  const auto manifest_path = parser.GetString("manifest");
+  if (!manifest_path.has_value()) {
+    return std::nullopt;
+  }
+
+  RoomPropertyManifestContext context;
+  RETURN_IF_ERROR(context.manifest.LoadFromFile(*manifest_path));
+  const auto* manifest_layout = context.manifest.GetDungeonStreamLayout(
+      core::DungeonStreamType::kObjects);
+  if (manifest_layout == nullptr) {
+    return absl::FailedPreconditionError(
+        "Manifest does not define dungeon_stream_regions.objects");
+  }
+  if (manifest_layout->strategy != core::DungeonWriteStrategy::kCopyOnWrite) {
+    return absl::FailedPreconditionError(
+        "dungeon_stream_regions.objects must use copy_on_write");
+  }
+  ASSIGN_OR_RETURN(context.allocator_layout,
+                   core::ToDungeonStreamAllocatorLayout(
+                       core::DungeonStreamType::kObjects, *manifest_layout));
+  return std::optional<RoomPropertyManifestContext>(std::move(context));
+}
+
+absl::Status ValidateRoomPropertyManifestConflicts(
+    const Rom& rom, int room_id, const RoomPropertyManifestContext& context) {
+  std::vector<std::pair<uint32_t, uint32_t>> ranges;
+
+  uint32_t pointer_table_snes = 0;
+  ASSIGN_OR_RETURN(pointer_table_snes,
+                   rom.ReadLong(zelda3::kRoomObjectPointer));
+  const uint32_t pointer_table_pc = SnesToPc(pointer_table_snes);
+  const uint64_t pointer_slot = static_cast<uint64_t>(pointer_table_pc) +
+                                static_cast<uint64_t>(room_id) * 3u;
+  if (pointer_slot + 3u > rom.size()) {
+    return absl::OutOfRangeError(
+        "Selected object pointer slot is outside the ROM");
+  }
+
+  uint32_t stream_snes = 0;
+  ASSIGN_OR_RETURN(stream_snes, rom.ReadLong(static_cast<int>(pointer_slot)));
+  const uint32_t stream_pc = SnesToPc(stream_snes);
+  if (static_cast<uint64_t>(stream_pc) + 2u > rom.size()) {
+    return absl::OutOfRangeError(
+        "Selected object stream header is outside the ROM");
+  }
+  ranges.emplace_back(stream_pc, stream_pc + 2u);
+
+  for (const auto& range : context.allocator_layout.allocation_ranges) {
+    ranges.emplace_back(range.begin, range.end);
+  }
+  const uint64_t cow_pointer_slot =
+      static_cast<uint64_t>(context.allocator_layout.pointer_table_pc) +
+      static_cast<uint64_t>(room_id) * 3u;
+  if (cow_pointer_slot + 3u > std::numeric_limits<uint32_t>::max()) {
+    return absl::OutOfRangeError("Selected COW pointer range overflows");
+  }
+  ranges.emplace_back(static_cast<uint32_t>(cow_pointer_slot),
+                      static_cast<uint32_t>(cow_pointer_slot + 3u));
+
+  const uint64_t door_pointer_slot =
+      static_cast<uint64_t>(zelda3::kDoorPointers) +
+      static_cast<uint64_t>(room_id) * 3u;
+  if (door_pointer_slot + 3u > std::numeric_limits<uint32_t>::max()) {
+    return absl::OutOfRangeError("Selected door pointer range overflows");
+  }
+  ranges.emplace_back(static_cast<uint32_t>(door_pointer_slot),
+                      static_cast<uint32_t>(door_pointer_slot + 3u));
+
+  if (!context.manifest.AnalyzePcWriteRanges(ranges).empty()) {
+    return absl::PermissionDeniedError("Write conflict with Hack Manifest");
+  }
+  return absl::OkStatus();
 }
 
 // Merge stop tiles from |existing| into |generated| without overwriting
@@ -618,19 +704,47 @@ absl::Status DungeonSetRoomPropertyCommandHandler::Execute(
   }
 
   const std::string prop = absl::AsciiStrToLower(property);
-  if (prop == "layout" || prop == "layout_id" || prop == "floor1" ||
-      prop == "floor2") {
-    const absl::Status property_status = absl::UnimplementedError(
-        absl::StrFormat("Property %s is stored in the dungeon object-stream "
-                        "header; persistence is not implemented",
-                        property));
+  const bool is_layout = prop == "layout" || prop == "layout_id";
+  const bool is_floor = prop == "floor1" || prop == "floor2";
+  const bool is_object_stream_header = is_layout || is_floor;
+  const int property_max = is_layout ? 0x07 : (is_floor ? 0x0F : 0xFF);
+  if (is_object_stream_header &&
+      (parsed_value < 0 || parsed_value > property_max)) {
+    const absl::Status property_status =
+        absl::InvalidArgumentError(absl::StrFormat(
+            "Property %s must be in range 0..%d", property, property_max));
     formatter.AddField("status", "error");
     formatter.AddField("error", std::string(property_status.message()));
     formatter.EndObject();
     return property_status;
   }
 
-  zelda3::Room room = zelda3::LoadRoomHeaderFromRom(rom, room_id);
+  std::optional<RoomPropertyManifestContext> manifest_context;
+  if (is_object_stream_header) {
+    auto context_or = LoadRoomPropertyManifestContext(parser);
+    if (!context_or.ok()) {
+      formatter.AddField("status", "error");
+      formatter.AddField("error", std::string(context_or.status().message()));
+      formatter.EndObject();
+      return context_or.status();
+    }
+    manifest_context = std::move(context_or).value();
+    if (manifest_context.has_value()) {
+      const absl::Status manifest_status =
+          ValidateRoomPropertyManifestConflicts(*rom, room_id,
+                                                *manifest_context);
+      if (!manifest_status.ok()) {
+        formatter.AddField("status", "error");
+        formatter.AddField("error", std::string(manifest_status.message()));
+        formatter.EndObject();
+        return manifest_status;
+      }
+      formatter.AddField("manifest", *parser.GetString("manifest"));
+      formatter.AddField("allocator_capability", "copy_on_write");
+    }
+  }
+
+  zelda3::Room room = zelda3::LoadRoomFromRom(rom, room_id);
   ScopedRomTransaction transaction(*rom);
   if (prop == "palette") {
     room.SetPalette(static_cast<uint8_t>(parsed_value & 0xFF));
@@ -638,6 +752,12 @@ absl::Status DungeonSetRoomPropertyCommandHandler::Execute(
     room.SetBlockset(static_cast<uint8_t>(parsed_value & 0xFF));
   } else if (prop == "spriteset") {
     room.SetSpriteset(static_cast<uint8_t>(parsed_value & 0xFF));
+  } else if (is_layout) {
+    room.SetLayoutId(static_cast<uint8_t>(parsed_value));
+  } else if (prop == "floor1") {
+    room.set_floor1(static_cast<uint8_t>(parsed_value));
+  } else if (prop == "floor2") {
+    room.set_floor2(static_cast<uint8_t>(parsed_value));
   } else if (prop == "effect") {
     room.SetEffect(static_cast<zelda3::EffectKey>(parsed_value & 0xFF));
   } else if (prop == "tag1") {
@@ -655,7 +775,12 @@ absl::Status DungeonSetRoomPropertyCommandHandler::Execute(
     return property_status;
   }
 
-  const absl::Status write_status = room.SaveRoomHeader();
+  const absl::Status write_status =
+      is_object_stream_header ? room.SaveObjectStreamHeader(
+                                    manifest_context.has_value()
+                                        ? &manifest_context->allocator_layout
+                                        : nullptr)
+                              : room.SaveRoomHeader();
   if (!write_status.ok()) {
     formatter.AddField("status", "error");
     formatter.AddField("write_error", std::string(write_status.message()));

--- a/src/cli/handlers/game/dungeon_commands.h
+++ b/src/cli/handlers/game/dungeon_commands.h
@@ -177,7 +177,7 @@ class DungeonSetRoomPropertyCommandHandler : public resources::CommandHandler {
   }
   std::string GetUsage() const {
     return "dungeon-set-room-property --room <room_id> --property <property> "
-           "--value <value> [--format <json|text>]";
+           "--value <value> [--manifest <path>] [--format <json|text>]";
   }
 
   absl::Status ValidateArgs(const resources::ArgumentParser& parser) override {

--- a/src/zelda3/dungeon/dungeon_editor_system.cc
+++ b/src/zelda3/dungeon/dungeon_editor_system.cc
@@ -14,6 +14,7 @@ namespace {
 
 absl::Status SaveSingleRoomState(Rom* rom, Room& room) {
   RETURN_IF_ERROR(room.SaveObjects());
+  RETURN_IF_ERROR(room.SaveObjectStreamHeader());
   RETURN_IF_ERROR(room.SaveSprites());
   RETURN_IF_ERROR(room.SaveRoomHeader());
 
@@ -94,6 +95,7 @@ absl::Status DungeonEditorSystem::SaveDungeon() {
       continue;
     }
     RETURN_IF_ERROR(room->SaveObjects());
+    RETURN_IF_ERROR(room->SaveObjectStreamHeader());
     RETURN_IF_ERROR(room->SaveSprites());
     RETURN_IF_ERROR(room->SaveRoomHeader());
   }

--- a/src/zelda3/dungeon/room.cc
+++ b/src/zelda3/dungeon/room.cc
@@ -2095,6 +2095,104 @@ absl::Status Room::SaveObjects(const DungeonStreamLayout* layout) {
   return absl::OkStatus();
 }
 
+absl::Status Room::SaveObjectStreamHeader(const DungeonStreamLayout* layout) {
+  if (rom_ == nullptr) {
+    return absl::InvalidArgumentError("ROM pointer is null");
+  }
+  if (!object_stream_header_dirty()) {
+    return absl::OkStatus();
+  }
+  if (floor1_graphics_ > 0x0F || floor2_graphics_ > 0x0F) {
+    return absl::InvalidArgumentError(
+        "Dungeon floor graphics values must be in range 0..15");
+  }
+  if (layout_id_ > 0x07) {
+    return absl::InvalidArgumentError(
+        "Dungeon layout ID must be in range 0..7");
+  }
+
+  const auto& rom_data = rom_->vector();
+  ASSIGN_OR_RETURN(const PhysicalStreamInfo stream_info,
+                   GetObjectStreamInfo(rom_data, room_id_));
+  if (stream_info.address < 0 ||
+      stream_info.address + 1 >= static_cast<int>(rom_data.size())) {
+    return absl::OutOfRangeError("Object stream header is out of range");
+  }
+
+  const uint8_t dirty_mask = save_dirty_state_.object_stream_header;
+  auto patch_header = [&](std::vector<uint8_t>* stream) -> absl::Status {
+    if (stream == nullptr || stream->size() < 2) {
+      return absl::DataLossError(
+          "Object stream is missing its two-byte header");
+    }
+    if ((dirty_mask & kObjectHeaderFloor1Dirty) != 0) {
+      (*stream)[0] = static_cast<uint8_t>(((*stream)[0] & 0xF0) |
+                                          (floor1_graphics_ & 0x0F));
+    }
+    if ((dirty_mask & kObjectHeaderFloor2Dirty) != 0) {
+      (*stream)[0] =
+          static_cast<uint8_t>(((*stream)[0] & 0x0F) | (floor2_graphics_ << 4));
+    }
+    if ((dirty_mask & kObjectHeaderLayoutDirty) != 0) {
+      (*stream)[1] = static_cast<uint8_t>(((*stream)[1] & 0xE3) |
+                                          ((layout_id_ & 0x07) << 2));
+    }
+    return absl::OkStatus();
+  };
+
+  bool requires_copy_on_write = stream_info.shared;
+  std::vector<uint8_t> replacement;
+  if (layout != nullptr) {
+    if (layout->kind != DungeonStreamKind::kObject) {
+      return absl::InvalidArgumentError(
+          "Object-stream header save requires an object stream layout");
+    }
+    ASSIGN_OR_RETURN(const DungeonStreamInventory inventory,
+                     InventoryDungeonStreams(*rom_, *layout));
+    if (!inventory.ok()) {
+      return absl::FailedPreconditionError(absl::StrFormat(
+          "Dungeon stream inventory has %zu issue(s); refusing object "
+          "header save",
+          inventory.issues.size()));
+    }
+    if (room_id_ < 0 ||
+        static_cast<size_t>(room_id_) >= inventory.streams.size()) {
+      return absl::OutOfRangeError(
+          "Room ID is outside the dungeon stream layout");
+    }
+    replacement = inventory.streams[room_id_].encoded_stream;
+    bool layout_requires_copy_on_write = false;
+    ASSIGN_OR_RETURN(layout_requires_copy_on_write,
+                     DungeonStreamRequiresCopyOnWrite(
+                         *rom_, room_id_, DungeonStreamKind::kObject, *layout,
+                         replacement.size()));
+    requires_copy_on_write =
+        requires_copy_on_write || layout_requires_copy_on_write;
+  }
+
+  if (requires_copy_on_write) {
+    if (layout == nullptr) {
+      return absl::FailedPreconditionError(absl::StrFormat(
+          "Room %d object stream at PC 0x%06X is shared; a copy-on-write "
+          "manifest is required to save its header",
+          room_id_, stream_info.address));
+    }
+    RETURN_IF_ERROR(patch_header(&replacement));
+    RETURN_IF_ERROR(RelocateDungeonStream(rom_, room_id_,
+                                          DungeonStreamKind::kObject, *layout,
+                                          std::move(replacement)));
+    ClearObjectStreamHeaderDirty();
+    return absl::OkStatus();
+  }
+
+  std::vector<uint8_t> header = {rom_data[stream_info.address],
+                                 rom_data[stream_info.address + 1]};
+  RETURN_IF_ERROR(patch_header(&header));
+  RETURN_IF_ERROR(rom_->WriteVector(stream_info.address, std::move(header)));
+  ClearObjectStreamHeaderDirty();
+  return absl::OkStatus();
+}
+
 absl::Status Room::SaveSprites(const DungeonStreamLayout* layout) {
   if (rom_ == nullptr) {
     return absl::InvalidArgumentError("ROM pointer is null");

--- a/src/zelda3/dungeon/room.h
+++ b/src/zelda3/dungeon/room.h
@@ -204,6 +204,7 @@ class Room {
 
     bool header = false;
     bool object_stream = false;
+    uint8_t object_stream_header = 0;
     bool sprites = false;
     bool chests = false;
     bool pot_items = false;
@@ -439,6 +440,12 @@ class Room {
   }
   bool object_stream_dirty() const { return save_dirty_state_.object_stream; }
   void ClearObjectStreamDirty() { save_dirty_state_.object_stream = false; }
+  bool object_stream_header_dirty() const {
+    return save_dirty_state_.object_stream_header != 0;
+  }
+  void ClearObjectStreamHeaderDirty() {
+    save_dirty_state_.object_stream_header = 0;
+  }
   void MarkGraphicsDirty() {
     dirty_state_.graphics = true;
     dirty_state_.textures = true;
@@ -580,6 +587,7 @@ class Room {
 
   bool HasUnsavedChanges() const {
     return save_dirty_state_.header || save_dirty_state_.object_stream ||
+           save_dirty_state_.object_stream_header != 0 ||
            save_dirty_state_.sprites || save_dirty_state_.chests ||
            save_dirty_state_.pot_items || save_dirty_state_.torches ||
            save_dirty_state_.blocks || custom_collision_dirty_ ||
@@ -592,6 +600,7 @@ class Room {
     SaveDirtySnapshot snapshot{
         .header = save_dirty_state_.header,
         .object_stream = save_dirty_state_.object_stream,
+        .object_stream_header = save_dirty_state_.object_stream_header,
         .sprites = save_dirty_state_.sprites,
         .chests = save_dirty_state_.chests,
         .pot_items = save_dirty_state_.pot_items,
@@ -615,6 +624,7 @@ class Room {
   void RestoreSaveDirtySnapshot(const SaveDirtySnapshot& snapshot) {
     save_dirty_state_.header = snapshot.header;
     save_dirty_state_.object_stream = snapshot.object_stream;
+    save_dirty_state_.object_stream_header = snapshot.object_stream_header;
     save_dirty_state_.sprites = snapshot.sprites;
     save_dirty_state_.chests = snapshot.chests;
     save_dirty_state_.pot_items = snapshot.pot_items;
@@ -907,6 +917,7 @@ class Room {
   void SetLayoutId(uint8_t id) {
     if (layout_id_ != id) {
       layout_id_ = id;
+      save_dirty_state_.object_stream_header |= kObjectHeaderLayoutDirty;
       MarkLayoutDirty();
     }
   }
@@ -917,12 +928,14 @@ class Room {
   void set_floor1(uint8_t value) {
     if (floor1_graphics_ != value) {
       floor1_graphics_ = value;
+      save_dirty_state_.object_stream_header |= kObjectHeaderFloor1Dirty;
       MarkGraphicsDirty();
     }
   }
   void set_floor2(uint8_t value) {
     if (floor2_graphics_ != value) {
       floor2_graphics_ = value;
+      save_dirty_state_.object_stream_header |= kObjectHeaderFloor2Dirty;
       MarkGraphicsDirty();
     }
   }
@@ -933,6 +946,8 @@ class Room {
 
   // Object saving (Phase 1, Task 1.3)
   absl::Status SaveObjects(const DungeonStreamLayout* layout = nullptr);
+  absl::Status SaveObjectStreamHeader(
+      const DungeonStreamLayout* layout = nullptr);
   std::vector<uint8_t> EncodeObjects() const;
   absl::Status SaveSprites(const DungeonStreamLayout* layout = nullptr);
   std::vector<uint8_t> EncodeSprites() const;
@@ -1000,12 +1015,17 @@ class Room {
   struct SaveDirtyState {
     bool header = false;
     bool object_stream = false;
+    uint8_t object_stream_header = 0;
     bool sprites = false;
     bool chests = false;
     bool pot_items = false;
     bool torches = false;
     bool blocks = false;
   };
+
+  static constexpr uint8_t kObjectHeaderFloor1Dirty = 1u << 0;
+  static constexpr uint8_t kObjectHeaderFloor2Dirty = 1u << 1;
+  static constexpr uint8_t kObjectHeaderLayoutDirty = 1u << 2;
 
   // Composite bitmap for merged layer output
   mutable gfx::Bitmap composite_bitmap_;

--- a/test/unit/cli/dungeon_edit_commands_test.cc
+++ b/test/unit/cli/dungeon_edit_commands_test.cc
@@ -46,6 +46,8 @@ constexpr std::array<uint8_t, 14> kRoomHeaderSentinel = {
     0xE4, 0xCF, 0x77, 0x88, 0x99, 0xAA, 0xBB,
 };
 constexpr uint16_t kRoomMessageSentinel = 0xDDCC;
+constexpr uint8_t kObjectHeaderByte0 = 0xA5;
+constexpr uint8_t kObjectHeaderByte1 = 0xE3;
 
 void ExpectInvalidArgument(const absl::Status& status,
                            const std::string& message_fragment) {
@@ -160,6 +162,30 @@ void InitializeRoomHeaderRom(Rom* rom) {
   rom->mutable_data()[zelda3::kMessagesIdDungeon] = kRoomMessageSentinel & 0xFF;
   rom->mutable_data()[zelda3::kMessagesIdDungeon + 1] =
       (kRoomMessageSentinel >> 8) & 0xFF;
+
+  WriteLong(rom, zelda3::kRoomObjectPointer, PcToSnes(kObjectPointerTablePc));
+  WriteLong(rom, kObjectPointerTablePc, PcToSnes(kObjectDataPc));
+  for (int room_id = 1; room_id < zelda3::kNumberOfRooms; ++room_id) {
+    WriteLong(rom, kObjectPointerTablePc + room_id * 3,
+              PcToSnes(kObjectDataPc + 0x10));
+  }
+  ASSERT_TRUE(rom->WriteVector(kObjectDataPc,
+                               {kObjectHeaderByte0, kObjectHeaderByte1, 0xFF,
+                                0xFF, 0xFF, 0xFF, 0xF0, 0xFF, 0xFF, 0xFF})
+                  .ok());
+  ASSERT_TRUE(
+      rom->WriteVector(kObjectDataPc + 0x10, {0x00, 0x00, 0xFF, 0xFF, 0xFF,
+                                              0xFF, 0xF0, 0xFF, 0xFF, 0xFF})
+          .ok());
+
+  const uint16_t pot_pointer = PcToSnes(kSyntheticPotTerminatorPc) & 0xFFFF;
+  for (int room_id = 0; room_id < zelda3::kNumberOfRooms; ++room_id) {
+    const int pointer = zelda3::kRoomItemsPointers + room_id * 2;
+    rom->mutable_data()[pointer] = pot_pointer & 0xFF;
+    rom->mutable_data()[pointer + 1] = (pot_pointer >> 8) & 0xFF;
+  }
+  rom->mutable_data()[kSyntheticPotTerminatorPc] = 0xFF;
+  rom->mutable_data()[kSyntheticPotTerminatorPc + 1] = 0xFF;
   rom->set_dirty(false);
 }
 
@@ -474,9 +500,60 @@ TEST(DungeonEditCommandsTest, SetRoomPropertyMockRomCommitsSerializedHeader) {
 }
 
 TEST(DungeonEditCommandsTest,
-     SetRoomPropertyRejectsUnimplementedObjectStreamPropertiesWithoutMutation) {
-  for (const std::string property :
-       {"layout", "layout_id", "floor1", "floor2"}) {
+     SetRoomPropertyPersistsObjectStreamHeaderFieldsWithPerFieldRmw) {
+  struct Case {
+    const char* property;
+    const char* value;
+    uint8_t expected_byte0;
+    uint8_t expected_byte1;
+    uint8_t expected_layout;
+    uint8_t expected_floor1;
+    uint8_t expected_floor2;
+  };
+  const std::array<Case, 4> cases = {{
+      {"layout", "0x03", kObjectHeaderByte0, 0xEF, 3, 5, 10},
+      {"layout_id", "0x04", kObjectHeaderByte0, 0xF3, 4, 5, 10},
+      {"floor1", "0x02", 0xA2, kObjectHeaderByte1, 0, 2, 10},
+      {"floor2", "0x03", 0x35, kObjectHeaderByte1, 0, 5, 3},
+  }};
+
+  for (const auto& test_case : cases) {
+    SCOPED_TRACE(test_case.property);
+    Rom rom;
+    InitializeRoomHeaderRom(&rom);
+    const std::vector<uint8_t> payload_before(rom.data() + kObjectDataPc + 2,
+                                              rom.data() + kObjectDataPc + 10);
+
+    handlers::DungeonSetRoomPropertyCommandHandler handler;
+    std::string output;
+    const absl::Status status = handler.Run(
+        {"--mock-rom", "--room=0x00",
+         "--property=" + std::string(test_case.property),
+         "--value=" + std::string(test_case.value), "--format=json"},
+        &rom, &output);
+
+    ASSERT_TRUE(status.ok()) << status;
+    EXPECT_EQ(rom.data()[kObjectDataPc], test_case.expected_byte0);
+    EXPECT_EQ(rom.data()[kObjectDataPc + 1], test_case.expected_byte1);
+    EXPECT_TRUE(std::equal(payload_before.begin(), payload_before.end(),
+                           rom.data() + kObjectDataPc + 2));
+    const zelda3::Room reloaded = zelda3::LoadRoomFromRom(&rom, 0);
+    EXPECT_EQ(reloaded.layout_id(), test_case.expected_layout);
+    EXPECT_EQ(reloaded.floor1(), test_case.expected_floor1);
+    EXPECT_EQ(reloaded.floor2(), test_case.expected_floor2);
+    EXPECT_THAT(output, HasSubstr("\"status\": \"success\""));
+    EXPECT_THAT(output, HasSubstr("\"save_status\": \"mock-rom-skipped\""));
+  }
+}
+
+TEST(DungeonEditCommandsTest,
+     SetRoomPropertyRejectsObjectStreamHeaderValuesOutsideEncodedRange) {
+  const std::array<std::pair<const char*, const char*>, 3> cases = {{
+      {"layout", "0x08"},
+      {"floor1", "0x10"},
+      {"floor2", "0x10"},
+  }};
+  for (const auto& [property, value] : cases) {
     SCOPED_TRACE(property);
     Rom rom;
     InitializeRoomHeaderRom(&rom);
@@ -484,31 +561,104 @@ TEST(DungeonEditCommandsTest,
     WriteRomFile(rom, cleanup.rom_path);
     rom.set_filename(cleanup.rom_path.string());
     rom.set_dirty(false);
-
-    const std::vector<uint8_t> before = rom.vector();
-    const std::vector<uint8_t> disk_before = ReadFile(cleanup.rom_path);
-    const std::string filename_before = rom.filename();
+    const auto before = rom.vector();
 
     handlers::DungeonSetRoomPropertyCommandHandler handler;
     std::string output;
     const absl::Status status =
-        handler.Run({"--room=0x00", "--property=" + property, "--value=0x02",
-                     "--format=json"},
+        handler.Run({"--room=0x00", "--property=" + std::string(property),
+                     "--value=" + std::string(value), "--format=json"},
                     &rom, &output);
 
-    EXPECT_TRUE(absl::IsUnimplemented(status)) << status;
-    EXPECT_THAT(std::string(status.message()),
-                HasSubstr("object-stream header"));
-    EXPECT_THAT(std::string(status.message()),
-                HasSubstr("persistence is not implemented"));
-    EXPECT_THAT(output, HasSubstr("\"status\": \"error\""));
-    EXPECT_THAT(output, HasSubstr("\"error\""));
+    ExpectInvalidArgument(status, "must be in range");
     EXPECT_EQ(rom.vector(), before);
     EXPECT_FALSE(rom.dirty());
-    EXPECT_EQ(rom.filename(), filename_before);
-    EXPECT_EQ(ReadFile(cleanup.rom_path), disk_before);
     EXPECT_EQ(CountBackupArtifacts(cleanup.rom_path), 0);
+    EXPECT_FALSE(std::filesystem::exists(cleanup.rom_path.string() + ".tmp"));
   }
+}
+
+TEST(DungeonEditCommandsTest,
+     SetRoomPropertySharedObjectHeaderFailsClosedWithoutManifest) {
+  Rom rom;
+  InitializeRoomHeaderRom(&rom);
+  SetRoomObjectPointer(&rom, 1, kObjectDataPc);
+  rom.set_dirty(false);
+  const auto before = rom.vector();
+
+  handlers::DungeonSetRoomPropertyCommandHandler handler;
+  std::string output;
+  const absl::Status status =
+      handler.Run({"--mock-rom", "--room=0x00", "--property=layout",
+                   "--value=0x03", "--format=json"},
+                  &rom, &output);
+
+  EXPECT_TRUE(absl::IsFailedPrecondition(status)) << status;
+  EXPECT_THAT(std::string(status.message()), HasSubstr("copy-on-write"));
+  EXPECT_EQ(rom.vector(), before);
+  EXPECT_FALSE(rom.dirty());
+}
+
+TEST(DungeonEditCommandsTest,
+     SetRoomPropertySharedObjectHeaderUsesManifestCopyOnWrite) {
+  Rom rom;
+  InitializeRoomHeaderRom(&rom);
+  SetRoomObjectPointer(&rom, 1, kObjectDataPc);
+  rom.set_dirty(false);
+  const std::vector<uint8_t> old_stream(rom.data() + kObjectDataPc,
+                                        rom.data() + kObjectDataPc + 10);
+  ScopedFileCleanup manifest_cleanup(MakeUniqueTempRomPath().string() +
+                                     ".manifest.json");
+  WriteObjectCowManifest(manifest_cleanup.file_path);
+
+  handlers::DungeonSetRoomPropertyCommandHandler handler;
+  std::string output;
+  const absl::Status status = handler.Run(
+      {"--mock-rom", "--room=0x00", "--property=layout", "--value=0x03",
+       "--manifest=" + manifest_cleanup.file_path.string(), "--format=json"},
+      &rom, &output);
+
+  ASSERT_TRUE(status.ok()) << status;
+  EXPECT_EQ(ReadRoomObjectPointerPc(rom, 0), kObjectAllocationPc);
+  EXPECT_EQ(ReadRoomObjectPointerPc(rom, 1), kObjectDataPc);
+  EXPECT_TRUE(std::equal(old_stream.begin(), old_stream.end(),
+                         rom.data() + kObjectDataPc));
+  EXPECT_EQ(rom.data()[kObjectAllocationPc], kObjectHeaderByte0);
+  EXPECT_EQ(rom.data()[kObjectAllocationPc + 1], 0xEF);
+  EXPECT_TRUE(std::equal(old_stream.begin() + 2, old_stream.end(),
+                         rom.data() + kObjectAllocationPc + 2));
+  EXPECT_THAT(output, HasSubstr("\"allocator_capability\": \"copy_on_write\""));
+}
+
+TEST(DungeonEditCommandsTest,
+     SetRoomPropertyManifestPreflightFailureCreatesNoSaveArtifacts) {
+  Rom rom;
+  InitializeRoomHeaderRom(&rom);
+  SetRoomObjectPointer(&rom, 1, kObjectDataPc);
+  ScopedRomArtifactsCleanup cleanup(MakeUniqueTempRomPath());
+  WriteRomFile(rom, cleanup.rom_path);
+  rom.set_filename(cleanup.rom_path.string());
+  rom.set_dirty(false);
+  ScopedFileCleanup manifest_cleanup(cleanup.rom_path.string() +
+                                     ".manifest.json");
+  WriteObjectCowManifest(manifest_cleanup.file_path,
+                         /*protect_allocation=*/true);
+  const auto before = rom.vector();
+  const auto disk_before = ReadFile(cleanup.rom_path);
+
+  handlers::DungeonSetRoomPropertyCommandHandler handler;
+  std::string output;
+  const absl::Status status = handler.Run(
+      {"--room=0x00", "--property=layout", "--value=0x03",
+       "--manifest=" + manifest_cleanup.file_path.string(), "--format=json"},
+      &rom, &output);
+
+  EXPECT_TRUE(absl::IsPermissionDenied(status)) << status;
+  EXPECT_EQ(rom.vector(), before);
+  EXPECT_FALSE(rom.dirty());
+  EXPECT_EQ(ReadFile(cleanup.rom_path), disk_before);
+  EXPECT_EQ(CountBackupArtifacts(cleanup.rom_path), 0);
+  EXPECT_FALSE(std::filesystem::exists(cleanup.rom_path.string() + ".tmp"));
 }
 
 TEST(DungeonEditCommandsTest,
@@ -646,6 +796,110 @@ TEST(DungeonEditCommandsTest, SetRoomPropertySavesBackupAndReopens) {
   EXPECT_EQ(room.staircase_room(2), 0xAA);
   EXPECT_EQ(room.staircase_room(3), 0xBB);
   EXPECT_EQ(room.message_id(), kRoomMessageSentinel);
+}
+
+TEST(DungeonEditCommandsTest,
+     SetRoomPropertyObjectHeaderDiskFailureRollsBackCallerRom) {
+  Rom rom;
+  InitializeRoomHeaderRom(&rom);
+  ScopedRomArtifactsCleanup cleanup(MakeUniqueTempRomPath());
+  WriteRomFile(rom, cleanup.rom_path);
+  rom.set_filename(cleanup.rom_path.string());
+  rom.set_dirty(false);
+  ASSERT_TRUE(
+      std::filesystem::create_directory(cleanup.rom_path.string() + ".tmp"));
+
+  const std::vector<uint8_t> before = rom.vector();
+  const std::vector<uint8_t> disk_before = ReadFile(cleanup.rom_path);
+  handlers::DungeonSetRoomPropertyCommandHandler handler;
+  std::string output;
+  const absl::Status status = handler.Run(
+      {"--room=0x00", "--property=layout", "--value=0x03", "--format=json"},
+      &rom, &output);
+
+  EXPECT_TRUE(absl::IsInternal(status)) << status;
+  EXPECT_EQ(rom.vector(), before);
+  EXPECT_FALSE(rom.dirty());
+  EXPECT_EQ(ReadFile(cleanup.rom_path), disk_before);
+  const auto backups = FindBackupArtifacts(cleanup.rom_path);
+  ASSERT_EQ(backups.size(), 1u);
+  EXPECT_EQ(ReadFile(backups.front()), disk_before);
+  EXPECT_THAT(output, HasSubstr("\"save_error\""));
+}
+
+TEST(DungeonEditCommandsTest,
+     SetRoomPropertyObjectHeaderRequiredBackupFailureRollsBackCallerRom) {
+#if defined(_WIN32)
+  GTEST_SKIP() << "NAME_MAX backup failure fixture is POSIX-only";
+#else
+  Rom rom;
+  InitializeRoomHeaderRom(&rom);
+  const auto parent = std::filesystem::temp_directory_path();
+  const long name_max = pathconf(parent.c_str(), _PC_NAME_MAX);
+  if (name_max < 128) {
+    GTEST_SKIP() << "Filesystem does not expose a usable NAME_MAX";
+  }
+  std::string filename =
+      "yaze_object_header_backup_" +
+      std::to_string(
+          std::chrono::steady_clock::now().time_since_epoch().count());
+  const size_t target_length = static_cast<size_t>(name_max) - 4;
+  ASSERT_LT(filename.size(), target_length);
+  filename.append(target_length - filename.size(), 'h');
+  ScopedRomArtifactsCleanup cleanup(parent / filename);
+  WriteRomFile(rom, cleanup.rom_path);
+  rom.set_filename(cleanup.rom_path.string());
+  rom.set_dirty(false);
+
+  const std::vector<uint8_t> before = rom.vector();
+  const std::vector<uint8_t> disk_before = ReadFile(cleanup.rom_path);
+  handlers::DungeonSetRoomPropertyCommandHandler handler;
+  std::string output;
+  const absl::Status status = handler.Run(
+      {"--room=0x00", "--property=floor1", "--value=0x02", "--format=json"},
+      &rom, &output);
+
+  EXPECT_FALSE(status.ok());
+  EXPECT_THAT(std::string(status.message()), HasSubstr("required ROM backup"));
+  EXPECT_EQ(rom.vector(), before);
+  EXPECT_FALSE(rom.dirty());
+  EXPECT_EQ(ReadFile(cleanup.rom_path), disk_before);
+  EXPECT_EQ(CountBackupArtifacts(cleanup.rom_path), 0);
+  EXPECT_FALSE(std::filesystem::exists(cleanup.rom_path.string() + ".tmp"));
+#endif
+}
+
+TEST(DungeonEditCommandsTest,
+     SetRoomPropertyObjectHeaderSavesBackupAndReopens) {
+  Rom rom;
+  InitializeRoomHeaderRom(&rom);
+  ScopedRomArtifactsCleanup cleanup(MakeUniqueTempRomPath());
+  WriteRomFile(rom, cleanup.rom_path);
+  rom.set_filename(cleanup.rom_path.string());
+  const std::vector<uint8_t> disk_before = ReadFile(cleanup.rom_path);
+
+  handlers::DungeonSetRoomPropertyCommandHandler handler;
+  std::string output;
+  const absl::Status status = handler.Run(
+      {"--room=0x00", "--property=layout", "--value=0x03", "--format=json"},
+      &rom, &output);
+
+  ASSERT_TRUE(status.ok()) << status;
+  std::vector<uint8_t> expected = disk_before;
+  expected[kObjectDataPc + 1] = 0xEF;
+  EXPECT_EQ(rom.vector(), expected);
+  EXPECT_EQ(ReadFile(cleanup.rom_path), expected);
+  EXPECT_FALSE(rom.dirty());
+  const auto backups = FindBackupArtifacts(cleanup.rom_path);
+  ASSERT_EQ(backups.size(), 1u);
+  EXPECT_EQ(ReadFile(backups.front()), disk_before);
+
+  Rom reopened;
+  ASSERT_TRUE(reopened.LoadFromFile(cleanup.rom_path.string()).ok());
+  const zelda3::Room room = zelda3::LoadRoomFromRom(&reopened, 0);
+  EXPECT_EQ(room.layout_id(), 3);
+  EXPECT_EQ(room.floor1(), 5);
+  EXPECT_EQ(room.floor2(), 10);
 }
 
 TEST(DungeonEditCommandsTest,

--- a/test/unit/editor/dungeon_editor_v2_rom_safety_test.cc
+++ b/test/unit/editor/dungeon_editor_v2_rom_safety_test.cc
@@ -326,6 +326,7 @@ TEST(DungeonEditorV2RomSafetyTest,
   auto& room = editor->rooms()[0];
   room.SetLoaded(true);
   ASSERT_TRUE(room.AddObject(zelda3::RoomObject(0x10, 10, 10, 0, 0)).ok());
+  room.SetLayoutId(3);
 
   DungeonSaveFlagsGuard guard;
   ConfigureMinimalDungeonSave();
@@ -351,7 +352,9 @@ TEST(DungeonEditorV2RomSafetyTest,
   EXPECT_EQ(SnesToPc(*rom.ReadLong(0x0F8003)), kRoom0ObjectPc);
   EXPECT_TRUE(std::equal(old_stream.begin(), old_stream.end(),
                          rom.data() + kRoom0ObjectPc));
+  EXPECT_EQ((rom.data()[kObjectAllocationPc + 1] >> 2) & 0x07, 3);
   EXPECT_FALSE(room.object_stream_dirty());
+  EXPECT_FALSE(room.object_stream_header_dirty());
 }
 
 TEST(DungeonEditorV2RomSafetyTest,
@@ -1576,6 +1579,42 @@ TEST(DungeonEditorV2RomSafetyTest,
 
   editor->rooms()[0].SetPalette(0x2A);
   EXPECT_FALSE(editor->CollectWriteRanges().empty());
+}
+
+TEST(DungeonEditorV2RomSafetyTest,
+     SaveRoomPersistsObjectHeaderPropertiesUnderSaveObjects) {
+  Rom rom;
+  ASSERT_TRUE(rom.LoadFromData(std::vector<uint8_t>(0x200000, 0)).ok());
+  SetupRoomObjectPointers(rom);
+  rom.mutable_data()[kRoom0ObjectPc] = 0xA5;
+  rom.mutable_data()[kRoom0ObjectPc + 1] = 0xE3;
+  const std::vector<uint8_t> payload_before(rom.data() + kRoom0ObjectPc + 2,
+                                            rom.data() + kRoom0ObjectPc + 10);
+
+  auto editor = std::make_unique<DungeonEditorV2>(&rom);
+  editor->rooms()[0] = zelda3::LoadRoomFromRom(&rom, 0);
+  editor->rooms()[0].SetLayoutId(3);
+  editor->rooms()[0].set_floor1(2);
+  editor->rooms()[0].set_floor2(4);
+
+  DungeonSaveFlagsGuard guard;
+  ConfigureMinimalDungeonSave();
+
+  const auto write_ranges = editor->CollectWriteRanges();
+  EXPECT_NE(std::find(write_ranges.begin(), write_ranges.end(),
+                      std::pair<uint32_t, uint32_t>{kRoom0ObjectPc,
+                                                    kRoom0ObjectPc + 2}),
+            write_ranges.end());
+  ASSERT_TRUE(editor->SaveRoom(0).ok());
+
+  const zelda3::Room reloaded = zelda3::LoadRoomFromRom(&rom, 0);
+  EXPECT_EQ(reloaded.layout_id(), 3);
+  EXPECT_EQ(reloaded.floor1(), 2);
+  EXPECT_EQ(reloaded.floor2(), 4);
+  EXPECT_EQ(rom.data()[kRoom0ObjectPc + 1] & 0xE3, 0xE3);
+  EXPECT_TRUE(std::equal(payload_before.begin(), payload_before.end(),
+                         rom.data() + kRoom0ObjectPc + 2));
+  EXPECT_FALSE(editor->rooms()[0].object_stream_header_dirty());
 }
 
 TEST(DungeonEditorV2RomSafetyTest, PendingRoomCountTracksRoomDirtyState) {

--- a/test/unit/zelda3/dungeon/dungeon_editor_system_test.cc
+++ b/test/unit/zelda3/dungeon/dungeon_editor_system_test.cc
@@ -205,6 +205,33 @@ TEST_F(DungeonEditorSystemTest, SaveRoomPersistsExternalRoomPotItemsAndHeader) {
   EXPECT_EQ(reloaded.message_id(), 0x1357);
 }
 
+TEST_F(DungeonEditorSystemTest,
+       SaveRoomPersistsLayoutAndFloorObjectStreamHeaderFields) {
+  DungeonEditorSystem system(rom_.get());
+  ASSERT_TRUE(system.Initialize().ok());
+
+  rom_->mutable_data()[kRoom0ObjectPc] = 0xA5;
+  rom_->mutable_data()[kRoom0ObjectPc + 1] = 0xE3;
+  const std::vector<uint8_t> payload_before(rom_->data() + kRoom0ObjectPc + 2,
+                                            rom_->data() + kRoom0ObjectPc + 10);
+  Room external_room = LoadRoomFromRom(rom_.get(), 0);
+  system.SetExternalRoom(&external_room);
+
+  external_room.SetLayoutId(3);
+  external_room.set_floor1(2);
+  external_room.set_floor2(4);
+  ASSERT_TRUE(system.SaveRoom(0).ok());
+
+  Room reloaded = LoadRoomFromRom(rom_.get(), 0);
+  EXPECT_EQ(reloaded.layout_id(), 3);
+  EXPECT_EQ(reloaded.floor1(), 2);
+  EXPECT_EQ(reloaded.floor2(), 4);
+  EXPECT_EQ(rom_->data()[kRoom0ObjectPc + 1] & 0xE3, 0xE3);
+  EXPECT_TRUE(std::equal(payload_before.begin(), payload_before.end(),
+                         rom_->data() + kRoom0ObjectPc + 2));
+  EXPECT_FALSE(external_room.object_stream_header_dirty());
+}
+
 TEST_F(DungeonEditorSystemTest, SaveRoomPreservesOtherRoomIndexedData) {
   DungeonEditorSystem system(rom_.get());
   ASSERT_TRUE(system.Initialize().ok());

--- a/test/unit/zelda3/dungeon/dungeon_save_test.cc
+++ b/test/unit/zelda3/dungeon/dungeon_save_test.cc
@@ -383,6 +383,158 @@ TEST_F(DungeonSaveTest, SaveObjects_SharedStreamFailsWithoutMutation) {
 }
 
 TEST_F(DungeonSaveTest,
+       SaveObjectStreamHeaderUsesPerFieldRmwAndPreservesPayload) {
+  constexpr int kStreamPc = 0x100000;
+  WriteEmptyObjectStream(kStreamPc, 0xA5, 0xE3);
+  const std::vector<uint8_t> payload(rom_->data() + kStreamPc + 2,
+                                     rom_->data() + kStreamPc + 10);
+
+  room_->set_floor1(0x02);
+  EXPECT_TRUE(room_->object_stream_header_dirty());
+  EXPECT_FALSE(room_->object_stream_dirty());
+  ASSERT_TRUE(room_->SaveObjectStreamHeader().ok());
+  EXPECT_EQ(rom_->data()[kStreamPc], 0xA2);
+  EXPECT_EQ(rom_->data()[kStreamPc + 1], 0xE3);
+
+  room_->set_floor2(0x03);
+  ASSERT_TRUE(room_->SaveObjectStreamHeader().ok());
+  EXPECT_EQ(rom_->data()[kStreamPc], 0x32);
+  EXPECT_EQ(rom_->data()[kStreamPc + 1], 0xE3);
+
+  room_->SetLayoutId(0x04);
+  ASSERT_TRUE(room_->SaveObjectStreamHeader().ok());
+  EXPECT_EQ(rom_->data()[kStreamPc], 0x32);
+  EXPECT_EQ(rom_->data()[kStreamPc + 1], 0xF3);
+  EXPECT_TRUE(
+      std::equal(payload.begin(), payload.end(), rom_->data() + kStreamPc + 2));
+  EXPECT_FALSE(room_->object_stream_header_dirty());
+  EXPECT_FALSE(room_->object_stream_dirty());
+}
+
+TEST_F(DungeonSaveTest,
+       SaveObjectStreamHeaderRejectsOutOfRangeValueWithoutMutation) {
+  WriteEmptyObjectStream(0x100000, 0xA5, 0xE3);
+  room_->SetLayoutId(0x08);
+  const auto before = rom_->vector();
+
+  const auto status = room_->SaveObjectStreamHeader();
+
+  EXPECT_EQ(status.code(), absl::StatusCode::kInvalidArgument);
+  EXPECT_EQ(rom_->vector(), before);
+  EXPECT_TRUE(room_->object_stream_header_dirty());
+}
+
+TEST_F(DungeonSaveTest,
+       SaveObjectStreamHeaderSharedStreamFailsClosedWithoutManifest) {
+  SetObjectRoomPointer(1, 0x100000);
+  WriteEmptyObjectStream(0x100000, 0xA5, 0xE3);
+  room_->SetLayoutId(0x03);
+  const auto before = rom_->vector();
+
+  const auto status = room_->SaveObjectStreamHeader();
+
+  EXPECT_EQ(status.code(), absl::StatusCode::kFailedPrecondition);
+  EXPECT_EQ(rom_->vector(), before);
+  EXPECT_TRUE(room_->object_stream_header_dirty());
+  EXPECT_FALSE(room_->object_stream_dirty());
+}
+
+TEST_F(DungeonSaveTest,
+       SaveObjectStreamHeaderDetachesSharedStreamWithManifestLayout) {
+  constexpr int kOldStreamPc = 0x100000;
+  constexpr int kRelocatedStreamPc = 0x100200;
+  SetObjectRoomPointer(1, kOldStreamPc);
+  WriteEmptyObjectStream(kOldStreamPc, 0xA5, 0xE3);
+  const std::vector<uint8_t> old_stream(rom_->data() + kOldStreamPc,
+                                        rom_->data() + kOldStreamPc + 10);
+  room_->set_floor2(0x03);
+  const auto layout = MakeObjectLayout();
+
+  const auto status = room_->SaveObjectStreamHeader(&layout);
+
+  ASSERT_TRUE(status.ok()) << status.message();
+  EXPECT_EQ(GetObjectRoomPointer(0), kRelocatedStreamPc);
+  EXPECT_EQ(GetObjectRoomPointer(1), kOldStreamPc);
+  EXPECT_EQ(GetDoorPointer(0), kRelocatedStreamPc + 8);
+  EXPECT_TRUE(std::equal(old_stream.begin(), old_stream.end(),
+                         rom_->data() + kOldStreamPc));
+  EXPECT_EQ(rom_->data()[kRelocatedStreamPc], 0x35);
+  EXPECT_EQ(rom_->data()[kRelocatedStreamPc + 1], 0xE3);
+  EXPECT_TRUE(std::equal(old_stream.begin() + 2, old_stream.end(),
+                         rom_->data() + kRelocatedStreamPc + 2));
+  EXPECT_FALSE(room_->object_stream_header_dirty());
+}
+
+TEST_F(DungeonSaveTest,
+       SaveObjectStreamHeaderDetachesOverlappingSuffixWithManifestLayout) {
+  constexpr int kOwnerStreamPc = 0x100000;
+  constexpr int kSuffixStreamPc = kOwnerStreamPc + 2;
+  constexpr int kRelocatedStreamPc = 0x100200;
+  SetObjectRoomPointer(0, kSuffixStreamPc);
+  SetObjectRoomPointer(1, kOwnerStreamPc);
+  ASSERT_TRUE(rom_->WriteVector(kOwnerStreamPc, {0x00, 0x00, 0xFF, 0xFF, 0xFF,
+                                                 0xFF, 0xFF, 0xFF, 0xFF, 0xFF})
+                  .ok());
+  const std::vector<uint8_t> owner_stream(rom_->data() + kOwnerStreamPc,
+                                          rom_->data() + kOwnerStreamPc + 10);
+  room_->SetLayoutId(0x03);
+  const auto layout = MakeObjectLayout();
+
+  const auto status = room_->SaveObjectStreamHeader(&layout);
+
+  ASSERT_TRUE(status.ok()) << status.message();
+  EXPECT_EQ(GetObjectRoomPointer(0), kRelocatedStreamPc);
+  EXPECT_EQ(GetObjectRoomPointer(1), kOwnerStreamPc);
+  EXPECT_TRUE(std::equal(owner_stream.begin(), owner_stream.end(),
+                         rom_->data() + kOwnerStreamPc));
+  EXPECT_EQ(rom_->data()[kRelocatedStreamPc], 0xFF);
+  EXPECT_EQ(rom_->data()[kRelocatedStreamPc + 1], 0xEF);
+  EXPECT_TRUE(std::equal(owner_stream.begin() + 4, owner_stream.end(),
+                         rom_->data() + kRelocatedStreamPc + 2));
+  EXPECT_FALSE(room_->object_stream_header_dirty());
+}
+
+TEST_F(DungeonSaveTest,
+       SaveObjectStreamHeaderAllocatorExhaustionRollsBackRomAndDirtyState) {
+  SetObjectRoomPointer(1, 0x100000);
+  WriteEmptyObjectStream(0x100000, 0xA5, 0xE3);
+  room_->set_floor1(0x02);
+  const auto before = rom_->vector();
+  const auto layout = MakeObjectLayout({0x100200, 0x100204});
+
+  const auto status = room_->SaveObjectStreamHeader(&layout);
+
+  EXPECT_EQ(status.code(), absl::StatusCode::kResourceExhausted);
+  EXPECT_EQ(rom_->vector(), before);
+  EXPECT_TRUE(room_->object_stream_header_dirty());
+  EXPECT_FALSE(room_->object_stream_dirty());
+}
+
+TEST_F(DungeonSaveTest,
+       SaveObjectsThenHeaderPreservesCombinedPayloadAndPropertyEdits) {
+  constexpr int kOldStreamPc = 0x100000;
+  constexpr int kRelocatedStreamPc = 0x100200;
+  SetObjectRoomPointer(1, kOldStreamPc);
+  WriteEmptyObjectStream(kOldStreamPc, 0xA5, 0xE3);
+  ASSERT_TRUE(room_->AddObject(RoomObject(0x10, 10, 10, 0, 0)).ok());
+  room_->SetLayoutId(0x03);
+  const auto encoded = room_->EncodeObjects();
+  const auto layout = MakeObjectLayout();
+
+  ASSERT_TRUE(room_->SaveObjects(&layout).ok());
+  ASSERT_TRUE(room_->SaveObjectStreamHeader(&layout).ok());
+
+  EXPECT_EQ(GetObjectRoomPointer(0), kRelocatedStreamPc);
+  EXPECT_EQ(GetObjectRoomPointer(1), kOldStreamPc);
+  EXPECT_EQ(rom_->data()[kRelocatedStreamPc], 0xA5);
+  EXPECT_EQ(rom_->data()[kRelocatedStreamPc + 1], 0xEF);
+  EXPECT_TRUE(std::equal(encoded.begin(), encoded.end(),
+                         rom_->data() + kRelocatedStreamPc + 2));
+  EXPECT_FALSE(room_->object_stream_dirty());
+  EXPECT_FALSE(room_->object_stream_header_dirty());
+}
+
+TEST_F(DungeonSaveTest,
        SaveObjects_SharedStreamDetachesWithDeclaredAllocatorSpace) {
   constexpr int kOldStreamPc = 0x100000;
   constexpr int kRelocatedStreamPc = 0x100200;

--- a/test/unit/zelda3/dungeon/room_manipulation_test.cc
+++ b/test/unit/zelda3/dungeon/room_manipulation_test.cc
@@ -217,6 +217,26 @@ TEST_F(RoomManipulationTest, TracksSpecialTileObjectSaveDomains) {
   EXPECT_TRUE(room_->HasUnsavedChanges());
 }
 
+TEST_F(RoomManipulationTest,
+       TracksObjectStreamHeaderDirtyStateAcrossSnapshots) {
+  room_->SetLayoutId(3);
+  room_->set_floor1(4);
+
+  EXPECT_TRUE(room_->object_stream_header_dirty());
+  EXPECT_FALSE(room_->object_stream_dirty());
+  EXPECT_TRUE(room_->HasUnsavedChanges());
+  const Room::SaveDirtySnapshot snapshot = room_->CaptureSaveDirtySnapshot();
+
+  room_->ClearSaveDirtyState();
+  EXPECT_FALSE(room_->object_stream_header_dirty());
+  EXPECT_FALSE(room_->HasUnsavedChanges());
+
+  room_->RestoreSaveDirtySnapshot(snapshot);
+  EXPECT_TRUE(room_->object_stream_header_dirty());
+  EXPECT_FALSE(room_->object_stream_dirty());
+  EXPECT_TRUE(room_->HasUnsavedChanges());
+}
+
 }  // namespace test
 }  // namespace zelda3
 }  // namespace yaze


### PR DESCRIPTION
## Summary

- persist dungeon `layout`, `floor1`, and `floor2` through their real two-byte object-stream header rather than the unrelated 14-byte room header
- track each field with a dedicated dirty mask so header-only edits never re-encode the object payload
- preserve every non-target bit and payload byte with per-field read/modify/write
- fail exact shared streams closed without a manifest; use manifest-backed full-stream copy-on-write for alias/overlap cases while updating object and door pointers
- save payload before stream header and bind the same ordering/ranges into `DungeonEditorSystem` and `DungeonEditorV2`
- enable transactional CLI writes with strict value ranges and optional manifest allocation context

## Safety coverage

- unique-stream per-field save/reopen and payload identity
- invalid values rejected before mutation
- manifestless shared stream rejected without mutation
- manifest-backed COW pointer/door/alias preservation and exhaustion rollback
- combined payload + header dirty save ordering
- CLI required-backup / disk failure rollback
- GUI/system dirty-state, range, save, and reopen coverage

## Verification

- unit target build passed
- focused core/CLI/GUI/system suite: **26/26 passed**
- broader dungeon/editor suite: **215/215 passed**
- pre-push validation passed
- independent strict review: no blocker or high-severity finding
- full local suite: **2702 passed, 13 skipped**; 8 unrelated baseline/environment failures were limited to the local ROM fixture-size expectation and ASAR-disabled/CLI-unavailable tests

## Residual validation

- no canonical ROM was written and no real-ROM integration case ran in this slice
- manifestless non-exact overlaps remain deliberately outside scope; exact aliases fail closed and manifest inventory handles overlap COW

Fixes #129
