### PR TITLE
fix(dungeon): honor bitmap surface row pitch

### DIFF
--- a/src/zelda3/dungeon/object_drawer.cc
+++ b/src/zelda3/dungeon/object_drawer.cc
@@ -1,6 +1,7 @@
 #include "object_drawer.h"
 
 #include <cstdio>
+#include <cstring>
 #include <filesystem>
 
 #include "absl/strings/str_format.h"
@@ -18,6 +19,46 @@
 
 namespace yaze {
 namespace zelda3 {
+namespace {
+
+void SyncModifiedBitmapToSurface(gfx::Bitmap& bitmap, const char* layer_name) {
+  SDL_Surface* surface = bitmap.surface();
+  if (!bitmap.modified() || surface == nullptr || bitmap.size() == 0) {
+    return;
+  }
+
+  const int width = bitmap.width();
+  const int height = bitmap.height();
+  if (width <= 0 || height <= 0 || surface->w < width || surface->h < height ||
+      surface->pitch < width) {
+    LOG_DEBUG("ObjectDrawer",
+              "%s surface dimensions cannot hold bitmap: surface=%dx%d "
+              "pitch=%d bitmap=%dx%d",
+              layer_name, surface->w, surface->h, surface->pitch, width,
+              height);
+    return;
+  }
+
+  const size_t row_bytes = static_cast<size_t>(width);
+  const size_t required_bytes = row_bytes * static_cast<size_t>(height);
+  if (bitmap.size() < required_bytes) {
+    LOG_DEBUG("ObjectDrawer", "%s bitmap data too small: data=%zu needed=%zu",
+              layer_name, bitmap.size(), required_bytes);
+    return;
+  }
+
+  SDL_LockSurface(surface);
+  auto* destination = static_cast<uint8_t*>(surface->pixels);
+  const uint8_t* source = bitmap.data();
+  for (int y = 0; y < height; ++y) {
+    std::memcpy(destination + static_cast<size_t>(y) *
+                                  static_cast<size_t>(surface->pitch),
+                source + static_cast<size_t>(y) * row_bytes, row_bytes);
+  }
+  SDL_UnlockSurface(surface);
+}
+
+}  // namespace
 
 ObjectDrawer::ObjectDrawer(Rom* rom, int room_id,
                            const uint8_t* room_gfx_buffer)
@@ -420,47 +461,10 @@ absl::Status ObjectDrawer::DrawObjectList(
   LOG_DEBUG("ObjectDrawer", "Buffer routing: to_BG1=%d, to_BG2=%d, BothBGs=%d",
             to_bg1, to_bg2, both_bgs);
 
-  // NOTE: Palette is already set in Room::RenderRoomGraphics() before calling
-  // this function. We just need to sync the pixel data to the SDL surface.
-  auto& bg1_bmp = bg1.bitmap();
-  auto& bg2_bmp = bg2.bitmap();
-
-  // Sync bitmap data to SDL surfaces (palette already applied)
-  if (bg1_bmp.modified() && bg1_bmp.surface() &&
-      bg1_bmp.mutable_data().size() > 0) {
-    SDL_LockSurface(bg1_bmp.surface());
-    // Safety check: ensure surface can hold the data
-    // Note: This assumes 8bpp surface where pitch >= width
-    size_t surface_size = bg1_bmp.surface()->h * bg1_bmp.surface()->pitch;
-    size_t buffer_size = bg1_bmp.mutable_data().size();
-
-    if (surface_size >= buffer_size) {
-      // TODO: Handle pitch mismatch properly (copy row by row)
-      // For now, just ensure we don't overflow
-      memcpy(bg1_bmp.surface()->pixels, bg1_bmp.mutable_data().data(),
-             buffer_size);
-    } else {
-      LOG_DEBUG("ObjectDrawer", "BG1 Surface too small: surf=%zu buf=%zu",
-                surface_size, buffer_size);
-    }
-    SDL_UnlockSurface(bg1_bmp.surface());
-  }
-
-  if (bg2_bmp.modified() && bg2_bmp.surface() &&
-      bg2_bmp.mutable_data().size() > 0) {
-    SDL_LockSurface(bg2_bmp.surface());
-    size_t surface_size = bg2_bmp.surface()->h * bg2_bmp.surface()->pitch;
-    size_t buffer_size = bg2_bmp.mutable_data().size();
-
-    if (surface_size >= buffer_size) {
-      memcpy(bg2_bmp.surface()->pixels, bg2_bmp.mutable_data().data(),
-             buffer_size);
-    } else {
-      LOG_DEBUG("ObjectDrawer", "BG2 Surface too small: surf=%zu buf=%zu",
-                surface_size, buffer_size);
-    }
-    SDL_UnlockSurface(bg2_bmp.surface());
-  }
+  // The palette is already applied by Room::RenderRoomGraphics(). SDL can pad
+  // indexed surface rows, so synchronize each row using the surface pitch.
+  SyncModifiedBitmapToSurface(bg1.bitmap(), "BG1");
+  SyncModifiedBitmapToSurface(bg2.bitmap(), "BG2");
 
   return status;
 }

--- a/src/zelda3/dungeon/object_drawer.cc
+++ b/src/zelda3/dungeon/object_drawer.cc
@@ -21,6 +21,14 @@ namespace yaze {
 namespace zelda3 {
 namespace {
 
+bool LockSurface(SDL_Surface* surface) {
+#if SDL_MAJOR_VERSION >= 3
+  return SDL_LockSurface(surface);
+#else
+  return SDL_LockSurface(surface) == 0;
+#endif
+}
+
 void SyncModifiedBitmapToSurface(gfx::Bitmap& bitmap, const char* layer_name) {
   SDL_Surface* surface = bitmap.surface();
   if (!bitmap.modified() || surface == nullptr || bitmap.size() == 0) {
@@ -47,7 +55,11 @@ void SyncModifiedBitmapToSurface(gfx::Bitmap& bitmap, const char* layer_name) {
     return;
   }
 
-  SDL_LockSurface(surface);
+  if (!LockSurface(surface)) {
+    LOG_DEBUG("ObjectDrawer", "%s surface lock failed: %s", layer_name,
+              SDL_GetError());
+    return;
+  }
   auto* destination = static_cast<uint8_t*>(surface->pixels);
   const uint8_t* source = bitmap.data();
   for (int y = 0; y < height; ++y) {

--- a/src/zelda3/dungeon/object_drawer.cc
+++ b/src/zelda3/dungeon/object_drawer.cc
@@ -35,6 +35,12 @@ void SyncModifiedBitmapToSurface(gfx::Bitmap& bitmap, const char* layer_name) {
     return;
   }
 
+  if (bitmap.depth() != 8) {
+    LOG_DEBUG("ObjectDrawer", "%s bitmap depth is not indexed 8bpp: %d",
+              layer_name, bitmap.depth());
+    return;
+  }
+
   const int width = bitmap.width();
   const int height = bitmap.height();
   if (width <= 0 || height <= 0 || surface->w < width || surface->h < height ||

--- a/test/unit/zelda3/dungeon/object_drawing_comprehensive_test.cc
+++ b/test/unit/zelda3/dungeon/object_drawing_comprehensive_test.cc
@@ -1283,8 +1283,12 @@ TEST_F(ObjectDrawingComprehensiveTest,
   bg2.EnsureBitmapInitialized();
   ASSERT_NE(bg1.bitmap().surface(), nullptr);
   ASSERT_NE(bg2.bitmap().surface(), nullptr);
-  ASSERT_GT(bg1.bitmap().surface()->pitch, bg1.bitmap().width());
-  ASSERT_GT(bg2.bitmap().surface()->pitch, bg2.bitmap().width());
+  ASSERT_GE(bg1.bitmap().surface()->pitch, bg1.bitmap().width());
+  ASSERT_GE(bg2.bitmap().surface()->pitch, bg2.bitmap().width());
+  if (bg1.bitmap().surface()->pitch == bg1.bitmap().width() ||
+      bg2.bitmap().surface()->pitch == bg2.bitmap().width()) {
+    GTEST_SKIP() << "SDL backend did not pad the indexed surface rows";
+  }
 
   auto prepare_bitmap = [](gfx::Bitmap& bitmap, uint8_t seed) {
     auto& data = bitmap.mutable_data();

--- a/test/unit/zelda3/dungeon/object_drawing_comprehensive_test.cc
+++ b/test/unit/zelda3/dungeon/object_drawing_comprehensive_test.cc
@@ -11,6 +11,8 @@
  * 6. BothBG flag propagation
  */
 
+#include <cstring>
+
 #include "gtest/gtest.h"
 #include "rom/rom.h"
 #include "zelda3/dungeon/draw_routines/draw_routine_registry.h"
@@ -1268,6 +1270,67 @@ TEST_F(ObjectDrawingComprehensiveTest, ParityObjectDrawerFallback) {
   RoomObject obj(0x00, 0, 0, 0, 0);
   auto status = drawer.DrawObject(obj, bg1, bg2, dummy_palette, nullptr);
   EXPECT_TRUE(status.ok()) << "DrawObject should not fail with empty tiles";
+}
+
+TEST_F(ObjectDrawingComprehensiveTest,
+       ObjectListSurfaceSyncHonorsPaddedRowPitch) {
+  constexpr int kWidth = 17;
+  constexpr int kHeight = 3;
+
+  gfx::BackgroundBuffer bg1(kWidth, kHeight);
+  gfx::BackgroundBuffer bg2(kWidth, kHeight);
+  bg1.EnsureBitmapInitialized();
+  bg2.EnsureBitmapInitialized();
+  ASSERT_NE(bg1.bitmap().surface(), nullptr);
+  ASSERT_NE(bg2.bitmap().surface(), nullptr);
+  ASSERT_GT(bg1.bitmap().surface()->pitch, bg1.bitmap().width());
+  ASSERT_GT(bg2.bitmap().surface()->pitch, bg2.bitmap().width());
+
+  auto prepare_bitmap = [](gfx::Bitmap& bitmap, uint8_t seed) {
+    auto& data = bitmap.mutable_data();
+    ASSERT_EQ(data.size(), static_cast<size_t>(bitmap.width()) *
+                               static_cast<size_t>(bitmap.height()));
+    for (int y = 0; y < bitmap.height(); ++y) {
+      for (int x = 0; x < bitmap.width(); ++x) {
+        data[static_cast<size_t>(y * bitmap.width() + x)] =
+            static_cast<uint8_t>(seed + y * 32 + x);
+      }
+    }
+
+    SDL_LockSurface(bitmap.surface());
+    std::memset(bitmap.surface()->pixels, 0xEE,
+                static_cast<size_t>(bitmap.surface()->pitch) *
+                    static_cast<size_t>(bitmap.surface()->h));
+    SDL_UnlockSurface(bitmap.surface());
+    bitmap.set_modified(true);
+  };
+
+  prepare_bitmap(bg1.bitmap(), 0x10);
+  prepare_bitmap(bg2.bitmap(), 0x80);
+
+  ObjectDrawer drawer(rom_.get(), /*room_id=*/0);
+  gfx::PaletteGroup palette_group;
+  ASSERT_TRUE(drawer.DrawObjectList({}, bg1, bg2, palette_group).ok());
+
+  auto expect_surface_matches = [](const gfx::Bitmap& bitmap) {
+    SDL_LockSurface(bitmap.surface());
+    const auto* pixels = static_cast<const uint8_t*>(bitmap.surface()->pixels);
+    for (int y = 0; y < bitmap.height(); ++y) {
+      for (int x = 0; x < bitmap.width(); ++x) {
+        EXPECT_EQ(pixels[y * bitmap.surface()->pitch + x],
+                  bitmap.at(y * bitmap.width() + x))
+            << "mismatch at (" << x << ", " << y << ")";
+      }
+      for (int x = bitmap.width(); x < bitmap.surface()->pitch; ++x) {
+        EXPECT_EQ(pixels[y * bitmap.surface()->pitch + x], 0xEE)
+            << "surface padding was overwritten at row " << y;
+      }
+    }
+    SDL_UnlockSurface(bitmap.surface());
+  };
+
+  expect_surface_matches(bg1.bitmap());
+  expect_surface_matches(bg2.bitmap());
 }
 
 }  // namespace zelda3


### PR DESCRIPTION
## Summary
- copy modified dungeon object bitmaps into SDL surfaces one row at a time
- honor destination surface pitch instead of assuming tightly packed rows
- handle SDL2 and SDL3 surface-lock success semantics without touching pixels after a failed lock
- cover both dungeon background layers with a deliberately padded indexed surface

## Verification
- red/green regression: the padded-row test failed before the row-wise copy and passes after it
- `cmake --build --preset mac-ai --target yaze_test_unit --parallel 8`
- `ObjectDrawingComprehensiveTest.*:ObjectDrawerRegistryReplayTest.*`: **117/117 passed**
- `YAZE_PREPUSH_BUILD_DIR=build/presets/mac-ai scripts/pre-push.sh`
- strict delegated re-review: no blocker, high, or medium findings

## Scope / residual risk
- changes only object-render bitmap-to-surface synchronization; ROM data and save paths are untouched
- the padding-specific assertion is skipped on SDL backends that return tightly packed 8-bit surfaces
