### PR TITLE
fix(dungeon): defer BG2 reveal masks to compositing

### DIFF
--- a/src/app/gfx/render/background_buffer.cc
+++ b/src/app/gfx/render/background_buffer.cc
@@ -34,6 +34,13 @@ void BackgroundBuffer::EnsureCoverageBufferAllocated() {
   }
 }
 
+void BackgroundBuffer::EnsureBG1RevealMaskAllocated() {
+  const size_t total_pixels = static_cast<size_t>(width_ * height_);
+  if (bg1_reveal_mask_buffer_.size() != total_pixels) {
+    bg1_reveal_mask_buffer_.assign(total_pixels, 0);
+  }
+}
+
 std::vector<uint8_t>& BackgroundBuffer::mutable_priority_data() {
   EnsurePriorityBufferAllocated();
   return priority_buffer_;
@@ -42,6 +49,11 @@ std::vector<uint8_t>& BackgroundBuffer::mutable_priority_data() {
 std::vector<uint8_t>& BackgroundBuffer::mutable_coverage_data() {
   EnsureCoverageBufferAllocated();
   return coverage_buffer_;
+}
+
+std::vector<uint8_t>& BackgroundBuffer::mutable_bg1_reveal_mask_data() {
+  EnsureBG1RevealMaskAllocated();
+  return bg1_reveal_mask_buffer_;
 }
 
 void BackgroundBuffer::SetTileAt(int x_pos, int y_pos, uint16_t value) {
@@ -76,6 +88,7 @@ void BackgroundBuffer::ClearBuffer() {
   }
   ClearPriorityBuffer();
   ClearCoverageBuffer();
+  ClearBG1RevealMask();
 }
 
 void BackgroundBuffer::ClearPriorityBuffer() {
@@ -89,6 +102,57 @@ void BackgroundBuffer::ClearCoverageBuffer() {
   // 0 indicates the layer never wrote here; 1 indicates it did.
   if (!coverage_buffer_.empty()) {
     std::fill(coverage_buffer_.begin(), coverage_buffer_.end(), 0);
+  }
+}
+
+void BackgroundBuffer::ClearBG1RevealMask() {
+  if (!bg1_reveal_mask_buffer_.empty()) {
+    std::fill(bg1_reveal_mask_buffer_.begin(), bg1_reveal_mask_buffer_.end(),
+              0);
+  }
+}
+
+void BackgroundBuffer::ClearBG1RevealMask(BG1RevealMaskSource source) {
+  if (bg1_reveal_mask_buffer_.empty()) {
+    return;
+  }
+  const uint8_t keep_mask = static_cast<uint8_t>(~static_cast<uint8_t>(source));
+  for (auto& value : bg1_reveal_mask_buffer_) {
+    value &= keep_mask;
+  }
+}
+
+void BackgroundBuffer::ClearBG1RevealMaskRect(BG1RevealMaskSource source,
+                                              int start_x, int start_y,
+                                              int width, int height) {
+  if (bg1_reveal_mask_buffer_.empty() || width <= 0 || height <= 0) {
+    return;
+  }
+  const uint8_t keep_mask = static_cast<uint8_t>(~static_cast<uint8_t>(source));
+  const int end_x = std::min(start_x + width, width_);
+  const int end_y = std::min(start_y + height, height_);
+  for (int y = std::max(start_y, 0); y < end_y; ++y) {
+    for (int x = std::max(start_x, 0); x < end_x; ++x) {
+      bg1_reveal_mask_buffer_[static_cast<size_t>(y * width_ + x)] &= keep_mask;
+    }
+  }
+}
+
+void BackgroundBuffer::SetBG1RevealMaskRect(BG1RevealMaskSource source,
+                                            int start_x, int start_y, int width,
+                                            int height) {
+  if (width <= 0 || height <= 0) {
+    return;
+  }
+  EnsureBG1RevealMaskAllocated();
+  const uint8_t source_mask = static_cast<uint8_t>(source);
+  const int end_x = std::min(start_x + width, width_);
+  const int end_y = std::min(start_y + height, height_);
+  for (int y = std::max(start_y, 0); y < end_y; ++y) {
+    for (int x = std::max(start_x, 0); x < end_x; ++x) {
+      bg1_reveal_mask_buffer_[static_cast<size_t>(y * width_ + x)] |=
+          source_mask;
+    }
   }
 }
 

--- a/src/app/gfx/render/background_buffer.h
+++ b/src/app/gfx/render/background_buffer.h
@@ -10,6 +10,11 @@
 namespace yaze {
 namespace gfx {
 
+enum class BG1RevealMaskSource : uint8_t {
+  kBG2Layout = 1 << 0,
+  kBG2Objects = 1 << 1,
+};
+
 class BackgroundBuffer {
  public:
   BackgroundBuffer(int width = 512, int height = 512);
@@ -52,6 +57,21 @@ class BackgroundBuffer {
   const std::vector<uint8_t>& coverage_data() const { return coverage_buffer_; }
   std::vector<uint8_t>& mutable_coverage_data();
 
+  // Per-pixel cross-layer reveal bits carried by raw BG1 target buffers.
+  // Each bit identifies the BG2 source layer that requested the reveal, so
+  // compositing can ignore that request when its owner is hidden while later
+  // BG1 writes can clear only the source bit they supersede.
+  void ClearBG1RevealMask();
+  void ClearBG1RevealMask(BG1RevealMaskSource source);
+  void ClearBG1RevealMaskRect(BG1RevealMaskSource source, int start_x,
+                              int start_y, int width, int height);
+  void SetBG1RevealMaskRect(BG1RevealMaskSource source, int start_x,
+                            int start_y, int width, int height);
+  const std::vector<uint8_t>& bg1_reveal_mask_data() const {
+    return bg1_reveal_mask_buffer_;
+  }
+  std::vector<uint8_t>& mutable_bg1_reveal_mask_data();
+
   // Accessors
   std::vector<uint16_t>& buffer() { return buffer_; }
   const std::vector<uint16_t>& buffer() const { return buffer_; }
@@ -62,10 +82,12 @@ class BackgroundBuffer {
   void EnsureTileBufferAllocated();
   void EnsurePriorityBufferAllocated();
   void EnsureCoverageBufferAllocated();
+  void EnsureBG1RevealMaskAllocated();
 
   std::vector<uint16_t> buffer_;
   std::vector<uint8_t> priority_buffer_;  // Per-pixel priority (0 or 1)
   std::vector<uint8_t> coverage_buffer_;  // Per-pixel coverage (0=unset,1=set)
+  std::vector<uint8_t> bg1_reveal_mask_buffer_;  // Per-pixel BG1 reveal mask
   gfx::Bitmap bitmap_;
   int width_;
   int height_;

--- a/src/zelda3/dungeon/object_drawer.cc
+++ b/src/zelda3/dungeon/object_drawer.cc
@@ -395,8 +395,7 @@ absl::Status ObjectDrawer::DrawObject(
   active_mask_source_bg_ = nullptr;
   registry_secondary_bg_ = nullptr;
 
-  // BG2 Mask Propagation: ONLY layer-2 mask/pit objects should mark BG1 as
-  // transparent.
+  // BG2 mask propagation is deferred to compositing so raw BG1 stays intact.
   //
   // Ordinary BG2 overlay objects now mask per-pixel as they draw, which keeps
   // transparent cutouts intact for platforms/statues/stairs. Full-rect masking
@@ -411,16 +410,15 @@ absl::Status ObjectDrawer::DrawObject(
     const auto [mask_px_x, mask_px_y, pixel_width, pixel_height] =
         DimensionService::Get().GetSelectionBoundsPixels(object);
 
-    LOG_DEBUG(
-        "ObjectDrawer",
-        "Pit mask 0x%03X at (%d,%d) -> marking %dx%d pixels transparent in BG1",
-        object.id_, mask_px_x / 8, mask_px_y / 8, pixel_width, pixel_height);
+    LOG_DEBUG("ObjectDrawer",
+              "Pit mask 0x%03X at (%d,%d) -> recording %dx%d BG1 reveal pixels",
+              object.id_, mask_px_x / 8, mask_px_y / 8, pixel_width,
+              pixel_height);
 
-    MarkBg1RectTransparent(bg1, mask_px_x, mask_px_y, pixel_width,
-                           pixel_height);
+    MarkBg1RectRevealed(bg1, mask_px_x, mask_px_y, pixel_width, pixel_height);
     if (layout_bg1 != nullptr) {
-      MarkBg1RectTransparent(*layout_bg1, mask_px_x, mask_px_y, pixel_width,
-                             pixel_height);
+      MarkBg1RectRevealed(*layout_bg1, mask_px_x, mask_px_y, pixel_width,
+                          pixel_height);
     }
   }
 
@@ -1503,6 +1501,8 @@ void ObjectDrawer::DrawDoor(const DoorDef& door, int door_index,
         const int pixel_x = (start_tile_x + dx) * 8;
         const int pixel_y = (start_tile_y + dy) * 8;
 
+        target.ClearBG1RevealMaskRect(bg1_reveal_mask_source_, pixel_x, pixel_y,
+                                      8, 8);
         DrawTileToBitmap(bitmap, tile_info, pixel_x, pixel_y, room_gfx_buffer_);
 
         const uint8_t priority = tile_info.over_ ? 1 : 0;
@@ -1548,6 +1548,8 @@ void ObjectDrawer::DrawDoor(const DoorDef& door, int door_index,
         const int pixel_x = (start_tile_x + dx) * 8;
         const int pixel_y = (start_tile_y + dy) * 8;
 
+        target.ClearBG1RevealMaskRect(bg1_reveal_mask_source_, pixel_x, pixel_y,
+                                      8, 8);
         DrawTileToBitmap(bitmap, tile_info, pixel_x, pixel_y, room_gfx_buffer_);
 
         const uint8_t priority = tile_info.over_ ? 1 : 0;
@@ -1892,6 +1894,9 @@ void ObjectDrawer::DrawDoorIndicator(gfx::BackgroundBuffer& bg, int tile_x,
   int bitmap_width = bitmap.width();
   int bitmap_height = bitmap.height();
 
+  bg.ClearBG1RevealMaskRect(bg1_reveal_mask_source_, pixel_x, pixel_y,
+                            pixel_width, pixel_height);
+
   // Draw filled rectangle with border
   for (int py = 0; py < pixel_height; py++) {
     for (int px = 0; px < pixel_width; px++) {
@@ -2086,43 +2091,14 @@ void ObjectDrawer::DrawRightwardsDecor4x3spaced4_1to16(
 // Utility Methods
 // ============================================================================
 
-void ObjectDrawer::MarkBg1RectTransparent(gfx::BackgroundBuffer& bg1,
-                                          int start_px, int start_py,
-                                          int pixel_width, int pixel_height) {
-  auto& bitmap = bg1.bitmap();
-  if (!bitmap.is_active() || bitmap.width() == 0) {
-    return;
-  }
-
-  int canvas_width = bitmap.width();
-  int canvas_height = bitmap.height();
-  auto& data = bitmap.mutable_data();
-
-  for (int py = start_py; py < start_py + pixel_height && py < canvas_height;
-       py++) {
-    if (py < 0)
-      continue;
-    for (int px = start_px; px < start_px + pixel_width && px < canvas_width;
-         px++) {
-      if (px < 0)
-        continue;
-      int idx = py * canvas_width + px;
-      if (idx >= 0 && idx < static_cast<int>(data.size())) {
-        data[idx] = 255;
-      }
-    }
-  }
-  bitmap.set_modified(true);
+void ObjectDrawer::MarkBg1RectRevealed(gfx::BackgroundBuffer& bg1, int start_px,
+                                       int start_py, int pixel_width,
+                                       int pixel_height) {
+  bg1.SetBG1RevealMaskRect(bg1_reveal_mask_source_, start_px, start_py,
+                           pixel_width, pixel_height);
 }
 
-void ObjectDrawer::MarkBG1Transparent(gfx::BackgroundBuffer& bg1, int tile_x,
-                                      int tile_y, int pixel_width,
-                                      int pixel_height) {
-  MarkBg1RectTransparent(bg1, tile_x * 8, tile_y * 8, pixel_width,
-                         pixel_height);
-}
-
-void ObjectDrawer::MarkBg1OpaqueTilePixelsTransparent(
+void ObjectDrawer::MarkBg1OpaqueTilePixelsRevealed(
     gfx::BackgroundBuffer& bg1, const gfx::TileInfo& tile_info, int pixel_x,
     int pixel_y, const uint8_t* tiledata) {
   auto& bitmap = bg1.bitmap();
@@ -2140,7 +2116,8 @@ void ObjectDrawer::MarkBg1OpaqueTilePixelsTransparent(
 
   const int tile_base_x = tile_col * 8;
   const int tile_base_y = tile_row * 1024;
-  bool any_pixels_changed = false;
+  auto& reveal_mask = bg1.mutable_bg1_reveal_mask_data();
+  const uint8_t source_mask = static_cast<uint8_t>(bg1_reveal_mask_source_);
 
   for (int py = 0; py < 8; ++py) {
     const int src_row = tile_info.vertical_mirror_ ? (7 - py) : py;
@@ -2163,16 +2140,8 @@ void ObjectDrawer::MarkBg1OpaqueTilePixelsTransparent(
       }
 
       const int dest_index = dest_y * bitmap.width() + dest_x;
-      auto& dst = bitmap.mutable_data()[dest_index];
-      if (dst != 255) {
-        dst = 255;
-        any_pixels_changed = true;
-      }
+      reveal_mask[dest_index] |= source_mask;
     }
-  }
-
-  if (any_pixels_changed) {
-    bitmap.set_modified(true);
   }
 }
 
@@ -2201,17 +2170,22 @@ void ObjectDrawer::WriteTile8(gfx::BackgroundBuffer& bg, int tile_x, int tile_y,
     return;
   }
 
-  // Draw single 8x8 tile directly to bitmap
-  DrawTileToBitmap(bitmap, tile_info, tile_x * 8, tile_y * 8, gfx_data);
+  // A later BG1 tilemap write supersedes an earlier reveal request from the
+  // same logical stream, including transparent pixels in the 8x8 footprint.
+  bg.ClearBG1RevealMaskRect(bg1_reveal_mask_source_, tile_x * 8, tile_y * 8, 8,
+                            8);
+
   const bool should_mark_bg1_mask =
       active_mask_source_bg_ != nullptr && (&bg == active_mask_source_bg_);
+  // Draw single 8x8 tile directly to bitmap.
+  DrawTileToBitmap(bitmap, tile_info, tile_x * 8, tile_y * 8, gfx_data);
   if (should_mark_bg1_mask && active_object_bg1_mask_ != nullptr) {
-    MarkBg1OpaqueTilePixelsTransparent(*active_object_bg1_mask_, tile_info,
-                                       tile_x * 8, tile_y * 8, gfx_data);
+    MarkBg1OpaqueTilePixelsRevealed(*active_object_bg1_mask_, tile_info,
+                                    tile_x * 8, tile_y * 8, gfx_data);
   }
   if (should_mark_bg1_mask && active_layout_bg1_mask_ != nullptr) {
-    MarkBg1OpaqueTilePixelsTransparent(*active_layout_bg1_mask_, tile_info,
-                                       tile_x * 8, tile_y * 8, gfx_data);
+    MarkBg1OpaqueTilePixelsRevealed(*active_layout_bg1_mask_, tile_info,
+                                    tile_x * 8, tile_y * 8, gfx_data);
   }
 
   // Mark coverage for the full 8x8 tile region (even if pixels are transparent).
@@ -3296,6 +3270,9 @@ void yaze::zelda3::ObjectDrawer::DrawMissingCustomObjectPlaceholder(
   const int width = bitmap.width();
   const int height = bitmap.height();
 
+  bg.ClearBG1RevealMaskRect(bg1_reveal_mask_source_, start_x, start_y,
+                            kPlaceholderSizePx, kPlaceholderSizePx);
+
   for (int py = 0; py < kPlaceholderSizePx; ++py) {
     const int dest_y = start_y + py;
     if (dest_y < 0 || dest_y >= height)
@@ -3421,6 +3398,8 @@ void yaze::zelda3::ObjectDrawer::DrawPotItem(uint8_t item_id, int x, int y,
   // Draw a 4x4 colored square as item indicator
   int bitmap_width = bitmap.width();
   int bitmap_height = bitmap.height();
+
+  bg.ClearBG1RevealMaskRect(bg1_reveal_mask_source_, pixel_x, pixel_y, 4, 4);
 
   for (int py = 0; py < 4; py++) {
     for (int px = 0; px < 4; px++) {

--- a/src/zelda3/dungeon/object_drawer.h
+++ b/src/zelda3/dungeon/object_drawer.h
@@ -44,7 +44,7 @@ class ObjectDrawer {
    * @param bg1 Background layer 1 buffer (object buffer)
    * @param bg2 Background layer 2 buffer (object buffer)
    * @param palette_group Current palette group for color mapping
-   * @param layout_bg1 Optional layout buffer to mask for BG2 object transparency
+   * @param layout_bg1 Optional second BG1 target for room-object reveal masks
    * @return Status of the drawing operation
    */
   absl::Status DrawObject(const RoomObject& object, gfx::BackgroundBuffer& bg1,
@@ -78,6 +78,9 @@ class ObjectDrawer {
   void SetAllowTrackCornerAliases(bool allow) {
     allow_track_corner_aliases_ = allow;
   }
+  void SetBG1RevealMaskSource(gfx::BG1RevealMaskSource source) {
+    bg1_reveal_mask_source_ = source;
+  }
 
   /**
    * @brief Draw a door to background buffers
@@ -104,7 +107,7 @@ class ObjectDrawer {
    * @param bg1 Background layer 1 buffer (object buffer)
    * @param bg2 Background layer 2 buffer (object buffer)
    * @param palette_group Current palette group for color mapping
-   * @param layout_bg1 Optional layout buffer to mask for BG2 object transparency
+   * @param layout_bg1 Optional second BG1 target for room-object reveal masks
    * @param reset_room_event_indices If true, reset the chest-only and shared
    *        chest/lock counters before drawing (set false on subsequent USDASM
    *        list passes; see Room::RenderObjectsToBackground)
@@ -251,28 +254,13 @@ class ObjectDrawer {
   // Uses metadata instead of hardcoded routine IDs
   static bool RoutineDrawsToBothBGs(int routine_id);
 
-  /**
-   * @brief Mark BG1 pixels as transparent where BG2 overlay objects are drawn
-   *
-   * This creates "holes" in BG1 that allow BG2 content to show through,
-   * matching SNES behavior where Layer 1 objects only write to BG2 tilemap.
-   *
-   * @param bg1 Background layer 1 buffer to mark transparent
-   * @param tile_x Object X position in tiles
-   * @param tile_y Object Y position in tiles
-   * @param pixel_width Width of the object in pixels
-   * @param pixel_height Height of the object in pixels
-   */
-  void MarkBG1Transparent(gfx::BackgroundBuffer& bg1, int tile_x, int tile_y,
-                          int pixel_width, int pixel_height);
-
-  // Pixel-space variant for explicit rectangular transparency writes.
-  void MarkBg1RectTransparent(gfx::BackgroundBuffer& bg1, int start_px,
-                              int start_py, int pixel_width, int pixel_height);
-  void MarkBg1OpaqueTilePixelsTransparent(gfx::BackgroundBuffer& bg1,
-                                          const gfx::TileInfo& tile_info,
-                                          int pixel_x, int pixel_y,
-                                          const uint8_t* tiledata);
+  // Record a deferred BG1 reveal instead of mutating the raw BG1 pixels.
+  void MarkBg1RectRevealed(gfx::BackgroundBuffer& bg1, int start_px,
+                           int start_py, int pixel_width, int pixel_height);
+  void MarkBg1OpaqueTilePixelsRevealed(gfx::BackgroundBuffer& bg1,
+                                       const gfx::TileInfo& tile_info,
+                                       int pixel_x, int pixel_y,
+                                       const uint8_t* tiledata);
   static bool RequiresRectangularBg1Mask(const RoomObject& object);
 
   // Door indicator fallback when graphics unavailable
@@ -310,6 +298,8 @@ class ObjectDrawer {
   gfx::BackgroundBuffer* active_object_bg1_mask_ = nullptr;
   gfx::BackgroundBuffer* active_layout_bg1_mask_ = nullptr;
   gfx::BackgroundBuffer* active_mask_source_bg_ = nullptr;
+  gfx::BG1RevealMaskSource bg1_reveal_mask_source_ =
+      gfx::BG1RevealMaskSource::kBG2Objects;
   const uint8_t*
       room_gfx_buffer_;  // Room-specific graphics buffer (current_gfx16_)
 

--- a/src/zelda3/dungeon/room.cc
+++ b/src/zelda3/dungeon/room.cc
@@ -1248,6 +1248,10 @@ void Room::LoadLayoutTilesToBuffer() {
     return;
   }
 
+  // Rebuild only layout-owned reveal requests. Room-object masks share this
+  // raw BG1 target and remain valid when just the layout is rerendered.
+  bg1_buffer_.ClearBG1RevealMask(gfx::BG1RevealMaskSource::kBG2Layout);
+
   // Load layout tiles from ROM if not already loaded
   layout_.SetRom(rom_);
   auto layout_status = layout_.LoadLayout(layout_id_);
@@ -1347,6 +1351,7 @@ void Room::RenderObjectsToBackground() {
   // correct tiles
   ObjectDrawer drawer(rom_, room_id_, current_gfx16_.data());
   drawer.SetAllowTrackCornerAliases(RoomUsesTrackCornerAliases(tile_objects_));
+  drawer.SetBG1RevealMaskSource(gfx::BG1RevealMaskSource::kBG2Objects);
   // NOTE: BothBG routines (ceiling corners, merged stairs, prison cells) are
   // handled by DrawRoutineRegistry's draws_to_both_bgs flag. The room object
   // stream is split here as primary -> BG2 overlay -> BG1 overlay, while the
@@ -1370,6 +1375,11 @@ void Room::RenderObjectsToBackground() {
   // can cause objects to incorrectly clear the layout.
   object_bg1_buffer_.ClearCoverageBuffer();
   object_bg2_buffer_.ClearCoverageBuffer();
+
+  // Room-object masks target both raw BG1 stacks. Clear only their source bit
+  // so layout-owned reveals survive an object-only rerender.
+  object_bg1_buffer_.ClearBG1RevealMask(gfx::BG1RevealMaskSource::kBG2Objects);
+  bg1_buffer_.ClearBG1RevealMask(gfx::BG1RevealMaskSource::kBG2Objects);
 
   // Log stream distribution for this room.
   // USDASM order is: main list -> BG2 overlay list -> BG1 overlay list.
@@ -1400,8 +1410,9 @@ void Room::RenderObjectsToBackground() {
   // `tile_objects_[].layer_` holds the list index (0/1/2) for save/load, not
   // the buffer name. Map with MapRoomObjectListIndexToDrawLayer before drawing.
   // BothBG routines still fan out to both buffers via DrawRoutineRegistry.
-  // Pass bg1_buffer_ for BG2 mask propagation so pits/layer masks can create
-  // holes in BG1 that reveal BG2 beneath.
+  // Pass bg1_buffer_ as the second raw BG1 target. BG2 room objects record
+  // deferred reveal bits on both layout and object targets without mutating
+  // either bitmap.
   //
   // Three DrawObjectList passes match USDASM list order; the shared chest/
   // big-key-lock event index continues across passes (reset only on the first

--- a/src/zelda3/dungeon/room_layer_manager.cc
+++ b/src/zelda3/dungeon/room_layer_manager.cc
@@ -16,11 +16,14 @@ namespace {
 
 // Helper to copy SDL palette from source surface to destination bitmap
 // Uses vector extraction + SetPalette for reliable palette application
-void ApplySDLPaletteToBitmap(SDL_Surface* src_surface, gfx::Bitmap& dst_bitmap) {
-  if (!src_surface || !src_surface->format) return;
+void ApplySDLPaletteToBitmap(SDL_Surface* src_surface,
+                             gfx::Bitmap& dst_bitmap) {
+  if (!src_surface || !src_surface->format)
+    return;
 
   SDL_Palette* src_pal = src_surface->format->palette;
-  if (!src_pal || src_pal->ncolors == 0) return;
+  if (!src_pal || src_pal->ncolors == 0)
+    return;
 
   // Extract palette colors into a vector
   std::vector<SDL_Color> colors(256);
@@ -47,7 +50,7 @@ void ApplySDLPaletteToBitmap(SDL_Surface* src_surface, gfx::Bitmap& dst_bitmap) 
 }  // namespace
 
 void RoomLayerManager::CompositeToOutput(Room& room,
-                                          gfx::Bitmap& output) const {
+                                         gfx::Bitmap& output) const {
   constexpr int kWidth = 512;
   constexpr int kHeight = 512;
   constexpr int kPixelCount = kWidth * kHeight;
@@ -56,11 +59,11 @@ void RoomLayerManager::CompositeToOutput(Room& room,
   static int last_room_id = -1;
   if (room.id() != last_room_id) {
     last_room_id = room.id();
-    LOG_DEBUG("LayerManager", "Room %03X: BG1_Layout(vis=%d,blend=%d) "
+    LOG_DEBUG("LayerManager",
+              "Room %03X: BG1_Layout(vis=%d,blend=%d) "
               "BG1_Objects(vis=%d,blend=%d) BG2_Layout(vis=%d,blend=%d) "
               "BG2_Objects(vis=%d,blend=%d) MergeType=%d",
-              room.id(),
-              IsLayerVisible(LayerType::BG1_Layout),
+              room.id(), IsLayerVisible(LayerType::BG1_Layout),
               static_cast<int>(GetLayerBlendMode(LayerType::BG1_Layout)),
               IsLayerVisible(LayerType::BG1_Objects),
               static_cast<int>(GetLayerBlendMode(LayerType::BG1_Objects)),
@@ -73,8 +76,7 @@ void RoomLayerManager::CompositeToOutput(Room& room,
 
   // Ensure output bitmap is properly sized
   if (output.width() != kWidth || output.height() != kHeight) {
-    output.Create(kWidth, kHeight, 8,
-                  std::vector<uint8_t>(kPixelCount, 0));
+    output.Create(kWidth, kHeight, 8, std::vector<uint8_t>(kPixelCount, 0));
   } else {
     // Clear to backdrop (0). Transparent pixels (255) from layers will reveal
     // this backdrop, matching SNES behavior when all layers are transparent.
@@ -156,9 +158,10 @@ void RoomLayerManager::CompositeToOutput(Room& room,
 
     // Check if BG2 uses translucent blending (water rooms, color math effects).
     // When translucent, overlapping BG1+BG2 pixels are averaged in RGB space.
-    const bool bg2_translucent =
-        (GetLayerBlendMode(LayerType::BG2_Layout) == LayerBlendMode::Translucent) ||
-        (GetLayerBlendMode(LayerType::BG2_Objects) == LayerBlendMode::Translucent);
+    const bool bg2_translucent = (GetLayerBlendMode(LayerType::BG2_Layout) ==
+                                  LayerBlendMode::Translucent) ||
+                                 (GetLayerBlendMode(LayerType::BG2_Objects) ==
+                                  LayerBlendMode::Translucent);
 
     // Build palette lookup table for color blending (only when needed).
     // Extract from the output bitmap's SDL palette so we can do RGB math.
@@ -177,8 +180,9 @@ void RoomLayerManager::CompositeToOutput(Room& room,
     // Searches within the same 16-color bank as the BG1 pixel to preserve
     // palette coherence (avoids cross-bank color artifacts).
     auto find_nearest_in_bank = [&](uint8_t base_idx, uint8_t r, uint8_t g,
-                                     uint8_t b) -> uint8_t {
-      if (pal_lut.empty()) return base_idx;
+                                    uint8_t b) -> uint8_t {
+      if (pal_lut.empty())
+        return base_idx;
       int bank_start = (base_idx / 16) * 16;
       int bank_end = bank_start + 16;
       int best_idx = base_idx;
@@ -205,8 +209,8 @@ void RoomLayerManager::CompositeToOutput(Room& room,
       if (pal_lut.empty() || winner_idx == other_idx) {
         return winner_idx;
       }
-      const size_t key =
-          (static_cast<size_t>(winner_idx) << 8) | static_cast<size_t>(other_idx);
+      const size_t key = (static_cast<size_t>(winner_idx) << 8) |
+                         static_cast<size_t>(other_idx);
       if (blend_cache_valid[key] != 0) {
         return blend_cache[key];
       }
@@ -252,9 +256,9 @@ void RoomLayerManager::CompositeToOutput(Room& room,
       uint8_t bg1_pixel = 255;
       uint8_t bg1_pri = 0;
       const bool bg1_obj_wrote =
-          bg1_obj_on &&
-          ((idx < static_cast<int>(bg1_obj_cov.size()) && bg1_obj_cov[idx] != 0) ||
-           !IsTransparent(bg1_obj_px[idx]));
+          bg1_obj_on && ((idx < static_cast<int>(bg1_obj_cov.size()) &&
+                          bg1_obj_cov[idx] != 0) ||
+                         !IsTransparent(bg1_obj_px[idx]));
       if (bg1_obj_wrote) {
         if (!bg1_revealed_at(bg1_objects, idx)) {
           bg1_pixel = bg1_obj_px[idx];
@@ -270,9 +274,9 @@ void RoomLayerManager::CompositeToOutput(Room& room,
       uint8_t bg2_pixel = 255;
       uint8_t bg2_pri = 0;
       const bool bg2_obj_wrote =
-          bg2_obj_on &&
-          ((idx < static_cast<int>(bg2_obj_cov.size()) && bg2_obj_cov[idx] != 0) ||
-           !IsTransparent(bg2_obj_px[idx]));
+          bg2_obj_on && ((idx < static_cast<int>(bg2_obj_cov.size()) &&
+                          bg2_obj_cov[idx] != 0) ||
+                         !IsTransparent(bg2_obj_px[idx]));
       if (bg2_obj_wrote) {
         bg2_pixel = bg2_obj_px[idx];
         bg2_pri = bg2_obj_pri[idx];

--- a/src/zelda3/dungeon/room_layer_manager.cc
+++ b/src/zelda3/dungeon/room_layer_manager.cc
@@ -90,6 +90,38 @@ void RoomLayerManager::CompositeToOutput(Room& room,
   auto& bg2_layout = GetLayerBuffer(room, LayerType::BG2_Layout);
   auto& bg2_objects = GetLayerBuffer(room, LayerType::BG2_Objects);
 
+  auto layer_enabled = [&](LayerType type,
+                           const gfx::BackgroundBuffer& buffer) {
+    if (!IsLayerVisible(type) ||
+        GetLayerBlendMode(type) == LayerBlendMode::Off) {
+      return false;
+    }
+    const auto& bitmap = buffer.bitmap();
+    return bitmap.is_active() && bitmap.width() > 0;
+  };
+
+  const bool bg1_layout_on = layer_enabled(LayerType::BG1_Layout, bg1_layout);
+  const bool bg1_obj_on = layer_enabled(LayerType::BG1_Objects, bg1_objects);
+  const bool bg2_layout_on = layer_enabled(LayerType::BG2_Layout, bg2_layout);
+  const bool bg2_obj_on = layer_enabled(LayerType::BG2_Objects, bg2_objects);
+
+  auto bg1_revealed_at = [&](const gfx::BackgroundBuffer& target, int index) {
+    const auto& mask = target.bg1_reveal_mask_data();
+    if (index < 0 || index >= static_cast<int>(mask.size())) {
+      return false;
+    }
+    const uint8_t value = mask[index];
+    const bool layout_reveal =
+        bg2_layout_on &&
+        (value & static_cast<uint8_t>(gfx::BG1RevealMaskSource::kBG2Layout)) !=
+            0;
+    const bool object_reveal =
+        bg2_obj_on &&
+        (value & static_cast<uint8_t>(gfx::BG1RevealMaskSource::kBG2Objects)) !=
+            0;
+    return layout_reveal || object_reveal;
+  };
+
   // Copy palette from first available visible layer
   auto CopyPaletteIfNeeded = [&](const gfx::Bitmap& src_bitmap) {
     if (!palette_copied && src_bitmap.surface()) {
@@ -108,20 +140,6 @@ void RoomLayerManager::CompositeToOutput(Room& room,
     // then resolve BG1 vs BG2 per-pixel using the stored priority buffers.
     // When BG2 is translucent (water rooms, color math), we blend colors
     // using the SDL palette instead of simple overwrite.
-    auto layer_enabled = [&](LayerType type, const gfx::BackgroundBuffer& buf) {
-      if (!IsLayerVisible(type)) {
-        return false;
-      }
-      if (GetLayerBlendMode(type) == LayerBlendMode::Off) {
-        return false;
-      }
-      const auto& bmp = buf.bitmap();
-      if (!bmp.is_active() || bmp.width() == 0) {
-        return false;
-      }
-      return true;
-    };
-
     // Ensure the output palette matches the room's SDL palette.
     if (layer_enabled(LayerType::BG1_Layout, bg1_layout)) {
       CopyPaletteIfNeeded(bg1_layout.bitmap());
@@ -229,11 +247,6 @@ void RoomLayerManager::CompositeToOutput(Room& room,
     const auto& bg1_obj_cov = bg1_objects.coverage_data();
     const auto& bg2_obj_cov = bg2_objects.coverage_data();
 
-    const bool bg1_layout_on = layer_enabled(LayerType::BG1_Layout, bg1_layout);
-    const bool bg1_obj_on = layer_enabled(LayerType::BG1_Objects, bg1_objects);
-    const bool bg2_layout_on = layer_enabled(LayerType::BG2_Layout, bg2_layout);
-    const bool bg2_obj_on = layer_enabled(LayerType::BG2_Objects, bg2_objects);
-
     auto& dst_data = output.mutable_data();
     for (int idx = 0; idx < kPixelCount; ++idx) {
       uint8_t bg1_pixel = 255;
@@ -243,11 +256,15 @@ void RoomLayerManager::CompositeToOutput(Room& room,
           ((idx < static_cast<int>(bg1_obj_cov.size()) && bg1_obj_cov[idx] != 0) ||
            !IsTransparent(bg1_obj_px[idx]));
       if (bg1_obj_wrote) {
-        bg1_pixel = bg1_obj_px[idx];
-        bg1_pri = bg1_obj_pri[idx];
+        if (!bg1_revealed_at(bg1_objects, idx)) {
+          bg1_pixel = bg1_obj_px[idx];
+          bg1_pri = bg1_obj_pri[idx];
+        }
       } else if (bg1_layout_on && !IsTransparent(bg1_layout_px[idx])) {
-        bg1_pixel = bg1_layout_px[idx];
-        bg1_pri = bg1_layout_pri[idx];
+        if (!bg1_revealed_at(bg1_layout, idx)) {
+          bg1_pixel = bg1_layout_px[idx];
+          bg1_pri = bg1_layout_pri[idx];
+        }
       }
 
       uint8_t bg2_pixel = 255;
@@ -301,16 +318,15 @@ void RoomLayerManager::CompositeToOutput(Room& room,
     // - Dark: Darkened blend (reduced brightness)
     // - Off: Layer is hidden
     //
-    // IMPORTANT: Transparent pixels (255) in BG1 layers ALWAYS reveal BG2 beneath.
-    // This is how pits work: mask objects write 255 to BG1, allowing BG2 to show.
-    auto CompositeLayer = [&](gfx::BackgroundBuffer& buffer, LayerType layer_type) {
-      if (!IsLayerVisible(layer_type)) return;
+    // Transparent BG1 pixels and active source-owned reveal bits expose BG2.
+    // The deferred bits preserve raw BG1 when their owning BG2 layer is hidden.
+    auto CompositeLayer = [&](gfx::BackgroundBuffer& buffer,
+                              LayerType layer_type) {
+      if (!layer_enabled(layer_type, buffer))
+        return;
 
       const auto& src_bitmap = buffer.bitmap();
-      if (!src_bitmap.is_active() || src_bitmap.width() == 0) return;
-
       LayerBlendMode blend_mode = GetLayerBlendMode(layer_type);
-      if (blend_mode == LayerBlendMode::Off) return;
 
       CopyPaletteIfNeeded(src_bitmap);
 
@@ -321,11 +337,16 @@ void RoomLayerManager::CompositeToOutput(Room& room,
       uint8_t layer_alpha = GetLayerAlpha(layer_type);
 
       for (int idx = 0; idx < kPixelCount; ++idx) {
+        const bool is_bg1_layer = layer_type == LayerType::BG1_Layout ||
+                                  layer_type == LayerType::BG1_Objects;
+        if (is_bg1_layer && bg1_revealed_at(buffer, idx)) {
+          continue;
+        }
         uint8_t src_pixel = src_data[idx];
 
-        // Skip transparent pixels (255 = fill color for undrawn areas)
-        // This is CRITICAL for pits: transparent BG1 pixels reveal BG2 beneath
-        if (IsTransparent(src_pixel)) continue;
+        // Skip transparent pixels (255 = fill color for undrawn areas).
+        if (IsTransparent(src_pixel))
+          continue;
 
         // Apply blend mode
         switch (blend_mode) {

--- a/src/zelda3/dungeon/room_layout.cc
+++ b/src/zelda3/dungeon/room_layout.cc
@@ -135,6 +135,7 @@ absl::Status RoomLayout::Draw(int room_id, const uint8_t* gfx_data,
 
   ObjectDrawer drawer(rom_, room_id, gfx_data);
   drawer.SetAllowTrackCornerAliases(false);
+  drawer.SetBG1RevealMaskSource(gfx::BG1RevealMaskSource::kBG2Layout);
 
   std::vector<RoomObject> render_objects = objects_;
   for (auto& obj : render_objects) {
@@ -147,8 +148,7 @@ absl::Status RoomLayout::Draw(int room_id, const uint8_t* gfx_data,
   // upper-layer tilemap pointer set for the visible room shell. Keep track-corner
   // aliases disabled so vanilla wall corners survive, but preserve BG2 routing for
   // pit/mask objects that intentionally reveal the lower layer.
-  return drawer.DrawObjectList(render_objects, bg1, bg2, palette_group, state,
-                               &bg1);
+  return drawer.DrawObjectList(render_objects, bg1, bg2, palette_group, state);
 }
 
 }  // namespace yaze::zelda3

--- a/test/integration/zelda3/dungeon_room_regression_fixtures_test.cc
+++ b/test/integration/zelda3/dungeon_room_regression_fixtures_test.cc
@@ -500,11 +500,10 @@ TEST_F(DungeonRoomRegressionFixturesTest,
     ASSERT_NE(state, nullptr);
     state->SetFloorBombable(0x065, test_case.bombed);
 
-    // The Mesen fixtures isolate the raw upper SNES tilemap. Yaze's normal
-    // combined render lets lower-tilemap masks clear upper-layer pixels for
-    // the editor composite, so omit list 1 before rendering this BG1-only
-    // comparison. Room 0x065 has no BothBG objects in that list.
-    auto& objects = room.GetTileObjects();
+    // The Mesen fixtures isolate the raw upper SNES tilemap. Keep the complete
+    // room stream: lower-layer reveal masks are now deferred until compositing
+    // and must be inactive when both BG2 layers are hidden below.
+    const auto& objects = room.GetTileObjects();
     const auto lower_list_count = std::count_if(
         objects.begin(), objects.end(),
         [](const RoomObject& obj) { return obj.GetLayerValue() == 1; });
@@ -515,12 +514,6 @@ TEST_F(DungeonRoomRegressionFixturesTest,
             << "Room 0x065 BG1-only reconstruction assumptions changed.";
       }
     }
-    objects.erase(std::remove_if(objects.begin(), objects.end(),
-                                 [](const RoomObject& object) {
-                                   return object.GetLayerValue() == 1;
-                                 }),
-                  objects.end());
-
     room.LoadSprites();
     room.SetRenderEntranceBlockset(kRoom065EntranceBlockset);
     room.RenderRoomGraphics();

--- a/test/unit/zelda3/dungeon/custom_object_room_render_test.cc
+++ b/test/unit/zelda3/dungeon/custom_object_room_render_test.cc
@@ -176,6 +176,62 @@ TEST_F(CustomObjectRoomRenderTest,
 }
 
 TEST_F(CustomObjectRoomRenderTest,
+       ObjectRerenderClearsOnlyObjectOwnedRevealBits) {
+  RoomObject lower(/*id=*/0x34, /*x=*/2, /*y=*/3, /*size=*/0, /*layer=*/1);
+  lower.tiles_loaded_ = true;
+  lower.tiles_ = {gfx::TileInfo(/*id=*/0, /*pal=*/2, false, false, false)};
+  Room room = MakeRoomWithObject(lower);
+  RenderObjectBuffers(room);
+
+  const uint8_t object_bit =
+      static_cast<uint8_t>(gfx::BG1RevealMaskSource::kBG2Objects);
+  const uint8_t layout_bit =
+      static_cast<uint8_t>(gfx::BG1RevealMaskSource::kBG2Layout);
+  const auto& initial_mask = room.object_bg1_buffer().bg1_reveal_mask_data();
+  const auto masked =
+      std::find_if(initial_mask.begin(), initial_mask.end(),
+                   [&](uint8_t value) { return (value & object_bit) != 0; });
+  ASSERT_NE(masked, initial_mask.end());
+  const size_t index = static_cast<size_t>(masked - initial_mask.begin());
+  const int x = static_cast<int>(index % 512);
+  const int y = static_cast<int>(index / 512);
+
+  room.object_bg1_buffer().SetBG1RevealMaskRect(
+      gfx::BG1RevealMaskSource::kBG2Layout, x, y, 1, 1);
+  room.bg1_buffer().SetBG1RevealMaskRect(gfx::BG1RevealMaskSource::kBG2Layout,
+                                         x, y, 1, 1);
+
+  room.SetTileObjects({});
+  room.MarkObjectsDirty();
+  RenderObjectBuffers(room);
+
+  EXPECT_EQ(room.object_bg1_buffer().bg1_reveal_mask_data()[index] & object_bit,
+            0);
+  EXPECT_NE(room.object_bg1_buffer().bg1_reveal_mask_data()[index] & layout_bit,
+            0);
+  EXPECT_EQ(room.bg1_buffer().bg1_reveal_mask_data()[index] & object_bit, 0);
+  EXPECT_NE(room.bg1_buffer().bg1_reveal_mask_data()[index] & layout_bit, 0);
+}
+
+TEST_F(CustomObjectRoomRenderTest, EmptyLayoutClearsOnlyLayoutOwnedRevealBits) {
+  WriteLayoutObjects(/*layout_id=*/0, {});
+  Room room(/*room_id=*/0, rom_.get(), &game_data_);
+  room.SetLayoutId(0);
+  room.bg1_buffer().SetBG1RevealMaskRect(gfx::BG1RevealMaskSource::kBG2Layout,
+                                         0, 0, 1, 1);
+  room.bg1_buffer().SetBG1RevealMaskRect(gfx::BG1RevealMaskSource::kBG2Objects,
+                                         0, 0, 1, 1);
+
+  room.LoadLayoutTilesToBuffer();
+
+  const uint8_t value = room.bg1_buffer().bg1_reveal_mask_data()[0];
+  EXPECT_EQ(value & static_cast<uint8_t>(gfx::BG1RevealMaskSource::kBG2Layout),
+            0);
+  EXPECT_NE(value & static_cast<uint8_t>(gfx::BG1RevealMaskSource::kBG2Objects),
+            0);
+}
+
+TEST_F(CustomObjectRoomRenderTest,
        MissingCustomObjectBinDrawsDiagnosticPlaceholderOnRoomCanvas) {
   EnableCustomObjects({"missing_track.bin"});
 

--- a/test/unit/zelda3/dungeon/object_drawer_registry_replay_test.cc
+++ b/test/unit/zelda3/dungeon/object_drawer_registry_replay_test.cc
@@ -2518,7 +2518,10 @@ TEST(ObjectDrawerRegistryReplayTest,
   }
 }
 
-TEST(ObjectDrawerMaskPropagationTest, Layer2PitMaskMarksBG1Transparent) {
+constexpr uint8_t kBG2ObjectRevealMask =
+    static_cast<uint8_t>(gfx::BG1RevealMaskSource::kBG2Objects);
+
+TEST(ObjectDrawerMaskPropagationTest, Layer2PitMaskRecordsBG1Reveal) {
   ScopedCustomObjectsFlag disable_custom(false);
 
   Rom rom;
@@ -2568,9 +2571,10 @@ TEST(ObjectDrawerMaskPropagationTest, Layer2PitMaskMarksBG1Transparent) {
                               /*state=*/nullptr, /*layout_bg1=*/&layout_bg1)
                   .ok());
 
-  // Both the object BG1 buffer and the layout BG1 buffer should be masked.
-  EXPECT_EQ(obj_bg1.bitmap().data()[idx], 255);
-  EXPECT_EQ(layout_bg1.bitmap().data()[idx], 255);
+  EXPECT_EQ(obj_bg1.bitmap().data()[idx], 10);
+  EXPECT_EQ(layout_bg1.bitmap().data()[idx], 11);
+  EXPECT_NE(obj_bg1.bg1_reveal_mask_data()[idx] & kBG2ObjectRevealMask, 0);
+  EXPECT_NE(layout_bg1.bg1_reveal_mask_data()[idx] & kBG2ObjectRevealMask, 0);
 }
 
 TEST(ObjectDrawerMaskPropagationTest, Layer2LargeCeilingMasksBG1Transparent) {
@@ -2617,8 +2621,10 @@ TEST(ObjectDrawerMaskPropagationTest, Layer2LargeCeilingMasksBG1Transparent) {
                               /*state=*/nullptr, /*layout_bg1=*/&layout_bg1)
                   .ok());
 
-  EXPECT_EQ(obj_bg1.bitmap().data()[idx], 255);
-  EXPECT_EQ(layout_bg1.bitmap().data()[idx], 255);
+  EXPECT_EQ(obj_bg1.bitmap().data()[idx], 10);
+  EXPECT_EQ(layout_bg1.bitmap().data()[idx], 11);
+  EXPECT_NE(obj_bg1.bg1_reveal_mask_data()[idx] & kBG2ObjectRevealMask, 0);
+  EXPECT_NE(layout_bg1.bg1_reveal_mask_data()[idx] & kBG2ObjectRevealMask, 0);
 }
 
 TEST(ObjectDrawerMaskPropagationTest, Layer2WaterFloorMasksBG1Transparent) {
@@ -2668,8 +2674,10 @@ TEST(ObjectDrawerMaskPropagationTest, Layer2WaterFloorMasksBG1Transparent) {
                               /*state=*/nullptr, /*layout_bg1=*/&layout_bg1)
                   .ok());
 
-  EXPECT_EQ(obj_bg1.bitmap().data()[idx], 255);
-  EXPECT_EQ(layout_bg1.bitmap().data()[idx], 255);
+  EXPECT_EQ(obj_bg1.bitmap().data()[idx], 10);
+  EXPECT_EQ(layout_bg1.bitmap().data()[idx], 11);
+  EXPECT_NE(obj_bg1.bg1_reveal_mask_data()[idx] & kBG2ObjectRevealMask, 0);
+  EXPECT_NE(layout_bg1.bg1_reveal_mask_data()[idx] & kBG2ObjectRevealMask, 0);
 }
 
 TEST(ObjectDrawerMaskPropagationTest, Layer2FloodWaterMasksBG1Transparent) {
@@ -2721,8 +2729,12 @@ TEST(ObjectDrawerMaskPropagationTest, Layer2FloodWaterMasksBG1Transparent) {
                                 /*layout_bg1=*/&layout_bg1)
                     .ok());
 
-    EXPECT_EQ(obj_bg1.bitmap().data()[idx], 255) << object_id;
-    EXPECT_EQ(layout_bg1.bitmap().data()[idx], 255) << object_id;
+    EXPECT_EQ(obj_bg1.bitmap().data()[idx], 10) << object_id;
+    EXPECT_EQ(layout_bg1.bitmap().data()[idx], 11) << object_id;
+    EXPECT_NE(obj_bg1.bg1_reveal_mask_data()[idx] & kBG2ObjectRevealMask, 0)
+        << object_id;
+    EXPECT_NE(layout_bg1.bg1_reveal_mask_data()[idx] & kBG2ObjectRevealMask, 0)
+        << object_id;
   }
 }
 
@@ -2766,16 +2778,76 @@ TEST(ObjectDrawerMaskPropagationTest,
   const int opaque_idx = base_y * obj_bg1.bitmap().width() + base_x;
   const int transparent_idx = opaque_idx + 1;
   ASSERT_LT(transparent_idx, static_cast<int>(obj_bg1.bitmap().size()));
+  const auto obj_bg1_before = obj_bg1.bitmap().vector();
+  const auto layout_bg1_before = layout_bg1.bitmap().vector();
 
   ASSERT_TRUE(drawer
                   .DrawObject(obj, obj_bg1, obj_bg2, palette_group,
                               /*state=*/nullptr, /*layout_bg1=*/&layout_bg1)
                   .ok());
 
-  EXPECT_EQ(obj_bg1.bitmap().data()[opaque_idx], 255);
-  EXPECT_EQ(layout_bg1.bitmap().data()[opaque_idx], 255);
-  EXPECT_EQ(obj_bg1.bitmap().data()[transparent_idx], 10);
-  EXPECT_EQ(layout_bg1.bitmap().data()[transparent_idx], 11);
+  EXPECT_EQ(obj_bg1.bitmap().vector(), obj_bg1_before);
+  EXPECT_EQ(layout_bg1.bitmap().vector(), layout_bg1_before);
+  EXPECT_NE(obj_bg1.bg1_reveal_mask_data()[opaque_idx] & kBG2ObjectRevealMask,
+            0);
+  EXPECT_NE(
+      layout_bg1.bg1_reveal_mask_data()[opaque_idx] & kBG2ObjectRevealMask, 0);
+  EXPECT_EQ(
+      obj_bg1.bg1_reveal_mask_data()[transparent_idx] & kBG2ObjectRevealMask,
+      0);
+  EXPECT_EQ(
+      layout_bg1.bg1_reveal_mask_data()[transparent_idx] & kBG2ObjectRevealMask,
+      0);
+}
+
+TEST(ObjectDrawerMaskPropagationTest,
+     LaterBG1WriteClearsOnlyItsStreamRevealBit) {
+  ScopedCustomObjectsFlag disable_custom(false);
+
+  Rom rom;
+  ASSERT_TRUE(rom.LoadFromData(std::vector<uint8_t>(1024 * 1024, 0)).ok());
+
+  std::array<uint8_t, 0x10000> gfx{};
+  gfx[0] = 1;
+
+  gfx::BackgroundBuffer obj_bg1(512, 512);
+  gfx::BackgroundBuffer obj_bg2(512, 512);
+  gfx::BackgroundBuffer layout_bg1(512, 512);
+  for (auto* buffer : {&obj_bg1, &obj_bg2, &layout_bg1}) {
+    buffer->EnsureBitmapInitialized();
+    buffer->bitmap().Fill(255);
+  }
+
+  ObjectDrawer drawer(&rom, /*room_id=*/0, gfx.data());
+  RoomObject lower(0x0034, /*x=*/2, /*y=*/3, /*size=*/0, /*layer=*/1);
+  lower.tiles_loaded_ = true;
+  lower.tiles_ = {gfx::TileInfo(/*id=*/0, /*pal=*/2, false, false, false)};
+  gfx::PaletteGroup palette_group;
+
+  ASSERT_TRUE(drawer
+                  .DrawObject(lower, obj_bg1, obj_bg2, palette_group,
+                              /*state=*/nullptr, /*layout_bg1=*/&layout_bg1)
+                  .ok());
+
+  const int pixel_x = (lower.x_ + 3) * 8;
+  const int pixel_y = lower.y_ * 8;
+  const int index = pixel_y * obj_bg1.bitmap().width() + pixel_x;
+  ASSERT_NE(obj_bg1.bg1_reveal_mask_data()[index] & kBG2ObjectRevealMask, 0);
+
+  obj_bg1.SetBG1RevealMaskRect(gfx::BG1RevealMaskSource::kBG2Layout, pixel_x,
+                               pixel_y, 1, 1);
+  RoomObject later_upper = lower;
+  later_upper.layer_ = RoomObject::LayerType::BG1;
+  ASSERT_TRUE(
+      drawer.DrawObject(later_upper, obj_bg1, obj_bg2, palette_group).ok());
+
+  const uint8_t remaining = obj_bg1.bg1_reveal_mask_data()[index];
+  EXPECT_EQ(remaining & kBG2ObjectRevealMask, 0);
+  EXPECT_NE(
+      remaining & static_cast<uint8_t>(gfx::BG1RevealMaskSource::kBG2Layout),
+      0);
+  EXPECT_NE(obj_bg1.bitmap().data()[index], 255);
+  EXPECT_NE(layout_bg1.bg1_reveal_mask_data()[index] & kBG2ObjectRevealMask, 0);
 }
 
 TEST(ObjectDrawerMaskPropagationTest, Layer2SpiralStairsUsePerPixelMasking) {
@@ -2826,10 +2898,18 @@ TEST(ObjectDrawerMaskPropagationTest, Layer2SpiralStairsUsePerPixelMasking) {
                               /*state=*/nullptr, /*layout_bg1=*/&layout_bg1)
                   .ok());
 
-  EXPECT_EQ(obj_bg1.bitmap().data()[opaque_idx], 255);
-  EXPECT_EQ(layout_bg1.bitmap().data()[opaque_idx], 255);
-  EXPECT_EQ(obj_bg1.bitmap().data()[transparent_idx], 10);
-  EXPECT_EQ(layout_bg1.bitmap().data()[transparent_idx], 11);
+  EXPECT_EQ(obj_bg1.bitmap().data()[opaque_idx], 10);
+  EXPECT_EQ(layout_bg1.bitmap().data()[opaque_idx], 11);
+  EXPECT_NE(obj_bg1.bg1_reveal_mask_data()[opaque_idx] & kBG2ObjectRevealMask,
+            0);
+  EXPECT_NE(
+      layout_bg1.bg1_reveal_mask_data()[opaque_idx] & kBG2ObjectRevealMask, 0);
+  EXPECT_EQ(
+      obj_bg1.bg1_reveal_mask_data()[transparent_idx] & kBG2ObjectRevealMask,
+      0);
+  EXPECT_EQ(
+      layout_bg1.bg1_reveal_mask_data()[transparent_idx] & kBG2ObjectRevealMask,
+      0);
 }
 
 TEST(ObjectDrawerRegistryReplayTest,
@@ -3098,10 +3178,22 @@ TEST(ObjectDrawerMaskPropagationTest,
     const int transparent_idx = opaque_idx + 1;
 
     ASSERT_LT(transparent_idx, static_cast<int>(obj_bg1.bitmap().size()));
-    EXPECT_EQ(obj_bg1.bitmap().data()[opaque_idx], 255) << object_id;
-    EXPECT_EQ(layout_bg1.bitmap().data()[opaque_idx], 255) << object_id;
-    EXPECT_EQ(obj_bg1.bitmap().data()[transparent_idx], 10) << object_id;
-    EXPECT_EQ(layout_bg1.bitmap().data()[transparent_idx], 11) << object_id;
+    EXPECT_EQ(obj_bg1.bitmap().data()[opaque_idx], 10) << object_id;
+    EXPECT_EQ(layout_bg1.bitmap().data()[opaque_idx], 11) << object_id;
+    EXPECT_NE(obj_bg1.bg1_reveal_mask_data()[opaque_idx] & kBG2ObjectRevealMask,
+              0)
+        << object_id;
+    EXPECT_NE(
+        layout_bg1.bg1_reveal_mask_data()[opaque_idx] & kBG2ObjectRevealMask, 0)
+        << object_id;
+    EXPECT_EQ(
+        obj_bg1.bg1_reveal_mask_data()[transparent_idx] & kBG2ObjectRevealMask,
+        0)
+        << object_id;
+    EXPECT_EQ(layout_bg1.bg1_reveal_mask_data()[transparent_idx] &
+                  kBG2ObjectRevealMask,
+              0)
+        << object_id;
   }
 }
 

--- a/test/unit/zelda3/dungeon/room_layer_manager_test.cc
+++ b/test/unit/zelda3/dungeon/room_layer_manager_test.cc
@@ -1,5 +1,5 @@
-#include "gtest/gtest.h"
 #include "zelda3/dungeon/room_layer_manager.h"
+#include "gtest/gtest.h"
 #include "zelda3/dungeon/room.h"
 
 namespace yaze {
@@ -24,7 +24,8 @@ TEST_F(RoomLayerManagerTest, DefaultVisibilityAllLayersVisible) {
 TEST_F(RoomLayerManagerTest, SetLayerVisibleWorks) {
   manager_.SetLayerVisible(LayerType::BG1_Objects, false);
   EXPECT_FALSE(manager_.IsLayerVisible(LayerType::BG1_Objects));
-  EXPECT_TRUE(manager_.IsLayerVisible(LayerType::BG1_Layout));  // Others unchanged
+  EXPECT_TRUE(
+      manager_.IsLayerVisible(LayerType::BG1_Layout));  // Others unchanged
 
   manager_.SetLayerVisible(LayerType::BG1_Objects, true);
   EXPECT_TRUE(manager_.IsLayerVisible(LayerType::BG1_Objects));
@@ -33,13 +34,15 @@ TEST_F(RoomLayerManagerTest, SetLayerVisibleWorks) {
 TEST_F(RoomLayerManagerTest, ResetRestoresDefaults) {
   manager_.SetLayerVisible(LayerType::BG1_Layout, false);
   manager_.SetLayerVisible(LayerType::BG2_Objects, false);
-  manager_.SetLayerBlendMode(LayerType::BG2_Layout, LayerBlendMode::Translucent);
+  manager_.SetLayerBlendMode(LayerType::BG2_Layout,
+                             LayerBlendMode::Translucent);
 
   manager_.Reset();
 
   EXPECT_TRUE(manager_.IsLayerVisible(LayerType::BG1_Layout));
   EXPECT_TRUE(manager_.IsLayerVisible(LayerType::BG2_Objects));
-  EXPECT_EQ(manager_.GetLayerBlendMode(LayerType::BG2_Layout), LayerBlendMode::Normal);
+  EXPECT_EQ(manager_.GetLayerBlendMode(LayerType::BG2_Layout),
+            LayerBlendMode::Normal);
 }
 
 // =============================================================================
@@ -47,15 +50,18 @@ TEST_F(RoomLayerManagerTest, ResetRestoresDefaults) {
 // =============================================================================
 
 TEST_F(RoomLayerManagerTest, DefaultBlendModeIsNormal) {
-  EXPECT_EQ(manager_.GetLayerBlendMode(LayerType::BG1_Layout), LayerBlendMode::Normal);
-  EXPECT_EQ(manager_.GetLayerBlendMode(LayerType::BG2_Layout), LayerBlendMode::Normal);
+  EXPECT_EQ(manager_.GetLayerBlendMode(LayerType::BG1_Layout),
+            LayerBlendMode::Normal);
+  EXPECT_EQ(manager_.GetLayerBlendMode(LayerType::BG2_Layout),
+            LayerBlendMode::Normal);
 }
 
 TEST_F(RoomLayerManagerTest, SetBlendModeUpdatesAlpha) {
   manager_.SetLayerBlendMode(LayerType::BG2_Layout, LayerBlendMode::Normal);
   EXPECT_EQ(manager_.GetLayerAlpha(LayerType::BG2_Layout), 255);
 
-  manager_.SetLayerBlendMode(LayerType::BG2_Layout, LayerBlendMode::Translucent);
+  manager_.SetLayerBlendMode(LayerType::BG2_Layout,
+                             LayerBlendMode::Translucent);
   EXPECT_EQ(manager_.GetLayerAlpha(LayerType::BG2_Layout), 180);
 
   manager_.SetLayerBlendMode(LayerType::BG2_Layout, LayerBlendMode::Off);
@@ -128,7 +134,8 @@ TEST_F(RoomLayerManagerTest, ApplyLayerMergingNormal) {
   manager_.ApplyLayerMerging(merge);
 
   EXPECT_FALSE(manager_.IsBG2OnTop());  // Normal has Layer2OnTop=false
-  EXPECT_EQ(manager_.GetLayerBlendMode(LayerType::BG2_Layout), LayerBlendMode::Normal);
+  EXPECT_EQ(manager_.GetLayerBlendMode(LayerType::BG2_Layout),
+            LayerBlendMode::Normal);
 }
 
 TEST_F(RoomLayerManagerTest, ApplyLayerMergingTranslucent) {
@@ -136,19 +143,24 @@ TEST_F(RoomLayerManagerTest, ApplyLayerMergingTranslucent) {
   manager_.ApplyLayerMerging(merge);
 
   EXPECT_TRUE(manager_.IsBG2OnTop());
-  EXPECT_EQ(manager_.GetLayerBlendMode(LayerType::BG2_Layout), LayerBlendMode::Translucent);
-  EXPECT_EQ(manager_.GetLayerBlendMode(LayerType::BG2_Objects), LayerBlendMode::Translucent);
+  EXPECT_EQ(manager_.GetLayerBlendMode(LayerType::BG2_Layout),
+            LayerBlendMode::Translucent);
+  EXPECT_EQ(manager_.GetLayerBlendMode(LayerType::BG2_Objects),
+            LayerBlendMode::Translucent);
 }
 
 TEST_F(RoomLayerManagerTest, ApplyLayerMergingOff) {
   LayerMergeType merge{0x00, "Off", false, false, false};
   manager_.ApplyLayerMerging(merge);
 
-  EXPECT_EQ(manager_.GetLayerBlendMode(LayerType::BG2_Layout), LayerBlendMode::Normal);
-  EXPECT_EQ(manager_.GetLayerBlendMode(LayerType::BG2_Objects), LayerBlendMode::Normal);
+  EXPECT_EQ(manager_.GetLayerBlendMode(LayerType::BG2_Layout),
+            LayerBlendMode::Normal);
+  EXPECT_EQ(manager_.GetLayerBlendMode(LayerType::BG2_Objects),
+            LayerBlendMode::Normal);
 }
 
-TEST_F(RoomLayerManagerTest, ApplyRoomEffectMovingWaterPromotesBG2Translucency) {
+TEST_F(RoomLayerManagerTest,
+       ApplyRoomEffectMovingWaterPromotesBG2Translucency) {
   manager_.SetLayerBlendMode(LayerType::BG2_Layout, LayerBlendMode::Normal);
   manager_.SetLayerBlendMode(LayerType::BG2_Objects, LayerBlendMode::Normal);
 
@@ -177,15 +189,21 @@ TEST_F(RoomLayerManagerTest, ApplyRoomEffectPreservesExplicitBlendModes) {
 // =============================================================================
 
 TEST_F(RoomLayerManagerTest, GetLayerNameReturnsCorrectStrings) {
-  EXPECT_STREQ(RoomLayerManager::GetLayerName(LayerType::BG1_Layout), "BG1 Layout");
-  EXPECT_STREQ(RoomLayerManager::GetLayerName(LayerType::BG1_Objects), "BG1 Objects");
-  EXPECT_STREQ(RoomLayerManager::GetLayerName(LayerType::BG2_Layout), "BG2 Layout");
-  EXPECT_STREQ(RoomLayerManager::GetLayerName(LayerType::BG2_Objects), "BG2 Objects");
+  EXPECT_STREQ(RoomLayerManager::GetLayerName(LayerType::BG1_Layout),
+               "BG1 Layout");
+  EXPECT_STREQ(RoomLayerManager::GetLayerName(LayerType::BG1_Objects),
+               "BG1 Objects");
+  EXPECT_STREQ(RoomLayerManager::GetLayerName(LayerType::BG2_Layout),
+               "BG2 Layout");
+  EXPECT_STREQ(RoomLayerManager::GetLayerName(LayerType::BG2_Objects),
+               "BG2 Objects");
 }
 
 TEST_F(RoomLayerManagerTest, GetBlendModeNameReturnsCorrectStrings) {
-  EXPECT_STREQ(RoomLayerManager::GetBlendModeName(LayerBlendMode::Normal), "Normal");
-  EXPECT_STREQ(RoomLayerManager::GetBlendModeName(LayerBlendMode::Translucent), "Translucent");
+  EXPECT_STREQ(RoomLayerManager::GetBlendModeName(LayerBlendMode::Normal),
+               "Normal");
+  EXPECT_STREQ(RoomLayerManager::GetBlendModeName(LayerBlendMode::Translucent),
+               "Translucent");
   EXPECT_STREQ(RoomLayerManager::GetBlendModeName(LayerBlendMode::Off), "Off");
 }
 

--- a/test/unit/zelda3/dungeon/room_layer_manager_test.cc
+++ b/test/unit/zelda3/dungeon/room_layer_manager_test.cc
@@ -311,6 +311,90 @@ TEST_F(RoomLayerManagerTest, Coverage_ObjectTransparentWriteClearsLayout) {
 }
 
 TEST_F(RoomLayerManagerTest,
+       CrossLayerRevealMasksFollowOwnerVisibilityAndTargetOrder) {
+  for (const bool priority_compositing : {true, false}) {
+    SCOPED_TRACE(priority_compositing ? "priority" : "simple");
+    RoomLayerManager manager;
+    manager.SetPriorityCompositing(priority_compositing);
+
+    Room room(/*room_id=*/0, /*rom=*/nullptr);
+    for (auto* buffer :
+         {&room.bg1_buffer(), &room.bg2_buffer(), &room.object_bg1_buffer(),
+          &room.object_bg2_buffer()}) {
+      buffer->EnsureBitmapInitialized();
+      buffer->bitmap().Fill(255);
+      buffer->ClearPriorityBuffer();
+      buffer->ClearCoverageBuffer();
+      buffer->ClearBG1RevealMask();
+    }
+
+    // Layout-owned reveal at pixel 0.
+    room.bg1_buffer().bitmap().mutable_data()[0] = 11;
+    room.bg1_buffer().mutable_priority_data()[0] = 0;
+    room.bg2_buffer().bitmap().mutable_data()[0] = 21;
+    room.bg2_buffer().mutable_priority_data()[0] = 0;
+    room.bg1_buffer().SetBG1RevealMaskRect(gfx::BG1RevealMaskSource::kBG2Layout,
+                                           0, 0, 1, 1);
+
+    // Object-owned reveal at pixel 1.
+    room.object_bg1_buffer().bitmap().mutable_data()[1] = 12;
+    room.object_bg1_buffer().mutable_priority_data()[1] = 0;
+    room.object_bg1_buffer().mutable_coverage_data()[1] = 1;
+    room.object_bg2_buffer().bitmap().mutable_data()[1] = 22;
+    room.object_bg2_buffer().mutable_priority_data()[1] = 0;
+    room.object_bg2_buffer().mutable_coverage_data()[1] = 1;
+    room.object_bg1_buffer().SetBG1RevealMaskRect(
+        gfx::BG1RevealMaskSource::kBG2Objects, 1, 0, 1, 1);
+
+    // A layout reveal must not suppress a later BG1 object at pixel 2.
+    room.bg1_buffer().bitmap().mutable_data()[2] = 13;
+    room.bg2_buffer().bitmap().mutable_data()[2] = 23;
+    room.bg1_buffer().SetBG1RevealMaskRect(gfx::BG1RevealMaskSource::kBG2Layout,
+                                           2, 0, 1, 1);
+    room.object_bg1_buffer().bitmap().mutable_data()[2] = 14;
+    room.object_bg1_buffer().mutable_priority_data()[2] = 0;
+    room.object_bg1_buffer().mutable_coverage_data()[2] = 1;
+
+    // A later BG1 object has cleared its target's object-source bit at pixel 3;
+    // the corresponding layout-target bit must not punch through that object.
+    room.bg1_buffer().bitmap().mutable_data()[3] = 15;
+    room.bg1_buffer().SetBG1RevealMaskRect(
+        gfx::BG1RevealMaskSource::kBG2Objects, 3, 0, 1, 1);
+    room.object_bg1_buffer().bitmap().mutable_data()[3] = 16;
+    room.object_bg1_buffer().mutable_priority_data()[3] = 0;
+    room.object_bg1_buffer().mutable_coverage_data()[3] = 1;
+    room.object_bg2_buffer().bitmap().mutable_data()[3] = 24;
+    room.object_bg2_buffer().mutable_coverage_data()[3] = 1;
+
+    const auto raw_layout = room.bg1_buffer().bitmap().vector();
+    const auto raw_objects = room.object_bg1_buffer().bitmap().vector();
+    auto expect_pixels = [&](uint8_t pixel0, uint8_t pixel1) {
+      const auto& composite = room.GetCompositeBitmap(manager);
+      ASSERT_TRUE(composite.is_active());
+      EXPECT_EQ(composite.data()[0], pixel0);
+      EXPECT_EQ(composite.data()[1], pixel1);
+      EXPECT_EQ(composite.data()[2], 14);
+      EXPECT_EQ(composite.data()[3], 16);
+    };
+
+    expect_pixels(21, 22);
+
+    manager.SetLayerVisible(LayerType::BG2_Layout, false);
+    expect_pixels(11, 22);
+
+    manager.SetLayerVisible(LayerType::BG2_Layout, true);
+    manager.SetLayerVisible(LayerType::BG2_Objects, false);
+    expect_pixels(21, 12);
+
+    manager.SetLayerVisible(LayerType::BG2_Objects, true);
+    expect_pixels(21, 22);
+
+    EXPECT_EQ(room.bg1_buffer().bitmap().vector(), raw_layout);
+    EXPECT_EQ(room.object_bg1_buffer().bitmap().vector(), raw_objects);
+  }
+}
+
+TEST_F(RoomLayerManagerTest,
        CompositeCacheInvalidatesWhenLayerManagerStateChanges) {
   Room room(/*room_id=*/0, /*rom=*/nullptr);
   room.bg1_buffer().EnsureBitmapInitialized();


### PR DESCRIPTION
Fixes #139

## Summary
- preserve raw BG1 layout and object buffers instead of replacing masked pixels with transparent index `255`
- record lazy per-pixel reveal bits by BG2 layout/object ownership
- clear only the relevant source-owned bits when later BG1 writes or partial rerenders supersede a reveal
- apply reveals during both priority and simple compositing only while their owning BG2 source is visible and enabled
- retain the complete room `0x065` object stream in the independent intact/bombed Mesen regression

## Verification
- focused mask, ownership, lifecycle, visibility, target-order, and layer-manager unit coverage: **33/33 passed**
- canonical-US room `0x065` complete-stream Mesen regression: **1/1 passed**, exact RGBA for intact and bombed states with both BG2 sources hidden
- clean exact-`master` differential at `607f908df2183c6b1ce28c79241a1d549f4a1846`: all five full-room visible composite checksums and non-backdrop counts are unchanged
  - room `0x016`: `2251720105443116807` / `208440` on both clean master and this branch

`DungeonRoomRegressionFixturesTest.PerLayerFingerprintsMatchGolden` already has stale hard-coded raw/checksum expectations on clean master. The clean-worktree differential above separates those pre-existing failures from this change: visible composites are identical, while raw BG1 bytes change only in mask-affected rooms as intended.

## Regression coverage
- rectangular pit, ceiling, water-floor, and flood-water masks
- ordinary, spiral-stair, and diagonal per-pixel masks
- later BG1 writes overriding only their own stream's reveal bit
- layout/object rerenders preserving the other source's reveal state
- source visibility and layout/object target order under priority and simple compositing
- room `0x065` with all four list-1 `0xFF0` objects retained

## Scope / residual
- no ROM-writing or persistence path changed
- no ROM or visual fixture was modified
- reveal masks allocate lazily; a mask-bearing room can retain up to roughly 512 KiB across its two BG1 targets
