### PR TITLE
fix(cli): make collision exports ROM-alias-safe

### DIFF
--- a/docs/internal/agents/rom-safety-guardrails.md
+++ b/docs/internal/agents/rom-safety-guardrails.md
@@ -33,10 +33,17 @@ This repo is used to edit ROM hacks (including Oracle of Secrets). Treat ROM wri
 - Import `--report` is accepted only with a non-sandbox `--dry-run`; every
   write-mode or sandbox invocation rejects it before ROM loading or sandbox
   creation. Report paths must not alias the active ROM. The guard is rechecked
-  immediately before the direct report write, but a local path-swap TOCTOU
-  remains; use a trusted directory that other processes cannot modify.
-  Collision/water JSON export reports use the same active-ROM alias guard and
-  are also rejected with `--sandbox`.
+  immediately before publishing the report.
+- Collision/water JSON exports carry command-scoped source and active ROM path
+  identities, including the sandbox copy path. `--out` and `--report` must not
+  alias either ROM or each other through normalized, symlink, or hardlink
+  paths. Both JSON artifacts are written to exclusive same-directory temporary
+  files and atomically replaced. Existing artifacts receive command-local
+  rollback copies, so a later publication failure restores any earlier member
+  of the output/report pair. A target-link swap cannot truncate a ROM inode.
+  Export reports are allowed with `--sandbox` under these guards. Artifact
+  parent directories must already exist and should be trusted: replacing an
+  ancestor directory entry concurrently remains outside this guard.
 - `dungeon-generate-track-collision --write` applies the same contract to a
   single room or the complete `--rooms` batch. Batch serialization and the one
   required-backup disk save are all-or-nothing; a later-room failure restores
@@ -251,8 +258,10 @@ Safety semantics:
 - `--report <path>` is non-sandbox dry-run-only and writes machine-readable
   JSON with `status`, `mode`, and structured error code/message. It must name a
   separate writable file, never the active ROM through a direct, normalized,
-  symlink, or hardlink path. Use a trusted report directory because a local
-  path swap between the identity check and open is not guarded.
+  symlink, or hardlink path. Reports are published through an exclusive
+  same-directory temporary file and atomic replacement. Use an existing,
+  trusted parent directory; concurrent ancestor-directory replacement remains
+  outside this guard.
 - `dungeon-import-custom-collision-json --replace-all` is destructive and requires `--force` in write mode.
 - `dungeon-import-water-fill-json --strict-masks` fails closed if SRAM mask normalization would be needed.
 

--- a/docs/public/reference/z3ed-command-reference.md
+++ b/docs/public/reference/z3ed-command-reference.md
@@ -152,7 +152,9 @@ These commands operate directly on ROM data (no GUI required).
 - `dungeon-list-sprites --room <hex>`
 - `dungeon-list-objects --room <hex>`
 - `dungeon-list-custom-collision --room <hex> [--tiles <hex,hex,...>] [--nonzero] [--all]`
+- `dungeon-export-custom-collision-json --out <path> [--room <hex> | --rooms <hex,hex,...> | --all] [--report <path>] [--sandbox]`
 - `dungeon-import-custom-collision-json --in <path> [--dry-run [--report <path>]] [--sandbox | --mock-rom] [--replace-all --force]`
+- `dungeon-export-water-fill-json --out <path> [--room <hex> | --rooms <hex,hex,...> | --all] [--report <path>] [--sandbox]`
 - `dungeon-import-water-fill-json --in <path> [--dry-run [--report <path>]] [--sandbox | --mock-rom] [--strict-masks]`
 - `dungeon-minecart-audit [--room <hex> | --rooms <hex,hex,...> | --all] [--only-issues]`
 - `dungeon-map --room <hex> [--layer <0|1|2>]` *(overlays Oracle custom collision tiles when present)*
@@ -185,7 +187,8 @@ staged in exclusive same-directory temporary files and published with
 rename/replace after a final path-identity check. Collision/water JSON exports
 use the same ROM-alias checks; when `--out` and `--report` are published
 together, a partial publication is rolled back before the command returns.
