### PR TITLE
fix(dungeon): refresh cached rooms after palette edits

### DIFF
--- a/src/app/editor/dungeon/dungeon_canvas_overlays.cc
+++ b/src/app/editor/dungeon/dungeon_canvas_overlays.cc
@@ -541,7 +541,9 @@ gfx::Bitmap* DungeonCanvasViewer::PrepareRoomCompositeBitmap(int room_id) {
   auto& room = *room_ptr;
   // Connected/compare views revisit already-materialized rooms. Honor Room's
   // render dirtiness so those cached buffers refresh lazily before compositing.
-  room.PrepareForRender(current_entrance_blockset_);
+  // Do not apply this viewer's active-room entrance override to an arbitrary
+  // connected target; the room retains its own render context.
+  room.PrepareForRender();
 
   auto& layer_mgr = GetRoomLayerManager(room_id);
   layer_mgr.ApplyLayerMerging(room.layer_merging());

--- a/src/app/editor/dungeon/dungeon_canvas_overlays.cc
+++ b/src/app/editor/dungeon/dungeon_canvas_overlays.cc
@@ -539,10 +539,9 @@ gfx::Bitmap* DungeonCanvasViewer::PrepareRoomCompositeBitmap(int room_id) {
     return nullptr;
   }
   auto& room = *room_ptr;
-  auto& bg1_bitmap = room.bg1_buffer().bitmap();
-  if (!bg1_bitmap.is_active() || bg1_bitmap.width() == 0) {
-    (void)LoadAndRenderRoomGraphics(room_id);
-  }
+  // Connected/compare views revisit already-materialized rooms. Honor Room's
+  // render dirtiness so those cached buffers refresh lazily before compositing.
+  room.PrepareForRender(current_entrance_blockset_);
 
   auto& layer_mgr = GetRoomLayerManager(room_id);
   layer_mgr.ApplyLayerMerging(room.layer_merging());

--- a/src/app/editor/dungeon/dungeon_canvas_room_render.cc
+++ b/src/app/editor/dungeon/dungeon_canvas_room_render.cc
@@ -149,16 +149,11 @@ void DungeonCanvasViewer::PrepareRoomStateForCanvas(zelda3::Room& room,
     room.LoadPotItems();
   }
 
-  auto& bg1_bitmap = room.bg1_buffer().bitmap();
-  const bool needs_render = !bg1_bitmap.is_active() || bg1_bitmap.width() == 0;
-
-  static int last_rendered_room = -1;
-  static bool has_rendered = false;
-  if (needs_render && (last_rendered_room != room_id || !has_rendered)) {
-    (void)LoadAndRenderRoomGraphics(room_id);
-    last_rendered_room = room_id;
-    has_rendered = true;
-  }
+  // Existing room buffers can still be stale after palette, object, or layout
+  // edits. Let Room's dirty-state-aware preparation decide whether the cached
+  // graphics need to be rebuilt instead of treating an allocated BG1 surface
+  // as proof that the room is current.
+  room.PrepareForRender(current_entrance_blockset_);
 
   if (rom_ && rom_->is_loaded()) {
     gfx::Arena::Get().ProcessTextureQueue(renderer_);

--- a/src/app/editor/dungeon/dungeon_canvas_viewer.h
+++ b/src/app/editor/dungeon/dungeon_canvas_viewer.h
@@ -703,6 +703,8 @@ class DungeonCanvasViewer {
   friend class DungeonCanvasViewerTestPeer;
   friend class
       DungeonEditorPaletteRefreshTest_CachedRoomRefreshesThroughViewerCompositePreparation_Test;
+  friend class
+      DungeonEditorPaletteRefreshTest_CachedCompositePreparationPreservesTargetEntranceContext_Test;
 
   struct ChangePingRect {
     int x = 0;

--- a/src/app/editor/dungeon/dungeon_canvas_viewer.h
+++ b/src/app/editor/dungeon/dungeon_canvas_viewer.h
@@ -701,6 +701,8 @@ class DungeonCanvasViewer {
 
  private:
   friend class DungeonCanvasViewerTestPeer;
+  friend class
+      DungeonEditorPaletteRefreshTest_CachedRoomRefreshesThroughViewerCompositePreparation_Test;
 
   struct ChangePingRect {
     int x = 0;

--- a/src/app/editor/dungeon/dungeon_editor_v2.cc
+++ b/src/app/editor/dungeon/dungeon_editor_v2.cc
@@ -636,7 +636,9 @@ absl::Status DungeonEditorV2::Load() {
     owned_minecart_track_editor_panel_ = std::move(minecart_panel);
   }
 
-  palette_editor_.SetOnPaletteChanged([this](int /*palette_id*/) {
+  palette_editor_.SetOnPaletteChanged([this](int palette_id) {
+    InvalidateDungeonPaletteUsers(palette_id);
+
     auto apply_palette = [this](DungeonCanvasViewer* viewer) {
       if (!viewer) {
         return;
@@ -767,6 +769,22 @@ absl::Status DungeonEditorV2::Load() {
 
   is_loaded_ = true;
   return absl::OkStatus();
+}
+
+void DungeonEditorV2::InvalidateDungeonPaletteUsers(int palette_id) {
+  if (palette_id < 0) {
+    return;
+  }
+
+  // Editing palette bytes does not change a room header, so the room's normal
+  // property cache cannot detect this dependency change. Mark every cached
+  // room that resolves to the edited concrete palette; inactive rooms will
+  // redraw lazily the next time they are shown.
+  rooms_.ForEachMaterialized([palette_id](int, zelda3::Room& room) {
+    if (room.ResolveDungeonPaletteId() == palette_id) {
+      room.MarkGraphicsDirty();
+    }
+  });
 }
 
 absl::Status DungeonEditorV2::Update() {

--- a/src/app/editor/dungeon/dungeon_editor_v2.cc
+++ b/src/app/editor/dungeon/dungeon_editor_v2.cc
@@ -331,7 +331,7 @@ void DungeonEditorV2::Initialize() {
           }
         },
         [this]() { SaveAllRooms(); }, [this]() { return GetWorkbenchViewer(); },
-        [this]() { return GetWorkbenchCompareViewer(); },
+        [this](int room_id) { return GetWorkbenchCompareViewer(room_id); },
         [this]() -> const std::deque<int>& { return recent_rooms_; },
         [this](int room_id) {
           recent_rooms_.erase(
@@ -636,62 +636,65 @@ absl::Status DungeonEditorV2::Load() {
     owned_minecart_track_editor_panel_ = std::move(minecart_panel);
   }
 
-  palette_editor_.SetOnPaletteChanged([this](gui::DungeonPaletteChange change) {
-    InvalidateDungeonPaletteUsers(change);
+  palette_editor_.SetOnDungeonPaletteChanged(
+      [this](gui::DungeonPaletteChange change) {
+        InvalidateDungeonPaletteUsers(change);
 
-    auto apply_palette = [this](DungeonCanvasViewer* viewer) {
-      if (!viewer) {
-        return;
-      }
-      viewer->SetCurrentPaletteId(current_palette_id_);
-      viewer->SetCurrentPaletteGroup(current_palette_group_);
-    };
+        auto apply_palette = [this](DungeonCanvasViewer* viewer) {
+          if (!viewer) {
+            return;
+          }
+          viewer->SetCurrentPaletteId(current_palette_id_);
+          viewer->SetCurrentPaletteGroup(current_palette_group_);
+        };
 
-    if (current_room_id_ >= 0 && current_room_id_ < (int)rooms_.size() &&
-        game_data()) {
-      auto& dungeon_main_pal_group = game_data()->palette_groups.dungeon_main;
-      if (current_palette_id_ >= 0 &&
-          current_palette_id_ <
-              static_cast<int>(dungeon_main_pal_group.size())) {
-        current_palette_group_id_ = current_palette_id_;
-        current_palette_ = dungeon_main_pal_group[current_palette_id_];
-        if (auto pal_group =
-                gfx::CreatePaletteGroupFromLargePalette(current_palette_);
-            pal_group.ok()) {
-          current_palette_group_ = pal_group.value();
-          apply_palette(workbench_viewer_.get());
-          apply_palette(workbench_compare_viewer_.get());
-          if (!IsWorkbenchWorkflowEnabled()) {
-            if (auto* existing_viewer = room_viewers_.Get(current_room_id_)) {
-              apply_palette(existing_viewer->get());
+        if (current_room_id_ >= 0 && current_room_id_ < (int)rooms_.size() &&
+            game_data()) {
+          auto& dungeon_main_pal_group =
+              game_data()->palette_groups.dungeon_main;
+          if (current_palette_id_ >= 0 &&
+              current_palette_id_ <
+                  static_cast<int>(dungeon_main_pal_group.size())) {
+            current_palette_group_id_ = current_palette_id_;
+            current_palette_ = dungeon_main_pal_group[current_palette_id_];
+            if (auto pal_group =
+                    gfx::CreatePaletteGroupFromLargePalette(current_palette_);
+                pal_group.ok()) {
+              current_palette_group_ = pal_group.value();
+              apply_palette(workbench_viewer_.get());
+              apply_palette(workbench_compare_viewer_.get());
+              if (!IsWorkbenchWorkflowEnabled()) {
+                if (auto* existing_viewer =
+                        room_viewers_.Get(current_room_id_)) {
+                  apply_palette(existing_viewer->get());
+                }
+              }
+              if (object_selector_panel_) {
+                object_selector_panel_->SetCurrentPaletteGroup(
+                    current_palette_group_);
+              }
+              if (room_graphics_panel_) {
+                room_graphics_panel_->SetCurrentPaletteGroup(
+                    current_palette_group_);
+              }
             }
           }
-          if (object_selector_panel_) {
-            object_selector_panel_->SetCurrentPaletteGroup(
-                current_palette_group_);
-          }
-          if (room_graphics_panel_) {
-            room_graphics_panel_->SetCurrentPaletteGroup(
-                current_palette_group_);
+        }
+
+        bool rendered_current_room = false;
+        for (int i = 0; i < active_rooms_.Size; i++) {
+          int room_id = active_rooms_[i];
+          if (room_id >= 0 && room_id < (int)rooms_.size()) {
+            rooms_[room_id].RenderRoomGraphics();
+            rendered_current_room |= room_id == current_room_id_;
           }
         }
-      }
-    }
 
-    bool rendered_current_room = false;
-    for (int i = 0; i < active_rooms_.Size; i++) {
-      int room_id = active_rooms_[i];
-      if (room_id >= 0 && room_id < (int)rooms_.size()) {
-        rooms_[room_id].RenderRoomGraphics();
-        rendered_current_room |= room_id == current_room_id_;
-      }
-    }
-
-    if (!rendered_current_room && current_room_id_ >= 0 &&
-        current_room_id_ < static_cast<int>(rooms_.size())) {
-      rooms_[current_room_id_].RenderRoomGraphics();
-    }
-  });
+        if (!rendered_current_room && current_room_id_ >= 0 &&
+            current_room_id_ < static_cast<int>(rooms_.size())) {
+          rooms_[current_room_id_].RenderRoomGraphics();
+        }
+      });
 
   // Oracle of Secrets: load editor-authored water fill zones (best-effort).
   {
@@ -2112,7 +2115,7 @@ DungeonCanvasViewer* DungeonEditorV2::GetWorkbenchViewer() {
   return viewer;
 }
 
-DungeonCanvasViewer* DungeonEditorV2::GetWorkbenchCompareViewer() {
+DungeonCanvasViewer* DungeonEditorV2::GetWorkbenchCompareViewer(int room_id) {
   if (!workbench_compare_viewer_) {
     workbench_compare_viewer_ = std::make_unique<DungeonCanvasViewer>(rom_);
     auto* viewer = workbench_compare_viewer_.get();
@@ -2142,7 +2145,7 @@ DungeonCanvasViewer* DungeonEditorV2::GetWorkbenchCompareViewer() {
   }
 
   auto* viewer = workbench_compare_viewer_.get();
-  RefreshWorkbenchViewerRuntimeContext(viewer, current_room_id_);
+  RefreshWorkbenchViewerRuntimeContext(viewer, room_id);
   viewer->SetObjectInteractionEnabled(false);
   viewer->SetHeaderReadOnly(true);
   viewer->SetHeaderVisible(false);

--- a/src/app/editor/dungeon/dungeon_editor_v2.cc
+++ b/src/app/editor/dungeon/dungeon_editor_v2.cc
@@ -636,8 +636,8 @@ absl::Status DungeonEditorV2::Load() {
     owned_minecart_track_editor_panel_ = std::move(minecart_panel);
   }
 
-  palette_editor_.SetOnPaletteChanged([this](int palette_id) {
-    InvalidateDungeonPaletteUsers(palette_id);
+  palette_editor_.SetOnPaletteChanged([this](gui::DungeonPaletteChange change) {
+    InvalidateDungeonPaletteUsers(change);
 
     auto apply_palette = [this](DungeonCanvasViewer* viewer) {
       if (!viewer) {
@@ -771,8 +771,15 @@ absl::Status DungeonEditorV2::Load() {
   return absl::OkStatus();
 }
 
-void DungeonEditorV2::InvalidateDungeonPaletteUsers(int palette_id) {
-  if (palette_id < 0) {
+void DungeonEditorV2::InvalidateDungeonPaletteUsers(
+    gui::DungeonPaletteChange change) {
+  if (change.source == gui::DungeonRenderPaletteSource::kHud) {
+    rooms_.ForEachMaterialized(
+        [](int, zelda3::Room& room) { room.MarkGraphicsDirty(); });
+    return;
+  }
+
+  if (change.palette_id < 0) {
     return;
   }
 
@@ -780,8 +787,8 @@ void DungeonEditorV2::InvalidateDungeonPaletteUsers(int palette_id) {
   // property cache cannot detect this dependency change. Mark every cached
   // room that resolves to the edited concrete palette; inactive rooms will
   // redraw lazily the next time they are shown.
-  rooms_.ForEachMaterialized([palette_id](int, zelda3::Room& room) {
-    if (room.ResolveDungeonPaletteId() == palette_id) {
+  rooms_.ForEachMaterialized([change](int, zelda3::Room& room) {
+    if (room.ResolveDungeonPaletteId() == change.palette_id) {
       room.MarkGraphicsDirty();
     }
   });

--- a/src/app/editor/dungeon/dungeon_editor_v2.h
+++ b/src/app/editor/dungeon/dungeon_editor_v2.h
@@ -261,6 +261,8 @@ class DungeonEditorV2 : public Editor {
       DungeonEditorPaletteRefreshTest_SharedHudEditRefreshesRoomUsingDifferentDungeonPalette_Test;
   friend class
       DungeonEditorPaletteRefreshTest_DungeonMainEditRefreshesResolvedAliasesOnly_Test;
+  friend class
+      DungeonEditorPaletteRefreshTest_CachedRoomRefreshesThroughViewerCompositePreparation_Test;
 
   gfx::IRenderer* renderer_ = nullptr;
 

--- a/src/app/editor/dungeon/dungeon_editor_v2.h
+++ b/src/app/editor/dungeon/dungeon_editor_v2.h
@@ -263,6 +263,8 @@ class DungeonEditorV2 : public Editor {
       DungeonEditorPaletteRefreshTest_DungeonMainEditRefreshesResolvedAliasesOnly_Test;
   friend class
       DungeonEditorPaletteRefreshTest_CachedRoomRefreshesThroughViewerCompositePreparation_Test;
+  friend class
+      DungeonEditorPaletteRefreshTest_CompareViewerScopesEntranceContextToRequestedRoom_Test;
 
   gfx::IRenderer* renderer_ = nullptr;
 
@@ -300,7 +302,7 @@ class DungeonEditorV2 : public Editor {
   // Helper to get or create a viewer for a specific room
   DungeonCanvasViewer* GetViewerForRoom(int room_id);
   DungeonCanvasViewer* GetWorkbenchViewer();
-  DungeonCanvasViewer* GetWorkbenchCompareViewer();
+  DungeonCanvasViewer* GetWorkbenchCompareViewer(int room_id);
   void RefreshWorkbenchViewerRuntimeContext(DungeonCanvasViewer* viewer,
                                             int room_id);
   void TouchViewerLru(int room_id);

--- a/src/app/editor/dungeon/dungeon_editor_v2.h
+++ b/src/app/editor/dungeon/dungeon_editor_v2.h
@@ -257,6 +257,8 @@ class DungeonEditorV2 : public Editor {
       DungeonEditorV2RomSafetyTest_SaveAllRoomsRollsBackEarlierWritesOnLateFailure_Test;
   friend class
       DungeonEditorV2RomSafetyTest_LateCoordinatorRollbackRestoresEntranceDirtyState_Test;
+  friend class
+      DungeonEditorPaletteRefreshTest_InvalidatesRoomsUsingEditedResolvedPalette_Test;
 
   gfx::IRenderer* renderer_ = nullptr;
 
@@ -274,6 +276,7 @@ class DungeonEditorV2 : public Editor {
 
   // Sync all sub-panels to the current room configuration
   void SyncPanelsToRoom(int room_id);
+  void InvalidateDungeonPaletteUsers(int palette_id);
   uint8_t ResolveSelectedEntranceBlocksetForRoom(int room_id) const;
   void ApplyEntranceRenderContext(int room_id);
   void ConfigureViewerRenderContext(DungeonCanvasViewer* viewer, int room_id);

--- a/src/app/editor/dungeon/dungeon_editor_v2.h
+++ b/src/app/editor/dungeon/dungeon_editor_v2.h
@@ -258,7 +258,9 @@ class DungeonEditorV2 : public Editor {
   friend class
       DungeonEditorV2RomSafetyTest_LateCoordinatorRollbackRestoresEntranceDirtyState_Test;
   friend class
-      DungeonEditorPaletteRefreshTest_InvalidatesRoomsUsingEditedResolvedPalette_Test;
+      DungeonEditorPaletteRefreshTest_SharedHudEditRefreshesRoomUsingDifferentDungeonPalette_Test;
+  friend class
+      DungeonEditorPaletteRefreshTest_DungeonMainEditRefreshesResolvedAliasesOnly_Test;
 
   gfx::IRenderer* renderer_ = nullptr;
 
@@ -276,7 +278,7 @@ class DungeonEditorV2 : public Editor {
 
   // Sync all sub-panels to the current room configuration
   void SyncPanelsToRoom(int room_id);
-  void InvalidateDungeonPaletteUsers(int palette_id);
+  void InvalidateDungeonPaletteUsers(gui::DungeonPaletteChange change);
   uint8_t ResolveSelectedEntranceBlocksetForRoom(int room_id) const;
   void ApplyEntranceRenderContext(int room_id);
   void ConfigureViewerRenderContext(DungeonCanvasViewer* viewer, int room_id);

--- a/src/app/editor/dungeon/workspace/dungeon_workbench_content.cc
+++ b/src/app/editor/dungeon/workspace/dungeon_workbench_content.cc
@@ -294,7 +294,7 @@ DungeonWorkbenchContent::DungeonWorkbenchContent(
     std::function<void(int)> on_save_room,
     std::function<void()> on_save_all_rooms,
     std::function<DungeonCanvasViewer*()> get_viewer,
-    std::function<DungeonCanvasViewer*()> get_compare_viewer,
+    std::function<DungeonCanvasViewer*(int)> get_compare_viewer,
     std::function<const std::deque<int>&()> get_recent_rooms,
     std::function<void(int)> forget_recent_room,
     std::function<void(bool)> set_workflow_mode, Rom* rom)
@@ -556,7 +556,7 @@ void DungeonWorkbenchContent::Draw(bool* p_open) {
 
   DungeonCanvasViewer* primary_viewer = get_viewer_ ? get_viewer_() : nullptr;
   DungeonCanvasViewer* compare_viewer =
-      get_compare_viewer_ ? get_compare_viewer_() : nullptr;
+      get_compare_viewer_ ? get_compare_viewer_(compare_room_id_) : nullptr;
   const float splitter_w = gui::UIConfig::kSplitterWidth;
   const float total_w = std::max(ImGui::GetContentRegionAvail().x, 1.0f);
   // Relaxed from 320 px to 260 px so the Inspect pane can breathe at widths
@@ -1088,6 +1088,9 @@ void DungeonWorkbenchContent::DrawSplitView(
   ImGui::TableSetupColumn("Compare", ImGuiTableColumnFlags_WidthStretch);
   ImGui::TableNextRow();
 
+  DungeonCanvasViewer* compare_viewer =
+      get_compare_viewer_ ? get_compare_viewer_(compare_room_id_) : nullptr;
+
   // Active pane (minimum height so canvas never collapses)
   ImGui::TableNextColumn();
   ImGui::AlignTextToFramePadding();
@@ -1108,9 +1111,7 @@ void DungeonWorkbenchContent::DrawSplitView(
   ImGui::TableNextColumn();
   ImGui::AlignTextToFramePadding();
   const project::YazeProject* compare_project =
-      get_compare_viewer_ && get_compare_viewer_()
-          ? get_compare_viewer_()->project()
-          : active_project;
+      compare_viewer ? compare_viewer->project() : active_project;
   ImGui::TextDisabled(
       ICON_MD_COMPARE_ARROWS " Compare [%03X] %s", compare_room_id_,
       dungeon_project_labels::GetRoomLabel(compare_project, compare_room_id_)
@@ -1119,8 +1120,7 @@ void DungeonWorkbenchContent::DrawSplitView(
   const bool split_compare_open = gui::LayoutHelpers::BeginContentChild(
       "##SplitCompare", ImVec2(0.0f, gui::UIConfig::kContentMinHeightCanvas));
   if (split_compare_open) {
-    if (auto* compare_viewer =
-            get_compare_viewer_ ? get_compare_viewer_() : nullptr) {
+    if (compare_viewer) {
       if (layout_state_.sync_split_view) {
         compare_viewer->canvas().ApplyScaleSnapshot(
             primary_viewer.canvas().GetConfig());

--- a/src/app/editor/dungeon/workspace/dungeon_workbench_content.h
+++ b/src/app/editor/dungeon/workspace/dungeon_workbench_content.h
@@ -79,7 +79,7 @@ class DungeonWorkbenchContent : public WindowContent {
       std::function<void(int)> on_save_room,
       std::function<void()> on_save_all_rooms,
       std::function<DungeonCanvasViewer*()> get_viewer,
-      std::function<DungeonCanvasViewer*()> get_compare_viewer,
+      std::function<DungeonCanvasViewer*(int)> get_compare_viewer,
       std::function<const std::deque<int>&()> get_recent_rooms,
       std::function<void(int)> forget_recent_room,
       std::function<void(bool)> set_workflow_mode, Rom* rom = nullptr);
@@ -242,7 +242,7 @@ class DungeonWorkbenchContent : public WindowContent {
   std::function<void(int)> on_save_room_;
   std::function<void()> on_save_all_rooms_;
   std::function<DungeonCanvasViewer*()> get_viewer_;
-  std::function<DungeonCanvasViewer*()> get_compare_viewer_;
+  std::function<DungeonCanvasViewer*(int)> get_compare_viewer_;
   std::function<const std::deque<int>&()> get_recent_rooms_;
   std::function<void(int)> forget_recent_room_;
   std::function<void(bool)> set_workflow_mode_;

--- a/src/app/gui/widgets/palette_editor_widget.cc
+++ b/src/app/gui/widgets/palette_editor_widget.cc
@@ -23,11 +23,6 @@ namespace gui {
 
 namespace {
 
-enum class DungeonRenderPaletteSource {
-  kHud,
-  kDungeonMain,
-};
-
 struct DungeonRenderColorTarget {
   DungeonRenderPaletteSource source;
   int palette_index;
@@ -179,7 +174,7 @@ absl::Status PaletteEditorWidget::ApplyDungeonRenderColorEdit(
   }
 
   if (on_palette_changed_) {
-    on_palette_changed_(current_palette_id_);
+    on_palette_changed_({current_palette_id_, target->source});
   }
   return absl::OkStatus();
 }
@@ -298,7 +293,8 @@ void PaletteEditorWidget::DrawColorPicker() {
         gui::ConvertSnesColorToImVec4(palette[selected_color_index_]);
 
     if (on_palette_changed_) {
-      on_palette_changed_(current_palette_id_);
+      on_palette_changed_(
+          {current_palette_id_, DungeonRenderPaletteSource::kDungeonMain});
     }
   }
 
@@ -316,7 +312,8 @@ void PaletteEditorWidget::DrawColorPicker() {
     palette[selected_color_index_] = original_color;
     dungeon_pal_group[current_palette_id_] = palette;
     if (on_palette_changed_) {
-      on_palette_changed_(current_palette_id_);
+      on_palette_changed_(
+          {current_palette_id_, DungeonRenderPaletteSource::kDungeonMain});
     }
   }
 }
@@ -691,7 +688,8 @@ void PaletteEditorWidget::DrawPaletteGrid(gfx::SnesPalette& palette, int cols) {
       temp_color_ = palette[i].rgb();
       editing_color_ = temp_color_;
       if (on_palette_changed_) {
-        on_palette_changed_(current_palette_id_);
+        on_palette_changed_(
+            {current_palette_id_, DungeonRenderPaletteSource::kDungeonMain});
       }
     }
 
@@ -707,7 +705,8 @@ void PaletteEditorWidget::DrawPaletteGrid(gfx::SnesPalette& palette, int cols) {
       if (ImGui::MenuItem(tr("Reset to Black"))) {
         palette[i] = gfx::SnesColor(0);
         if (on_palette_changed_) {
-          on_palette_changed_(current_palette_id_);
+          on_palette_changed_(
+              {current_palette_id_, DungeonRenderPaletteSource::kDungeonMain});
         }
       }
       ImGui::EndPopup();
@@ -741,7 +740,8 @@ void PaletteEditorWidget::DrawPaletteGrid(gfx::SnesPalette& palette, int cols) {
           editing_color_ = temp_color_;
         }
         if (on_palette_changed_) {
-          on_palette_changed_(current_palette_id_);
+          on_palette_changed_(
+              {current_palette_id_, DungeonRenderPaletteSource::kDungeonMain});
         }
       }
       if (gui::PrimaryButton("Apply")) {

--- a/src/app/gui/widgets/palette_editor_widget.h
+++ b/src/app/gui/widgets/palette_editor_widget.h
@@ -16,6 +16,16 @@
 namespace yaze {
 namespace gui {
 
+enum class DungeonRenderPaletteSource {
+  kHud,
+  kDungeonMain,
+};
+
+struct DungeonPaletteChange {
+  int palette_id;
+  DungeonRenderPaletteSource source;
+};
+
 class PaletteEditorWidget {
  public:
   PaletteEditorWidget() = default;
@@ -38,8 +48,9 @@ class PaletteEditorWidget {
   void SavePaletteBackup(const gfx::SnesPalette& palette);
   bool RestorePaletteBackup(gfx::SnesPalette& palette);
 
-  // Callback when palette is modified
-  void SetOnPaletteChanged(std::function<void(int palette_id)> callback) {
+  // Callback when a dungeon palette is modified. HUD colors are shared by
+  // every dungeon room; dungeon-main colors are scoped to palette_id.
+  void SetOnPaletteChanged(std::function<void(DungeonPaletteChange)> callback) {
     on_palette_changed_ = callback;
   }
 
@@ -92,7 +103,7 @@ class PaletteEditorWidget {
   ImVec4 editing_color_{0, 0, 0, 1};
 
   // Callback for palette changes
-  std::function<void(int palette_id)> on_palette_changed_;
+  std::function<void(DungeonPaletteChange)> on_palette_changed_;
 
   // Color editing state
   int editing_color_index_ = -1;

--- a/src/app/gui/widgets/palette_editor_widget.h
+++ b/src/app/gui/widgets/palette_editor_widget.h
@@ -48,13 +48,7 @@ class PaletteEditorWidget {
   void SavePaletteBackup(const gfx::SnesPalette& palette);
   bool RestorePaletteBackup(gfx::SnesPalette& palette);
 
-  // Callback when a dungeon palette is modified. HUD colors are shared by
-  // every dungeon room; dungeon-main colors are scoped to palette_id.
-  void SetOnPaletteChanged(std::function<void(DungeonPaletteChange)> callback) {
-    on_palette_changed_ = callback;
-  }
-  // Preserve the original palette-id-only callback shape for callers that do
-  // not need to distinguish shared HUD edits from dungeon-main edits.
+  // Original palette-id-only callback retained for source compatibility.
   void SetOnPaletteChanged(std::function<void(int)> callback) {
     if (!callback) {
       on_palette_changed_ = {};
@@ -63,6 +57,13 @@ class PaletteEditorWidget {
     on_palette_changed_ = [callback](DungeonPaletteChange change) {
       callback(change.palette_id);
     };
+  }
+
+  // Typed callback for dungeon rendering consumers that must distinguish
+  // shared HUD edits from palette-scoped dungeon-main edits.
+  void SetOnDungeonPaletteChanged(
+      std::function<void(DungeonPaletteChange)> callback) {
+    on_palette_changed_ = callback;
   }
 
   // Get/Set current editing palette

--- a/src/app/gui/widgets/palette_editor_widget.h
+++ b/src/app/gui/widgets/palette_editor_widget.h
@@ -53,6 +53,17 @@ class PaletteEditorWidget {
   void SetOnPaletteChanged(std::function<void(DungeonPaletteChange)> callback) {
     on_palette_changed_ = callback;
   }
+  // Preserve the original palette-id-only callback shape for callers that do
+  // not need to distinguish shared HUD edits from dungeon-main edits.
+  void SetOnPaletteChanged(std::function<void(int)> callback) {
+    if (!callback) {
+      on_palette_changed_ = {};
+      return;
+    }
+    on_palette_changed_ = [callback](DungeonPaletteChange change) {
+      callback(change.palette_id);
+    };
+  }
 
   // Get/Set current editing palette
   int GetCurrentPaletteId() const { return current_palette_id_; }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -293,6 +293,7 @@ if(YAZE_BUILD_TESTS)
     unit/editor/dungeon_usage_tracker_test.cc
     unit/editor/dungeon_entrance_edit_policy_test.cc
     unit/editor/dungeon_editor_v2_rom_safety_test.cc
+    unit/editor/dungeon_editor_palette_refresh_test.cc
     unit/editor/dungeon_overlay_controls_test.cc
     unit/editor/dungeon_object_selector_palette_test.cc
     unit/editor/dungeon_workbench_toolbar_test.cc
@@ -584,6 +585,7 @@ if(YAZE_BUILD_TESTS)
     unit/editor/dungeon_layout_defaults_test.cc
     unit/editor/dungeon_selection_snapshot_test.cc
     unit/editor/dungeon_canvas_viewer_navigation_test.cc
+    unit/editor/dungeon_editor_palette_refresh_test.cc
     unit/editor/dungeon_object_selector_palette_test.cc
     unit/editor/dungeon_workbench_toolbar_test.cc
     unit/editor/dungeon_workbench_content_test.cc

--- a/test/integration/palette_manager_test.cc
+++ b/test/integration/palette_manager_test.cc
@@ -349,7 +349,7 @@ TEST_F(PaletteManagerTest, DungeonRenderEditsMapToManagedHudAndDungeonColors) {
   int callback_palette = -1;
   gui::DungeonRenderPaletteSource callback_source =
       gui::DungeonRenderPaletteSource::kDungeonMain;
-  widget.SetOnPaletteChanged([&](gui::DungeonPaletteChange change) {
+  widget.SetOnDungeonPaletteChanged([&](gui::DungeonPaletteChange change) {
     ++callback_count;
     callback_palette = change.palette_id;
     callback_source = change.source;
@@ -526,7 +526,7 @@ TEST_F(PaletteManagerTest,
   stale_widget.SetDungeonRenderPaletteMode(true);
   stale_widget.SetCurrentPaletteId(1);
   int callback_count = 0;
-  stale_widget.SetOnPaletteChanged(
+  stale_widget.SetOnDungeonPaletteChanged(
       [&](gui::DungeonPaletteChange) { ++callback_count; });
 
   constexpr int kDungeonDisplayIndex = 99;

--- a/test/integration/palette_manager_test.cc
+++ b/test/integration/palette_manager_test.cc
@@ -347,9 +347,12 @@ TEST_F(PaletteManagerTest, DungeonRenderEditsMapToManagedHudAndDungeonColors) {
   widget.SetCurrentPaletteId(1);
   int callback_count = 0;
   int callback_palette = -1;
-  widget.SetOnPaletteChanged([&](int palette_id) {
+  gui::DungeonRenderPaletteSource callback_source =
+      gui::DungeonRenderPaletteSource::kDungeonMain;
+  widget.SetOnPaletteChanged([&](gui::DungeonPaletteChange change) {
     ++callback_count;
-    callback_palette = palette_id;
+    callback_palette = change.palette_id;
+    callback_source = change.source;
   });
 
   constexpr int kHudDisplayIndex = 17;
@@ -362,10 +365,12 @@ TEST_F(PaletteManagerTest, DungeonRenderEditsMapToManagedHudAndDungeonColors) {
 
   ASSERT_TRUE(
       widget.ApplyDungeonRenderColorEdit(kHudDisplayIndex, new_hud_color).ok());
+  EXPECT_EQ(callback_source, gui::DungeonRenderPaletteSource::kHud);
   ASSERT_TRUE(
       widget
           .ApplyDungeonRenderColorEdit(kDungeonDisplayIndex, new_dungeon_color)
           .ok());
+  EXPECT_EQ(callback_source, gui::DungeonRenderPaletteSource::kDungeonMain);
 
   EXPECT_TRUE(manager.IsColorModified("hud", 0, kHudDisplayIndex));
   EXPECT_TRUE(manager.IsColorModified("dungeon_main", 1, kDungeonColorIndex));
@@ -521,7 +526,8 @@ TEST_F(PaletteManagerTest,
   stale_widget.SetDungeonRenderPaletteMode(true);
   stale_widget.SetCurrentPaletteId(1);
   int callback_count = 0;
-  stale_widget.SetOnPaletteChanged([&](int) { ++callback_count; });
+  stale_widget.SetOnPaletteChanged(
+      [&](gui::DungeonPaletteChange) { ++callback_count; });
 
   constexpr int kDungeonDisplayIndex = 99;
   constexpr int kDungeonColorIndex = 62;

--- a/test/unit/editor/dungeon_editor_palette_refresh_test.cc
+++ b/test/unit/editor/dungeon_editor_palette_refresh_test.cc
@@ -152,7 +152,7 @@ TEST_F(DungeonEditorPaletteRefreshTest,
   editor_->palette_editor_.Initialize(&game_data_);
   editor_->palette_editor_.SetDungeonRenderPaletteMode(true);
   editor_->palette_editor_.SetCurrentPaletteId(3);
-  editor_->palette_editor_.SetOnPaletteChanged(
+  editor_->palette_editor_.SetOnDungeonPaletteChanged(
       [this](gui::DungeonPaletteChange change) {
         editor_->InvalidateDungeonPaletteUsers(change);
       });
@@ -191,7 +191,7 @@ TEST_F(DungeonEditorPaletteRefreshTest,
   editor_->palette_editor_.Initialize(&game_data_);
   editor_->palette_editor_.SetDungeonRenderPaletteMode(true);
   editor_->palette_editor_.SetCurrentPaletteId(3);
-  editor_->palette_editor_.SetOnPaletteChanged(
+  editor_->palette_editor_.SetOnDungeonPaletteChanged(
       [this](gui::DungeonPaletteChange change) {
         editor_->InvalidateDungeonPaletteUsers(change);
       });
@@ -256,7 +256,7 @@ TEST_F(DungeonEditorPaletteRefreshTest,
   editor_->palette_editor_.Initialize(&game_data_);
   editor_->palette_editor_.SetDungeonRenderPaletteMode(true);
   editor_->palette_editor_.SetCurrentPaletteId(3);
-  editor_->palette_editor_.SetOnPaletteChanged(
+  editor_->palette_editor_.SetOnDungeonPaletteChanged(
       [this](gui::DungeonPaletteChange change) {
         editor_->InvalidateDungeonPaletteUsers(change);
       });
@@ -283,15 +283,71 @@ TEST_F(DungeonEditorPaletteRefreshTest,
 }
 
 TEST_F(DungeonEditorPaletteRefreshTest,
-       LegacyPaletteIdCallbackRemainsSupported) {
+       CachedCompositePreparationPreservesTargetEntranceContext) {
+  constexpr int kCachedRoomId = 1;
+  constexpr uint8_t kTargetEntranceBlockset = 1;
+  constexpr uint8_t kViewerEntranceBlockset = 2;
+  constexpr uint8_t kTargetSheet = 9;
+  constexpr uint8_t kViewerSheet = 10;
+  game_data_.main_blockset_ids[kTargetEntranceBlockset][0] = kTargetSheet;
+  game_data_.main_blockset_ids[kViewerEntranceBlockset][0] = kViewerSheet;
+
+  DungeonRoomStore rooms(&rom_, &game_data_);
+  auto& cached_room = rooms[kCachedRoomId];
+  cached_room.SetTileObjects({});
+  cached_room.SetRenderEntranceBlockset(kTargetEntranceBlockset);
+  cached_room.PrepareForRender();
+  ASSERT_EQ(cached_room.render_entrance_blockset(), kTargetEntranceBlockset);
+  ASSERT_EQ(cached_room.blocks()[0], kTargetSheet);
+  cached_room.MarkGraphicsDirty();
+
+  DungeonCanvasViewer viewer(&rom_);
+  viewer.SetGameData(&game_data_);
+  viewer.SetRooms(&rooms);
+  viewer.SetEntranceRenderContext(/*entrance_id=*/0x12,
+                                  kViewerEntranceBlockset);
+
+  ASSERT_NE(viewer.PrepareRoomCompositeBitmap(kCachedRoomId), nullptr);
+  EXPECT_EQ(cached_room.render_entrance_blockset(), kTargetEntranceBlockset);
+  EXPECT_EQ(cached_room.blocks()[0], kTargetSheet);
+  EXPECT_NE(cached_room.blocks()[0], kViewerSheet);
+  gfx::Arena::Get().ClearTextureQueue();
+}
+
+TEST_F(DungeonEditorPaletteRefreshTest,
+       CompareViewerScopesEntranceContextToRequestedRoom) {
+  constexpr int kCompareRoomId = 1;
+  constexpr int kUnrelatedRoomId = 2;
+  constexpr uint8_t kEntranceBlockset = 3;
+  editor_->current_room_id_ = 0;
+  editor_->current_entrance_id_ = 0;
+  editor_->entrances_[0].room_ = kCompareRoomId;
+  editor_->entrances_[0].blockset_ = kEntranceBlockset;
+
+  DungeonCanvasViewer* compare_viewer =
+      editor_->GetWorkbenchCompareViewer(kCompareRoomId);
+  ASSERT_NE(compare_viewer, nullptr);
+  EXPECT_EQ(compare_viewer->current_entrance_id(), 0);
+  EXPECT_EQ(compare_viewer->current_entrance_blockset(), kEntranceBlockset);
+
+  compare_viewer = editor_->GetWorkbenchCompareViewer(kUnrelatedRoomId);
+  ASSERT_NE(compare_viewer, nullptr);
+  EXPECT_EQ(compare_viewer->current_entrance_id(), -1);
+  EXPECT_EQ(compare_viewer->current_entrance_blockset(), 0xFF);
+}
+
+TEST_F(DungeonEditorPaletteRefreshTest,
+       LegacyPaletteIdCallbackSupportsGenericLambdaAndNullReset) {
   gui::PaletteEditorWidget widget;
   widget.Initialize(&game_data_);
   widget.SetDungeonRenderPaletteMode(true);
   widget.SetCurrentPaletteId(3);
 
   int notified_palette_id = -1;
-  widget.SetOnPaletteChanged([&notified_palette_id](int palette_id) {
+  int callback_count = 0;
+  widget.SetOnPaletteChanged([&](auto palette_id) {
     notified_palette_id = palette_id;
+    ++callback_count;
   });
 
   ASSERT_TRUE(widget
@@ -299,6 +355,14 @@ TEST_F(DungeonEditorPaletteRefreshTest,
                       /*display_index=*/33, gfx::SnesColor(0x4210))
                   .ok());
   EXPECT_EQ(notified_palette_id, 3);
+  EXPECT_EQ(callback_count, 1);
+
+  widget.SetOnPaletteChanged(nullptr);
+  ASSERT_TRUE(widget
+                  .ApplyDungeonRenderColorEdit(
+                      /*display_index=*/34, gfx::SnesColor(0x5294))
+                  .ok());
+  EXPECT_EQ(callback_count, 1);
 }
 
 }  // namespace yaze::editor

--- a/test/unit/editor/dungeon_editor_palette_refresh_test.cc
+++ b/test/unit/editor/dungeon_editor_palette_refresh_test.cc
@@ -4,8 +4,12 @@
 #include <memory>
 #include <vector>
 
+#include "app/editor/dungeon/dungeon_canvas_viewer.h"
+#include "app/gfx/resource/arena.h"
 #include "app/gfx/util/palette_manager.h"
 #include "app/platform/sdl_compat.h"
+#include "framework/mock_renderer.h"
+#include "gmock/gmock.h"
 #include "gtest/gtest.h"
 #include "rom/rom.h"
 #include "rom/snes.h"
@@ -35,6 +39,7 @@ void SeedPaletteGroup(gfx::PaletteGroup* group, int palette_count,
 class DungeonEditorPaletteRefreshTest : public ::testing::Test {
  protected:
   void SetUp() override {
+    gfx::Arena::Get().ClearTextureQueue();
     gfx::PaletteManager::Get().ResetForTesting();
 
     ASSERT_TRUE(rom_.LoadFromData(std::vector<uint8_t>(0x200000, 0)).ok());
@@ -84,7 +89,10 @@ class DungeonEditorPaletteRefreshTest : public ::testing::Test {
     editor_->SetGameData(&game_data_);
   }
 
-  void TearDown() override { gfx::PaletteManager::Get().ResetForTesting(); }
+  void TearDown() override {
+    gfx::Arena::Get().ClearTextureQueue();
+    gfx::PaletteManager::Get().ResetForTesting();
+  }
 
   void RenderToCleanState(zelda3::Room& room) {
     room.RenderRoomGraphics();
@@ -212,6 +220,85 @@ TEST_F(DungeonEditorPaletteRefreshTest,
   EXPECT_EQ(unrelated_before.r, unrelated_after.r);
   EXPECT_EQ(unrelated_before.g, unrelated_after.g);
   EXPECT_EQ(unrelated_before.b, unrelated_after.b);
+}
+
+TEST_F(DungeonEditorPaletteRefreshTest,
+       CachedRoomRefreshesThroughViewerCompositePreparation) {
+  constexpr int kCurrentRoomId = 0;
+  constexpr int kCachedRoomId = 1;
+  constexpr int kHudDisplayIndex = 17;
+  editor_->current_room_id_ = kCurrentRoomId;
+
+  auto& cached_room = editor_->rooms_[kCachedRoomId];
+  cached_room.SetPalette(6);  // Resolves away from selected palette 3.
+  cached_room.SetTileObjects({});
+
+  ::testing::NiceMock<yaze::test::MockRenderer> renderer;
+  DungeonCanvasViewer viewer(&rom_);
+  viewer.SetGameData(&game_data_);
+  viewer.SetRenderer(&renderer);
+  viewer.SetRooms(&editor_->rooms_);
+
+  EXPECT_CALL(renderer, CreateTexture).Times(::testing::AtLeast(1));
+  EXPECT_CALL(renderer, UpdateTexture).Times(::testing::AtLeast(1));
+  gfx::Bitmap* first_composite =
+      viewer.PrepareRoomCompositeBitmap(kCachedRoomId);
+  ASSERT_NE(first_composite, nullptr);
+  gfx::Arena::Get().ProcessTextureQueue(&renderer);
+  ASSERT_NE(first_composite->texture(), nullptr);
+  ASSERT_FALSE(cached_room.IsCompositeDirty());
+  ASSERT_TRUE(::testing::Mock::VerifyAndClearExpectations(&renderer));
+
+  const SDL_Color before =
+      ReadSurfacePaletteColor(cached_room, kHudDisplayIndex);
+  const gfx::SnesColor edited_color(0x03E0);
+
+  editor_->palette_editor_.Initialize(&game_data_);
+  editor_->palette_editor_.SetDungeonRenderPaletteMode(true);
+  editor_->palette_editor_.SetCurrentPaletteId(3);
+  editor_->palette_editor_.SetOnPaletteChanged(
+      [this](gui::DungeonPaletteChange change) {
+        editor_->InvalidateDungeonPaletteUsers(change);
+      });
+
+  ASSERT_TRUE(editor_->palette_editor_
+                  .ApplyDungeonRenderColorEdit(kHudDisplayIndex, edited_color)
+                  .ok());
+  ASSERT_TRUE(cached_room.IsCompositeDirty());
+
+  // Exercise the connected/compare composite preparation path. The test must
+  // not call Room::RenderRoomGraphics directly after the edit.
+  EXPECT_CALL(renderer, UpdateTexture).Times(::testing::AtLeast(1));
+  gfx::Bitmap* refreshed_composite =
+      viewer.PrepareRoomCompositeBitmap(kCachedRoomId);
+  ASSERT_EQ(refreshed_composite, first_composite);
+  gfx::Arena::Get().ProcessTextureQueue(&renderer);
+
+  const SDL_Color after =
+      ReadSurfacePaletteColor(cached_room, kHudDisplayIndex);
+  EXPECT_NE(before.g, after.g);
+  ExpectSurfaceColor(after, edited_color);
+  EXPECT_FALSE(cached_room.IsCompositeDirty());
+  EXPECT_NE(refreshed_composite->texture(), nullptr);
+}
+
+TEST_F(DungeonEditorPaletteRefreshTest,
+       LegacyPaletteIdCallbackRemainsSupported) {
+  gui::PaletteEditorWidget widget;
+  widget.Initialize(&game_data_);
+  widget.SetDungeonRenderPaletteMode(true);
+  widget.SetCurrentPaletteId(3);
+
+  int notified_palette_id = -1;
+  widget.SetOnPaletteChanged([&notified_palette_id](int palette_id) {
+    notified_palette_id = palette_id;
+  });
+
+  ASSERT_TRUE(widget
+                  .ApplyDungeonRenderColorEdit(
+                      /*display_index=*/33, gfx::SnesColor(0x4210))
+                  .ok());
+  EXPECT_EQ(notified_palette_id, 3);
 }
 
 }  // namespace yaze::editor

--- a/test/unit/editor/dungeon_editor_palette_refresh_test.cc
+++ b/test/unit/editor/dungeon_editor_palette_refresh_test.cc
@@ -1,63 +1,217 @@
 #include "app/editor/dungeon/dungeon_editor_v2.h"
 
 #include <cstdint>
+#include <memory>
 #include <vector>
 
+#include "app/gfx/util/palette_manager.h"
+#include "app/platform/sdl_compat.h"
 #include "gtest/gtest.h"
 #include "rom/rom.h"
+#include "rom/snes.h"
+#include "zelda3/dungeon/dungeon_rom_addresses.h"
 #include "zelda3/dungeon/room_layer_manager.h"
 #include "zelda3/game_data.h"
 
 namespace yaze::editor {
+namespace {
 
-TEST(DungeonEditorPaletteRefreshTest,
-     InvalidatesRoomsUsingEditedResolvedPalette) {
-  Rom rom;
-  std::vector<uint8_t> rom_data(0x100000, 0);
-  ASSERT_TRUE(rom.LoadFromData(rom_data).ok());
+void SeedPaletteGroup(gfx::PaletteGroup* group, int palette_count,
+                      int color_count, uint16_t seed) {
+  ASSERT_NE(group, nullptr);
+  group->clear();
+  for (int palette_index = 0; palette_index < palette_count; ++palette_index) {
+    gfx::SnesPalette palette;
+    for (int color_index = 0; color_index < color_count; ++color_index) {
+      palette.AddColor(gfx::SnesColor(static_cast<uint16_t>(
+          (seed + palette_index * color_count + color_index) & 0x7FFF)));
+    }
+    group->AddPalette(palette);
+  }
+}
 
-  zelda3::GameData game_data(&rom);
-  game_data.palette_groups.dungeon_main.resize(4);
+}  // namespace
 
-  // Palette-set IDs 5 and 7 both resolve to concrete dungeon palette 3,
-  // while set 6 resolves to palette 2. The raw header values are not direct
-  // dungeon_main indices.
-  game_data.paletteset_ids[5][0] = 2;
-  game_data.paletteset_ids[6][0] = 4;
-  game_data.paletteset_ids[7][0] = 6;
-  ASSERT_TRUE(rom.WriteWord(zelda3::kDungeonPalettePointerTable + 2,
-                            3 * zelda3::kDungeonPaletteBytes)
+class DungeonEditorPaletteRefreshTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    gfx::PaletteManager::Get().ResetForTesting();
+
+    ASSERT_TRUE(rom_.LoadFromData(std::vector<uint8_t>(0x200000, 0)).ok());
+    const int layout_address = SnesToPc(zelda3::kRoomLayoutPointers.front());
+    ASSERT_GE(layout_address, 0);
+    ASSERT_LT(layout_address + 1, static_cast<int>(rom_.size()));
+    rom_.mutable_data()[layout_address] = 0xFF;
+    rom_.mutable_data()[layout_address + 1] = 0xFF;
+
+    game_data_.graphics_buffer.assign(zelda3::kNumGfxSheets * 4096, 0);
+    for (auto& ids : game_data_.main_blockset_ids) {
+      ids.fill(0);
+    }
+    for (auto& ids : game_data_.room_blockset_ids) {
+      ids.fill(0);
+    }
+    for (auto& ids : game_data_.spriteset_ids) {
+      ids.fill(0);
+    }
+    for (auto& ids : game_data_.paletteset_ids) {
+      ids.fill(0);
+    }
+
+    SeedPaletteGroup(&game_data_.palette_groups.hud, /*palette_count=*/1,
+                     /*color_count=*/32, /*seed=*/0x0100);
+    SeedPaletteGroup(&game_data_.palette_groups.dungeon_main,
+                     /*palette_count=*/4, /*color_count=*/90,
+                     /*seed=*/0x0200);
+
+    // Palette-set IDs 5 and 7 resolve to concrete dungeon palette 3, while
+    // set 6 resolves to palette 2.
+    game_data_.paletteset_ids[5][0] = 2;
+    game_data_.paletteset_ids[6][0] = 4;
+    game_data_.paletteset_ids[7][0] = 6;
+    ASSERT_TRUE(rom_.WriteWord(zelda3::kDungeonPalettePointerTable + 2,
+                               3 * zelda3::kDungeonPaletteBytes)
+                    .ok());
+    ASSERT_TRUE(rom_.WriteWord(zelda3::kDungeonPalettePointerTable + 4,
+                               2 * zelda3::kDungeonPaletteBytes)
+                    .ok());
+    ASSERT_TRUE(rom_.WriteWord(zelda3::kDungeonPalettePointerTable + 6,
+                               3 * zelda3::kDungeonPaletteBytes)
+                    .ok());
+
+    gfx::PaletteManager::Get().Initialize(&game_data_);
+    editor_ = std::make_unique<DungeonEditorV2>(&rom_);
+    editor_->SetGameData(&game_data_);
+  }
+
+  void TearDown() override { gfx::PaletteManager::Get().ResetForTesting(); }
+
+  void RenderToCleanState(zelda3::Room& room) {
+    room.RenderRoomGraphics();
+    room.GetCompositeBitmap(layer_manager_);
+    ASSERT_FALSE(room.IsCompositeDirty());
+
+    // A second render must hit Room::RenderRoomGraphics's clean-cache return.
+    room.RenderRoomGraphics();
+    ASSERT_FALSE(room.IsCompositeDirty());
+  }
+
+  SDL_Color ReadSurfacePaletteColor(zelda3::Room& room, int color_index) {
+    auto* surface = room.bg1_buffer().bitmap().surface();
+    if (surface == nullptr) {
+      ADD_FAILURE() << "Room render did not create a BG1 surface";
+      return {};
+    }
+    SDL_Palette* palette = platform::GetSurfacePalette(surface);
+    if (palette == nullptr || color_index < 0 ||
+        color_index >= palette->ncolors) {
+      ADD_FAILURE() << "Room render did not install the requested SDL color";
+      return {};
+    }
+    return palette->colors[color_index];
+  }
+
+  void ExpectSurfaceColor(const SDL_Color& actual,
+                          const gfx::SnesColor& expected) {
+    const ImVec4 rgb = expected.rgb();
+    EXPECT_EQ(actual.r, static_cast<Uint8>(rgb.x));
+    EXPECT_EQ(actual.g, static_cast<Uint8>(rgb.y));
+    EXPECT_EQ(actual.b, static_cast<Uint8>(rgb.z));
+    EXPECT_EQ(actual.a, 255);
+  }
+
+  Rom rom_;
+  zelda3::GameData game_data_{&rom_};
+  std::unique_ptr<DungeonEditorV2> editor_;
+  zelda3::RoomLayerManager layer_manager_;
+};
+
+TEST_F(DungeonEditorPaletteRefreshTest,
+       SharedHudEditRefreshesRoomUsingDifferentDungeonPalette) {
+  auto& selected_palette_room = editor_->rooms_[0];
+  selected_palette_room.SetPalette(5);  // Resolves to dungeon palette 3.
+  auto& different_palette_room = editor_->rooms_[1];
+  different_palette_room.SetPalette(6);  // Resolves to dungeon palette 2.
+
+  RenderToCleanState(selected_palette_room);
+  RenderToCleanState(different_palette_room);
+
+  constexpr int kHudDisplayIndex = 17;
+  const SDL_Color before =
+      ReadSurfacePaletteColor(different_palette_room, kHudDisplayIndex);
+  const gfx::SnesColor edited_color(0x001F);
+
+  editor_->palette_editor_.Initialize(&game_data_);
+  editor_->palette_editor_.SetDungeonRenderPaletteMode(true);
+  editor_->palette_editor_.SetCurrentPaletteId(3);
+  editor_->palette_editor_.SetOnPaletteChanged(
+      [this](gui::DungeonPaletteChange change) {
+        editor_->InvalidateDungeonPaletteUsers(change);
+      });
+
+  ASSERT_TRUE(editor_->palette_editor_
+                  .ApplyDungeonRenderColorEdit(kHudDisplayIndex, edited_color)
                   .ok());
-  ASSERT_TRUE(rom.WriteWord(zelda3::kDungeonPalettePointerTable + 4,
-                            2 * zelda3::kDungeonPaletteBytes)
-                  .ok());
-  ASSERT_TRUE(rom.WriteWord(zelda3::kDungeonPalettePointerTable + 6,
-                            3 * zelda3::kDungeonPaletteBytes)
-                  .ok());
+  EXPECT_TRUE(selected_palette_room.IsCompositeDirty());
+  EXPECT_TRUE(different_palette_room.IsCompositeDirty());
 
-  DungeonEditorV2 editor(&rom);
-  editor.SetGameData(&game_data);
+  different_palette_room.RenderRoomGraphics();
+  const SDL_Color after =
+      ReadSurfacePaletteColor(different_palette_room, kHudDisplayIndex);
+  EXPECT_NE(before.r, after.r);
+  ExpectSurfaceColor(after, edited_color);
+}
 
-  auto& matching_room = editor.rooms_[0];
+TEST_F(DungeonEditorPaletteRefreshTest,
+       DungeonMainEditRefreshesResolvedAliasesOnly) {
+  auto& matching_room = editor_->rooms_[0];
   matching_room.SetPalette(5);
-  auto& other_room = editor.rooms_[1];
-  other_room.SetPalette(6);
-  auto& other_matching_room = editor.rooms_[2];
-  other_matching_room.SetPalette(7);
+  auto& unrelated_room = editor_->rooms_[1];
+  unrelated_room.SetPalette(6);
+  auto& aliased_matching_room = editor_->rooms_[2];
+  aliased_matching_room.SetPalette(7);
 
-  zelda3::RoomLayerManager layer_manager;
-  matching_room.GetCompositeBitmap(layer_manager);
-  other_room.GetCompositeBitmap(layer_manager);
-  other_matching_room.GetCompositeBitmap(layer_manager);
-  ASSERT_FALSE(matching_room.IsCompositeDirty());
-  ASSERT_FALSE(other_room.IsCompositeDirty());
-  ASSERT_FALSE(other_matching_room.IsCompositeDirty());
+  RenderToCleanState(matching_room);
+  RenderToCleanState(unrelated_room);
+  RenderToCleanState(aliased_matching_room);
 
-  editor.InvalidateDungeonPaletteUsers(/*palette_id=*/3);
+  constexpr int kDungeonDisplayIndex = 33;
+  const SDL_Color unrelated_before =
+      ReadSurfacePaletteColor(unrelated_room, kDungeonDisplayIndex);
+  const gfx::SnesColor edited_color(0x7C00);
 
+  editor_->palette_editor_.Initialize(&game_data_);
+  editor_->palette_editor_.SetDungeonRenderPaletteMode(true);
+  editor_->palette_editor_.SetCurrentPaletteId(3);
+  editor_->palette_editor_.SetOnPaletteChanged(
+      [this](gui::DungeonPaletteChange change) {
+        editor_->InvalidateDungeonPaletteUsers(change);
+      });
+
+  ASSERT_TRUE(
+      editor_->palette_editor_
+          .ApplyDungeonRenderColorEdit(kDungeonDisplayIndex, edited_color)
+          .ok());
   EXPECT_TRUE(matching_room.IsCompositeDirty());
-  EXPECT_FALSE(other_room.IsCompositeDirty());
-  EXPECT_TRUE(other_matching_room.IsCompositeDirty());
+  EXPECT_FALSE(unrelated_room.IsCompositeDirty());
+  EXPECT_TRUE(aliased_matching_room.IsCompositeDirty());
+
+  matching_room.RenderRoomGraphics();
+  aliased_matching_room.RenderRoomGraphics();
+  unrelated_room.RenderRoomGraphics();
+  EXPECT_FALSE(unrelated_room.IsCompositeDirty());
+
+  ExpectSurfaceColor(
+      ReadSurfacePaletteColor(matching_room, kDungeonDisplayIndex),
+      edited_color);
+  ExpectSurfaceColor(
+      ReadSurfacePaletteColor(aliased_matching_room, kDungeonDisplayIndex),
+      edited_color);
+  const SDL_Color unrelated_after =
+      ReadSurfacePaletteColor(unrelated_room, kDungeonDisplayIndex);
+  EXPECT_EQ(unrelated_before.r, unrelated_after.r);
+  EXPECT_EQ(unrelated_before.g, unrelated_after.g);
+  EXPECT_EQ(unrelated_before.b, unrelated_after.b);
 }
 
 }  // namespace yaze::editor

--- a/test/unit/editor/dungeon_editor_palette_refresh_test.cc
+++ b/test/unit/editor/dungeon_editor_palette_refresh_test.cc
@@ -1,0 +1,63 @@
+#include "app/editor/dungeon/dungeon_editor_v2.h"
+
+#include <cstdint>
+#include <vector>
+
+#include "gtest/gtest.h"
+#include "rom/rom.h"
+#include "zelda3/dungeon/room_layer_manager.h"
+#include "zelda3/game_data.h"
+
+namespace yaze::editor {
+
+TEST(DungeonEditorPaletteRefreshTest,
+     InvalidatesRoomsUsingEditedResolvedPalette) {
+  Rom rom;
+  std::vector<uint8_t> rom_data(0x100000, 0);
+  ASSERT_TRUE(rom.LoadFromData(rom_data).ok());
+
+  zelda3::GameData game_data(&rom);
+  game_data.palette_groups.dungeon_main.resize(4);
+
+  // Palette-set IDs 5 and 7 both resolve to concrete dungeon palette 3,
+  // while set 6 resolves to palette 2. The raw header values are not direct
+  // dungeon_main indices.
+  game_data.paletteset_ids[5][0] = 2;
+  game_data.paletteset_ids[6][0] = 4;
+  game_data.paletteset_ids[7][0] = 6;
+  ASSERT_TRUE(rom.WriteWord(zelda3::kDungeonPalettePointerTable + 2,
+                            3 * zelda3::kDungeonPaletteBytes)
+                  .ok());
+  ASSERT_TRUE(rom.WriteWord(zelda3::kDungeonPalettePointerTable + 4,
+                            2 * zelda3::kDungeonPaletteBytes)
+                  .ok());
+  ASSERT_TRUE(rom.WriteWord(zelda3::kDungeonPalettePointerTable + 6,
+                            3 * zelda3::kDungeonPaletteBytes)
+                  .ok());
+
+  DungeonEditorV2 editor(&rom);
+  editor.SetGameData(&game_data);
+
+  auto& matching_room = editor.rooms_[0];
+  matching_room.SetPalette(5);
+  auto& other_room = editor.rooms_[1];
+  other_room.SetPalette(6);
+  auto& other_matching_room = editor.rooms_[2];
+  other_matching_room.SetPalette(7);
+
+  zelda3::RoomLayerManager layer_manager;
+  matching_room.GetCompositeBitmap(layer_manager);
+  other_room.GetCompositeBitmap(layer_manager);
+  other_matching_room.GetCompositeBitmap(layer_manager);
+  ASSERT_FALSE(matching_room.IsCompositeDirty());
+  ASSERT_FALSE(other_room.IsCompositeDirty());
+  ASSERT_FALSE(other_matching_room.IsCompositeDirty());
+
+  editor.InvalidateDungeonPaletteUsers(/*palette_id=*/3);
+
+  EXPECT_TRUE(matching_room.IsCompositeDirty());
+  EXPECT_FALSE(other_room.IsCompositeDirty());
+  EXPECT_TRUE(other_matching_room.IsCompositeDirty());
+}
+
+}  // namespace yaze::editor

--- a/test/unit/editor/dungeon_workbench_content_test.cc
+++ b/test/unit/editor/dungeon_workbench_content_test.cc
@@ -38,7 +38,7 @@ DungeonWorkbenchContent MakeWorkbenchForToolStateTests(
   return DungeonWorkbenchContent(
       nullptr, &current_room_id, [](int) {}, [](int, RoomSelectionIntent) {},
       [](int) {}, []() {}, []() -> DungeonCanvasViewer* { return nullptr; },
-      []() -> DungeonCanvasViewer* { return nullptr; },
+      [](int) -> DungeonCanvasViewer* { return nullptr; },
       [&recent_rooms]() -> const std::deque<int>& { return recent_rooms; },
       [](int) {}, [](bool) {});
 }


### PR DESCRIPTION
## Summary
- invalidate every materialized dungeon room affected by a palette edit
- distinguish shared HUD color changes from dungeon-main palette changes, including multiple room palette-set IDs that resolve to the same concrete palette
- make active, cached, connected, and compare-room render preparation honor dirty graphics lazily instead of treating an allocated BG1 surface as current
- preserve each target room's entrance blockset context and configure compare viewers for the actual compare room
- retain the legacy palette-id callback API while adding a distinct typed dungeon-palette change callback

## Verification
- focused viewer/palette/workbench/ROM-safety suite: **72/72 passed**
- `PaletteManagerTest.*`: **34/34 passed**
- `YAZE_PREPUSH_BUILD_DIR=build/presets/mac-ai scripts/pre-push.sh`: build/format plus UI regression **27/27 passed**
- repeated strict delegated reviews: final exact branch has no blocker, high, or medium findings

## Regression coverage
- clean rendered caches become dirty after matching dungeon-main edits
- shared HUD edits invalidate rooms using different dungeon-main palettes
- cached non-current composites refresh through the real viewer path and update their textures/palette bytes
- unrelated dungeon-main users remain clean
- arbitrary connected targets retain their own entrance context
- compare viewers resolve context from the compare room rather than the primary room
- legacy typed/generic callbacks and null reset remain source-compatible

## Scope / residual
- no ROM persistence path or canonical ROM was modified
- no interactive GUI or real Oracle ROM visual pass was performed in this slice
- held project/session PR #114 overlaps palette/editor surfaces and will need normal integration review before it is reconsidered
