### PR TITLE
fix(cli): persist collision JSON imports transactionally

### DIFF
--- a/docs/internal/agents/rom-safety-guardrails.md
+++ b/docs/internal/agents/rom-safety-guardrails.md
@@ -24,6 +24,17 @@ This repo is used to edit ROM hacks (including Oracle of Secrets). Treat ROM wri
   `dungeon-set-collision-tile` wrap their serializer, required backup, and disk
   commit in `ScopedRomTransaction`. Any failure restores the caller's ROM
   bytes, filename, size, and dirty state.
+- Non-dry-run `dungeon-import-custom-collision-json` and
+  `dungeon-import-water-fill-json` use the same transaction and required-backup
+  contract, then immediately save the active ROM. With `--sandbox`, the active
+  target is the sandbox copy; the source ROM is not saved or backed up.
+- Import `--report` is accepted only with a non-sandbox `--dry-run`; every
+  write-mode or sandbox invocation rejects it before ROM loading or sandbox
+  creation. Report paths must not alias the active ROM. The guard is rechecked
+  immediately before the direct report write, but a local path-swap TOCTOU
+  remains; use a trusted directory that other processes cannot modify.
+  Collision/water JSON export reports use the same active-ROM alias guard and
+  are also rejected with `--sandbox`.
 - Other CLI writers that still set only `backup=true` remain best-effort and
   must be audited before opting into the strict transaction path.
 
@@ -226,7 +237,16 @@ When importing dungeon collision or water-fill JSON, use a two-step flow:
 Safety semantics:
 
 - `--dry-run` performs full parsing/validation and emits impact counts without writing.
-- `--report <path>` writes machine-readable JSON with `status`, `mode`, and structured error code/message.
+- Without `--dry-run`, imports immediately save the active ROM with a required
+  backup. `--sandbox` redirects that one save and its backup to the sandbox
+  copy, leaving the source ROM and source directory unchanged.
+- `--mock-rom` is an explicit in-memory test mode and cannot be combined with
+  `--sandbox`; the command rejects that combination before creating a sandbox.
+- `--report <path>` is non-sandbox dry-run-only and writes machine-readable
+  JSON with `status`, `mode`, and structured error code/message. It must name a
+  separate writable file, never the active ROM through a direct, normalized,
+  symlink, or hardlink path. Use a trusted report directory because a local
+  path swap between the identity check and open is not guarded.
 - `dungeon-import-custom-collision-json --replace-all` is destructive and requires `--force` in write mode.
 - `dungeon-import-water-fill-json --strict-masks` fails closed if SRAM mask normalization would be needed.
 

--- a/docs/public/reference/z3ed-command-reference.md
+++ b/docs/public/reference/z3ed-command-reference.md
@@ -152,6 +152,8 @@ These commands operate directly on ROM data (no GUI required).
 - `dungeon-list-sprites --room <hex>`
 - `dungeon-list-objects --room <hex>`
 - `dungeon-list-custom-collision --room <hex> [--tiles <hex,hex,...>] [--nonzero] [--all]`
+- `dungeon-import-custom-collision-json --in <path> [--dry-run [--report <path>]] [--sandbox | --mock-rom] [--replace-all --force]`
+- `dungeon-import-water-fill-json --in <path> [--dry-run [--report <path>]] [--sandbox | --mock-rom] [--strict-masks]`
 - `dungeon-minecart-audit [--room <hex> | --rooms <hex,hex,...> | --all] [--only-issues]`
 - `dungeon-map --room <hex> [--layer <0|1|2>]` *(overlays Oracle custom collision tiles when present)*
 - `dungeon-list-chests --room <hex>`
@@ -170,6 +172,19 @@ an explicit manifest defines `dungeon_stream_regions.objects` with the
 ownership guard: protected current-stream, allocation, object-pointer, or
 door-pointer writes are rejected before either dry-run or write can mutate ROM
 bytes.