-Export reports cannot be combined with `--sandbox`.
+Exports may use `--sandbox`; their explicit `--out` and `--report` artifacts
+must remain separate from both the sandbox ROM and its source ROM.
 
 When `--spawn` is set, the ID must be `0x00`-`0x06`. Both entrance commands
 report the dedicated spawn fields (`quadrant`, `overworld_door_tilemap`, and

--- a/docs/public/reference/z3ed-command-reference.md
+++ b/docs/public/reference/z3ed-command-reference.md
@@ -180,11 +180,12 @@ sandbox copy; the source ROM and its directory remain unchanged. `--mock-rom`
 is an in-memory test mode and is rejected when combined with `--sandbox`.
 `--report` is accepted only with a non-sandbox `--dry-run`; write-mode and
 sandbox imports reject it before ROM or sandbox work. Report paths must not
-alias the active ROM, including through symlinks or hardlinks. Reports use a
-direct file write after a final identity recheck; use a trusted directory
-because a local path-swap race remains between that check and open.
-Collision/water JSON export reports use the same ROM-alias check and cannot be
-combined with `--sandbox`.
+alias the active ROM, including through symlinks or hardlinks. Reports are
+staged in exclusive same-directory temporary files and published with
+rename/replace after a final path-identity check. Collision/water JSON exports
+use the same ROM-alias checks; when `--out` and `--report` are published
+together, a partial publication is rolled back before the command returns.
+Export reports cannot be combined with `--sandbox`.
 
 When `--spawn` is set, the ID must be `0x00`-`0x06`. Both entrance commands
 report the dedicated spawn fields (`quadrant`, `overworld_door_tilemap`, and

--- a/src/cli/handlers/game/dungeon_collision_commands.cc
+++ b/src/cli/handlers/game/dungeon_collision_commands.cc
@@ -1122,6 +1122,8 @@ absl::Status DungeonExportCustomCollisionJsonCommandHandler::ExecuteWithContext(
     return absl::OkStatus();
   }();
 
+  // Resolve again after the export body as defense-in-depth against path
+  // identity changes between initial validation and publication.
   auto final_artifact_paths_or =
       ResolveExportArtifactPaths(parser, invocation_context);
   absl::Status final_path_status = final_artifact_paths_or.status();
@@ -1132,11 +1134,18 @@ absl::Status DungeonExportCustomCollisionJsonCommandHandler::ExecuteWithContext(
         "artifact was published");
   }
 
-  absl::Status final_status = final_path_status;
-  if (final_path_status.ok() && !status.ok()) {
-    final_status =
-        FinalizeExportWithReport(artifact_paths, std::move(report), status);
-  } else if (final_path_status.ok()) {
+  absl::Status final_status;
+  if (!status.ok()) {
+    // Do not let a coincident path re-resolution failure shadow the original
+    // business error. An unsafe final path suppresses report publication, but
+    // callers still receive the command failure that stopped the export.
+    final_status = final_path_status.ok()
+                       ? FinalizeExportWithReport(artifact_paths,
+                                                  std::move(report), status)
+                       : status;
+  } else if (!final_path_status.ok()) {
+    final_status = final_path_status;
+  } else {
     final_status = PublishExportArtifactsAtomically(
         artifact_paths.out_path, exported_json, artifact_paths.report_path,
         report.dump(2) + "\n");
@@ -1349,6 +1358,8 @@ absl::Status DungeonExportWaterFillJsonCommandHandler::ExecuteWithContext(
     return absl::OkStatus();
   }();
 
+  // Resolve again after the export body as defense-in-depth against path
+  // identity changes between initial validation and publication.
   auto final_artifact_paths_or =
       ResolveExportArtifactPaths(parser, invocation_context);
   absl::Status final_path_status = final_artifact_paths_or.status();
@@ -1359,11 +1370,18 @@ absl::Status DungeonExportWaterFillJsonCommandHandler::ExecuteWithContext(
         "artifact was published");
   }
 
-  absl::Status final_status = final_path_status;
-  if (final_path_status.ok() && !status.ok()) {
-    final_status =
-        FinalizeExportWithReport(artifact_paths, std::move(report), status);
-  } else if (final_path_status.ok()) {
+  absl::Status final_status;
+  if (!status.ok()) {
+    // Do not let a coincident path re-resolution failure shadow the original
+    // business error. An unsafe final path suppresses report publication, but
+    // callers still receive the command failure that stopped the export.
+    final_status = final_path_status.ok()
+                       ? FinalizeExportWithReport(artifact_paths,
+                                                  std::move(report), status)
+                       : status;
+  } else if (!final_path_status.ok()) {
+    final_status = final_path_status;
+  } else {
     final_status = PublishExportArtifactsAtomically(
         artifact_paths.out_path, exported_json, artifact_paths.report_path,
         report.dump(2) + "\n");

--- a/src/cli/handlers/game/dungeon_collision_commands.cc
+++ b/src/cli/handlers/game/dungeon_collision_commands.cc
@@ -2,10 +2,14 @@
 
 #include <algorithm>
 #include <array>
+#include <atomic>
+#include <cerrno>
+#include <chrono>
 #include <cstdint>
 #include <filesystem>
 #include <fstream>
 #include <ios>
+#include <limits>
 #include <sstream>
 #include <string>
 #include <system_error>
@@ -32,6 +36,16 @@
 #include "zelda3/dungeon/oracle_rom_safety_preflight.h"
 #include "zelda3/dungeon/room.h"
 #include "zelda3/dungeon/water_fill_zone.h"
+
+#if defined(_WIN32)
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+#include <windows.h>
+#else
+#include <fcntl.h>
+#include <unistd.h>
+#endif
 
 ABSL_DECLARE_FLAG(bool, sandbox);
 
@@ -147,28 +161,470 @@ absl::StatusOr<std::string> ReadTextFile(const std::string& path) {
   return ss.str();
 }
 
-absl::Status WriteTextFile(const std::string& path,
-                           const std::string& content) {
-  std::ofstream out(path, std::ios::out | std::ios::binary | std::ios::trunc);
-  if (!out.is_open()) {
-    return absl::PermissionDeniedError(
-        absl::StrFormat("Cannot open file for writing: %s", path));
+absl::StatusOr<std::filesystem::path> ResolveStableArtifactPath(
+    const std::filesystem::path& path) {
+  std::error_code absolute_ec;
+  std::filesystem::path absolute = std::filesystem::absolute(path, absolute_ec);
+  if (absolute_ec) {
+    return absl::InvalidArgumentError(absl::StrFormat(
+        "Cannot normalize path %s: %s", path.string(), absolute_ec.message()));
   }
-  out.write(content.data(), static_cast<std::streamsize>(content.size()));
-  out.flush();
-  const bool write_failed = !out.good();
-  out.close();
-  if (write_failed || out.fail()) {
+  absolute = absolute.lexically_normal();
+
+  // Resolve every existing component once. Publication then uses this stable
+  // path instead of following a caller-supplied parent symlink a second time.
+  std::error_code canonical_ec;
+  const std::filesystem::path canonical =
+      std::filesystem::weakly_canonical(absolute, canonical_ec);
+  if (canonical_ec) {
+    return absl::FailedPreconditionError(
+        absl::StrFormat("Cannot safely resolve path %s: %s", absolute.string(),
+                        canonical_ec.message()));
+  }
+  const std::filesystem::path resolved = canonical.lexically_normal();
+  const std::filesystem::path parent = resolved.parent_path();
+  std::error_code parent_ec;
+  const auto parent_status = std::filesystem::status(parent, parent_ec);
+  if (parent_ec || !std::filesystem::exists(parent_status) ||
+      !std::filesystem::is_directory(parent_status)) {
+    return absl::FailedPreconditionError(absl::StrFormat(
+        "Artifact parent directory must already exist: %s%s", parent.string(),
+        !parent_ec ? "" : absl::StrFormat(" (%s)", parent_ec.message())));
+  }
+  return resolved;
+}
+
+std::filesystem::path NextArtifactTempPath(
+    const std::filesystem::path& target_path) {
+  static std::atomic<uint64_t> sequence{0};
+  const uint64_t tick = static_cast<uint64_t>(
+      std::chrono::steady_clock::now().time_since_epoch().count());
+  const uint64_t id = sequence.fetch_add(1, std::memory_order_relaxed);
+
+  std::filesystem::path temp_name = target_path.filename();
+  temp_name += absl::StrFormat(".yaze-tmp-%016x-%016x", tick, id);
+  const auto parent = target_path.parent_path().empty()
+                          ? std::filesystem::path(".")
+                          : target_path.parent_path();
+  return parent / temp_name;
+}
+
+absl::StatusOr<std::filesystem::path> WriteExclusiveArtifactTemp(
+    const std::filesystem::path& target_path, absl::string_view content) {
+  constexpr int kMaxCreateAttempts = 100;
+
+  for (int attempt = 0; attempt < kMaxCreateAttempts; ++attempt) {
+    const std::filesystem::path temp_path = NextArtifactTempPath(target_path);
+
+#if defined(_WIN32)
+    HANDLE file = CreateFileW(
+        temp_path.wstring().c_str(), GENERIC_WRITE, 0, nullptr, CREATE_NEW,
+        FILE_ATTRIBUTE_NORMAL | FILE_FLAG_WRITE_THROUGH, nullptr);
+    if (file == INVALID_HANDLE_VALUE) {
+      const DWORD error = GetLastError();
+      if (error == ERROR_FILE_EXISTS || error == ERROR_ALREADY_EXISTS) {
+        continue;
+      }
+      return absl::PermissionDeniedError(absl::StrFormat(
+          "Cannot create temporary artifact for %s: %s", target_path.string(),
+          std::error_code(static_cast<int>(error), std::system_category())
+              .message()));
+    }
+
+    size_t written_total = 0;
+    while (written_total < content.size()) {
+      const size_t remaining = content.size() - written_total;
+      const DWORD chunk = static_cast<DWORD>(
+          std::min<size_t>(remaining, std::numeric_limits<DWORD>::max()));
+      DWORD written = 0;
+      if (!WriteFile(file, content.data() + written_total, chunk, &written,
+                     nullptr) ||
+          written == 0) {
+        const DWORD error = GetLastError();
+        CloseHandle(file);
+        std::error_code cleanup_ec;
+        std::filesystem::remove(temp_path, cleanup_ec);
+        return absl::InternalError(absl::StrFormat(
+            "Failed while writing temporary artifact for %s: %s",
+            target_path.string(),
+            std::error_code(static_cast<int>(error), std::system_category())
+                .message()));
+      }
+      written_total += written;
+    }
+
+    if (!FlushFileBuffers(file)) {
+      const DWORD error = GetLastError();
+      CloseHandle(file);
+      std::error_code cleanup_ec;
+      std::filesystem::remove(temp_path, cleanup_ec);
+      return absl::InternalError(absl::StrFormat(
+          "Failed to flush temporary artifact for %s: %s", target_path.string(),
+          std::error_code(static_cast<int>(error), std::system_category())
+              .message()));
+    }
+    if (!CloseHandle(file)) {
+      const DWORD error = GetLastError();
+      std::error_code cleanup_ec;
+      std::filesystem::remove(temp_path, cleanup_ec);
+      return absl::InternalError(absl::StrFormat(
+          "Failed to close temporary artifact for %s: %s", target_path.string(),
+          std::error_code(static_cast<int>(error), std::system_category())
+              .message()));
+    }
+#else
+    const int fd =
+        open(temp_path.c_str(), O_WRONLY | O_CREAT | O_EXCL, S_IRUSR | S_IWUSR);
+    if (fd < 0) {
+      const int error = errno;
+      if (error == EEXIST) {
+        continue;
+      }
+      return absl::PermissionDeniedError(absl::StrFormat(
+          "Cannot create temporary artifact for %s: %s", target_path.string(),
+          std::error_code(error, std::generic_category()).message()));
+    }
+
+    size_t written_total = 0;
+    while (written_total < content.size()) {
+      const size_t remaining = content.size() - written_total;
+      const size_t chunk = std::min<size_t>(remaining, 1024 * 1024);
+      const ssize_t written = write(fd, content.data() + written_total, chunk);
+      if (written < 0 && errno == EINTR) {
+        continue;
+      }
+      if (written <= 0) {
+        const int error = written < 0 ? errno : EIO;
+        close(fd);
+        std::error_code cleanup_ec;
+        std::filesystem::remove(temp_path, cleanup_ec);
+        return absl::InternalError(absl::StrFormat(
+            "Failed while writing temporary artifact for %s: %s",
+            target_path.string(),
+            std::error_code(error, std::generic_category()).message()));
+      }
+      written_total += static_cast<size_t>(written);
+    }
+
+    if (fsync(fd) != 0) {
+      const int error = errno;
+      close(fd);
+      std::error_code cleanup_ec;
+      std::filesystem::remove(temp_path, cleanup_ec);
+      return absl::InternalError(absl::StrFormat(
+          "Failed to flush temporary artifact for %s: %s", target_path.string(),
+          std::error_code(error, std::generic_category()).message()));
+    }
+    if (close(fd) != 0) {
+      const int error = errno;
+      std::error_code cleanup_ec;
+      std::filesystem::remove(temp_path, cleanup_ec);
+      return absl::InternalError(absl::StrFormat(
+          "Failed to close temporary artifact for %s: %s", target_path.string(),
+          std::error_code(error, std::generic_category()).message()));
+    }
+#endif
+
+    return temp_path;
+  }
+
+  return absl::ResourceExhaustedError(
+      absl::StrFormat("Could not allocate a unique temporary artifact for %s",
+                      target_path.string()));
+}
+
+absl::Status ReplaceArtifactFromTemp(const std::filesystem::path& temp_path,
+                                     const std::filesystem::path& target_path) {
+  std::error_code rename_ec;
+  std::filesystem::rename(temp_path, target_path, rename_ec);
+#if defined(_WIN32)
+  if (rename_ec) {
+    if (MoveFileExW(temp_path.wstring().c_str(), target_path.wstring().c_str(),
+                    MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH)) {
+      rename_ec.clear();
+    } else {
+      rename_ec = std::error_code(static_cast<int>(GetLastError()),
+                                  std::system_category());
+    }
+  }
+#endif
+  if (rename_ec) {
     return absl::InternalError(
-        absl::StrFormat("Failed while writing file: %s", path));
+        absl::StrFormat("Failed to publish artifact %s: %s",
+                        target_path.string(), rename_ec.message()));
   }
   return absl::OkStatus();
+}
+
+absl::Status ValidatePublishTarget(const std::filesystem::path& target_path) {
+  std::error_code status_ec;
+  const auto status = std::filesystem::symlink_status(target_path, status_ec);
+  if (status_ec && status_ec != std::errc::no_such_file_or_directory) {
+    return absl::FailedPreconditionError(
+        absl::StrFormat("Cannot inspect artifact target %s: %s",
+                        target_path.string(), status_ec.message()));
+  }
+  if (!status_ec && std::filesystem::is_directory(status)) {
+    return absl::FailedPreconditionError(
+        absl::StrFormat("Artifact target is a directory, not a file: %s",
+                        target_path.string()));
+  }
+  if (!status_ec && std::filesystem::exists(status) &&
+      !std::filesystem::is_regular_file(status) &&
+      !std::filesystem::is_symlink(status)) {
+    return absl::FailedPreconditionError(absl::StrFormat(
+        "Artifact target is not a replaceable file: %s", target_path.string()));
+  }
+  return absl::OkStatus();
+}
+
+absl::StatusOr<std::optional<std::filesystem::path>> CreateArtifactRollbackCopy(
+    const std::filesystem::path& target_path) {
+  std::error_code status_ec;
+  const auto status = std::filesystem::symlink_status(target_path, status_ec);
+  if (status_ec == std::errc::no_such_file_or_directory ||
+      (!status_ec && !std::filesystem::exists(status))) {
+    return std::nullopt;
+  }
+  if (status_ec) {
+    return absl::FailedPreconditionError(
+        absl::StrFormat("Cannot inspect existing artifact %s: %s",
+                        target_path.string(), status_ec.message()));
+  }
+
+  constexpr int kMaxCreateAttempts = 100;
+  for (int attempt = 0; attempt < kMaxCreateAttempts; ++attempt) {
+    const std::filesystem::path rollback_path =
+        NextArtifactTempPath(target_path);
+    std::error_code copy_ec;
+    if (std::filesystem::is_symlink(status)) {
+      std::filesystem::copy_symlink(target_path, rollback_path, copy_ec);
+    } else {
+      std::filesystem::copy_file(target_path, rollback_path,
+                                 std::filesystem::copy_options::none, copy_ec);
+    }
+    if (!copy_ec) {
+      return rollback_path;
+    }
+    if (copy_ec == std::errc::file_exists) {
+      continue;
+    }
+    return absl::FailedPreconditionError(absl::StrFormat(
+        "Cannot preserve existing artifact %s before publication: %s",
+        target_path.string(), copy_ec.message()));
+  }
+
+  return absl::ResourceExhaustedError(
+      absl::StrFormat("Could not allocate a rollback copy for artifact %s",
+                      target_path.string()));
+}
+
+struct PendingArtifactPublication {
+  std::filesystem::path target_path;
+  std::string content;
+  std::filesystem::path temp_path;
+  std::optional<std::filesystem::path> rollback_path;
+  bool published = false;
+  bool preserve_rollback_copy = false;
+};
+
+void CleanupPendingArtifactFiles(
+    const std::vector<PendingArtifactPublication>& artifacts) {
+  for (const auto& artifact : artifacts) {
+    std::error_code cleanup_ec;
+    if (!artifact.temp_path.empty()) {
+      std::filesystem::remove(artifact.temp_path, cleanup_ec);
+    }
+    if (artifact.rollback_path.has_value() &&
+        !artifact.preserve_rollback_copy) {
+      cleanup_ec.clear();
+      std::filesystem::remove(*artifact.rollback_path, cleanup_ec);
+    }
+  }
+}
+
+absl::Status RollBackPublishedArtifacts(
+    std::vector<PendingArtifactPublication>* artifacts,
+    const absl::Status& publication_failure) {
+  absl::Status rollback_failure = absl::OkStatus();
+  for (auto it = artifacts->rbegin(); it != artifacts->rend(); ++it) {
+    if (!it->published) {
+      continue;
+    }
+
+    if (it->rollback_path.has_value()) {
+      const absl::Status restore_status =
+          ReplaceArtifactFromTemp(*it->rollback_path, it->target_path);
+      if (!restore_status.ok() && rollback_failure.ok()) {
+        it->preserve_rollback_copy = true;
+        rollback_failure = absl::InternalError(absl::StrFormat(
+            "%s; preserved the original artifact at %s",
+            restore_status.message(), it->rollback_path->string()));
+      } else if (!restore_status.ok()) {
+        it->preserve_rollback_copy = true;
+      } else if (restore_status.ok()) {
+        it->rollback_path.reset();
+      }
+    } else {
+      std::error_code remove_ec;
+      if (!std::filesystem::remove(it->target_path, remove_ec) || remove_ec) {
+        if (rollback_failure.ok()) {
+          rollback_failure = absl::InternalError(absl::StrFormat(
+              "Could not remove newly published artifact %s during rollback: "
+              "%s",
+              it->target_path.string(),
+              remove_ec ? remove_ec.message() : "artifact was missing"));
+        }
+      }
+    }
+    it->published = false;
+  }
+
+  if (!rollback_failure.ok()) {
+    return absl::DataLossError(absl::StrFormat(
+        "Artifact publication failed (%s) and rollback failed (%s)",
+        publication_failure.message(), rollback_failure.message()));
+  }
+  return publication_failure;
+}
+
+absl::Status RejectArtifactSetAliasesAfterPublication(
+    const std::vector<PendingArtifactPublication>& artifacts) {
+  for (size_t lhs_index = 0; lhs_index < artifacts.size(); ++lhs_index) {
+    for (size_t rhs_index = lhs_index + 1; rhs_index < artifacts.size();
+         ++rhs_index) {
+      std::error_code equivalent_ec;
+      if (std::filesystem::equivalent(artifacts[lhs_index].target_path,
+                                      artifacts[rhs_index].target_path,
+                                      equivalent_ec)) {
+        return absl::InvalidArgumentError(absl::StrFormat(
+            "Export artifact paths alias each other on this filesystem: %s "
+            "and %s",
+            artifacts[lhs_index].target_path.string(),
+            artifacts[rhs_index].target_path.string()));
+      }
+
+      if (!equivalent_ec) {
+        continue;
+      }
+
+      // A just-published target makes native case/Unicode aliases exist under
+      // both spellings. If both spellings now exist but the filesystem cannot
+      // compare them, fail closed and roll the publication back.
+      std::error_code lhs_exists_ec;
+      std::error_code rhs_exists_ec;
+      const bool lhs_exists = std::filesystem::exists(
+          artifacts[lhs_index].target_path, lhs_exists_ec);
+      const bool rhs_exists = std::filesystem::exists(
+          artifacts[rhs_index].target_path, rhs_exists_ec);
+      if (lhs_exists_ec || rhs_exists_ec || (lhs_exists && rhs_exists)) {
+        return absl::FailedPreconditionError(absl::StrFormat(
+            "Could not safely distinguish export artifact paths %s and %s: "
+            "%s",
+            artifacts[lhs_index].target_path.string(),
+            artifacts[rhs_index].target_path.string(),
+            equivalent_ec.message()));
+      }
+    }
+  }
+  return absl::OkStatus();
+}
+
+absl::Status PublishArtifactSetAtomically(
+    std::vector<PendingArtifactPublication> artifacts) {
+  for (const auto& artifact : artifacts) {
+    const absl::Status target_status =
+        ValidatePublishTarget(artifact.target_path);
+    if (!target_status.ok()) {
+      CleanupPendingArtifactFiles(artifacts);
+      return target_status;
+    }
+  }
+
+  for (auto& artifact : artifacts) {
+    auto temp_or =
+        WriteExclusiveArtifactTemp(artifact.target_path, artifact.content);
+    if (!temp_or.ok()) {
+      CleanupPendingArtifactFiles(artifacts);
+      return temp_or.status();
+    }
+    artifact.temp_path = *temp_or;
+  }
+
+  for (auto& artifact : artifacts) {
+    auto rollback_or = CreateArtifactRollbackCopy(artifact.target_path);
+    if (!rollback_or.ok()) {
+      CleanupPendingArtifactFiles(artifacts);
+      return rollback_or.status();
+    }
+    artifact.rollback_path = std::move(*rollback_or);
+  }
+
+  for (auto& artifact : artifacts) {
+    const absl::Status publish_status =
+        ReplaceArtifactFromTemp(artifact.temp_path, artifact.target_path);
+    if (!publish_status.ok()) {
+      const absl::Status final_status =
+          RollBackPublishedArtifacts(&artifacts, publish_status);
+      CleanupPendingArtifactFiles(artifacts);
+      return final_status;
+    }
+    artifact.temp_path.clear();
+    artifact.published = true;
+
+    const absl::Status alias_status =
+        RejectArtifactSetAliasesAfterPublication(artifacts);
+    if (!alias_status.ok()) {
+      const absl::Status final_status =
+          RollBackPublishedArtifacts(&artifacts, alias_status);
+      CleanupPendingArtifactFiles(artifacts);
+      return final_status;
+    }
+  }
+
+  CleanupPendingArtifactFiles(artifacts);
+  return absl::OkStatus();
+}
+
+absl::Status PublishResolvedTextFileAtomically(
+    const std::filesystem::path& target_path, absl::string_view content) {
+  std::vector<PendingArtifactPublication> artifacts;
+  artifacts.push_back(PendingArtifactPublication{
+      .target_path = target_path,
+      .content = std::string(content),
+  });
+  return PublishArtifactSetAtomically(std::move(artifacts));
+}
+
+absl::Status PublishExportArtifactsAtomically(
+    const std::filesystem::path& out_path, absl::string_view out_content,
+    const std::optional<std::filesystem::path>& report_path,
+    absl::string_view report_content) {
+  // Callers pass paths resolved and ROM-checked at command start. Do not follow
+  // the caller's raw path again after a parent symlink could have changed.
+  std::vector<PendingArtifactPublication> artifacts;
+  artifacts.push_back(PendingArtifactPublication{
+      .target_path = out_path,
+      .content = std::string(out_content),
+  });
+  if (report_path.has_value()) {
+    artifacts.push_back(PendingArtifactPublication{
+        .target_path = *report_path,
+        .content = std::string(report_content),
+    });
+  }
+  return PublishArtifactSetAtomically(std::move(artifacts));
 }
 
 absl::Status ValidateImportArguments(const resources::ArgumentParser& parser,
                                      absl::string_view command_name) {
   RETURN_IF_ERROR(parser.RequireArgs({"in"}));
-  const bool has_report = parser.GetString("report").has_value();
+  const auto report_path = parser.GetString("report");
+  const bool has_report = report_path.has_value();
+  if (has_report && report_path->empty()) {
+    return absl::InvalidArgumentError(
+        absl::StrFormat("%s: --report cannot be empty", command_name));
+  }
   const bool sandbox_requested =
       parser.HasFlag("sandbox") || absl::GetFlag(FLAGS_sandbox);
   if (has_report && !parser.HasFlag("dry-run")) {
@@ -193,26 +649,21 @@ absl::Status ValidateImportArguments(const resources::ArgumentParser& parser,
 absl::Status ValidateExportArguments(const resources::ArgumentParser& parser,
                                      absl::string_view command_name) {
   RETURN_IF_ERROR(parser.RequireArgs({"out"}));
-  const bool sandbox_requested =
-      parser.HasFlag("sandbox") || absl::GetFlag(FLAGS_sandbox);
-  if (parser.GetString("report").has_value() && sandbox_requested) {
-    return absl::InvalidArgumentError(absl::StrFormat(
-        "%s: --report cannot be combined with --sandbox; export from the "
-        "source ROM or omit --report",
-        command_name));
+  if (parser.GetString("out")->empty()) {
+    return absl::InvalidArgumentError(
+        absl::StrFormat("%s: --out cannot be empty", command_name));
+  }
+  if (const auto report = parser.GetString("report");
+      report.has_value() && report->empty()) {
+    return absl::InvalidArgumentError(
+        absl::StrFormat("%s: --report cannot be empty", command_name));
   }
   return absl::OkStatus();
 }
 
 absl::StatusOr<std::filesystem::path> NormalizedAbsolutePath(
     const std::filesystem::path& path) {
-  std::error_code absolute_ec;
-  std::filesystem::path absolute = std::filesystem::absolute(path, absolute_ec);
-  if (absolute_ec) {
-    return absl::InvalidArgumentError(absl::StrFormat(
-        "Cannot normalize path %s: %s", path.string(), absolute_ec.message()));
-  }
-  return absolute.lexically_normal();
+  return ResolveStableArtifactPath(path);
 }
 
 absl::StatusOr<bool> PathsAlias(const std::filesystem::path& lhs,
@@ -247,14 +698,95 @@ absl::StatusOr<bool> PathsAlias(const std::filesystem::path& lhs,
   return false;
 }
 
-absl::Status RejectReportRomAliases(const resources::ArgumentParser& parser,
-                                    const Rom* rom) {
-  const auto report_path_value = parser.GetString("report");
-  if (!report_path_value.has_value() || report_path_value->empty()) {
-    return absl::OkStatus();
+absl::Status RejectArtifactRomAliases(
+    absl::string_view option_name, const std::filesystem::path& artifact_path,
+    const resources::CommandInvocationContext& invocation_context) {
+  if (invocation_context.active_rom_path.has_value()) {
+    ASSIGN_OR_RETURN(
+        const bool aliases_active_rom,
+        PathsAlias(artifact_path, *invocation_context.active_rom_path));
+    if (aliases_active_rom) {
+      return absl::InvalidArgumentError(absl::StrFormat(
+          "%s path aliases the active ROM; choose a separate artifact file: "
+          "%s",
+          option_name, artifact_path.string()));
+    }
   }
 
-  const std::filesystem::path report_path(*report_path_value);
+  if (invocation_context.source_rom_path.has_value()) {
+    ASSIGN_OR_RETURN(
+        const bool aliases_source_rom,
+        PathsAlias(artifact_path, *invocation_context.source_rom_path));
+    if (aliases_source_rom) {
+      return absl::InvalidArgumentError(absl::StrFormat(
+          "%s path aliases the %s; choose a separate artifact file: %s",
+          option_name,
+          invocation_context.sandbox_enabled ? "sandbox source ROM"
+                                             : "source ROM",
+          artifact_path.string()));
+    }
+  }
+
+  return absl::OkStatus();
+}
+
+struct ResolvedExportArtifactPaths {
+  std::filesystem::path out_path;
+  std::optional<std::filesystem::path> report_path;
+
+  bool operator==(const ResolvedExportArtifactPaths&) const = default;
+};
+
+absl::StatusOr<ResolvedExportArtifactPaths> ResolveExportArtifactPaths(
+    const resources::ArgumentParser& parser,
+    const resources::CommandInvocationContext& invocation_context) {
+  const auto out_path_value = parser.GetString("out");
+  if (!out_path_value.has_value() || out_path_value->empty()) {
+    return absl::InvalidArgumentError("--out must name an artifact file");
+  }
+
+  ASSIGN_OR_RETURN(const auto out_path,
+                   ResolveStableArtifactPath(*out_path_value));
+  RETURN_IF_ERROR(
+      RejectArtifactRomAliases("--out", out_path, invocation_context));
+
+  ResolvedExportArtifactPaths resolved_paths{.out_path = out_path};
+
+  const auto report_path_value = parser.GetString("report");
+  if (!report_path_value.has_value()) {
+    return resolved_paths;
+  }
+  if (report_path_value->empty()) {
+    return absl::InvalidArgumentError("--report must name an artifact file");
+  }
+
+  ASSIGN_OR_RETURN(const auto report_path,
+                   ResolveStableArtifactPath(*report_path_value));
+  RETURN_IF_ERROR(
+      RejectArtifactRomAliases("--report", report_path, invocation_context));
+
+  ASSIGN_OR_RETURN(const bool artifacts_alias,
+                   PathsAlias(out_path, report_path));
+  if (artifacts_alias) {
+    return absl::InvalidArgumentError(absl::StrFormat(
+        "--out and --report paths alias each other; choose separate artifact "
+        "files: %s",
+        out_path.string()));
+  }
+
+  resolved_paths.report_path = report_path;
+  return resolved_paths;
+}
+
+absl::StatusOr<std::optional<std::filesystem::path>> ResolveReportArtifactPath(
+    const resources::ArgumentParser& parser, const Rom* rom) {
+  const auto report_path_value = parser.GetString("report");
+  if (!report_path_value.has_value() || report_path_value->empty()) {
+    return std::nullopt;
+  }
+
+  ASSIGN_OR_RETURN(const auto report_path,
+                   ResolveStableArtifactPath(*report_path_value));
   if (rom != nullptr && !rom->filename().empty()) {
     ASSIGN_OR_RETURN(
         const bool aliases_active_rom,
@@ -267,7 +799,7 @@ absl::Status RejectReportRomAliases(const resources::ArgumentParser& parser,
     }
   }
 
-  return absl::OkStatus();
+  return report_path;
 }
 
 std::string StatusCodeName(absl::StatusCode code) {
@@ -319,18 +851,18 @@ json BuildBaseReport(absl::string_view command_name, bool dry_run) {
   };
 }
 
-absl::Status WriteReportIfRequested(const resources::ArgumentParser& parser,
-                                    const json& report) {
-  auto report_path = parser.GetString("report");
-  if (!report_path.has_value()) {
-    return absl::OkStatus();
-  }
-  return WriteTextFile(*report_path, report.dump(2) + "\n");
+void AddStructuredError(resources::OutputFormatter& formatter,
+                        const absl::Status& status) {
+  formatter.AddField("status", "error");
+  formatter.BeginObject("error");
+  formatter.AddField("code", StatusCodeName(status.code()));
+  formatter.AddField("message", std::string(status.message()));
+  formatter.EndObject();
 }
 
-absl::Status FinalizeWithReport(const resources::ArgumentParser& parser,
-                                json report, const absl::Status& status,
-                                const Rom* protected_rom = nullptr) {
+absl::Status FinalizeWithReport(
+    const std::optional<std::filesystem::path>& resolved_report_path,
+    json report, const absl::Status& status) {
   if (!status.ok()) {
     report["status"] = "error";
     report["error"] = json{
@@ -340,11 +872,9 @@ absl::Status FinalizeWithReport(const resources::ArgumentParser& parser,
   }
 
   absl::Status report_status = absl::OkStatus();
-  if (protected_rom != nullptr) {
-    report_status = RejectReportRomAliases(parser, protected_rom);
-  }
-  if (report_status.ok()) {
-    report_status = WriteReportIfRequested(parser, report);
+  if (resolved_report_path.has_value()) {
+    report_status = PublishResolvedTextFileAtomically(*resolved_report_path,
+                                                      report.dump(2) + "\n");
   }
   if (!report_status.ok()) {
     if (status.ok()) {
@@ -356,6 +886,13 @@ absl::Status FinalizeWithReport(const resources::ArgumentParser& parser,
   }
 
   return status;
+}
+
+absl::Status FinalizeExportWithReport(
+    const ResolvedExportArtifactPaths& artifact_paths, json report,
+    const absl::Status& status) {
+  return FinalizeWithReport(artifact_paths.report_path, std::move(report),
+                            status);
 }
 
 json BuildPreflightJson(
@@ -519,14 +1056,37 @@ absl::Status DungeonListCustomCollisionCommandHandler::Execute(
 absl::Status DungeonExportCustomCollisionJsonCommandHandler::Execute(
     Rom* rom, const resources::ArgumentParser& parser,
     resources::OutputFormatter& formatter) {
-  RETURN_IF_ERROR(RejectReportRomAliases(parser, rom));
+  resources::CommandInvocationContext invocation_context;
+  if (rom != nullptr && !rom->filename().empty()) {
+    invocation_context.source_rom_path = std::filesystem::path(rom->filename());
+    invocation_context.active_rom_path = std::filesystem::path(rom->filename());
+  }
+  return ExecuteWithContext(rom, parser, formatter, invocation_context);
+}
+
+absl::Status DungeonExportCustomCollisionJsonCommandHandler::ExecuteWithContext(
+    Rom* rom, const resources::ArgumentParser& parser,
+    resources::OutputFormatter& formatter,
+    const resources::CommandInvocationContext& invocation_context) {
+  auto artifact_paths_or =
+      ResolveExportArtifactPaths(parser, invocation_context);
+  if (!artifact_paths_or.ok()) {
+    AddStructuredError(formatter, artifact_paths_or.status());
+    return artifact_paths_or.status();
+  }
+  const ResolvedExportArtifactPaths artifact_paths = *artifact_paths_or;
 
   json report = BuildBaseReport(GetName(), /*dry_run=*/false);
+  std::string out_path;
+  std::string exported_json;
+  int requested_rooms = 0;
+  int exported_room_count = 0;
   const absl::Status status = [&]() -> absl::Status {
     ASSIGN_OR_RETURN(const auto room_ids, ParseRoomSelection(parser));
-    const std::string out_path = parser.GetString("out").value();
+    out_path = parser.GetString("out").value();
+    requested_rooms = static_cast<int>(room_ids.size());
     report["out_path"] = out_path;
-    report["requested_rooms"] = static_cast<int>(room_ids.size());
+    report["requested_rooms"] = requested_rooms;
 
     std::vector<zelda3::CustomCollisionRoomEntry> export_rooms;
     export_rooms.reserve(room_ids.size());
@@ -554,32 +1114,56 @@ absl::Status DungeonExportCustomCollisionJsonCommandHandler::Execute(
     }
 
     ASSIGN_OR_RETURN(
-        const std::string exported_json,
+        exported_json,
         zelda3::DumpCustomCollisionRoomsToJsonString(export_rooms));
-    RETURN_IF_ERROR(WriteTextFile(out_path, exported_json));
-    report["exported_rooms"] = static_cast<int>(export_rooms.size());
+    exported_room_count = static_cast<int>(export_rooms.size());
+    report["exported_rooms"] = exported_room_count;
 
-    formatter.BeginObject("Custom Collision Export");
-    formatter.AddField("out_path", out_path);
-    formatter.AddField("requested_rooms", static_cast<int>(room_ids.size()));
-    formatter.AddField("exported_rooms", static_cast<int>(export_rooms.size()));
-    formatter.AddField("status", "success");
-    formatter.EndObject();
     return absl::OkStatus();
   }();
 
-  return FinalizeWithReport(parser, std::move(report), status, rom);
+  auto final_artifact_paths_or =
+      ResolveExportArtifactPaths(parser, invocation_context);
+  absl::Status final_path_status = final_artifact_paths_or.status();
+  if (final_artifact_paths_or.ok() &&
+      *final_artifact_paths_or != artifact_paths) {
+    final_path_status = absl::FailedPreconditionError(
+        "Export artifact path identity changed during the command; no "
+        "artifact was published");
+  }
+
+  absl::Status final_status = final_path_status;
+  if (final_path_status.ok() && !status.ok()) {
+    final_status =
+        FinalizeExportWithReport(artifact_paths, std::move(report), status);
+  } else if (final_path_status.ok()) {
+    final_status = PublishExportArtifactsAtomically(
+        artifact_paths.out_path, exported_json, artifact_paths.report_path,
+        report.dump(2) + "\n");
+  }
+  if (!final_status.ok()) {
+    AddStructuredError(formatter, final_status);
+    return final_status;
+  }
+
+  formatter.BeginObject("Custom Collision Export");
+  formatter.AddField("out_path", out_path);
+  formatter.AddField("requested_rooms", requested_rooms);
+  formatter.AddField("exported_rooms", exported_room_count);
+  formatter.AddField("status", "success");
+  formatter.EndObject();
+  return absl::OkStatus();
 }
 
 absl::Status DungeonImportCustomCollisionJsonCommandHandler::Execute(
     Rom* rom, const resources::ArgumentParser& parser,
     resources::OutputFormatter& formatter) {
-  const absl::Status report_alias_status = RejectReportRomAliases(parser, rom);
-  if (!report_alias_status.ok()) {
-    // FinalizeWithReport would write to the rejected path and could truncate
-    // the active ROM. Return this guard failure directly.
-    return report_alias_status;
+  auto report_path_or = ResolveReportArtifactPath(parser, rom);
+  if (!report_path_or.ok()) {
+    AddStructuredError(formatter, report_path_or.status());
+    return report_path_or.status();
   }
+  const std::optional<std::filesystem::path> report_path = *report_path_or;
 
   const bool dry_run = parser.HasFlag("dry-run");
   json report = BuildBaseReport(GetName(), dry_run);
@@ -703,20 +1287,43 @@ absl::Status DungeonImportCustomCollisionJsonCommandHandler::Execute(
     return absl::OkStatus();
   }();
 
-  return FinalizeWithReport(parser, std::move(report), status, rom);
+  return FinalizeWithReport(report_path, std::move(report), status);
 }
 
 absl::Status DungeonExportWaterFillJsonCommandHandler::Execute(
     Rom* rom, const resources::ArgumentParser& parser,
     resources::OutputFormatter& formatter) {
-  RETURN_IF_ERROR(RejectReportRomAliases(parser, rom));
+  resources::CommandInvocationContext invocation_context;
+  if (rom != nullptr && !rom->filename().empty()) {
+    invocation_context.source_rom_path = std::filesystem::path(rom->filename());
+    invocation_context.active_rom_path = std::filesystem::path(rom->filename());
+  }
+  return ExecuteWithContext(rom, parser, formatter, invocation_context);
+}
+
+absl::Status DungeonExportWaterFillJsonCommandHandler::ExecuteWithContext(
+    Rom* rom, const resources::ArgumentParser& parser,
+    resources::OutputFormatter& formatter,
+    const resources::CommandInvocationContext& invocation_context) {
+  auto artifact_paths_or =
+      ResolveExportArtifactPaths(parser, invocation_context);
+  if (!artifact_paths_or.ok()) {
+    AddStructuredError(formatter, artifact_paths_or.status());
+    return artifact_paths_or.status();
+  }
+  const ResolvedExportArtifactPaths artifact_paths = *artifact_paths_or;
 
   json report = BuildBaseReport(GetName(), /*dry_run=*/false);
+  std::string out_path;
+  std::string exported_json;
+  int requested_rooms = 0;
+  int exported_zone_count = 0;
   const absl::Status status = [&]() -> absl::Status {
-    const std::string out_path = parser.GetString("out").value();
+    out_path = parser.GetString("out").value();
     ASSIGN_OR_RETURN(const auto room_ids, ParseRoomSelection(parser));
+    requested_rooms = static_cast<int>(room_ids.size());
     report["out_path"] = out_path;
-    report["requested_rooms"] = static_cast<int>(room_ids.size());
+    report["requested_rooms"] = requested_rooms;
 
     if (!zelda3::HasWaterFillReservedRegion(rom->vector().size())) {
       return absl::FailedPreconditionError(
@@ -734,32 +1341,56 @@ absl::Status DungeonExportWaterFillJsonCommandHandler::Execute(
       filtered.push_back(zone);
     }
 
-    ASSIGN_OR_RETURN(const std::string exported_json,
+    ASSIGN_OR_RETURN(exported_json,
                      zelda3::DumpWaterFillZonesToJsonString(filtered));
-    RETURN_IF_ERROR(WriteTextFile(out_path, exported_json));
-    report["exported_zones"] = static_cast<int>(filtered.size());
+    exported_zone_count = static_cast<int>(filtered.size());
+    report["exported_zones"] = exported_zone_count;
 
-    formatter.BeginObject("Water Fill Export");
-    formatter.AddField("out_path", out_path);
-    formatter.AddField("requested_rooms", static_cast<int>(room_ids.size()));
-    formatter.AddField("exported_zones", static_cast<int>(filtered.size()));
-    formatter.AddField("status", "success");
-    formatter.EndObject();
     return absl::OkStatus();
   }();
 
-  return FinalizeWithReport(parser, std::move(report), status, rom);
+  auto final_artifact_paths_or =
+      ResolveExportArtifactPaths(parser, invocation_context);
+  absl::Status final_path_status = final_artifact_paths_or.status();
+  if (final_artifact_paths_or.ok() &&
+      *final_artifact_paths_or != artifact_paths) {
+    final_path_status = absl::FailedPreconditionError(
+        "Export artifact path identity changed during the command; no "
+        "artifact was published");
+  }
+
+  absl::Status final_status = final_path_status;
+  if (final_path_status.ok() && !status.ok()) {
+    final_status =
+        FinalizeExportWithReport(artifact_paths, std::move(report), status);
+  } else if (final_path_status.ok()) {
+    final_status = PublishExportArtifactsAtomically(
+        artifact_paths.out_path, exported_json, artifact_paths.report_path,
+        report.dump(2) + "\n");
+  }
+  if (!final_status.ok()) {
+    AddStructuredError(formatter, final_status);
+    return final_status;
+  }
+
+  formatter.BeginObject("Water Fill Export");
+  formatter.AddField("out_path", out_path);
+  formatter.AddField("requested_rooms", requested_rooms);
+  formatter.AddField("exported_zones", exported_zone_count);
+  formatter.AddField("status", "success");
+  formatter.EndObject();
+  return absl::OkStatus();
 }
 
 absl::Status DungeonImportWaterFillJsonCommandHandler::Execute(
     Rom* rom, const resources::ArgumentParser& parser,
     resources::OutputFormatter& formatter) {
-  const absl::Status report_alias_status = RejectReportRomAliases(parser, rom);
-  if (!report_alias_status.ok()) {
-    // FinalizeWithReport would write to the rejected path and could truncate
-    // the active ROM. Return this guard failure directly.
-    return report_alias_status;
+  auto report_path_or = ResolveReportArtifactPath(parser, rom);
+  if (!report_path_or.ok()) {
+    AddStructuredError(formatter, report_path_or.status());
+    return report_path_or.status();
   }
+  const std::optional<std::filesystem::path> report_path = *report_path_or;
 
   const bool dry_run = parser.HasFlag("dry-run");
   const bool strict_masks = parser.HasFlag("strict-masks");
@@ -850,7 +1481,7 @@ absl::Status DungeonImportWaterFillJsonCommandHandler::Execute(
     return absl::OkStatus();
   }();
 
-  return FinalizeWithReport(parser, std::move(report), status, rom);
+  return FinalizeWithReport(report_path, std::move(report), status);
 }
 
 absl::Status DungeonImportCustomCollisionJsonCommandHandler::ValidateArgs(

--- a/src/cli/handlers/game/dungeon_collision_commands.h
+++ b/src/cli/handlers/game/dungeon_collision_commands.h
@@ -49,6 +49,11 @@ class DungeonExportCustomCollisionJsonCommandHandler
 
   absl::Status Execute(Rom* rom, const resources::ArgumentParser& parser,
                        resources::OutputFormatter& formatter) override;
+
+  absl::Status ExecuteWithContext(
+      Rom* rom, const resources::ArgumentParser& parser,
+      resources::OutputFormatter& formatter,
+      const resources::CommandInvocationContext& invocation_context) override;
 };
 
 class DungeonImportCustomCollisionJsonCommandHandler
@@ -95,6 +100,11 @@ class DungeonExportWaterFillJsonCommandHandler
 
   absl::Status Execute(Rom* rom, const resources::ArgumentParser& parser,
                        resources::OutputFormatter& formatter) override;
+
+  absl::Status ExecuteWithContext(
+      Rom* rom, const resources::ArgumentParser& parser,
+      resources::OutputFormatter& formatter,
+      const resources::CommandInvocationContext& invocation_context) override;
 };
 
 class DungeonImportWaterFillJsonCommandHandler

--- a/src/cli/handlers/game/dungeon_collision_commands.h
+++ b/src/cli/handlers/game/dungeon_collision_commands.h
@@ -41,7 +41,7 @@ class DungeonExportCustomCollisionJsonCommandHandler
   std::string GetUsage() const override {
     return "dungeon-export-custom-collision-json --out <path> "
            "[--room <room_id> | --rooms <hex,hex,...> | --all] "
-           "[--report <path>] "
+           "[--report <path>] [--sandbox] "
            "[--format <json|text>]";
   }
 
@@ -92,7 +92,7 @@ class DungeonExportWaterFillJsonCommandHandler
   std::string GetUsage() const override {
     return "dungeon-export-water-fill-json --out <path> "
            "[--room <room_id> | --rooms <hex,hex,...> | --all] "
-           "[--report <path>] "
+           "[--report <path>] [--sandbox] "
            "[--format <json|text>]";
   }
 

--- a/src/cli/service/resources/command_handler.cc
+++ b/src/cli/service/resources/command_handler.cc
@@ -6,6 +6,7 @@
 
 #include "absl/flags/declare.h"
 #include "absl/flags/flag.h"
+#include "absl/strings/str_format.h"
 #include "cli/service/rom/rom_sandbox_manager.h"
 #include "util/macro.h"
 
@@ -14,6 +15,31 @@ ABSL_DECLARE_FLAG(bool, sandbox);
 namespace yaze {
 namespace cli {
 namespace resources {
+namespace {
+
+absl::StatusOr<std::filesystem::path> CaptureRomPathIdentity(
+    const std::filesystem::path& path) {
+  std::error_code absolute_ec;
+  const std::filesystem::path absolute =
+      std::filesystem::absolute(path, absolute_ec).lexically_normal();
+  if (absolute_ec) {
+    return absl::FailedPreconditionError(
+        absl::StrFormat("Cannot capture ROM path identity for %s: %s",
+                        path.string(), absolute_ec.message()));
+  }
+
+  std::error_code canonical_ec;
+  const std::filesystem::path canonical =
+      std::filesystem::weakly_canonical(absolute, canonical_ec);
+  if (canonical_ec) {
+    return absl::FailedPreconditionError(
+        absl::StrFormat("Cannot capture ROM path identity for %s: %s",
+                        absolute.string(), canonical_ec.message()));
+  }
+  return canonical.lexically_normal();
+}
+
+}  // namespace
 
 absl::Status CommandHandler::Run(const std::vector<std::string>& args,
                                  Rom* rom_context,
@@ -79,12 +105,20 @@ absl::Status CommandHandler::Run(const std::vector<std::string>& args,
   Rom* rom = nullptr;
   std::optional<Rom> sandbox_rom;
   bool sandbox_enabled = false;
+  CommandInvocationContext invocation_context;
 
   // Set symbol provider regardless of ROM loading (it might load its own symbols)
   SetSymbolProvider(context.GetSymbolProvider());
 
   if (RequiresRom()) {
     ASSIGN_OR_RETURN(rom, context.GetRom());
+    if (!rom->filename().empty()) {
+      ASSIGN_OR_RETURN(
+          const auto rom_path_identity,
+          CaptureRomPathIdentity(std::filesystem::path(rom->filename())));
+      invocation_context.source_rom_path = rom_path_identity;
+      invocation_context.active_rom_path = rom_path_identity;
+    }
     SetRomContext(rom);
     SetProjectContext(context.GetProjectContext());
 
@@ -95,6 +129,14 @@ absl::Status CommandHandler::Run(const std::vector<std::string>& args,
       if (!sandbox_or.ok()) {
         return sandbox_or.status();
       }
+      invocation_context.sandbox_enabled = true;
+      if (!invocation_context.source_rom_path.has_value()) {
+        ASSIGN_OR_RETURN(invocation_context.source_rom_path,
+                         CaptureRomPathIdentity(
+                             std::filesystem::path(sandbox_or->source_rom)));
+      }
+      ASSIGN_OR_RETURN(invocation_context.active_rom_path,
+                       CaptureRomPathIdentity(sandbox_or->rom_path));
       sandbox_rom.emplace();
       auto load_status =
           sandbox_rom->LoadFromFile(sandbox_or->rom_path.string());
@@ -115,7 +157,8 @@ absl::Status CommandHandler::Run(const std::vector<std::string>& args,
   formatter.BeginObject(GetOutputTitle());
 
   // 9. Execute command business logic
-  auto execute_status = Execute(rom, parser, formatter);
+  auto execute_status =
+      ExecuteWithContext(rom, parser, formatter, invocation_context);
   if (!execute_status.ok()) {
     // Preserve structured output for failing commands so callers can inspect
     // machine-readable diagnostics even when status is non-OK.

--- a/src/cli/service/resources/command_handler.h
+++ b/src/cli/service/resources/command_handler.h
@@ -1,7 +1,9 @@
 #ifndef YAZE_SRC_CLI_SERVICE_RESOURCES_COMMAND_HANDLER_H_
 #define YAZE_SRC_CLI_SERVICE_RESOURCES_COMMAND_HANDLER_H_
 
+#include <filesystem>
 #include <map>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -14,6 +16,15 @@
 namespace yaze {
 namespace cli {
 namespace resources {
+
+// Immutable ROM path identity captured for one CommandHandler::Run invocation.
+// The source path remains the caller's ROM when sandbox mode swaps the active
+// path to a command-local copy.
+struct CommandInvocationContext {
+  std::optional<std::filesystem::path> source_rom_path;
+  std::optional<std::filesystem::path> active_rom_path;
+  bool sandbox_enabled = false;
+};
 
 /**
  * @class CommandHandler
@@ -156,6 +167,19 @@ class CommandHandler {
    */
   virtual absl::Status Execute(Rom* rom, const ArgumentParser& parser,
                                OutputFormatter& formatter) = 0;
+
+  /**
+   * @brief Execute with immutable, invocation-scoped ROM path identity.
+   *
+   * Handlers that protect filesystem outputs from aliasing a source or
+   * sandbox ROM can override this hook. Existing handlers continue through
+   * Execute() without carrying mutable state on singleton handler instances.
+   */
+  virtual absl::Status ExecuteWithContext(
+      Rom* rom, const ArgumentParser& parser, OutputFormatter& formatter,
+      const CommandInvocationContext& invocation_context) {
+    return Execute(rom, parser, formatter);
+  }
 
   /**
    * @brief Get the default output format ("json" or "text")

--- a/test/unit/cli/dungeon_collision_json_commands_test.cc
+++ b/test/unit/cli/dungeon_collision_json_commands_test.cc
@@ -1,6 +1,7 @@
 #include "cli/handlers/game/dungeon_collision_commands.h"
 
 #include <algorithm>
+#include <barrier>
 #include <chrono>
 #include <cstdint>
 #include <filesystem>
@@ -8,6 +9,7 @@
 #include <iterator>
 #include <string>
 #include <system_error>
+#include <thread>
 #include <utility>
 #include <vector>
 
@@ -25,6 +27,10 @@
 #include "zelda3/dungeon/dungeon_rom_addresses.h"
 #include "zelda3/dungeon/track_collision_generator.h"
 #include "zelda3/dungeon/water_fill_zone.h"
+
+#if defined(__APPLE__)
+#include <sys/stat.h>
+#endif
 
 ABSL_DECLARE_FLAG(bool, sandbox);
 
@@ -91,6 +97,26 @@ class ScopedTempDirectory {
   std::filesystem::path path_;
 };
 
+#if defined(__APPLE__)
+class ScopedImmutableFile {
+ public:
+  explicit ScopedImmutableFile(const std::filesystem::path& path)
+      : path_(path), enabled_(::chflags(path_.c_str(), UF_IMMUTABLE) == 0) {}
+
+  ~ScopedImmutableFile() {
+    if (enabled_) {
+      ::chflags(path_.c_str(), 0);
+    }
+  }
+
+  bool enabled() const { return enabled_; }
+
+ private:
+  std::filesystem::path path_;
+  bool enabled_;
+};
+#endif
+
 class ScopedSandboxRoot {
  public:
   explicit ScopedSandboxRoot(const std::filesystem::path& root)
@@ -99,17 +125,57 @@ class ScopedSandboxRoot {
   }
 
   ~ScopedSandboxRoot() {
-    if (!sandbox_id_.empty()) {
-      RomSandboxManager::Instance().RemoveSandbox(sandbox_id_).IgnoreError();
+    for (const auto& sandbox_id : sandbox_ids_) {
+      RomSandboxManager::Instance().RemoveSandbox(sandbox_id).IgnoreError();
     }
     RomSandboxManager::Instance().SetRootDirectory(original_root_);
   }
 
-  void Track(std::string sandbox_id) { sandbox_id_ = std::move(sandbox_id); }
+  void Track(std::string sandbox_id) {
+    sandbox_ids_.push_back(std::move(sandbox_id));
+  }
 
  private:
   std::filesystem::path original_root_;
-  std::string sandbox_id_;
+  std::vector<std::string> sandbox_ids_;
+};
+
+class CoordinatedCollisionExportHandler final
+    : public handlers::DungeonExportCustomCollisionJsonCommandHandler {
+ public:
+  explicit CoordinatedCollisionExportHandler(std::barrier<>* rendezvous)
+      : rendezvous_(rendezvous) {}
+
+  absl::Status ExecuteWithContext(
+      Rom* rom, const resources::ArgumentParser& parser,
+      resources::OutputFormatter& formatter,
+      const resources::CommandInvocationContext& invocation_context) override {
+    rendezvous_->arrive_and_wait();
+
+    const auto expected_source = parser.GetString("expected-source");
+    if (!expected_source.has_value() ||
+        !invocation_context.source_rom_path.has_value()) {
+      return absl::FailedPreconditionError(
+          "Missing command-scoped sandbox source identity");
+    }
+
+    std::error_code expected_ec;
+    std::error_code actual_ec;
+    const auto expected = std::filesystem::weakly_canonical(
+        std::filesystem::path(*expected_source), expected_ec);
+    const auto actual = std::filesystem::weakly_canonical(
+        *invocation_context.source_rom_path, actual_ec);
+    if (expected_ec || actual_ec || expected != actual) {
+      return absl::FailedPreconditionError(
+          "Command borrowed another sandbox invocation's source identity");
+    }
+
+    return handlers::DungeonExportCustomCollisionJsonCommandHandler::
+        ExecuteWithContext(rom, parser, formatter, invocation_context);
+  }
+
+ private:
+  std::barrier<>* rendezvous_;
 };
 
 std::vector<std::filesystem::path> FindBackupArtifacts(
@@ -665,6 +731,516 @@ TEST(DungeonCollisionJsonCommandsTest, ExportReportsCannotAliasActiveRom) {
 }
 
 TEST(DungeonCollisionJsonCommandsTest,
+     ExportOutRejectsDirectNormalizedSymlinkAndHardlinkRomAliases) {
+  ScopedTempDirectory temp("export_out_aliases");
+  const auto rom_path = temp.path() / "target.sfc";
+  const auto lexical_parent = temp.path() / "lexical-parent";
+  ASSERT_TRUE(std::filesystem::create_directory(lexical_parent));
+
+  Rom rom;
+  ASSERT_TRUE(rom.LoadFromData(std::vector<uint8_t>(0x200000, 0x00)).ok());
+  WriteRomFile(rom, rom_path);
+  rom.set_filename(rom_path.string());
+  rom.set_dirty(true);
+
+  const auto memory_before = rom.vector();
+  const auto disk_before = ReadFileBytes(rom_path);
+  const std::string filename_before = rom.filename();
+
+  std::vector<std::pair<std::string, std::filesystem::path>> aliases = {
+      {"direct", rom_path},
+      {"normalized", lexical_parent / ".." / rom_path.filename()},
+  };
+
+  const auto symlink_alias = temp.path() / "collision-symlink.json";
+  std::error_code symlink_ec;
+  std::filesystem::create_symlink(rom_path, symlink_alias, symlink_ec);
+  if (!symlink_ec) {
+    aliases.emplace_back("symlink", symlink_alias);
+  }
+
+  const auto hardlink_alias = temp.path() / "collision-hardlink.json";
+  std::error_code hardlink_ec;
+  std::filesystem::create_hard_link(rom_path, hardlink_alias, hardlink_ec);
+  if (!hardlink_ec) {
+    aliases.emplace_back("hardlink", hardlink_alias);
+  }
+
+  handlers::DungeonExportCustomCollisionJsonCommandHandler handler;
+  for (const auto& [label, alias] : aliases) {
+    SCOPED_TRACE(label);
+    std::string output;
+    const absl::Status status = handler.Run(
+        {"--out", alias.string(), "--all", "--format=json"}, &rom, &output);
+
+    EXPECT_TRUE(absl::IsInvalidArgument(status)) << status;
+    EXPECT_THAT(std::string(status.message()),
+                testing::HasSubstr("--out path aliases the active ROM"));
+    EXPECT_THAT(output, testing::HasSubstr("\"status\": \"error\""));
+    EXPECT_THAT(output, testing::HasSubstr("INVALID_ARGUMENT"));
+    EXPECT_EQ(rom.vector(), memory_before);
+    EXPECT_EQ(rom.filename(), filename_before);
+    EXPECT_TRUE(rom.dirty());
+    EXPECT_EQ(ReadFileBytes(rom_path), disk_before);
+  }
+}
+
+TEST(DungeonCollisionJsonCommandsTest,
+     ExportOutAndReportAliasesFailBeforePublication) {
+  ScopedTempDirectory temp("export_artifact_aliases");
+  const auto rom_path = temp.path() / "target.sfc";
+  const auto same_path = temp.path() / "same.json";
+
+  Rom rom;
+  ASSERT_TRUE(rom.LoadFromData(std::vector<uint8_t>(0x200000, 0x00)).ok());
+  WriteRomFile(rom, rom_path);
+  rom.set_filename(rom_path.string());
+  rom.set_dirty(false);
+
+  handlers::DungeonExportCustomCollisionJsonCommandHandler handler;
+  std::string output;
+  absl::Status status =
+      handler.Run({"--out", same_path.string(), "--report", same_path.string(),
+                   "--all", "--format=json"},
+                  &rom, &output);
+  EXPECT_TRUE(absl::IsInvalidArgument(status)) << status;
+  EXPECT_THAT(std::string(status.message()),
+              testing::HasSubstr("alias each other"));
+  EXPECT_THAT(output, testing::HasSubstr("INVALID_ARGUMENT"));
+  EXPECT_FALSE(std::filesystem::exists(same_path));
+
+  const auto existing_out = temp.path() / "existing-out.json";
+  const auto report_hardlink = temp.path() / "report-hardlink.json";
+  WriteFile(existing_out, "previous artifact\n");
+  std::error_code hardlink_ec;
+  std::filesystem::create_hard_link(existing_out, report_hardlink, hardlink_ec);
+  if (!hardlink_ec) {
+    output.clear();
+    status = handler.Run({"--out", existing_out.string(), "--report",
+                          report_hardlink.string(), "--all", "--format=json"},
+                         &rom, &output);
+    EXPECT_TRUE(absl::IsInvalidArgument(status)) << status;
+    EXPECT_THAT(std::string(status.message()),
+                testing::HasSubstr("alias each other"));
+    EXPECT_EQ(ReadFile(existing_out), "previous artifact\n");
+    EXPECT_EQ(ReadFile(report_hardlink), "previous artifact\n");
+  }
+
+  const auto symlink_out = temp.path() / "symlink-out.json";
+  const auto report_symlink = temp.path() / "report-symlink.json";
+  WriteFile(symlink_out, "previous symlink artifact\n");
+  std::error_code symlink_ec;
+  std::filesystem::create_symlink(symlink_out, report_symlink, symlink_ec);
+  if (!symlink_ec) {
+    output.clear();
+    status = handler.Run({"--out", symlink_out.string(), "--report",
+                          report_symlink.string(), "--all", "--format=json"},
+                         &rom, &output);
+    EXPECT_TRUE(absl::IsInvalidArgument(status)) << status;
+    EXPECT_THAT(std::string(status.message()),
+                testing::HasSubstr("alias each other"));
+    EXPECT_EQ(ReadFile(symlink_out), "previous symlink artifact\n");
+    EXPECT_EQ(ReadFile(report_symlink), "previous symlink artifact\n");
+  }
+}
+
+TEST(DungeonCollisionJsonCommandsTest,
+     NewNativeEquivalentOutAndReportNamesRollBackPublication) {
+  ScopedTempDirectory temp("export_new_native_aliases");
+  const auto rom_path = temp.path() / "target.sfc";
+
+  Rom rom;
+  ASSERT_TRUE(rom.LoadFromData(std::vector<uint8_t>(0x200000, 0x00)).ok());
+  WriteRomFile(rom, rom_path);
+  rom.set_filename(rom_path.string());
+  rom.set_dirty(false);
+  const auto disk_before = ReadFileBytes(rom_path);
+
+  const std::vector<std::pair<std::filesystem::path, std::filesystem::path>>
+      candidates = {
+          {temp.path() / "collision.json", temp.path() / "COLLISION.JSON"},
+          {temp.path() / "caf\xC3\xA9.json", temp.path() / "cafe\xCC\x81.json"},
+      };
+
+  bool exercised = false;
+  handlers::DungeonExportCustomCollisionJsonCommandHandler handler;
+  for (const auto& [out_path, report_path] : candidates) {
+    WriteFile(out_path, "filesystem-equivalence probe\n");
+    std::error_code equivalent_ec;
+    const bool native_alias =
+        std::filesystem::equivalent(out_path, report_path, equivalent_ec);
+    std::error_code remove_ec;
+    std::filesystem::remove(out_path, remove_ec);
+    ASSERT_FALSE(remove_ec) << remove_ec.message();
+    if (equivalent_ec || !native_alias) {
+      continue;
+    }
+
+    exercised = true;
+    std::string output;
+    const absl::Status status =
+        handler.Run({"--out", out_path.string(), "--report",
+                     report_path.string(), "--all", "--format=json"},
+                    &rom, &output);
+    EXPECT_FALSE(status.ok()) << status;
+    EXPECT_THAT(std::string(status.message()),
+                testing::HasSubstr("alias each other"));
+    EXPECT_THAT(output, testing::HasSubstr("\"status\": \"error\""));
+    EXPECT_FALSE(std::filesystem::exists(out_path));
+    EXPECT_FALSE(std::filesystem::exists(report_path));
+    EXPECT_EQ(ReadFileBytes(rom_path), disk_before);
+  }
+
+  if (!exercised) {
+    GTEST_SKIP() << "Filesystem exposes neither case nor Unicode equivalence";
+  }
+
+  for (const auto& entry : std::filesystem::directory_iterator(temp.path())) {
+    EXPECT_EQ(entry.path().filename().string().find(".yaze-tmp-"),
+              std::string::npos)
+        << entry.path();
+  }
+}
+
+TEST(DungeonCollisionJsonCommandsTest,
+     ExportOutRejectsCaseOrUnicodeEquivalentRomWhereSupported) {
+  ScopedTempDirectory temp("export_native_equivalence");
+  const auto rom_path = temp.path() / "\xC3\x89xport.sfc";  // NFC E-acute.
+
+  Rom rom;
+  ASSERT_TRUE(rom.LoadFromData(std::vector<uint8_t>(0x200000, 0x00)).ok());
+  WriteRomFile(rom, rom_path);
+  rom.set_filename(rom_path.string());
+  rom.set_dirty(false);
+  const auto disk_before = ReadFileBytes(rom_path);
+
+  const std::vector<std::filesystem::path> candidates = {
+      temp.path() / "\xC3\xA9xport.sfc",   // Case-equivalent where folded.
+      temp.path() / "E\xCC\x81xport.sfc",  // NFD equivalent where normalized.
+  };
+
+  bool exercised = false;
+  handlers::DungeonExportCustomCollisionJsonCommandHandler handler;
+  for (const auto& candidate : candidates) {
+    std::error_code equivalent_ec;
+    if (!std::filesystem::equivalent(rom_path, candidate, equivalent_ec) ||
+        equivalent_ec) {
+      continue;
+    }
+    exercised = true;
+    std::string output;
+    const absl::Status status = handler.Run(
+        {"--out", candidate.string(), "--all", "--format=json"}, &rom, &output);
+    EXPECT_TRUE(absl::IsInvalidArgument(status)) << status;
+    EXPECT_THAT(std::string(status.message()),
+                testing::HasSubstr("aliases the active ROM"));
+    EXPECT_EQ(ReadFileBytes(rom_path), disk_before);
+  }
+
+  if (!exercised) {
+    GTEST_SKIP() << "Filesystem exposes neither case nor Unicode equivalence";
+  }
+}
+
+TEST(DungeonCollisionJsonCommandsTest,
+     SandboxExportsRejectSourceRomAliasesAndPreserveCallerState) {
+  ScopedSandboxFlag sandbox_flag(false);
+  ScopedTempDirectory temp("sandbox_export_source_alias");
+  ScopedSandboxRoot sandbox_root(temp.path() / "sandboxes");
+  const auto source_path = temp.path() / "source.sfc";
+  const auto safe_out = temp.path() / "safe-out.json";
+
+  Rom source_rom;
+  ASSERT_TRUE(
+      source_rom.LoadFromData(std::vector<uint8_t>(0x200000, 0x00)).ok());
+  WriteRomFile(source_rom, source_path);
+  source_rom.set_filename(source_path.string());
+  source_rom.set_dirty(true);
+
+  const auto memory_before = source_rom.vector();
+  const auto disk_before = ReadFileBytes(source_path);
+  const std::string filename_before = source_rom.filename();
+
+  handlers::DungeonExportCustomCollisionJsonCommandHandler handler;
+  std::string output;
+  absl::Status status = handler.Run(
+      {"--out", source_path.string(), "--all", "--sandbox", "--format=json"},
+      &source_rom, &output);
+  EXPECT_TRUE(absl::IsInvalidArgument(status)) << status;
+  EXPECT_THAT(std::string(status.message()),
+              testing::HasSubstr("sandbox source ROM"));
+  EXPECT_THAT(output, testing::HasSubstr("INVALID_ARGUMENT"));
+  auto first_sandbox = RomSandboxManager::Instance().ActiveSandbox();
+  ASSERT_TRUE(first_sandbox.ok()) << first_sandbox.status();
+  sandbox_root.Track(first_sandbox->id);
+  EXPECT_EQ(ReadFileBytes(first_sandbox->rom_path), disk_before);
+
+  output.clear();
+  status =
+      handler.Run({"--out", safe_out.string(), "--report", source_path.string(),
+                   "--all", "--sandbox", "--format=json"},
+                  &source_rom, &output);
+  EXPECT_TRUE(absl::IsInvalidArgument(status)) << status;
+  EXPECT_THAT(std::string(status.message()),
+              testing::HasSubstr("sandbox source ROM"));
+  EXPECT_THAT(output, testing::HasSubstr("INVALID_ARGUMENT"));
+  auto second_sandbox = RomSandboxManager::Instance().ActiveSandbox();
+  ASSERT_TRUE(second_sandbox.ok()) << second_sandbox.status();
+  sandbox_root.Track(second_sandbox->id);
+  EXPECT_EQ(ReadFileBytes(second_sandbox->rom_path), disk_before);
+
+  EXPECT_EQ(source_rom.vector(), memory_before);
+  EXPECT_EQ(source_rom.filename(), filename_before);
+  EXPECT_TRUE(source_rom.dirty());
+  EXPECT_EQ(ReadFileBytes(source_path), disk_before);
+  EXPECT_FALSE(std::filesystem::exists(safe_out));
+  EXPECT_TRUE(FindBackupArtifacts(source_path).empty());
+}
+
+TEST(DungeonCollisionJsonCommandsTest,
+     ExportAndReportPublishValidJsonWithoutMutatingRom) {
+  ScopedTempDirectory temp("export_two_artifacts");
+  const auto rom_path = temp.path() / "target.sfc";
+  const auto out_path = temp.path() / "collision.json";
+  const auto report_path = temp.path() / "collision.report.json";
+
+  Rom rom;
+  ASSERT_TRUE(rom.LoadFromData(std::vector<uint8_t>(0x200000, 0x00)).ok());
+  WriteRomFile(rom, rom_path);
+  rom.set_filename(rom_path.string());
+  rom.set_dirty(true);
+  WriteFile(out_path, "previous output\n");
+  WriteFile(report_path, "previous report\n");
+
+  const auto memory_before = rom.vector();
+  const auto disk_before = ReadFileBytes(rom_path);
+  const std::string filename_before = rom.filename();
+
+  handlers::DungeonExportCustomCollisionJsonCommandHandler handler;
+  std::string output;
+  const absl::Status status =
+      handler.Run({"--out", out_path.string(), "--room=0x25", "--report",
+                   report_path.string(), "--format=json"},
+                  &rom, &output);
+  ASSERT_TRUE(status.ok()) << status;
+
+  auto rooms_or =
+      zelda3::LoadCustomCollisionRoomsFromJsonString(ReadFile(out_path));
+  ASSERT_TRUE(rooms_or.ok()) << rooms_or.status();
+  const auto report = nlohmann::json::parse(ReadFile(report_path));
+  EXPECT_EQ(report.value("command", ""),
+            "dungeon-export-custom-collision-json");
+  EXPECT_EQ(report.value("status", ""), "success");
+  EXPECT_EQ(report.value("out_path", ""), out_path.string());
+  EXPECT_THAT(output, testing::HasSubstr("\"status\": \"success\""));
+
+  EXPECT_EQ(rom.vector(), memory_before);
+  EXPECT_EQ(rom.filename(), filename_before);
+  EXPECT_TRUE(rom.dirty());
+  EXPECT_EQ(ReadFileBytes(rom_path), disk_before);
+
+  for (const auto& entry : std::filesystem::directory_iterator(temp.path())) {
+    EXPECT_EQ(entry.path().filename().string().find(".yaze-tmp-"),
+              std::string::npos)
+        << entry.path();
+  }
+}
+
+TEST(DungeonCollisionJsonCommandsTest,
+     ExportPublicationFailuresPreservePreviousArtifacts) {
+  ScopedTempDirectory temp("export_publish_failure");
+  const auto rom_path = temp.path() / "target.sfc";
+  const auto blocked_out = temp.path() / "blocked-out.json";
+  const auto blocked_out_marker = blocked_out / "previous.txt";
+  const auto error_report = temp.path() / "error.report.json";
+  ASSERT_TRUE(std::filesystem::create_directory(blocked_out));
+  WriteFile(blocked_out_marker, "previous output artifact\n");
+  WriteFile(error_report, "previous report artifact\n");
+
+  Rom rom;
+  ASSERT_TRUE(rom.LoadFromData(std::vector<uint8_t>(0x200000, 0x00)).ok());
+  WriteRomFile(rom, rom_path);
+  rom.set_filename(rom_path.string());
+  rom.set_dirty(true);
+  const auto memory_before = rom.vector();
+  const auto disk_before = ReadFileBytes(rom_path);
+  const std::string filename_before = rom.filename();
+
+  handlers::DungeonExportCustomCollisionJsonCommandHandler handler;
+  std::string output;
+  absl::Status status =
+      handler.Run({"--out", blocked_out.string(), "--room=0x25", "--report",
+                   error_report.string(), "--format=json"},
+                  &rom, &output);
+  EXPECT_FALSE(status.ok());
+  EXPECT_THAT(std::string(status.message()),
+              testing::HasSubstr("Artifact target is a directory"));
+  EXPECT_EQ(ReadFile(blocked_out_marker), "previous output artifact\n");
+  EXPECT_EQ(ReadFile(error_report), "previous report artifact\n");
+  EXPECT_THAT(output, testing::HasSubstr("\"status\": \"error\""));
+
+  const auto valid_out = temp.path() / "valid-out.json";
+  const auto blocked_report = temp.path() / "blocked-report.json";
+  const auto blocked_report_marker = blocked_report / "previous.txt";
+  ASSERT_TRUE(std::filesystem::create_directory(blocked_report));
+  WriteFile(blocked_report_marker, "previous report artifact\n");
+  WriteFile(valid_out, "previous output artifact\n");
+
+  output.clear();
+  status = handler.Run({"--out", valid_out.string(), "--room=0x25", "--report",
+                        blocked_report.string(), "--format=json"},
+                       &rom, &output);
+  EXPECT_FALSE(status.ok());
+  EXPECT_THAT(std::string(status.message()),
+              testing::HasSubstr("Artifact target is a directory"));
+  EXPECT_EQ(ReadFile(blocked_report_marker), "previous report artifact\n");
+  EXPECT_EQ(ReadFile(valid_out), "previous output artifact\n");
+  EXPECT_THAT(output, testing::HasSubstr("\"status\": \"error\""));
+
+  EXPECT_EQ(rom.vector(), memory_before);
+  EXPECT_EQ(rom.filename(), filename_before);
+  EXPECT_TRUE(rom.dirty());
+  EXPECT_EQ(ReadFileBytes(rom_path), disk_before);
+  for (const auto& entry : std::filesystem::directory_iterator(temp.path())) {
+    EXPECT_EQ(entry.path().filename().string().find(".yaze-tmp-"),
+              std::string::npos)
+        << entry.path();
+  }
+}
+
+TEST(DungeonCollisionJsonCommandsTest,
+     LaterReportPublicationFailureRestoresEarlierOutput) {
+#if !defined(__APPLE__)
+  GTEST_SKIP() << "Uses the macOS immutable-file flag to force late rename "
+                  "failure";
+#else
+  ScopedTempDirectory temp("export_late_report_failure");
+  const auto rom_path = temp.path() / "target.sfc";
+  const auto out_path = temp.path() / "collision.json";
+  const auto report_path = temp.path() / "collision.report.json";
+  WriteFile(out_path, "previous output artifact\n");
+  WriteFile(report_path, "previous report artifact\n");
+
+  Rom rom;
+  ASSERT_TRUE(rom.LoadFromData(std::vector<uint8_t>(0x200000, 0x00)).ok());
+  WriteRomFile(rom, rom_path);
+  rom.set_filename(rom_path.string());
+  rom.set_dirty(true);
+  const auto memory_before = rom.vector();
+  const auto disk_before = ReadFileBytes(rom_path);
+  const std::string filename_before = rom.filename();
+
+  {
+    ScopedImmutableFile immutable_report(report_path);
+    if (!immutable_report.enabled()) {
+      GTEST_SKIP() << "Could not set the immutable-file publication guard";
+    }
+
+    handlers::DungeonExportCustomCollisionJsonCommandHandler handler;
+    std::string output;
+    const absl::Status status =
+        handler.Run({"--out", out_path.string(), "--room=0x25", "--report",
+                     report_path.string(), "--format=json"},
+                    &rom, &output);
+    EXPECT_FALSE(status.ok()) << status;
+    EXPECT_THAT(std::string(status.message()),
+                testing::HasSubstr("Failed to publish artifact"));
+    EXPECT_THAT(output, testing::HasSubstr("\"status\": \"error\""));
+    EXPECT_EQ(ReadFile(out_path), "previous output artifact\n");
+    EXPECT_EQ(ReadFile(report_path), "previous report artifact\n");
+  }
+
+  EXPECT_EQ(rom.vector(), memory_before);
+  EXPECT_EQ(rom.filename(), filename_before);
+  EXPECT_TRUE(rom.dirty());
+  EXPECT_EQ(ReadFileBytes(rom_path), disk_before);
+  for (const auto& entry : std::filesystem::directory_iterator(temp.path())) {
+    EXPECT_EQ(entry.path().filename().string().find(".yaze-tmp-"),
+              std::string::npos)
+        << entry.path();
+  }
+#endif
+}
+
+TEST(DungeonCollisionJsonCommandsTest,
+     ConcurrentSandboxExportsKeepInvocationSourceIdentity) {
+  ScopedSandboxFlag sandbox_flag(false);
+  ScopedTempDirectory temp("concurrent_sandbox_exports");
+  const auto sandbox_root_path = temp.path() / "sandboxes";
+  ScopedSandboxRoot sandbox_root(sandbox_root_path);
+  const auto source_a_path = temp.path() / "source-a.sfc";
+  const auto source_b_path = temp.path() / "source-b.sfc";
+  const auto out_a = temp.path() / "a.json";
+  const auto out_b = temp.path() / "b.json";
+  const auto report_a = temp.path() / "a.report.json";
+  const auto report_b = temp.path() / "b.report.json";
+
+  Rom source_a;
+  Rom source_b;
+  ASSERT_TRUE(source_a.LoadFromData(std::vector<uint8_t>(0x200000, 0x00)).ok());
+  ASSERT_TRUE(source_b.LoadFromData(std::vector<uint8_t>(0x200000, 0x00)).ok());
+  WriteRomFile(source_a, source_a_path);
+  WriteRomFile(source_b, source_b_path);
+  source_a.set_filename(source_a_path.string());
+  source_b.set_filename(source_b_path.string());
+  source_a.set_dirty(true);
+  source_b.set_dirty(true);
+  const auto source_a_before = ReadFileBytes(source_a_path);
+  const auto source_b_before = ReadFileBytes(source_b_path);
+
+  std::barrier rendezvous(2);
+  CoordinatedCollisionExportHandler handler_a(&rendezvous);
+  CoordinatedCollisionExportHandler handler_b(&rendezvous);
+  absl::Status status_a = absl::UnknownError("not run");
+  absl::Status status_b = absl::UnknownError("not run");
+  std::string output_a;
+  std::string output_b;
+
+  std::thread thread_a([&]() {
+    status_a =
+        handler_a.Run({"--out", out_a.string(), "--report", report_a.string(),
+                       "--all", "--sandbox", "--expected-source",
+                       source_a_path.string(), "--format=json"},
+                      &source_a, &output_a);
+  });
+  std::thread thread_b([&]() {
+    status_b =
+        handler_b.Run({"--out", out_b.string(), "--report", report_b.string(),
+                       "--all", "--sandbox", "--expected-source",
+                       source_b_path.string(), "--format=json"},
+                      &source_b, &output_b);
+  });
+  thread_a.join();
+  thread_b.join();
+
+  EXPECT_TRUE(status_a.ok()) << status_a;
+  EXPECT_TRUE(status_b.ok()) << status_b;
+  EXPECT_TRUE(
+      zelda3::LoadCustomCollisionRoomsFromJsonString(ReadFile(out_a)).ok());
+  EXPECT_TRUE(
+      zelda3::LoadCustomCollisionRoomsFromJsonString(ReadFile(out_b)).ok());
+  EXPECT_EQ(nlohmann::json::parse(ReadFile(report_a)).value("status", ""),
+            "success");
+  EXPECT_EQ(nlohmann::json::parse(ReadFile(report_b)).value("status", ""),
+            "success");
+  EXPECT_TRUE(source_a.dirty());
+  EXPECT_TRUE(source_b.dirty());
+  EXPECT_EQ(source_a.filename(), source_a_path.string());
+  EXPECT_EQ(source_b.filename(), source_b_path.string());
+  EXPECT_EQ(ReadFileBytes(source_a_path), source_a_before);
+  EXPECT_EQ(ReadFileBytes(source_b_path), source_b_before);
+
+  int tracked = 0;
+  for (const auto& sandbox : RomSandboxManager::Instance().ListSandboxes()) {
+    if (sandbox.directory.parent_path() == sandbox_root_path) {
+      sandbox_root.Track(sandbox.id);
+      ++tracked;
+    }
+  }
+  EXPECT_EQ(tracked, 2);
+}
+
+TEST(DungeonCollisionJsonCommandsTest,
      DryRunReportCannotAliasUnicodeEquivalentRom) {
   ScopedTempDirectory temp("unicode_rom_alias");
   const auto rom_path = temp.path() / "\xC3\xA9.sfc";  // NFC: e-acute.
@@ -752,7 +1328,9 @@ TEST(DungeonCollisionJsonCommandsTest,
                    report_path.string(), "--format=json"},
                   &rom, &output);
 
-  EXPECT_TRUE(absl::IsPermissionDenied(status)) << status;
+  EXPECT_TRUE(absl::IsFailedPrecondition(status)) << status;
+  EXPECT_THAT(std::string(status.message()),
+              testing::HasSubstr("Artifact target is a directory"));
   EXPECT_THAT(output, testing::HasSubstr("\"mode\": \"dry-run\""));
   EXPECT_EQ(rom.vector(), before);
   EXPECT_TRUE(rom.dirty());
@@ -762,7 +1340,7 @@ TEST(DungeonCollisionJsonCommandsTest,
 }
 
 TEST(DungeonCollisionJsonCommandsTest,
-     ReportsRejectWriteModeAndSandboxBeforeContext) {
+     ImportReportsRejectWriteModeAndSandboxBeforeContext) {
   ScopedSandboxFlag sandbox_flag(false);
   ScopedTempDirectory temp("write_report_rejected");
   ScopedSandboxRoot sandbox_root(temp.path() / "sandboxes");
@@ -770,8 +1348,6 @@ TEST(DungeonCollisionJsonCommandsTest,
   const auto collision_path = temp.path() / "collision.json";
   const auto water_path = temp.path() / "water.json";
   const auto report_path = temp.path() / "report.json";
-  const auto collision_out = temp.path() / "collision-export.json";
-  const auto water_out = temp.path() / "water-export.json";
 
   Rom source_rom;
   ASSERT_TRUE(
@@ -786,8 +1362,6 @@ TEST(DungeonCollisionJsonCommandsTest,
   const std::vector<uint8_t> disk_before = ReadFileBytes(source_path);
   handlers::DungeonImportCustomCollisionJsonCommandHandler collision_handler;
   handlers::DungeonImportWaterFillJsonCommandHandler water_handler;
-  handlers::DungeonExportCustomCollisionJsonCommandHandler collision_export;
-  handlers::DungeonExportWaterFillJsonCommandHandler water_export;
 
   for (const std::vector<std::string>& mode_args :
        {std::vector<std::string>{}, std::vector<std::string>{"--mock-rom"},
@@ -837,23 +1411,6 @@ TEST(DungeonCollisionJsonCommandsTest,
     EXPECT_EQ(output, "untouched");
   }
 
-  for (auto* handler :
-       {static_cast<resources::CommandHandler*>(&collision_export),
-        static_cast<resources::CommandHandler*>(&water_export)}) {
-    const std::filesystem::path& out =
-        handler == &collision_export ? collision_out : water_out;
-    std::string output = "untouched";
-    const absl::Status status =
-        handler->Run({"--out", out.string(), "--all", "--sandbox", "--report",
-                      report_path.string(), "--format=json"},
-                     &source_rom, &output);
-    EXPECT_TRUE(absl::IsInvalidArgument(status)) << status;
-    EXPECT_THAT(std::string(status.message()),
-                testing::HasSubstr("--report cannot be combined with "
-                                   "--sandbox"));
-    EXPECT_EQ(output, "untouched");
-  }
-
   {
     ScopedSandboxFlag global_sandbox(true);
     std::string output = "untouched";
@@ -866,31 +1423,27 @@ TEST(DungeonCollisionJsonCommandsTest,
                 testing::HasSubstr("--report cannot be combined with "
                                    "--sandbox"));
     EXPECT_EQ(output, "untouched");
+  }
 
-    for (auto* handler :
-         {static_cast<resources::CommandHandler*>(&collision_export),
-          static_cast<resources::CommandHandler*>(&water_export)}) {
-      const std::filesystem::path& out =
-          handler == &collision_export ? collision_out : water_out;
-      output = "untouched";
-      const absl::Status export_status =
-          handler->Run({"--out", out.string(), "--all", "--report",
-                        report_path.string(), "--format=json"},
-                       &source_rom, &output);
-      EXPECT_TRUE(absl::IsInvalidArgument(export_status)) << export_status;
-      EXPECT_THAT(std::string(export_status.message()),
-                  testing::HasSubstr("--report cannot be combined with "
-                                     "--sandbox"));
-      EXPECT_EQ(output, "untouched");
-    }
+  for (auto* handler :
+       {static_cast<resources::CommandHandler*>(&collision_handler),
+        static_cast<resources::CommandHandler*>(&water_handler)}) {
+    const std::filesystem::path& input =
+        handler == &collision_handler ? collision_path : water_path;
+    std::string output = "untouched";
+    const absl::Status status = handler->Run(
+        {"--in", input.string(), "--dry-run", "--report", "", "--format=json"},
+        &source_rom, &output);
+    EXPECT_TRUE(absl::IsInvalidArgument(status)) << status;
+    EXPECT_THAT(std::string(status.message()),
+                testing::HasSubstr("--report cannot be empty"));
+    EXPECT_EQ(output, "untouched");
   }
 
   EXPECT_EQ(source_rom.vector(), before);
   EXPECT_TRUE(source_rom.dirty());
   EXPECT_EQ(ReadFileBytes(source_path), disk_before);
   EXPECT_FALSE(std::filesystem::exists(report_path));
-  EXPECT_FALSE(std::filesystem::exists(collision_out));
-  EXPECT_FALSE(std::filesystem::exists(water_out));
   EXPECT_TRUE(FindBackupArtifacts(source_path).empty());
   EXPECT_TRUE(
       absl::IsNotFound(RomSandboxManager::Instance().ActiveSandbox().status()));


### PR DESCRIPTION
## Stack

Depends on #135 and is intentionally based on `codex/dungeon-collision-json-transaction` so this PR shows only the export-path safety slice.

## Summary

- carry immutable source/active ROM identities per command invocation, including concurrent sandbox commands
- reject `--out`/`--report` paths that alias the active ROM, sandbox source ROM, or each other through direct, normalized, symlink, hardlink, and native case/Unicode-equivalent paths
- resolve output paths once through a trusted existing parent, stage with exclusive same-directory temporary files, and replace atomically
- publish export output/report as one rollback-capable set so a later failure restores earlier artifacts
- permit safe sandbox reports, preserve structured errors, and publish import reports atomically too

## Verification

- `cmake --build --preset mac-ai --target yaze_test_unit --parallel 8`
- `DungeonCollisionJsonCommandsTest.*`: **37/37 passed**
- track-collision + command-context/handler + editor-handler suites: **28/28 passed**
- pre-push validation passed
- strict delegated review: no blocker/high finding
- portability probes passed for MinGW Windows APIs/barrier, Emscripten filesystem calls, and iOS POSIX calls

## Safety / residual scope

- disposable fixtures only; no canonical Oracle ROM was modified
- trusted parent directories are required; concurrent replacement of an ancestor directory remains outside the guard
- cleanup failures may leave temp/recovery files, atomic replacement may change ACL/mode metadata, and deterministic rollback-restore failure coverage remains a follow-up gap
- full native Windows repository CI remains the hosted merge gate

Fixes #134