+
+The collision and water-fill JSON import commands validate without mutation
+when `--dry-run` is present. Without it, they immediately save the active ROM
+with a required backup. `--sandbox` redirects that save and backup to the
+sandbox copy; the source ROM and its directory remain unchanged. `--mock-rom`
+is an in-memory test mode and is rejected when combined with `--sandbox`.
+`--report` is accepted only with a non-sandbox `--dry-run`; write-mode and
+sandbox imports reject it before ROM or sandbox work. Report paths must not
+alias the active ROM, including through symlinks or hardlinks. Reports use a
+direct file write after a final identity recheck; use a trusted directory
+because a local path-swap race remains between that check and open.
+Collision/water JSON export reports use the same ROM-alias check and cannot be
+combined with `--sandbox`.
 
 When `--spawn` is set, the ID must be `0x00`-`0x06`. Both entrance commands
 report the dedicated spawn fields (`quadrant`, `overworld_door_tilemap`, and

--- a/src/cli/handlers/game/dungeon_collision_commands.cc
+++ b/src/cli/handlers/game/dungeon_collision_commands.cc
@@ -3,27 +3,37 @@
 #include <algorithm>
 #include <array>
 #include <cstdint>
+#include <filesystem>
 #include <fstream>
+#include <ios>
 #include <sstream>
 #include <string>
+#include <system_error>
 #include <unordered_map>
 #include <unordered_set>
+#include <utility>
 #include <vector>
 
+#include "absl/flags/declare.h"
+#include "absl/flags/flag.h"
 #include "absl/status/status.h"
 #include "absl/strings/ascii.h"
 #include "absl/strings/str_format.h"
 #include "absl/strings/str_split.h"
+#include "absl/strings/string_view.h"
 #include "absl/types/span.h"
 #include "cli/util/hex_util.h"
 #include "nlohmann/json.hpp"
 #include "rom/rom.h"
+#include "rom/transaction.h"
 #include "util/macro.h"
 #include "zelda3/dungeon/custom_collision.h"
 #include "zelda3/dungeon/dungeon_rom_addresses.h"
 #include "zelda3/dungeon/oracle_rom_safety_preflight.h"
 #include "zelda3/dungeon/room.h"
 #include "zelda3/dungeon/water_fill_zone.h"
+
+ABSL_DECLARE_FLAG(bool, sandbox);
 
 namespace yaze {
 namespace cli {
@@ -144,11 +154,119 @@ absl::Status WriteTextFile(const std::string& path,
     return absl::PermissionDeniedError(
         absl::StrFormat("Cannot open file for writing: %s", path));
   }
-  out << content;
-  if (!out.good()) {
+  out.write(content.data(), static_cast<std::streamsize>(content.size()));
+  out.flush();
+  const bool write_failed = !out.good();
+  out.close();
+  if (write_failed || out.fail()) {
     return absl::InternalError(
         absl::StrFormat("Failed while writing file: %s", path));
   }
+  return absl::OkStatus();
+}
+
+absl::Status ValidateImportArguments(const resources::ArgumentParser& parser,
+                                     absl::string_view command_name) {
+  RETURN_IF_ERROR(parser.RequireArgs({"in"}));
+  const bool has_report = parser.GetString("report").has_value();
+  const bool sandbox_requested =
+      parser.HasFlag("sandbox") || absl::GetFlag(FLAGS_sandbox);
+  if (has_report && !parser.HasFlag("dry-run")) {
+    return absl::InvalidArgumentError(absl::StrFormat(
+        "%s: --report is supported only with --dry-run; write-mode imports "
+        "must rely on command output and ROM backup verification",
+        command_name));
+  }
+  if (has_report && sandbox_requested) {
+    return absl::InvalidArgumentError(absl::StrFormat(
+        "%s: --report cannot be combined with --sandbox; run the reported "
+        "dry-run against the source ROM",
+        command_name));
+  }
+  if (parser.HasFlag("mock-rom") && sandbox_requested) {
+    return absl::InvalidArgumentError(absl::StrFormat(
+        "%s: --mock-rom and --sandbox are mutually exclusive", command_name));
+  }
+  return absl::OkStatus();
+}
+
+absl::Status ValidateExportArguments(const resources::ArgumentParser& parser,
+                                     absl::string_view command_name) {
+  RETURN_IF_ERROR(parser.RequireArgs({"out"}));
+  const bool sandbox_requested =
+      parser.HasFlag("sandbox") || absl::GetFlag(FLAGS_sandbox);
+  if (parser.GetString("report").has_value() && sandbox_requested) {
+    return absl::InvalidArgumentError(absl::StrFormat(
+        "%s: --report cannot be combined with --sandbox; export from the "
+        "source ROM or omit --report",
+        command_name));
+  }
+  return absl::OkStatus();
+}
+
+absl::StatusOr<std::filesystem::path> NormalizedAbsolutePath(
+    const std::filesystem::path& path) {
+  std::error_code absolute_ec;
+  std::filesystem::path absolute = std::filesystem::absolute(path, absolute_ec);
+  if (absolute_ec) {
+    return absl::InvalidArgumentError(absl::StrFormat(
+        "Cannot normalize path %s: %s", path.string(), absolute_ec.message()));
+  }
+  return absolute.lexically_normal();
+}
+
+absl::StatusOr<bool> PathsAlias(const std::filesystem::path& lhs,
+                                const std::filesystem::path& rhs) {
+  ASSIGN_OR_RETURN(const auto normalized_lhs, NormalizedAbsolutePath(lhs));
+  ASSIGN_OR_RETURN(const auto normalized_rhs, NormalizedAbsolutePath(rhs));
+  if (normalized_lhs == normalized_rhs) {
+    return true;
+  }
+
+  std::error_code equivalent_ec;
+  const bool equivalent = std::filesystem::equivalent(
+      normalized_lhs, normalized_rhs, equivalent_ec);
+  if (!equivalent_ec) {
+    return equivalent;
+  }
+
+  // equivalent() reports an error when either path does not exist. Lexical
+  // normalization above is sufficient in that case. If both paths do exist,
+  // fail closed rather than risk truncating a ROM we could not compare.
+  std::error_code lhs_exists_ec;
+  std::error_code rhs_exists_ec;
+  const bool lhs_exists =
+      std::filesystem::exists(normalized_lhs, lhs_exists_ec);
+  const bool rhs_exists =
+      std::filesystem::exists(normalized_rhs, rhs_exists_ec);
+  if (lhs_exists_ec || rhs_exists_ec || (lhs_exists && rhs_exists)) {
+    return absl::FailedPreconditionError(absl::StrFormat(
+        "Could not safely compare paths %s and %s: %s", normalized_lhs.string(),
+        normalized_rhs.string(), equivalent_ec.message()));
+  }
+  return false;
+}
+
+absl::Status RejectReportRomAliases(const resources::ArgumentParser& parser,
+                                    const Rom* rom) {
+  const auto report_path_value = parser.GetString("report");
+  if (!report_path_value.has_value() || report_path_value->empty()) {
+    return absl::OkStatus();
+  }
+
+  const std::filesystem::path report_path(*report_path_value);
+  if (rom != nullptr && !rom->filename().empty()) {
+    ASSIGN_OR_RETURN(
+        const bool aliases_active_rom,
+        PathsAlias(report_path, std::filesystem::path(rom->filename())));
+    if (aliases_active_rom) {
+      return absl::InvalidArgumentError(absl::StrFormat(
+          "--report path aliases the active ROM; choose a separate report "
+          "file: %s",
+          report_path.string()));
+    }
+  }
+
   return absl::OkStatus();
 }
 
@@ -211,7 +329,8 @@ absl::Status WriteReportIfRequested(const resources::ArgumentParser& parser,
 }
 
 absl::Status FinalizeWithReport(const resources::ArgumentParser& parser,
-                                json report, const absl::Status& status) {
+                                json report, const absl::Status& status,
+                                const Rom* protected_rom = nullptr) {
   if (!status.ok()) {
     report["status"] = "error";
     report["error"] = json{
@@ -220,7 +339,13 @@ absl::Status FinalizeWithReport(const resources::ArgumentParser& parser,
     };
   }
 
-  const auto report_status = WriteReportIfRequested(parser, report);
+  absl::Status report_status = absl::OkStatus();
+  if (protected_rom != nullptr) {
+    report_status = RejectReportRomAliases(parser, protected_rom);
+  }
+  if (report_status.ok()) {
+    report_status = WriteReportIfRequested(parser, report);
+  }
   if (!report_status.ok()) {
     if (status.ok()) {
       return report_status;
@@ -250,6 +375,41 @@ json BuildPreflightJson(
   }
   out["errors"] = std::move(errors);
   return out;
+}
+
+template <typename Serializer>
+absl::Status SerializeAndPersistImport(Rom* rom,
+                                       const resources::ArgumentParser& parser,
+                                       json* report, Serializer&& serializer) {
+  ScopedRomTransaction transaction(*rom);
+
+  const absl::Status write_status = std::forward<Serializer>(serializer)();
+  if (!write_status.ok()) {
+    (*report)["write_error"] = std::string(write_status.message());
+    return write_status;
+  }
+  (*report)["write_status"] = "success";
+
+  // Unit-test and embedding callers can explicitly request an in-memory write.
+  // A sandbox ROM is file-backed, so it follows the normal save path and writes
+  // only its sandbox copy.
+  if (parser.HasFlag("mock-rom")) {
+    (*report)["save_status"] = "mock-rom-skipped";
+    transaction.Commit();
+    return absl::OkStatus();
+  }
+
+  Rom::SaveSettings save_settings;
+  save_settings.require_backup = true;
+  const absl::Status save_status = rom->SaveToFile(save_settings);
+  if (!save_status.ok()) {
+    (*report)["save_error"] = std::string(save_status.message());
+    return save_status;
+  }
+
+  (*report)["save_status"] = "saved";
+  transaction.Commit();
+  return absl::OkStatus();
 }
 
 std::vector<int> RequiredCollisionRoomsForImportedWaterFillZones(
@@ -359,6 +519,8 @@ absl::Status DungeonListCustomCollisionCommandHandler::Execute(
 absl::Status DungeonExportCustomCollisionJsonCommandHandler::Execute(
     Rom* rom, const resources::ArgumentParser& parser,
     resources::OutputFormatter& formatter) {
+  RETURN_IF_ERROR(RejectReportRomAliases(parser, rom));
+
   json report = BuildBaseReport(GetName(), /*dry_run=*/false);
   const absl::Status status = [&]() -> absl::Status {
     ASSIGN_OR_RETURN(const auto room_ids, ParseRoomSelection(parser));
@@ -406,12 +568,19 @@ absl::Status DungeonExportCustomCollisionJsonCommandHandler::Execute(
     return absl::OkStatus();
   }();
 
-  return FinalizeWithReport(parser, std::move(report), status);
+  return FinalizeWithReport(parser, std::move(report), status, rom);
 }
 
 absl::Status DungeonImportCustomCollisionJsonCommandHandler::Execute(
     Rom* rom, const resources::ArgumentParser& parser,
     resources::OutputFormatter& formatter) {
+  const absl::Status report_alias_status = RejectReportRomAliases(parser, rom);
+  if (!report_alias_status.ok()) {
+    // FinalizeWithReport would write to the rejected path and could truncate
+    // the active ROM. Return this guard failure directly.
+    return report_alias_status;
+  }
+
   const bool dry_run = parser.HasFlag("dry-run");
   json report = BuildBaseReport(GetName(), dry_run);
   const absl::Status status = [&]() -> absl::Status {
@@ -506,7 +675,9 @@ absl::Status DungeonImportCustomCollisionJsonCommandHandler::Execute(
     report["replace_all_clears"] = replace_all_clears;
 
     if (!dry_run) {
-      RETURN_IF_ERROR(zelda3::SaveAllCollision(rom, absl::MakeSpan(rooms)));
+      RETURN_IF_ERROR(SerializeAndPersistImport(rom, parser, &report, [&]() {
+        return zelda3::SaveAllCollision(rom, absl::MakeSpan(rooms));
+      }));
     }
 
     report["populated_rooms"] = populated_rooms;
@@ -521,17 +692,25 @@ absl::Status DungeonImportCustomCollisionJsonCommandHandler::Execute(
                        static_cast<int>(imported_rooms.size()));
     formatter.AddField("populated_rooms", populated_rooms);
     formatter.AddField("cleared_rooms", cleared_rooms);
+    if (!dry_run) {
+      formatter.AddField("write_status",
+                         report.value("write_status", std::string("unknown")));
+      formatter.AddField("save_status",
+                         report.value("save_status", std::string("unknown")));
+    }
     formatter.AddField("status", "success");
     formatter.EndObject();
     return absl::OkStatus();
   }();
 
-  return FinalizeWithReport(parser, std::move(report), status);
+  return FinalizeWithReport(parser, std::move(report), status, rom);
 }
 
 absl::Status DungeonExportWaterFillJsonCommandHandler::Execute(
     Rom* rom, const resources::ArgumentParser& parser,
     resources::OutputFormatter& formatter) {
+  RETURN_IF_ERROR(RejectReportRomAliases(parser, rom));
+
   json report = BuildBaseReport(GetName(), /*dry_run=*/false);
   const absl::Status status = [&]() -> absl::Status {
     const std::string out_path = parser.GetString("out").value();
@@ -569,12 +748,19 @@ absl::Status DungeonExportWaterFillJsonCommandHandler::Execute(
     return absl::OkStatus();
   }();
 
-  return FinalizeWithReport(parser, std::move(report), status);
+  return FinalizeWithReport(parser, std::move(report), status, rom);
 }
 
 absl::Status DungeonImportWaterFillJsonCommandHandler::Execute(
     Rom* rom, const resources::ArgumentParser& parser,
     resources::OutputFormatter& formatter) {
+  const absl::Status report_alias_status = RejectReportRomAliases(parser, rom);
+  if (!report_alias_status.ok()) {
+    // FinalizeWithReport would write to the rejected path and could truncate
+    // the active ROM. Return this guard failure directly.
+    return report_alias_status;
+  }
+
   const bool dry_run = parser.HasFlag("dry-run");
   const bool strict_masks = parser.HasFlag("strict-masks");
   json report = BuildBaseReport(GetName(), dry_run);
@@ -642,7 +828,9 @@ absl::Status DungeonImportWaterFillJsonCommandHandler::Execute(
     }
 
     if (!dry_run) {
-      RETURN_IF_ERROR(zelda3::WriteWaterFillTable(rom, zones));
+      RETURN_IF_ERROR(SerializeAndPersistImport(rom, parser, &report, [&]() {
+        return zelda3::WriteWaterFillTable(rom, zones);
+      }));
     }
 
     formatter.BeginObject("Water Fill Import");
@@ -651,12 +839,38 @@ absl::Status DungeonImportWaterFillJsonCommandHandler::Execute(
     formatter.AddField("strict_masks", strict_masks);
     formatter.AddField("zone_count", static_cast<int>(zones.size()));
     formatter.AddField("normalized_masks", normalized_masks);
+    if (!dry_run) {
+      formatter.AddField("write_status",
+                         report.value("write_status", std::string("unknown")));
+      formatter.AddField("save_status",
+                         report.value("save_status", std::string("unknown")));
+    }
     formatter.AddField("status", "success");
     formatter.EndObject();
     return absl::OkStatus();
   }();
 
-  return FinalizeWithReport(parser, std::move(report), status);
+  return FinalizeWithReport(parser, std::move(report), status, rom);
+}
+
+absl::Status DungeonImportCustomCollisionJsonCommandHandler::ValidateArgs(
+    const resources::ArgumentParser& parser) {
+  return ValidateImportArguments(parser, GetName());
+}
+
+absl::Status DungeonExportCustomCollisionJsonCommandHandler::ValidateArgs(
+    const resources::ArgumentParser& parser) {
+  return ValidateExportArguments(parser, GetName());
+}
+
+absl::Status DungeonExportWaterFillJsonCommandHandler::ValidateArgs(
+    const resources::ArgumentParser& parser) {
+  return ValidateExportArguments(parser, GetName());
+}
+
+absl::Status DungeonImportWaterFillJsonCommandHandler::ValidateArgs(
+    const resources::ArgumentParser& parser) {
+  return ValidateImportArguments(parser, GetName());
 }
 
 }  // namespace handlers

--- a/src/cli/handlers/game/dungeon_collision_commands.h
+++ b/src/cli/handlers/game/dungeon_collision_commands.h
@@ -45,9 +45,7 @@ class DungeonExportCustomCollisionJsonCommandHandler
            "[--format <json|text>]";
   }
 
-  absl::Status ValidateArgs(const resources::ArgumentParser& parser) override {
-    return parser.RequireArgs({"out"});
-  }
+  absl::Status ValidateArgs(const resources::ArgumentParser& parser) override;
 
   absl::Status Execute(Rom* rom, const resources::ArgumentParser& parser,
                        resources::OutputFormatter& formatter) override;
@@ -60,22 +58,25 @@ class DungeonImportCustomCollisionJsonCommandHandler
     return "dungeon-import-custom-collision-json";
   }
   std::string GetDescription() const {
-    return "Import dungeon custom collision maps from JSON";
+    return "Validate custom collision JSON with --dry-run; otherwise import "
+           "and immediately save the active ROM (--sandbox saves only its "
+           "copy)";
   }
   std::string GetUsage() const override {
     return "dungeon-import-custom-collision-json --in <path> [--replace-all] "
-           "[--force] [--dry-run] [--report <path>] [--format <json|text>]";
+           "[--force] [--dry-run [--report <path>]] "
+           "[--sandbox | --mock-rom] "
+           "[--format <json|text>]";
   }
 
-  absl::Status ValidateArgs(const resources::ArgumentParser& parser) override {
-    return parser.RequireArgs({"in"});
-  }
+  absl::Status ValidateArgs(const resources::ArgumentParser& parser) override;
 
   absl::Status Execute(Rom* rom, const resources::ArgumentParser& parser,
                        resources::OutputFormatter& formatter) override;
 };
 
-class DungeonExportWaterFillJsonCommandHandler : public resources::CommandHandler {
+class DungeonExportWaterFillJsonCommandHandler
+    : public resources::CommandHandler {
  public:
   std::string GetName() const override {
     return "dungeon-export-water-fill-json";
@@ -90,30 +91,30 @@ class DungeonExportWaterFillJsonCommandHandler : public resources::CommandHandle
            "[--format <json|text>]";
   }
 
-  absl::Status ValidateArgs(const resources::ArgumentParser& parser) override {
-    return parser.RequireArgs({"out"});
-  }
+  absl::Status ValidateArgs(const resources::ArgumentParser& parser) override;
 
   absl::Status Execute(Rom* rom, const resources::ArgumentParser& parser,
                        resources::OutputFormatter& formatter) override;
 };
 
-class DungeonImportWaterFillJsonCommandHandler : public resources::CommandHandler {
+class DungeonImportWaterFillJsonCommandHandler
+    : public resources::CommandHandler {
  public:
   std::string GetName() const override {
     return "dungeon-import-water-fill-json";
   }
   std::string GetDescription() const {
-    return "Import dungeon water fill zones from JSON";
+    return "Validate water-fill JSON with --dry-run; otherwise import and "
+           "immediately save the active ROM (--sandbox saves only its copy)";
   }
   std::string GetUsage() const override {
-    return "dungeon-import-water-fill-json --in <path> [--dry-run] "
-           "[--strict-masks] [--report <path>] [--format <json|text>]";
+    return "dungeon-import-water-fill-json --in <path> "
+           "[--dry-run [--report <path>]] [--strict-masks] "
+           "[--sandbox | --mock-rom] "
+           "[--format <json|text>]";
   }
 
-  absl::Status ValidateArgs(const resources::ArgumentParser& parser) override {
-    return parser.RequireArgs({"in"});
-  }
+  absl::Status ValidateArgs(const resources::ArgumentParser& parser) override;
 
   absl::Status Execute(Rom* rom, const resources::ArgumentParser& parser,
                        resources::OutputFormatter& formatter) override;

--- a/src/cli/service/agent/tool_registration.cc
+++ b/src/cli/service/agent/tool_registration.cc
@@ -162,24 +162,40 @@ void RegisterBuiltinAgentTools(ToolRegistry& registry) {
       "dungeon-export-custom-collision-json --out=<path> "
       "[--room=<id>|--rooms=<ids>|--all] [--report=<path>]",
       {}, true, true, DungeonExportCustomCollisionJsonCommandHandler)
-  REGISTER_BUILTIN_AGENT_TOOL(
-      "dungeon-import-custom-collision-json", "dungeon",
-      "Import custom collision maps from JSON",
-      "dungeon-import-custom-collision-json --in=<path> "
-      "[--dry-run] [--replace-all --force] [--report=<path>]",
-      {}, true, true, DungeonImportCustomCollisionJsonCommandHandler)
+  RegisterBuiltinTool<DungeonImportCustomCollisionJsonCommandHandler>(
+      registry,
+      {"dungeon-import-custom-collision-json",
+       "dungeon",
+       "Import custom collision maps and immediately save unless --dry-run",
+       "dungeon-import-custom-collision-json --in=<path> "
+       "[--dry-run [--report=<path>]] [--sandbox | --mock-rom] "
+       "[--replace-all --force]",
+       {},
+       true,
+       true,
+       ToolAccess::kMutating,
+       {},
+       {"dry-run", "sandbox", "mock-rom", "replace-all", "force"}});
   REGISTER_BUILTIN_AGENT_TOOL(
       "dungeon-export-water-fill-json", "dungeon",
       "Export water fill zones to JSON",
       "dungeon-export-water-fill-json --out=<path> "
       "[--room=<id>|--rooms=<ids>|--all] [--report=<path>]",
       {}, true, true, DungeonExportWaterFillJsonCommandHandler)
-  REGISTER_BUILTIN_AGENT_TOOL(
-      "dungeon-import-water-fill-json", "dungeon",
-      "Import water fill zones from JSON",
-      "dungeon-import-water-fill-json --in=<path> [--dry-run] "
-      "[--strict-masks] [--report=<path>]",
-      {}, true, true, DungeonImportWaterFillJsonCommandHandler)
+  RegisterBuiltinTool<DungeonImportWaterFillJsonCommandHandler>(
+      registry,
+      {"dungeon-import-water-fill-json",
+       "dungeon",
+       "Import water fill zones and immediately save unless --dry-run",
+       "dungeon-import-water-fill-json --in=<path> "
+       "[--dry-run [--report=<path>]] [--sandbox | --mock-rom] "
+       "[--strict-masks]",
+       {},
+       true,
+       true,
+       ToolAccess::kMutating,
+       {},
+       {"dry-run", "sandbox", "mock-rom", "strict-masks"}});
   REGISTER_BUILTIN_AGENT_TOOL(
       "dungeon-minecart-audit", "dungeon",
       "Audit minecart-related room data (objects/sprites/collision)",

--- a/src/cli/service/rom/rom_sandbox_manager.cc
+++ b/src/cli/service/rom/rom_sandbox_manager.cc
@@ -114,7 +114,11 @@ RomSandboxManager::CreateSandbox(Rom& rom, absl::string_view description) {
   settings.save_new = false;
   settings.backup = false;
 
+  // Materializing a sandbox is not a save of the caller's source ROM. Preserve
+  // its editor state even though SaveToFile clears dirty on a successful write.
+  const bool source_dirty = rom.dirty();
   absl::Status save_status = rom.SaveToFile(settings);
+  rom.set_dirty(source_dirty);
   if (!save_status.ok()) {
     std::error_code cleanup_ec;
     std::filesystem::remove_all(sandbox_dir, cleanup_ec);

--- a/test/unit/cli/dungeon_collision_json_commands_test.cc
+++ b/test/unit/cli/dungeon_collision_json_commands_test.cc
@@ -1,23 +1,47 @@
 #include "cli/handlers/game/dungeon_collision_commands.h"
 
+#include <algorithm>
 #include <chrono>
+#include <cstdint>
 #include <filesystem>
 #include <fstream>
+#include <iterator>
 #include <string>
+#include <system_error>
+#include <utility>
 #include <vector>
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include "absl/flags/declare.h"
+#include "absl/flags/flag.h"
 #include "absl/status/status.h"
+#include "cli/service/rom/rom_sandbox_manager.h"
 #include "nlohmann/json.hpp"
 #include "rom/rom.h"
+#include "rom/snes.h"
 #include "zelda3/dungeon/custom_collision.h"
 #include "zelda3/dungeon/dungeon_rom_addresses.h"
+#include "zelda3/dungeon/track_collision_generator.h"
 #include "zelda3/dungeon/water_fill_zone.h"
+
+ABSL_DECLARE_FLAG(bool, sandbox);
 
 namespace yaze::cli {
 namespace {
+
+class ScopedSandboxFlag {
+ public:
+  explicit ScopedSandboxFlag(bool value)
+      : original_(absl::GetFlag(FLAGS_sandbox)) {
+    absl::SetFlag(&FLAGS_sandbox, value);
+  }
+  ~ScopedSandboxFlag() { absl::SetFlag(&FLAGS_sandbox, original_); }
+
+ private:
+  bool original_;
+};
 
 std::string ReadFile(const std::filesystem::path& path) {
   std::ifstream in(path, std::ios::in | std::ios::binary);
@@ -30,12 +54,115 @@ void WriteFile(const std::filesystem::path& path, const std::string& contents) {
   out << contents;
 }
 
+std::vector<uint8_t> ReadFileBytes(const std::filesystem::path& path) {
+  std::ifstream in(path, std::ios::in | std::ios::binary);
+  return std::vector<uint8_t>(std::istreambuf_iterator<char>(in),
+                              std::istreambuf_iterator<char>());
+}
+
+void WriteRomFile(const Rom& rom, const std::filesystem::path& path) {
+  std::ofstream out(path, std::ios::out | std::ios::binary | std::ios::trunc);
+  ASSERT_TRUE(out.is_open());
+  out.write(reinterpret_cast<const char*>(rom.data()),
+            static_cast<std::streamsize>(rom.size()));
+  ASSERT_TRUE(out.good());
+}
+
+class ScopedTempDirectory {
+ public:
+  explicit ScopedTempDirectory(const char* label) {
+    const auto nonce =
+        std::chrono::steady_clock::now().time_since_epoch().count();
+    path_ = std::filesystem::temp_directory_path() /
+            ("yaze_collision_json_" + std::string(label) + "_" +
+             std::to_string(nonce));
+    std::error_code ec;
+    EXPECT_TRUE(std::filesystem::create_directories(path_, ec)) << ec.message();
+  }
+
+  ~ScopedTempDirectory() {
+    std::error_code ec;
+    std::filesystem::remove_all(path_, ec);
+  }
+
+  const std::filesystem::path& path() const { return path_; }
+
+ private:
+  std::filesystem::path path_;
+};
+
+class ScopedSandboxRoot {
+ public:
+  explicit ScopedSandboxRoot(const std::filesystem::path& root)
+      : original_root_(RomSandboxManager::Instance().RootDirectory()) {
+    RomSandboxManager::Instance().SetRootDirectory(root);
+  }
+
+  ~ScopedSandboxRoot() {
+    if (!sandbox_id_.empty()) {
+      RomSandboxManager::Instance().RemoveSandbox(sandbox_id_).IgnoreError();
+    }
+    RomSandboxManager::Instance().SetRootDirectory(original_root_);
+  }
+
+  void Track(std::string sandbox_id) { sandbox_id_ = std::move(sandbox_id); }
+
+ private:
+  std::filesystem::path original_root_;
+  std::string sandbox_id_;
+};
+
+std::vector<std::filesystem::path> FindBackupArtifacts(
+    const std::filesystem::path& rom_path) {
+  std::vector<std::filesystem::path> backups;
+  std::error_code ec;
+  const std::string prefix = rom_path.filename().string() + "_backup_";
+  for (const auto& entry :
+       std::filesystem::directory_iterator(rom_path.parent_path(), ec)) {
+    if (ec || !entry.is_regular_file()) {
+      continue;
+    }
+    if (entry.path().filename().string().rfind(prefix, 0) == 0) {
+      backups.push_back(entry.path());
+    }
+  }
+  std::sort(backups.begin(), backups.end());
+  return backups;
+}
+
+void SetLong(Rom* rom, int address, uint32_t value) {
+  ASSERT_TRUE(rom->WriteByte(address, value & 0xFF).ok());
+  ASSERT_TRUE(rom->WriteByte(address + 1, (value >> 8) & 0xFF).ok());
+  ASSERT_TRUE(rom->WriteByte(address + 2, (value >> 16) & 0xFF).ok());
+}
+
+void WriteSingleCollisionImport(const std::filesystem::path& path) {
+  WriteFile(path,
+            "{\n"
+            "  \"version\": 1,\n"
+            "  \"rooms\": [\n"
+            "    { \"room_id\": \"0x25\", \"tiles\": [ [65, \"0xB7\"] ] }\n"
+            "  ]\n"
+            "}\n");
+}
+
+void WriteSingleWaterFillImport(const std::filesystem::path& path) {
+  WriteFile(
+      path,
+      "{\n"
+      "  \"version\": 1,\n"
+      "  \"zones\": [\n"
+      "    { \"room_id\": \"0x30\", \"mask\": \"0x01\", \"offsets\": [100] }\n"
+      "  ]\n"
+      "}\n");
+}
+
 void SeedCustomCollisionRooms(Rom* rom, const std::vector<int>& room_ids) {
   const auto nonce =
       std::chrono::steady_clock::now().time_since_epoch().count();
-  const auto in_path = std::filesystem::temp_directory_path() /
-                       ("yaze_seed_required_collision_" +
-                        std::to_string(nonce) + ".json");
+  const auto in_path =
+      std::filesystem::temp_directory_path() /
+      ("yaze_seed_required_collision_" + std::to_string(nonce) + ".json");
 
   nlohmann::json payload;
   payload["version"] = 1;
@@ -51,8 +178,8 @@ void SeedCustomCollisionRooms(Rom* rom, const std::vector<int>& room_ids) {
 
   handlers::DungeonImportCustomCollisionJsonCommandHandler handler;
   std::string output;
-  const auto status =
-      handler.Run({"--in", in_path.string(), "--format=json"}, rom, &output);
+  const auto status = handler.Run(
+      {"--in", in_path.string(), "--mock-rom", "--format=json"}, rom, &output);
   ASSERT_TRUE(status.ok()) << status.message();
 
   std::filesystem::remove(in_path);
@@ -67,27 +194,27 @@ TEST(DungeonCollisionJsonCommandsTest, CustomCollisionImportExportRoundTrip) {
   const auto out_path = std::filesystem::temp_directory_path() /
                         "yaze_custom_collision_export_test.json";
 
-  WriteFile(in_path,
-            "{\n"
-            "  \"version\": 1,\n"
-            "  \"rooms\": [\n"
-            "    { \"room_id\": \"0x25\", \"tiles\": [ [65, 8], [66, \"0xB7\"] ] }\n"
-            "  ]\n"
-            "}\n");
+  WriteFile(
+      in_path,
+      "{\n"
+      "  \"version\": 1,\n"
+      "  \"rooms\": [\n"
+      "    { \"room_id\": \"0x25\", \"tiles\": [ [65, 8], [66, \"0xB7\"] ] }\n"
+      "  ]\n"
+      "}\n");
 
   handlers::DungeonImportCustomCollisionJsonCommandHandler import_handler;
   std::string import_output;
-  auto import_status =
-      import_handler.Run({"--in", in_path.string(), "--format=json"}, &rom,
-                         &import_output);
+  auto import_status = import_handler.Run(
+      {"--in", in_path.string(), "--mock-rom", "--format=json"}, &rom,
+      &import_output);
   ASSERT_TRUE(import_status.ok()) << import_status.message();
 
   handlers::DungeonExportCustomCollisionJsonCommandHandler export_handler;
   std::string export_output;
-  auto export_status =
-      export_handler.Run({"--room=0x25", "--out", out_path.string(),
-                          "--format=json"},
-                         &rom, &export_output);
+  auto export_status = export_handler.Run(
+      {"--room=0x25", "--out", out_path.string(), "--format=json"}, &rom,
+      &export_output);
   ASSERT_TRUE(export_status.ok()) << export_status.message();
 
   auto rooms_or =
@@ -122,8 +249,8 @@ TEST(DungeonCollisionJsonCommandsTest,
 
   handlers::DungeonImportCustomCollisionJsonCommandHandler handler;
   std::string output;
-  const auto status = handler.Run({"--in", in_path.string(), "--format=json"},
-                                  &rom, &output);
+  const auto status =
+      handler.Run({"--in", in_path.string(), "--format=json"}, &rom, &output);
   EXPECT_FALSE(status.ok());
   EXPECT_EQ(status.code(), absl::StatusCode::kFailedPrecondition);
 
@@ -137,19 +264,20 @@ TEST(DungeonCollisionJsonCommandsTest, WaterFillImportNormalizesMasks) {
 
   const auto in_path = std::filesystem::temp_directory_path() /
                        "yaze_water_fill_import_test.json";
-  WriteFile(in_path,
-            "{\n"
-            "  \"version\": 1,\n"
-            "  \"zones\": [\n"
-            "    { \"room_id\": \"0x27\", \"mask\": \"0x01\", \"offsets\": [100] },\n"
-            "    { \"room_id\": \"0x25\", \"mask\": \"0x01\", \"offsets\": [200] }\n"
-            "  ]\n"
-            "}\n");
+  WriteFile(
+      in_path,
+      "{\n"
+      "  \"version\": 1,\n"
+      "  \"zones\": [\n"
+      "    { \"room_id\": \"0x27\", \"mask\": \"0x01\", \"offsets\": [100] },\n"
+      "    { \"room_id\": \"0x25\", \"mask\": \"0x01\", \"offsets\": [200] }\n"
+      "  ]\n"
+      "}\n");
 
   handlers::DungeonImportWaterFillJsonCommandHandler handler;
   std::string output;
-  const auto status =
-      handler.Run({"--in", in_path.string(), "--format=json"}, &rom, &output);
+  const auto status = handler.Run(
+      {"--in", in_path.string(), "--mock-rom", "--format=json"}, &rom, &output);
   ASSERT_TRUE(status.ok()) << status.message();
 
   auto zones_or = zelda3::LoadWaterFillTable(&rom);
@@ -193,7 +321,8 @@ TEST(DungeonCollisionJsonCommandsTest, WaterFillExportRespectsRoomFilter) {
   std::filesystem::remove(out_path);
 }
 
-TEST(DungeonCollisionJsonCommandsTest, CustomCollisionImportDryRunDoesNotWrite) {
+TEST(DungeonCollisionJsonCommandsTest,
+     CustomCollisionImportDryRunDoesNotWrite) {
   Rom rom;
   ASSERT_TRUE(rom.LoadFromData(std::vector<uint8_t>(0x200000, 0x00)).ok());
 
@@ -221,15 +350,741 @@ TEST(DungeonCollisionJsonCommandsTest, CustomCollisionImportDryRunDoesNotWrite) 
   std::filesystem::remove(in_path);
 }
 
+TEST(DungeonCollisionJsonCommandsTest,
+     CustomCollisionImportPersistsBackupAndReopens) {
+  ScopedTempDirectory temp("custom_reopen");
+  const auto rom_path = temp.path() / "target.sfc";
+  const auto in_path = temp.path() / "collision.json";
+
+  Rom rom;
+  ASSERT_TRUE(rom.LoadFromData(std::vector<uint8_t>(0x200000, 0x00)).ok());
+  zelda3::CustomCollisionMap preserved_map;
+  preserved_map.has_data = true;
+  preserved_map.tiles[130] = 0xBA;
+  ASSERT_TRUE(zelda3::WriteTrackCollision(&rom, 0x26, preserved_map).ok());
+  WriteRomFile(rom, rom_path);
+  rom.set_filename(rom_path.string());
+  rom.set_dirty(false);
+  const std::vector<uint8_t> disk_before = ReadFileBytes(rom_path);
+
+  WriteFile(
+      in_path,
+      "{\n"
+      "  \"version\": 1,\n"
+      "  \"rooms\": [\n"
+      "    { \"room_id\": \"0x25\", \"tiles\": [ [65, \"0xB7\"], [66, 8] ] }\n"
+      "  ]\n"
+      "}\n");
+
+  handlers::DungeonImportCustomCollisionJsonCommandHandler handler;
+  std::string output;
+  const absl::Status status =
+      handler.Run({"--in", in_path.string(), "--format=json"}, &rom, &output);
+
+  ASSERT_TRUE(status.ok()) << status;
+  EXPECT_THAT(output, testing::HasSubstr("\"write_status\": \"success\""));
+  EXPECT_THAT(output, testing::HasSubstr("\"save_status\": \"saved\""));
+  EXPECT_FALSE(rom.dirty());
+  EXPECT_NE(ReadFileBytes(rom_path), disk_before);
+
+  const auto backups = FindBackupArtifacts(rom_path);
+  ASSERT_EQ(backups.size(), 1u);
+  EXPECT_EQ(ReadFileBytes(backups.front()), disk_before);
+
+  Rom reopened;
+  ASSERT_TRUE(reopened.LoadFromFile(rom_path.string()).ok());
+  auto map_or = zelda3::LoadCustomCollisionMap(&reopened, 0x25);
+  ASSERT_TRUE(map_or.ok()) << map_or.status();
+  ASSERT_TRUE(map_or->has_data);
+  EXPECT_EQ(map_or->tiles[65], 0xB7);
+  EXPECT_EQ(map_or->tiles[66], 8);
+
+  auto preserved_or = zelda3::LoadCustomCollisionMap(&reopened, 0x26);
+  ASSERT_TRUE(preserved_or.ok()) << preserved_or.status();
+  ASSERT_TRUE(preserved_or->has_data);
+  EXPECT_EQ(preserved_or->tiles[130], 0xBA);
+}
+
+TEST(DungeonCollisionJsonCommandsTest,
+     WaterFillImportPersistsNormalizedTableBackupAndReopens) {
+  ScopedTempDirectory temp("water_reopen");
+  const auto rom_path = temp.path() / "target.sfc";
+  const auto in_path = temp.path() / "water.json";
+
+  Rom rom;
+  ASSERT_TRUE(rom.LoadFromData(std::vector<uint8_t>(0x200000, 0x00)).ok());
+  WriteRomFile(rom, rom_path);
+  rom.set_filename(rom_path.string());
+  rom.set_dirty(false);
+  const std::vector<uint8_t> disk_before = ReadFileBytes(rom_path);
+
+  WriteFile(
+      in_path,
+      "{\n"
+      "  \"version\": 1,\n"
+      "  \"zones\": [\n"
+      "    { \"room_id\": \"0x31\", \"mask\": \"0x01\", \"offsets\": [200] },\n"
+      "    { \"room_id\": \"0x30\", \"mask\": \"0x01\", \"offsets\": [100, "
+      "101] }\n"
+      "  ]\n"
+      "}\n");
+
+  handlers::DungeonImportWaterFillJsonCommandHandler handler;
+  std::string output;
+  const absl::Status status =
+      handler.Run({"--in", in_path.string(), "--format=json"}, &rom, &output);
+
+  ASSERT_TRUE(status.ok()) << status;
+  EXPECT_THAT(output, testing::HasSubstr("\"write_status\": \"success\""));
+  EXPECT_THAT(output, testing::HasSubstr("\"save_status\": \"saved\""));
+  EXPECT_FALSE(rom.dirty());
+  EXPECT_NE(ReadFileBytes(rom_path), disk_before);
+
+  const auto backups = FindBackupArtifacts(rom_path);
+  ASSERT_EQ(backups.size(), 1u);
+  EXPECT_EQ(ReadFileBytes(backups.front()), disk_before);
+
+  Rom reopened;
+  ASSERT_TRUE(reopened.LoadFromFile(rom_path.string()).ok());
+  auto zones_or = zelda3::LoadWaterFillTable(&reopened);
+  ASSERT_TRUE(zones_or.ok()) << zones_or.status();
+  ASSERT_EQ(zones_or->size(), 2u);
+  EXPECT_EQ((*zones_or)[0].room_id, 0x30);
+  EXPECT_EQ((*zones_or)[0].sram_bit_mask, 0x01);
+  EXPECT_EQ((*zones_or)[0].fill_offsets, (std::vector<uint16_t>{100, 101}));
+  EXPECT_EQ((*zones_or)[1].room_id, 0x31);
+  EXPECT_EQ((*zones_or)[1].sram_bit_mask, 0x02);
+  EXPECT_EQ((*zones_or)[1].fill_offsets, (std::vector<uint16_t>{200}));
+}
+
+TEST(DungeonCollisionJsonCommandsTest,
+     CustomCollisionSandboxWritesOnlySandboxCopyOnce) {
+  ScopedTempDirectory temp("sandbox");
+  ScopedSandboxRoot sandbox_root(temp.path() / "sandboxes");
+  const auto source_path = temp.path() / "source.sfc";
+  const auto in_path = temp.path() / "collision.json";
+
+  Rom source_rom;
+  ASSERT_TRUE(
+      source_rom.LoadFromData(std::vector<uint8_t>(0x200000, 0x00)).ok());
+  WriteRomFile(source_rom, source_path);
+  source_rom.set_filename(source_path.string());
+  source_rom.set_dirty(true);
+  const std::vector<uint8_t> source_before = ReadFileBytes(source_path);
+
+  WriteFile(in_path,
+            "{\n"
+            "  \"version\": 1,\n"
+            "  \"rooms\": [\n"
+            "    { \"room_id\": \"0x25\", \"tiles\": [ [65, \"0xB7\"] ] }\n"
+            "  ]\n"
+            "}\n");
+
+  handlers::DungeonImportCustomCollisionJsonCommandHandler handler;
+  std::string output;
+  const absl::Status status =
+      handler.Run({"--in", in_path.string(), "--sandbox", "--format=json"},
+                  &source_rom, &output);
+  auto sandbox_or = RomSandboxManager::Instance().ActiveSandbox();
+  if (sandbox_or.ok()) {
+    sandbox_root.Track(sandbox_or->id);
+  }
+  ASSERT_TRUE(status.ok()) << status;
+  ASSERT_TRUE(sandbox_or.ok()) << sandbox_or.status();
+
+  EXPECT_EQ(source_rom.vector(), source_before);
+  EXPECT_EQ(ReadFileBytes(source_path), source_before);
+  EXPECT_TRUE(source_rom.dirty());
+  EXPECT_TRUE(FindBackupArtifacts(source_path).empty());
+
+  const auto sandbox_backups = FindBackupArtifacts(sandbox_or->rom_path);
+  ASSERT_EQ(sandbox_backups.size(), 1u);
+  // A second generic auto-save would back up the already-modified sandbox.
+  EXPECT_EQ(ReadFileBytes(sandbox_backups.front()), source_before);
+
+  Rom reopened;
+  ASSERT_TRUE(reopened.LoadFromFile(sandbox_or->rom_path.string()).ok());
+  auto map_or = zelda3::LoadCustomCollisionMap(&reopened, 0x25);
+  ASSERT_TRUE(map_or.ok()) << map_or.status();
+  ASSERT_TRUE(map_or->has_data);
+  EXPECT_EQ(map_or->tiles[65], 0xB7);
+}
+
+TEST(DungeonCollisionJsonCommandsTest,
+     CustomCollisionReportNormalizedRomAliasIsRejectedWithoutMutation) {
+  ScopedTempDirectory temp("normalized_alias");
+  const auto rom_path = temp.path() / "target.sfc";
+  const auto in_path = temp.path() / "collision.json";
+  const auto lexical_parent = temp.path() / "lexical_parent";
+  ASSERT_TRUE(std::filesystem::create_directory(lexical_parent));
+  const auto report_alias = lexical_parent / ".." / rom_path.filename();
+
+  Rom rom;
+  ASSERT_TRUE(rom.LoadFromData(std::vector<uint8_t>(0x200000, 0x00)).ok());
+  WriteRomFile(rom, rom_path);
+  rom.set_filename(rom_path.string());
+  rom.set_dirty(false);
+  WriteSingleCollisionImport(in_path);
+
+  const std::vector<uint8_t> before = rom.vector();
+  const std::vector<uint8_t> disk_before = ReadFileBytes(rom_path);
+
+  handlers::DungeonImportCustomCollisionJsonCommandHandler handler;
+  std::string output;
+  const absl::Status status =
+      handler.Run({"--in", in_path.string(), "--dry-run", "--report",
+                   report_alias.string(), "--format=json"},
+                  &rom, &output);
+
+  EXPECT_TRUE(absl::IsInvalidArgument(status)) << status;
+  EXPECT_THAT(std::string(status.message()),
+              testing::HasSubstr("aliases the active ROM"));
+  EXPECT_EQ(rom.vector(), before);
+  EXPECT_FALSE(rom.dirty());
+  EXPECT_EQ(ReadFileBytes(rom_path), disk_before);
+  EXPECT_TRUE(FindBackupArtifacts(rom_path).empty());
+  EXPECT_FALSE(std::filesystem::exists(rom_path.string() + ".tmp"));
+}
+
+TEST(DungeonCollisionJsonCommandsTest,
+     CustomCollisionReportSymlinkRomAliasIsRejectedWithoutMutation) {
+  ScopedTempDirectory temp("symlink_alias");
+  const auto rom_path = temp.path() / "target.sfc";
+  const auto in_path = temp.path() / "collision.json";
+  const auto report_alias = temp.path() / "report-link.json";
+
+  Rom rom;
+  ASSERT_TRUE(rom.LoadFromData(std::vector<uint8_t>(0x200000, 0x00)).ok());
+  WriteRomFile(rom, rom_path);
+  rom.set_filename(rom_path.string());
+  rom.set_dirty(false);
+  WriteSingleCollisionImport(in_path);
+
+  std::error_code link_ec;
+  std::filesystem::create_symlink(rom_path, report_alias, link_ec);
+  if (link_ec) {
+    GTEST_SKIP() << "Symlinks unavailable: " << link_ec.message();
+  }
+
+  const std::vector<uint8_t> before = rom.vector();
+  const std::vector<uint8_t> disk_before = ReadFileBytes(rom_path);
+
+  handlers::DungeonImportCustomCollisionJsonCommandHandler handler;
+  std::string output;
+  const absl::Status status =
+      handler.Run({"--in", in_path.string(), "--dry-run", "--report",
+                   report_alias.string(), "--format=json"},
+                  &rom, &output);
+
+  EXPECT_TRUE(absl::IsInvalidArgument(status)) << status;
+  EXPECT_THAT(std::string(status.message()),
+              testing::HasSubstr("aliases the active ROM"));
+  EXPECT_EQ(rom.vector(), before);
+  EXPECT_FALSE(rom.dirty());
+  EXPECT_EQ(ReadFileBytes(rom_path), disk_before);
+  EXPECT_TRUE(std::filesystem::is_symlink(report_alias));
+  EXPECT_TRUE(FindBackupArtifacts(rom_path).empty());
+}
+
+TEST(DungeonCollisionJsonCommandsTest,
+     WaterFillReportHardlinkRomAliasIsRejectedWithoutMutation) {
+  ScopedTempDirectory temp("hardlink_alias");
+  const auto rom_path = temp.path() / "target.sfc";
+  const auto in_path = temp.path() / "water.json";
+  const auto report_alias = temp.path() / "report-hardlink.json";
+
+  Rom rom;
+  ASSERT_TRUE(rom.LoadFromData(std::vector<uint8_t>(0x200000, 0x00)).ok());
+  WriteRomFile(rom, rom_path);
+  rom.set_filename(rom_path.string());
+  rom.set_dirty(false);
+  WriteSingleWaterFillImport(in_path);
+
+  std::error_code link_ec;
+  std::filesystem::create_hard_link(rom_path, report_alias, link_ec);
+  if (link_ec) {
+    GTEST_SKIP() << "Hardlinks unavailable: " << link_ec.message();
+  }
+
+  const std::vector<uint8_t> before = rom.vector();
+  const std::vector<uint8_t> disk_before = ReadFileBytes(rom_path);
+
+  handlers::DungeonImportWaterFillJsonCommandHandler handler;
+  std::string output;
+  const absl::Status status =
+      handler.Run({"--in", in_path.string(), "--dry-run", "--report",
+                   report_alias.string(), "--format=json"},
+                  &rom, &output);
+
+  EXPECT_TRUE(absl::IsInvalidArgument(status)) << status;
+  EXPECT_THAT(std::string(status.message()),
+              testing::HasSubstr("aliases the active ROM"));
+  EXPECT_EQ(rom.vector(), before);
+  EXPECT_FALSE(rom.dirty());
+  EXPECT_EQ(ReadFileBytes(rom_path), disk_before);
+  EXPECT_TRUE(std::filesystem::exists(report_alias));
+  EXPECT_TRUE(FindBackupArtifacts(rom_path).empty());
+}
+
+TEST(DungeonCollisionJsonCommandsTest, ExportReportsCannotAliasActiveRom) {
+  ScopedTempDirectory temp("export_report_alias");
+  const auto rom_path = temp.path() / "target.sfc";
+  const auto collision_out = temp.path() / "collision.json";
+  const auto water_out = temp.path() / "water.json";
+
+  Rom rom;
+  ASSERT_TRUE(rom.LoadFromData(std::vector<uint8_t>(0x200000, 0x00)).ok());
+  WriteRomFile(rom, rom_path);
+  rom.set_filename(rom_path.string());
+  rom.set_dirty(false);
+  const std::vector<uint8_t> disk_before = ReadFileBytes(rom_path);
+
+  handlers::DungeonExportCustomCollisionJsonCommandHandler collision_handler;
+  std::string collision_output;
+  const absl::Status collision_status =
+      collision_handler.Run({"--out", collision_out.string(), "--all",
+                             "--report", rom_path.string(), "--format=json"},
+                            &rom, &collision_output);
+  EXPECT_TRUE(absl::IsInvalidArgument(collision_status)) << collision_status;
+  EXPECT_THAT(std::string(collision_status.message()),
+              testing::HasSubstr("aliases the active ROM"));
+
+  handlers::DungeonExportWaterFillJsonCommandHandler water_handler;
+  std::string water_output;
+  const absl::Status water_status =
+      water_handler.Run({"--out", water_out.string(), "--all", "--report",
+                         rom_path.string(), "--format=json"},
+                        &rom, &water_output);
+  EXPECT_TRUE(absl::IsInvalidArgument(water_status)) << water_status;
+  EXPECT_THAT(std::string(water_status.message()),
+              testing::HasSubstr("aliases the active ROM"));
+
+  EXPECT_EQ(ReadFileBytes(rom_path), disk_before);
+  EXPECT_FALSE(std::filesystem::exists(collision_out));
+  EXPECT_FALSE(std::filesystem::exists(water_out));
+}
+
+TEST(DungeonCollisionJsonCommandsTest,
+     DryRunReportCannotAliasUnicodeEquivalentRom) {
+  ScopedTempDirectory temp("unicode_rom_alias");
+  const auto rom_path = temp.path() / "\xC3\xA9.sfc";  // NFC: e-acute.
+  const auto in_path = temp.path() / "collision.json";
+  const auto report_path = temp.path() / "e\xCC\x81.sfc";  // NFD.
+
+  Rom rom;
+  ASSERT_TRUE(rom.LoadFromData(std::vector<uint8_t>(0x200000, 0x00)).ok());
+  WriteRomFile(rom, rom_path);
+  rom.set_filename(rom_path.string());
+  rom.set_dirty(false);
+  WriteSingleCollisionImport(in_path);
+
+  const std::vector<uint8_t> before = rom.vector();
+  const std::vector<uint8_t> disk_before = ReadFileBytes(rom_path);
+
+  std::error_code equivalent_ec;
+  const bool unicode_equivalent =
+      std::filesystem::equivalent(rom_path, report_path, equivalent_ec);
+  if (equivalent_ec || !unicode_equivalent) {
+    GTEST_SKIP() << "Filesystem does not equate NFC/NFD paths";
+  }
+
+  handlers::DungeonImportCustomCollisionJsonCommandHandler handler;
+  std::string output;
+  const absl::Status status =
+      handler.Run({"--in", in_path.string(), "--dry-run", "--report",
+                   report_path.string(), "--format=json"},
+                  &rom, &output);
+
+  EXPECT_TRUE(absl::IsInvalidArgument(status)) << status;
+  EXPECT_THAT(std::string(status.message()),
+              testing::HasSubstr("aliases the active ROM"));
+  EXPECT_EQ(rom.vector(), before);
+  EXPECT_FALSE(rom.dirty());
+  EXPECT_EQ(ReadFileBytes(rom_path), disk_before);
+  EXPECT_TRUE(FindBackupArtifacts(rom_path).empty());
+}
+
+TEST(DungeonCollisionJsonCommandsTest,
+     SandboxMaterializationFailurePreservesSourceDirty) {
+  ScopedTempDirectory temp("sandbox_save_failure");
+  ScopedSandboxRoot sandbox_root(temp.path() / "sandboxes");
+
+  Rom source_rom;
+  ASSERT_TRUE(
+      source_rom.LoadFromData(std::vector<uint8_t>(0x200000, 0x00)).ok());
+  // A trailing separator gives the source path an empty filename. The manager
+  // can create its sandbox directory, but SaveToFile cannot replace that
+  // directory with the ROM file, forcing the materialization save to fail.
+  source_rom.set_filename(temp.path().string() + "/");
+  source_rom.set_dirty(true);
+
+  const absl::StatusOr<RomSandboxManager::SandboxMetadata> sandbox_or =
+      RomSandboxManager::Instance().CreateSandbox(source_rom, "test failure");
+
+  EXPECT_FALSE(sandbox_or.ok());
+  EXPECT_TRUE(source_rom.dirty());
+  EXPECT_TRUE(
+      absl::IsNotFound(RomSandboxManager::Instance().ActiveSandbox().status()));
+}
+
+TEST(DungeonCollisionJsonCommandsTest,
+     CustomCollisionDryRunReportFailureDoesNotMutateRom) {
+  ScopedTempDirectory temp("directory_report");
+  const auto rom_path = temp.path() / "target.sfc";
+  const auto in_path = temp.path() / "collision.json";
+  const auto report_path = temp.path() / "report-directory";
+  ASSERT_TRUE(std::filesystem::create_directory(report_path));
+
+  Rom rom;
+  ASSERT_TRUE(rom.LoadFromData(std::vector<uint8_t>(0x200000, 0x00)).ok());
+  WriteRomFile(rom, rom_path);
+  rom.set_filename(rom_path.string());
+  rom.set_dirty(true);
+  WriteSingleCollisionImport(in_path);
+
+  const std::vector<uint8_t> before = rom.vector();
+  const std::vector<uint8_t> disk_before = ReadFileBytes(rom_path);
+
+  handlers::DungeonImportCustomCollisionJsonCommandHandler handler;
+  std::string output = "untouched";
+  const absl::Status status =
+      handler.Run({"--in", in_path.string(), "--dry-run", "--report",
+                   report_path.string(), "--format=json"},
+                  &rom, &output);
+
+  EXPECT_TRUE(absl::IsPermissionDenied(status)) << status;
+  EXPECT_THAT(output, testing::HasSubstr("\"mode\": \"dry-run\""));
+  EXPECT_EQ(rom.vector(), before);
+  EXPECT_TRUE(rom.dirty());
+  EXPECT_EQ(ReadFileBytes(rom_path), disk_before);
+  EXPECT_TRUE(std::filesystem::is_directory(report_path));
+  EXPECT_TRUE(FindBackupArtifacts(rom_path).empty());
+}
+
+TEST(DungeonCollisionJsonCommandsTest,
+     ReportsRejectWriteModeAndSandboxBeforeContext) {
+  ScopedSandboxFlag sandbox_flag(false);
+  ScopedTempDirectory temp("write_report_rejected");
+  ScopedSandboxRoot sandbox_root(temp.path() / "sandboxes");
+  const auto source_path = temp.path() / "source.sfc";
+  const auto collision_path = temp.path() / "collision.json";
+  const auto water_path = temp.path() / "water.json";
+  const auto report_path = temp.path() / "report.json";
+  const auto collision_out = temp.path() / "collision-export.json";
+  const auto water_out = temp.path() / "water-export.json";
+
+  Rom source_rom;
+  ASSERT_TRUE(
+      source_rom.LoadFromData(std::vector<uint8_t>(0x200000, 0x00)).ok());
+  WriteRomFile(source_rom, source_path);
+  source_rom.set_filename(source_path.string());
+  source_rom.set_dirty(true);
+  WriteSingleCollisionImport(collision_path);
+  WriteSingleWaterFillImport(water_path);
+
+  const std::vector<uint8_t> before = source_rom.vector();
+  const std::vector<uint8_t> disk_before = ReadFileBytes(source_path);
+  handlers::DungeonImportCustomCollisionJsonCommandHandler collision_handler;
+  handlers::DungeonImportWaterFillJsonCommandHandler water_handler;
+  handlers::DungeonExportCustomCollisionJsonCommandHandler collision_export;
+  handlers::DungeonExportWaterFillJsonCommandHandler water_export;
+
+  for (const std::vector<std::string>& mode_args :
+       {std::vector<std::string>{}, std::vector<std::string>{"--mock-rom"},
+        std::vector<std::string>{"--sandbox"}}) {
+    std::vector<std::string> collision_args = {"--in", collision_path.string(),
+                                               "--report", report_path.string(),
+                                               "--format=json"};
+    collision_args.insert(collision_args.end(), mode_args.begin(),
+                          mode_args.end());
+    std::string collision_output = "untouched";
+    const absl::Status collision_status =
+        collision_handler.Run(collision_args, &source_rom, &collision_output);
+    EXPECT_TRUE(absl::IsInvalidArgument(collision_status)) << collision_status;
+    EXPECT_THAT(
+        std::string(collision_status.message()),
+        testing::HasSubstr("--report is supported only with --dry-run"));
+    EXPECT_EQ(collision_output, "untouched");
+
+    std::vector<std::string> water_args = {"--in", water_path.string(),
+                                           "--report", report_path.string(),
+                                           "--format=json"};
+    water_args.insert(water_args.end(), mode_args.begin(), mode_args.end());
+    std::string water_output = "untouched";
+    const absl::Status water_status =
+        water_handler.Run(water_args, &source_rom, &water_output);
+    EXPECT_TRUE(absl::IsInvalidArgument(water_status)) << water_status;
+    EXPECT_THAT(
+        std::string(water_status.message()),
+        testing::HasSubstr("--report is supported only with --dry-run"));
+    EXPECT_EQ(water_output, "untouched");
+  }
+
+  for (auto* handler :
+       {static_cast<resources::CommandHandler*>(&collision_handler),
+        static_cast<resources::CommandHandler*>(&water_handler)}) {
+    const std::filesystem::path& input =
+        handler == &collision_handler ? collision_path : water_path;
+    std::string output = "untouched";
+    const absl::Status status =
+        handler->Run({"--in", input.string(), "--dry-run", "--sandbox",
+                      "--report", report_path.string(), "--format=json"},
+                     &source_rom, &output);
+    EXPECT_TRUE(absl::IsInvalidArgument(status)) << status;
+    EXPECT_THAT(std::string(status.message()),
+                testing::HasSubstr("--report cannot be combined with "
+                                   "--sandbox"));
+    EXPECT_EQ(output, "untouched");
+  }
+
+  for (auto* handler :
+       {static_cast<resources::CommandHandler*>(&collision_export),
+        static_cast<resources::CommandHandler*>(&water_export)}) {
+    const std::filesystem::path& out =
+        handler == &collision_export ? collision_out : water_out;
+    std::string output = "untouched";
+    const absl::Status status =
+        handler->Run({"--out", out.string(), "--all", "--sandbox", "--report",
+                      report_path.string(), "--format=json"},
+                     &source_rom, &output);
+    EXPECT_TRUE(absl::IsInvalidArgument(status)) << status;
+    EXPECT_THAT(std::string(status.message()),
+                testing::HasSubstr("--report cannot be combined with "
+                                   "--sandbox"));
+    EXPECT_EQ(output, "untouched");
+  }
+
+  {
+    ScopedSandboxFlag global_sandbox(true);
+    std::string output = "untouched";
+    const absl::Status status = collision_handler.Run(
+        {"--in", collision_path.string(), "--dry-run", "--report",
+         report_path.string(), "--format=json"},
+        &source_rom, &output);
+    EXPECT_TRUE(absl::IsInvalidArgument(status)) << status;
+    EXPECT_THAT(std::string(status.message()),
+                testing::HasSubstr("--report cannot be combined with "
+                                   "--sandbox"));
+    EXPECT_EQ(output, "untouched");
+
+    for (auto* handler :
+         {static_cast<resources::CommandHandler*>(&collision_export),
+          static_cast<resources::CommandHandler*>(&water_export)}) {
+      const std::filesystem::path& out =
+          handler == &collision_export ? collision_out : water_out;
+      output = "untouched";
+      const absl::Status export_status =
+          handler->Run({"--out", out.string(), "--all", "--report",
+                        report_path.string(), "--format=json"},
+                       &source_rom, &output);
+      EXPECT_TRUE(absl::IsInvalidArgument(export_status)) << export_status;
+      EXPECT_THAT(std::string(export_status.message()),
+                  testing::HasSubstr("--report cannot be combined with "
+                                     "--sandbox"));
+      EXPECT_EQ(output, "untouched");
+    }
+  }
+
+  EXPECT_EQ(source_rom.vector(), before);
+  EXPECT_TRUE(source_rom.dirty());
+  EXPECT_EQ(ReadFileBytes(source_path), disk_before);
+  EXPECT_FALSE(std::filesystem::exists(report_path));
+  EXPECT_FALSE(std::filesystem::exists(collision_out));
+  EXPECT_FALSE(std::filesystem::exists(water_out));
+  EXPECT_TRUE(FindBackupArtifacts(source_path).empty());
+  EXPECT_TRUE(
+      absl::IsNotFound(RomSandboxManager::Instance().ActiveSandbox().status()));
+}
+
+TEST(DungeonCollisionJsonCommandsTest,
+     MockRomAndSandboxAreRejectedForBothImportsBeforeMutation) {
+  ScopedTempDirectory temp("mock_sandbox");
+  ScopedSandboxRoot sandbox_root(temp.path() / "sandboxes");
+  const auto source_path = temp.path() / "source.sfc";
+  const auto collision_path = temp.path() / "collision.json";
+  const auto water_path = temp.path() / "water.json";
+
+  Rom source_rom;
+  ASSERT_TRUE(
+      source_rom.LoadFromData(std::vector<uint8_t>(0x200000, 0x00)).ok());
+  WriteRomFile(source_rom, source_path);
+  source_rom.set_filename(source_path.string());
+  source_rom.set_dirty(true);
+  WriteSingleCollisionImport(collision_path);
+  WriteSingleWaterFillImport(water_path);
+
+  const std::vector<uint8_t> before = source_rom.vector();
+  const std::vector<uint8_t> disk_before = ReadFileBytes(source_path);
+
+  handlers::DungeonImportCustomCollisionJsonCommandHandler collision_handler;
+  std::string collision_output = "untouched";
+  const absl::Status collision_status =
+      collision_handler.Run({"--in", collision_path.string(), "--mock-rom",
+                             "--sandbox", "--format=json"},
+                            &source_rom, &collision_output);
+  EXPECT_TRUE(absl::IsInvalidArgument(collision_status)) << collision_status;
+  EXPECT_THAT(std::string(collision_status.message()),
+              testing::HasSubstr("mutually exclusive"));
+  EXPECT_EQ(collision_output, "untouched");
+
+  handlers::DungeonImportWaterFillJsonCommandHandler water_handler;
+  std::string water_output = "untouched";
+  const absl::Status water_status = water_handler.Run(
+      {"--in", water_path.string(), "--mock-rom", "--sandbox", "--format=json"},
+      &source_rom, &water_output);
+  EXPECT_TRUE(absl::IsInvalidArgument(water_status)) << water_status;
+  EXPECT_THAT(std::string(water_status.message()),
+              testing::HasSubstr("mutually exclusive"));
+  EXPECT_EQ(water_output, "untouched");
+
+  EXPECT_EQ(source_rom.vector(), before);
+  EXPECT_TRUE(source_rom.dirty());
+  EXPECT_EQ(ReadFileBytes(source_path), disk_before);
+  EXPECT_TRUE(FindBackupArtifacts(source_path).empty());
+  EXPECT_TRUE(
+      absl::IsNotFound(RomSandboxManager::Instance().ActiveSandbox().status()));
+}
+
+TEST(DungeonCollisionJsonCommandsTest,
+     CustomCollisionSerializerFailureRollsBackPartialWrites) {
+  ScopedTempDirectory temp("serializer_failure");
+  const auto rom_path = temp.path() / "target.sfc";
+  const auto in_path = temp.path() / "collision.json";
+
+  Rom rom;
+  ASSERT_TRUE(rom.LoadFromData(std::vector<uint8_t>(0x200000, 0x00)).ok());
+
+  // Leave room for exactly one imported one-tile map. The second room then
+  // fails after the first room has already changed data and its pointer.
+  const int existing_pc = zelda3::kCustomCollisionDataSoftEnd - 17;
+  SetLong(&rom, zelda3::kCustomCollisionRoomPointers, PcToSnes(existing_pc));
+  ASSERT_TRUE(
+      rom.WriteVector(existing_pc, std::vector<uint8_t>{0xF0, 0xF0, 0x00, 0x00,
+                                                        0xB7, 0xFF, 0xFF})
+          .ok());
+  WriteRomFile(rom, rom_path);
+  rom.set_filename(rom_path.string());
+  rom.set_dirty(false);
+
+  WriteFile(in_path,
+            "{\n"
+            "  \"version\": 1,\n"
+            "  \"rooms\": [\n"
+            "    { \"room_id\": \"0x20\", \"tiles\": [ [1, \"0xB7\"] ] },\n"
+            "    { \"room_id\": \"0x21\", \"tiles\": [ [2, \"0xB8\"] ] }\n"
+            "  ]\n"
+            "}\n");
+
+  const std::vector<uint8_t> before = rom.vector();
+  const std::vector<uint8_t> disk_before = ReadFileBytes(rom_path);
+  const std::string filename_before = rom.filename();
+  const bool dirty_before = rom.dirty();
+
+  handlers::DungeonImportCustomCollisionJsonCommandHandler handler;
+  std::string output;
+  const absl::Status status =
+      handler.Run({"--in", in_path.string(), "--format=json"}, &rom, &output);
+
+  EXPECT_TRUE(absl::IsResourceExhausted(status)) << status;
+  EXPECT_EQ(rom.vector(), before);
+  EXPECT_EQ(rom.filename(), filename_before);
+  EXPECT_EQ(rom.dirty(), dirty_before);
+  EXPECT_EQ(ReadFileBytes(rom_path), disk_before);
+  EXPECT_TRUE(FindBackupArtifacts(rom_path).empty());
+  EXPECT_FALSE(std::filesystem::exists(rom_path.string() + ".tmp"));
+}
+
+TEST(DungeonCollisionJsonCommandsTest,
+     CustomCollisionRequiredBackupFailureRollsBackCallerRom) {
+  ScopedTempDirectory temp("backup_failure");
+  const auto rom_path = temp.path() / "target.sfc";
+  const auto in_path = temp.path() / "collision.json";
+  ASSERT_TRUE(std::filesystem::create_directory(rom_path));
+
+  Rom rom;
+  ASSERT_TRUE(rom.LoadFromData(std::vector<uint8_t>(0x200000, 0x00)).ok());
+  rom.set_filename(rom_path.string());
+  rom.set_dirty(false);
+  WriteFile(in_path,
+            "{\n"
+            "  \"version\": 1,\n"
+            "  \"rooms\": [\n"
+            "    { \"room_id\": \"0x25\", \"tiles\": [ [65, \"0xB7\"] ] }\n"
+            "  ]\n"
+            "}\n");
+
+  const std::vector<uint8_t> before = rom.vector();
+  const std::string filename_before = rom.filename();
+  const bool dirty_before = rom.dirty();
+
+  handlers::DungeonImportCustomCollisionJsonCommandHandler handler;
+  std::string output;
+  const absl::Status status =
+      handler.Run({"--in", in_path.string(), "--format=json"}, &rom, &output);
+
+  EXPECT_TRUE(absl::IsFailedPrecondition(status)) << status;
+  EXPECT_THAT(std::string(status.message()),
+              testing::HasSubstr("Could not create required ROM backup"));
+  EXPECT_EQ(rom.vector(), before);
+  EXPECT_EQ(rom.filename(), filename_before);
+  EXPECT_EQ(rom.dirty(), dirty_before);
+  EXPECT_TRUE(std::filesystem::is_directory(rom_path));
+  EXPECT_FALSE(std::filesystem::exists(rom_path.string() + ".tmp"));
+  EXPECT_TRUE(FindBackupArtifacts(rom_path).empty());
+}
+
+TEST(DungeonCollisionJsonCommandsTest,
+     WaterFillDiskSaveFailureRollsBackAndRetainsBackup) {
+  ScopedTempDirectory temp("disk_failure");
+  const auto rom_path = temp.path() / "target.sfc";
+  const auto in_path = temp.path() / "water.json";
+
+  Rom rom;
+  ASSERT_TRUE(rom.LoadFromData(std::vector<uint8_t>(0x200000, 0x00)).ok());
+  WriteRomFile(rom, rom_path);
+  rom.set_filename(rom_path.string());
+  rom.set_dirty(false);
+  ASSERT_TRUE(std::filesystem::create_directory(rom_path.string() + ".tmp"));
+
+  WriteFile(
+      in_path,
+      "{\n"
+      "  \"version\": 1,\n"
+      "  \"zones\": [\n"
+      "    { \"room_id\": \"0x30\", \"mask\": \"0x01\", \"offsets\": [100] }\n"
+      "  ]\n"
+      "}\n");
+
+  const std::vector<uint8_t> before = rom.vector();
+  const std::vector<uint8_t> disk_before = ReadFileBytes(rom_path);
+  const std::string filename_before = rom.filename();
+  const bool dirty_before = rom.dirty();
+
+  handlers::DungeonImportWaterFillJsonCommandHandler handler;
+  std::string output;
+  const absl::Status status =
+      handler.Run({"--in", in_path.string(), "--format=json"}, &rom, &output);
+
+  EXPECT_TRUE(absl::IsInternal(status)) << status;
+  EXPECT_THAT(std::string(status.message()),
+              testing::HasSubstr("Could not open temp ROM file for writing"));
+  EXPECT_EQ(rom.vector(), before);
+  EXPECT_EQ(rom.filename(), filename_before);
+  EXPECT_EQ(rom.dirty(), dirty_before);
+  EXPECT_EQ(ReadFileBytes(rom_path), disk_before);
+  EXPECT_TRUE(std::filesystem::is_directory(rom_path.string() + ".tmp"));
+
+  const auto backups = FindBackupArtifacts(rom_path);
+  ASSERT_EQ(backups.size(), 1u);
+  EXPECT_EQ(ReadFileBytes(backups.front()), disk_before);
+}
+
 TEST(DungeonCollisionJsonCommandsTest, CustomCollisionReplaceAllRequiresForce) {
   Rom rom;
   ASSERT_TRUE(rom.LoadFromData(std::vector<uint8_t>(0x200000, 0x00)).ok());
 
   const auto in_path = std::filesystem::temp_directory_path() /
                        "yaze_custom_collision_replace_all_requires_force.json";
-  const auto report_path =
-      std::filesystem::temp_directory_path() /
-      "yaze_custom_collision_replace_all_requires_force.report.json";
   WriteFile(in_path,
             "{\n"
             "  \"version\": 1,\n"
@@ -241,21 +1096,14 @@ TEST(DungeonCollisionJsonCommandsTest, CustomCollisionReplaceAllRequiresForce) {
   handlers::DungeonImportCustomCollisionJsonCommandHandler handler;
   std::string output;
   const auto status =
-      handler.Run({"--in", in_path.string(), "--replace-all",
-                   "--report", report_path.string(), "--format=json"},
+      handler.Run({"--in", in_path.string(), "--replace-all", "--format=json"},
                   &rom, &output);
   EXPECT_FALSE(status.ok());
   EXPECT_EQ(status.code(), absl::StatusCode::kFailedPrecondition);
-
-  const auto report = nlohmann::json::parse(ReadFile(report_path));
-  EXPECT_EQ(report.value("command", ""), "dungeon-import-custom-collision-json");
-  EXPECT_EQ(report.value("status", ""), "error");
-  EXPECT_TRUE(report.value("replace_all", false));
-  EXPECT_FALSE(report.value("force", true));
-  EXPECT_EQ(report["error"].value("code", ""), "FAILED_PRECONDITION");
+  EXPECT_THAT(std::string(status.message()),
+              testing::HasSubstr("--replace-all requires --force"));
 
   std::filesystem::remove(in_path);
-  std::filesystem::remove(report_path);
 }
 
 TEST(DungeonCollisionJsonCommandsTest, WaterFillImportDryRunDoesNotWrite) {
@@ -265,13 +1113,14 @@ TEST(DungeonCollisionJsonCommandsTest, WaterFillImportDryRunDoesNotWrite) {
 
   const auto in_path =
       std::filesystem::temp_directory_path() / "yaze_water_fill_dry_run.json";
-  WriteFile(in_path,
-            "{\n"
-            "  \"version\": 1,\n"
-            "  \"zones\": [\n"
-            "    { \"room_id\": \"0x27\", \"mask\": \"0x01\", \"offsets\": [100] }\n"
-            "  ]\n"
-            "}\n");
+  WriteFile(
+      in_path,
+      "{\n"
+      "  \"version\": 1,\n"
+      "  \"zones\": [\n"
+      "    { \"room_id\": \"0x27\", \"mask\": \"0x01\", \"offsets\": [100] }\n"
+      "  ]\n"
+      "}\n");
 
   handlers::DungeonImportWaterFillJsonCommandHandler handler;
   std::string output;
@@ -292,23 +1141,24 @@ TEST(DungeonCollisionJsonCommandsTest,
   Rom rom;
   ASSERT_TRUE(rom.LoadFromData(std::vector<uint8_t>(0x200000, 0x00)).ok());
 
-  const auto in_path =
-      std::filesystem::temp_directory_path() / "yaze_water_fill_required_room.json";
+  const auto in_path = std::filesystem::temp_directory_path() /
+                       "yaze_water_fill_required_room.json";
   const auto report_path = std::filesystem::temp_directory_path() /
                            "yaze_water_fill_required_room.report.json";
-  WriteFile(in_path,
-            "{\n"
-            "  \"version\": 1,\n"
-            "  \"zones\": [\n"
-            "    { \"room_id\": \"0x25\", \"mask\": \"0x01\", \"offsets\": [100] }\n"
-            "  ]\n"
-            "}\n");
+  WriteFile(
+      in_path,
+      "{\n"
+      "  \"version\": 1,\n"
+      "  \"zones\": [\n"
+      "    { \"room_id\": \"0x25\", \"mask\": \"0x01\", \"offsets\": [100] }\n"
+      "  ]\n"
+      "}\n");
 
   handlers::DungeonImportWaterFillJsonCommandHandler handler;
   std::string output;
   const auto status =
-      handler.Run({"--in", in_path.string(), "--dry-run",
-                   "--report", report_path.string(), "--format=json"},
+      handler.Run({"--in", in_path.string(), "--dry-run", "--report",
+                   report_path.string(), "--format=json"},
                   &rom, &output);
   EXPECT_FALSE(status.ok());
   EXPECT_EQ(status.code(), absl::StatusCode::kFailedPrecondition);
@@ -338,21 +1188,22 @@ TEST(DungeonCollisionJsonCommandsTest,
 
   const auto in_path =
       std::filesystem::temp_directory_path() / "yaze_water_fill_strict.json";
-  const auto report_path =
-      std::filesystem::temp_directory_path() / "yaze_water_fill_strict.report.json";
-  WriteFile(in_path,
-            "{\n"
-            "  \"version\": 1,\n"
-            "  \"zones\": [\n"
-            "    { \"room_id\": \"0x25\", \"mask\": \"0x01\", \"offsets\": [10] },\n"
-            "    { \"room_id\": \"0x27\", \"mask\": \"0x01\", \"offsets\": [20] }\n"
-            "  ]\n"
-            "}\n");
+  const auto report_path = std::filesystem::temp_directory_path() /
+                           "yaze_water_fill_strict.report.json";
+  WriteFile(
+      in_path,
+      "{\n"
+      "  \"version\": 1,\n"
+      "  \"zones\": [\n"
+      "    { \"room_id\": \"0x25\", \"mask\": \"0x01\", \"offsets\": [10] },\n"
+      "    { \"room_id\": \"0x27\", \"mask\": \"0x01\", \"offsets\": [20] }\n"
+      "  ]\n"
+      "}\n");
 
   handlers::DungeonImportWaterFillJsonCommandHandler handler;
   std::string output;
   const auto status =
-      handler.Run({"--in", in_path.string(), "--strict-masks",
+      handler.Run({"--in", in_path.string(), "--dry-run", "--strict-masks",
                    "--report", report_path.string(), "--format=json"},
                   &rom, &output);
   EXPECT_FALSE(status.ok());
@@ -397,19 +1248,20 @@ TEST(DungeonCollisionJsonCommandsTest,
       std::filesystem::temp_directory_path() / "yaze_water_fill_preflight.json";
   const auto report_path = std::filesystem::temp_directory_path() /
                            "yaze_water_fill_preflight.report.json";
-  WriteFile(in_path,
-            "{\n"
-            "  \"version\": 1,\n"
-            "  \"zones\": [\n"
-            "    { \"room_id\": \"0x25\", \"mask\": \"0x01\", \"offsets\": [32] }\n"
-            "  ]\n"
-            "}\n");
+  WriteFile(
+      in_path,
+      "{\n"
+      "  \"version\": 1,\n"
+      "  \"zones\": [\n"
+      "    { \"room_id\": \"0x25\", \"mask\": \"0x01\", \"offsets\": [32] }\n"
+      "  ]\n"
+      "}\n");
 
   handlers::DungeonImportWaterFillJsonCommandHandler handler;
   std::string output;
   const auto status =
-      handler.Run({"--in", in_path.string(), "--dry-run",
-                   "--report", report_path.string(), "--format=json"},
+      handler.Run({"--in", in_path.string(), "--dry-run", "--report",
+                   report_path.string(), "--format=json"},
                   &rom, &output);
   EXPECT_FALSE(status.ok());
   EXPECT_EQ(status.code(), absl::StatusCode::kFailedPrecondition);
@@ -436,24 +1288,25 @@ TEST(DungeonCollisionJsonCommandsTest,
 // SRAM bit masks.
 // ---------------------------------------------------------------------------
 
-TEST(DungeonCollisionJsonCommandsTest,
-     ZoraTempleProfileBothRoomsRoundtrip) {
+TEST(DungeonCollisionJsonCommandsTest, ZoraTempleProfileBothRoomsRoundtrip) {
   // Write both D4 zones with correct masks, then export+verify both survive.
   Rom rom;
   ASSERT_TRUE(rom.LoadFromData(std::vector<uint8_t>(0x200000, 0x00)).ok());
   SeedCustomCollisionRooms(&rom, {0x25, 0x27});
 
-  const auto in_path = std::filesystem::temp_directory_path() /
-                       "yaze_d4_profile_import.json";
-  const auto out_path = std::filesystem::temp_directory_path() /
-                        "yaze_d4_profile_export.json";
+  const auto in_path =
+      std::filesystem::temp_directory_path() / "yaze_d4_profile_import.json";
+  const auto out_path =
+      std::filesystem::temp_directory_path() / "yaze_d4_profile_export.json";
 
   WriteFile(in_path,
             "{\n"
             "  \"version\": 1,\n"
             "  \"zones\": [\n"
-            "    { \"room_id\": \"0x25\", \"mask\": \"0x02\", \"offsets\": [100, 101] },\n"
-            "    { \"room_id\": \"0x27\", \"mask\": \"0x01\", \"offsets\": [200, 201] }\n"
+            "    { \"room_id\": \"0x25\", \"mask\": \"0x02\", \"offsets\": "
+            "[100, 101] },\n"
+            "    { \"room_id\": \"0x27\", \"mask\": \"0x01\", \"offsets\": "
+            "[200, 201] }\n"
             "  ]\n"
             "}\n");
 
@@ -461,19 +1314,19 @@ TEST(DungeonCollisionJsonCommandsTest,
   std::string import_output;
   ASSERT_TRUE(
       import_handler
-          .Run({"--in", in_path.string(), "--format=json"}, &rom, &import_output)
+          .Run({"--in", in_path.string(), "--mock-rom", "--format=json"}, &rom,
+               &import_output)
           .ok());
 
   handlers::DungeonExportWaterFillJsonCommandHandler export_handler;
   std::string export_output;
-  ASSERT_TRUE(
-      export_handler
-          .Run({"--rooms=0x25,0x27", "--out", out_path.string(), "--format=json"},
-               &rom, &export_output)
-          .ok());
+  ASSERT_TRUE(export_handler
+                  .Run({"--rooms=0x25,0x27", "--out", out_path.string(),
+                        "--format=json"},
+                       &rom, &export_output)
+                  .ok());
 
-  auto zones_or =
-      zelda3::LoadWaterFillZonesFromJsonString(ReadFile(out_path));
+  auto zones_or = zelda3::LoadWaterFillZonesFromJsonString(ReadFile(out_path));
   ASSERT_TRUE(zones_or.ok()) << zones_or.status().message();
   ASSERT_EQ(zones_or->size(), 2u);
 
@@ -507,21 +1360,22 @@ TEST(DungeonCollisionJsonCommandsTest,
   ASSERT_TRUE(rom.LoadFromData(std::vector<uint8_t>(0x200000, 0x00)).ok());
   SeedCustomCollisionRooms(&rom, {0x25, 0x27});
 
-  const auto in_path = std::filesystem::temp_directory_path() /
-                       "yaze_d4_mask_norm.json";
-  WriteFile(in_path,
-            "{\n"
-            "  \"version\": 1,\n"
-            "  \"zones\": [\n"
-            "    { \"room_id\": \"0x27\", \"mask\": \"0x00\", \"offsets\": [50] },\n"
-            "    { \"room_id\": \"0x25\", \"mask\": \"0x00\", \"offsets\": [60] }\n"
-            "  ]\n"
-            "}\n");
+  const auto in_path =
+      std::filesystem::temp_directory_path() / "yaze_d4_mask_norm.json";
+  WriteFile(
+      in_path,
+      "{\n"
+      "  \"version\": 1,\n"
+      "  \"zones\": [\n"
+      "    { \"room_id\": \"0x27\", \"mask\": \"0x00\", \"offsets\": [50] },\n"
+      "    { \"room_id\": \"0x25\", \"mask\": \"0x00\", \"offsets\": [60] }\n"
+      "  ]\n"
+      "}\n");
 
   handlers::DungeonImportWaterFillJsonCommandHandler handler;
   std::string output;
-  const auto status =
-      handler.Run({"--in", in_path.string(), "--format=json"}, &rom, &output);
+  const auto status = handler.Run(
+      {"--in", in_path.string(), "--mock-rom", "--format=json"}, &rom, &output);
   ASSERT_TRUE(status.ok()) << status.message();
 
   auto zones_or = zelda3::LoadWaterFillTable(&rom);
@@ -545,8 +1399,10 @@ TEST(DungeonCollisionJsonCommandsTest,
   ASSERT_TRUE(rom.LoadFromData(std::vector<uint8_t>(0x200000, 0x00)).ok());
 
   std::vector<zelda3::WaterFillZoneEntry> zones;
-  zones.push_back({.room_id = 0x25, .sram_bit_mask = 0x02, .fill_offsets = {1, 2}});
-  zones.push_back({.room_id = 0x27, .sram_bit_mask = 0x01, .fill_offsets = {3, 4}});
+  zones.push_back(
+      {.room_id = 0x25, .sram_bit_mask = 0x02, .fill_offsets = {1, 2}});
+  zones.push_back(
+      {.room_id = 0x27, .sram_bit_mask = 0x01, .fill_offsets = {3, 4}});
   ASSERT_TRUE(zelda3::WriteWaterFillTable(&rom, zones).ok());
 
   const auto out_path = std::filesystem::temp_directory_path() /
@@ -554,8 +1410,9 @@ TEST(DungeonCollisionJsonCommandsTest,
   handlers::DungeonExportWaterFillJsonCommandHandler handler;
   std::string output;
   ASSERT_TRUE(
-      handler.Run({"--room=0x25", "--out", out_path.string(), "--format=json"},
-                  &rom, &output)
+      handler
+          .Run({"--room=0x25", "--out", out_path.string(), "--format=json"},
+               &rom, &output)
           .ok());
 
   auto exported_or =

--- a/test/unit/cli/dungeon_minecart_audit_test.cc
+++ b/test/unit/cli/dungeon_minecart_audit_test.cc
@@ -72,7 +72,8 @@ absl::Status InjectCollisionTile(Rom* rom, int room_id, int offset,
   }
   handlers::DungeonImportCustomCollisionJsonCommandHandler handler;
   std::string out;
-  const auto status = handler.Run({"--in", tmp, "--format=json"}, rom, &out);
+  const auto status =
+      handler.Run({"--in", tmp, "--mock-rom", "--format=json"}, rom, &out);
   std::filesystem::remove(tmp_path);
   return status;
 }
@@ -100,7 +101,8 @@ absl::Status InjectCollisionTiles(
   }
   handlers::DungeonImportCustomCollisionJsonCommandHandler handler;
   std::string out;
-  const auto status = handler.Run({"--in", tmp, "--format=json"}, rom, &out);
+  const auto status =
+      handler.Run({"--in", tmp, "--mock-rom", "--format=json"}, rom, &out);
   std::filesystem::remove(tmp_path);
   return status;
 }

--- a/test/unit/cli/dungeon_oracle_preflight_test.cc
+++ b/test/unit/cli/dungeon_oracle_preflight_test.cc
@@ -48,7 +48,8 @@ absl::Status InjectCollisionTile(Rom* rom, int room_id, int offset,
   }
   handlers::DungeonImportCustomCollisionJsonCommandHandler handler;
   std::string out;
-  const auto status = handler.Run({"--in", tmp, "--format=json"}, rom, &out);
+  const auto status =
+      handler.Run({"--in", tmp, "--mock-rom", "--format=json"}, rom, &out);
   std::filesystem::remove(tmp);
   return status;
 }

--- a/test/unit/cli/oracle_smoke_check_test.cc
+++ b/test/unit/cli/oracle_smoke_check_test.cc
@@ -53,7 +53,8 @@ absl::Status InjectCollisionTile(Rom* rom, int room_id, int offset) {
   }
   handlers::DungeonImportCustomCollisionJsonCommandHandler handler;
   std::string out;
-  auto status = handler.Run({"--in", tmp, "--format=json"}, rom, &out);
+  auto status =
+      handler.Run({"--in", tmp, "--mock-rom", "--format=json"}, rom, &out);
   std::filesystem::remove(tmp);
   return status;
 }

--- a/test/unit/cli/tool_dispatcher_test.cc
+++ b/test/unit/cli/tool_dispatcher_test.cc
@@ -96,6 +96,26 @@ TEST(ToolDispatcherUnitTest, RegistryInitializesBuiltinToolsOnDemand) {
       ToolRegistry::Get().GetToolDefinition("build-status").has_value());
 }
 
+TEST(ToolDispatcherUnitTest,
+     CollisionImportToolsDeclareStructuredBooleanFlags) {
+  const auto custom = ToolRegistry::Get().GetToolDefinition(
+      "dungeon-import-custom-collision-json");
+  ASSERT_TRUE(custom.has_value());
+  EXPECT_THAT(custom->flag_args, Contains("dry-run"));
+  EXPECT_THAT(custom->flag_args, Contains("sandbox"));
+  EXPECT_THAT(custom->flag_args, Contains("mock-rom"));
+  EXPECT_THAT(custom->flag_args, Contains("replace-all"));
+  EXPECT_THAT(custom->flag_args, Contains("force"));
+
+  const auto water =
+      ToolRegistry::Get().GetToolDefinition("dungeon-import-water-fill-json");
+  ASSERT_TRUE(water.has_value());
+  EXPECT_THAT(water->flag_args, Contains("dry-run"));
+  EXPECT_THAT(water->flag_args, Contains("sandbox"));
+  EXPECT_THAT(water->flag_args, Contains("mock-rom"));
+  EXPECT_THAT(water->flag_args, Contains("strict-masks"));
+}
+
 TEST(ToolDispatcherUnitTest, SharedValidationRejectsMissingRequiredArgs) {
   ToolRegistry::Get().RegisterTool(
       {"test-required-arg",

--- a/test/unit/zelda3/dungeon/oracle_rom_safety_preflight_test.cc
+++ b/test/unit/zelda3/dungeon/oracle_rom_safety_preflight_test.cc
@@ -130,7 +130,9 @@ TEST(OracleRomSafetyPreflightTest, SucceedsWhenRequiredRoomHasCollisionData) {
 
     yaze::cli::handlers::DungeonImportCustomCollisionJsonCommandHandler handler;
     std::string out;
-    ASSERT_TRUE(handler.Run({"--in", tmp, "--format=json"}, &rom, &out).ok());
+    ASSERT_TRUE(
+        handler.Run({"--in", tmp, "--mock-rom", "--format=json"}, &rom, &out)
+            .ok());
     std::filesystem::remove(tmp);
   }
 


### PR DESCRIPTION
## Summary
- persist custom-collision and water-fill JSON imports through one ROM transaction
- require the destination backup and roll back serializer, save, or backup failures
- preserve source dirty state while materializing a sandbox and write the sandbox copy once
- fail closed on unsafe report combinations and ROM-alias report paths
- register structured boolean flags correctly for agent tool calls

## Verification
- `cmake --build --preset mac-ai --target yaze_test_unit --parallel 8`
- focused collision/tool/preflight suite: **91/91 passed**
- combined post-sync transaction/header suite: **43/43 passed**
- `YAZE_PREPUSH_BUILD_DIR=build/presets/mac-ai scripts/pre-push.sh`
- strict delegated review: no blocker or high-severity findings

## Safety / residual scope
- tests use disposable ROM fixtures; no canonical Oracle ROM was modified
- local report-path replacement remains a TOCTOU risk in untrusted directories, so report output should use a trusted directory
- pre-existing export `--out` ROM-alias behavior is tracked separately in #134

Fixes #128
