### PR TITLE
fix(dungeon): match prison-cell USDASM layout

### DIFF
--- a/docs/internal/architecture/dungeon_editor_system.md
+++ b/docs/internal/architecture/dungeon_editor_system.md
@@ -129,7 +129,7 @@ Subsystem for accurate SNES-style layer compositing of dungeon room renders.
 
 **Draw Routine Registry:**
 - **DrawRoutineRegistry** (`zelda3/dungeon/draw_routines/draw_routine_registry.{h,cc}`) — Singleton mapping all 448 vanilla object IDs to routine IDs (0–130). 100% coverage: 256 subtype 1, 64 subtype 2, 128 subtype 3.
-- Per-routine metadata includes `draws_to_both_bgs` flag for routines that explicitly write both tilemaps (e.g., routine 2/kRightwards2x4, routine 19/Corner4x4, routine 97/PrisonCell).
+- Per-routine metadata includes `draws_to_both_bgs` for routines that explicitly write both tilemaps (for example, routine 2/kRightwards2x4 and routine 19/Corner4x4). Routine 97/PrisonCell follows the current object-stream tilemap selected by `$BF` and is not dual-layer.
 
 **Validation:**
 - 19 parity tests in `test/unit/zelda3/dungeon/object_drawing_comprehensive_test.cc` validate routine coverage, palette offsets, pit/mask identification, BothBG flags, water layer semantics, room effects, and layer merge behavior.

--- a/src/zelda3/dungeon/draw_routines/special_routines.cc
+++ b/src/zelda3/dungeon/draw_routines/special_routines.cc
@@ -1065,62 +1065,55 @@ void DrawStraightInterRoomStairs(const DrawContext& ctx) {
 
 void DrawPrisonCell(const DrawContext& ctx) {
   // ASM: RoomDraw_PrisonCell ($019C44)
-  // Draws prison cell bars to BOTH BG layers with horizontal flip for symmetry
-  // The ASM writes to $7E2xxx (BG1) and also uses ORA #$4000 for horizontal flip
-  // Pattern: 5 iterations drawing a complex bar pattern
-
-  if (ctx.tiles.size() < 6)
+  // The routine selects the current object-list tilemap through $BF, then
+  // writes one sparse 16x4 cell. Offsets below are the tile-coordinate form of
+  // the long writes at $019C5A-$019CC5. In particular, columns 7 and 8 remain
+  // open on rows 1-3 so objects drawn earlier (room 0x080's big-key lock) show
+  // through the cell opening.
+  if (ctx.tiles.size() < 6) {
     return;
+  }
 
-  // Prison cell layout based on ASM analysis:
-  // The routine draws 5 columns of bars, each with specific tile patterns
-  // Tiles at positions: (x, y), (x+7, y) for outer bars
-  // Middle bars with horizontal flip on one side
+  const int base_x = ctx.object.x_;
+  const int base_y = ctx.object.y_;
 
-  int base_x = ctx.object.x_;
-  int base_y = ctx.object.y_;
+  auto with_horizontal_mirror = [](gfx::TileInfo tile) {
+    // USDASM uses ORA #$4000 for these writes: force H-flip on rather than
+    // toggling whatever bit a modified ROM supplied in obj1488.
+    tile.horizontal_mirror_ = true;
+    return tile;
+  };
 
-  // Draw the prison cell pattern - 5 vertical bar segments
   for (int col = 0; col < 5; ++col) {
-    int x_offset = col;
-
-    // Each column has 4 rows of tiles
-    for (int row = 0; row < 4; ++row) {
-      size_t tile_idx = (row < static_cast<int>(ctx.tiles.size())) ? row : 0;
-
-      // Left side bar
-      DrawRoutineUtils::WriteTile8(ctx.target_bg, base_x + x_offset,
-                                   base_y + row, ctx.tiles[tile_idx]);
-
-      // Right side bar (mirrored horizontally)
-      auto mirrored_tile = ctx.tiles[tile_idx];
-      mirrored_tile.horizontal_mirror_ = !mirrored_tile.horizontal_mirror_;
-      DrawRoutineUtils::WriteTile8(ctx.target_bg, base_x + 9 - x_offset,
-                                   base_y + row, mirrored_tile);
-    }
+    const int left_x = base_x + 2 + col;
+    const int right_x = base_x + 9 + col;
+    DrawRoutineUtils::WriteTile8(ctx.target_bg, left_x, base_y, ctx.tiles[1]);
+    DrawRoutineUtils::WriteTile8(ctx.target_bg, right_x, base_y, ctx.tiles[1]);
+    DrawRoutineUtils::WriteTile8(ctx.target_bg, left_x, base_y + 1,
+                                 ctx.tiles[2]);
+    DrawRoutineUtils::WriteTile8(ctx.target_bg, right_x, base_y + 1,
+                                 with_horizontal_mirror(ctx.tiles[2]));
+    DrawRoutineUtils::WriteTile8(ctx.target_bg, left_x, base_y + 2,
+                                 ctx.tiles[4]);
+    DrawRoutineUtils::WriteTile8(ctx.target_bg, right_x, base_y + 2,
+                                 with_horizontal_mirror(ctx.tiles[4]));
+    DrawRoutineUtils::WriteTile8(ctx.target_bg, left_x, base_y + 3,
+                                 ctx.tiles[5]);
+    DrawRoutineUtils::WriteTile8(ctx.target_bg, right_x, base_y + 3,
+                                 with_horizontal_mirror(ctx.tiles[5]));
   }
 
-  // If we have a secondary BG buffer, draw the same pattern there
-  // This ensures the prison bars appear on both background layers
-  if (ctx.HasSecondaryBG()) {
-    for (int col = 0; col < 5; ++col) {
-      int x_offset = col;
-
-      for (int row = 0; row < 4; ++row) {
-        size_t tile_idx = (row < static_cast<int>(ctx.tiles.size())) ? row : 0;
-
-        // Left side bar
-        DrawRoutineUtils::WriteTile8(*ctx.secondary_bg, base_x + x_offset,
-                                     base_y + row, ctx.tiles[tile_idx]);
-
-        // Right side bar (mirrored)
-        auto mirrored_tile = ctx.tiles[tile_idx];
-        mirrored_tile.horizontal_mirror_ = !mirrored_tile.horizontal_mirror_;
-        DrawRoutineUtils::WriteTile8(*ctx.secondary_bg, base_x + 9 - x_offset,
-                                     base_y + row, mirrored_tile);
-      }
-    }
+  DrawRoutineUtils::WriteTile8(ctx.target_bg, base_x, base_y, ctx.tiles[0]);
+  DrawRoutineUtils::WriteTile8(ctx.target_bg, base_x + 15, base_y,
+                               with_horizontal_mirror(ctx.tiles[0]));
+  for (int x_offset : {1, 7, 8, 14}) {
+    DrawRoutineUtils::WriteTile8(ctx.target_bg, base_x + x_offset, base_y,
+                                 ctx.tiles[1]);
   }
+  DrawRoutineUtils::WriteTile8(ctx.target_bg, base_x + 1, base_y + 2,
+                               ctx.tiles[3]);
+  DrawRoutineUtils::WriteTile8(ctx.target_bg, base_x + 14, base_y + 2,
+                               with_horizontal_mirror(ctx.tiles[3]));
 }
 
 void DrawBigKeyLock(const DrawContext& ctx) {
@@ -1716,14 +1709,16 @@ void RegisterSpecialRoutines(std::vector<DrawRoutineInfo>& registry) {
       .category = DrawRoutineInfo::Category::Special,
   });
 
-  // Prison cell (Type 3 objects 0x20D, 0x217) draws to both BG layers.
+  // Prison cell (Type 3 objects 0x20D, 0x217) writes only to the tilemap
+  // selected by the current object stream ($BF in USDASM).
   registry.push_back(DrawRoutineInfo{
       .id = 97,  // DrawPrisonCell
       .name = "PrisonCell",
       .function = DrawPrisonCell,
-      .draws_to_both_bgs = true,
-      .base_width = 10,  // Columns x..x+9
+      .draws_to_both_bgs = false,
+      .base_width = 16,
       .base_height = 4,
+      .min_tiles = 6,
       .category = DrawRoutineInfo::Category::Special,
   });
 

--- a/src/zelda3/dungeon/draw_routines/special_routines.h
+++ b/src/zelda3/dungeon/draw_routines/special_routines.h
@@ -398,10 +398,10 @@ void DrawStraightInterRoomStairs(const DrawContext& ctx);
  * @brief Draw prison cell with bars (Type 3 objects 0x20D, 0x217)
  *
  * ASM: RoomDraw_PrisonCell ($019C44)
- * Draws to BOTH BG1 and BG2 with horizontal flip for symmetry.
- * Uses ctx.secondary_bg for dual-layer drawing when available.
+ * Draws a sparse 16x4 pattern on the current object-stream tilemap. Mirrored
+ * side bars leave the two center columns open below the top row.
  *
- * @param ctx Draw context with optional secondary_bg for dual-BG drawing
+ * @param ctx Draw context containing the target background and six tiles
  */
 void DrawPrisonCell(const DrawContext& ctx);
 

--- a/src/zelda3/dungeon/object_dimensions.cc
+++ b/src/zelda3/dungeon/object_dimensions.cc
@@ -906,9 +906,9 @@ void ObjectDimensionTable::InitializeDefaults() {
   dimensions_[0xF8E] = {1, 1, Dir::None, 0, false};
   dimensions_[0xF8F] = {1, 1, Dir::None, 0, false};
 
-  // Prison cell bars (10x4 tiles)
-  dimensions_[0xF8D] = {10, 4, Dir::None, 0, false};
-  dimensions_[0xF97] = {10, 4, Dir::None, 0, false};
+  // Prison cell bars ($019C44 spans x..x+15 and four rows)
+  dimensions_[0xF8D] = {16, 4, Dir::None, 0, false};
+  dimensions_[0xF97] = {16, 4, Dir::None, 0, false};
   // Rupee floor pattern
   dimensions_[0xF92] = {5, 8, Dir::None, 0, false};
   // Table/rock 4x3 repeated with 8-tile spacing

--- a/src/zelda3/dungeon/object_drawer.cc
+++ b/src/zelda3/dungeon/object_drawer.cc
@@ -1167,8 +1167,7 @@ void ObjectDrawer::InitializeDrawRoutines() {
       });
 
   // Routine 97 - Prison Cell (Type 3 objects 0x20D, 0x217)
-  // This routine draws to both BG1 and BG2 with horizontal flip symmetry
-  // Note: secondary_bg is set in DrawObject() for dual-BG objects
+  // USDASM selects one tilemap through $BF and draws a sparse 16x4 pattern.
   draw_routines_.push_back(
       [](ObjectDrawer* self, const RoomObject& obj, gfx::BackgroundBuffer& bg,
          std::span<const gfx::TileInfo> tiles, const DungeonState* state) {
@@ -3076,7 +3075,7 @@ std::pair<int, int> yaze::zelda3::ObjectDrawer::CalculateObjectDimensions(
       break;
 
     case 97:        // PrisonCell
-      width = 80;   // 10 tiles
+      width = 128;  // 16 tiles
       height = 32;  // 4 tiles
       break;
 

--- a/src/zelda3/dungeon/object_parser.cc
+++ b/src/zelda3/dungeon/object_parser.cc
@@ -330,6 +330,8 @@ absl::StatusOr<std::vector<gfx::TileInfo>> ObjectParser::ParseSubtype3(
     int16_t object_id) {
   constexpr int kBombableFloorOpenTileOffset = 0x05BA;
   constexpr int kBombableFloorStateTileCount = 16;
+  constexpr int kPrisonCellTileOffset = 0x1488;
+  constexpr int kPrisonCellTileCount = 6;
   constexpr int kBigKeyLockTileOffset = 0x1494;
   constexpr int kClosedChestTileOffset = 0x149C;
   constexpr int kOpenChestTileOffset = 0x14A4;
@@ -374,6 +376,15 @@ absl::StatusOr<std::vector<gfx::TileInfo>> ObjectParser::ParseSubtype3(
     intact_tiles->insert(intact_tiles->end(), open_tiles->begin(),
                          open_tiles->end());
     return intact_tiles;
+  }
+
+  // Both PrisonCell IDs dispatch to RoomDraw_PrisonCell, which ignores the
+  // subtype table pointer and loads literal obj1488. F8D's vanilla table entry
+  // does not point there, so following the table would render the two aliases
+  // differently even though the game does not.
+  if (object_id == 0xF8D || object_id == 0xF97) {
+    return ReadTileData(kRoomObjectTileAddress + kPrisonCellTileOffset,
+                        kPrisonCellTileCount);
   }
 
   // BigKeyLock overwrites the table-derived X register with obj1494 before
@@ -537,6 +548,12 @@ int ObjectParser::GetSubtype3TileCount(int16_t object_id) const {
   }
   if (object_id == 0xF82) {
     return 28;
+  }
+
+  // RoomDraw_PrisonCell loads literal obj1488 and consumes its six words for
+  // both object aliases.
+  if (object_id == 0xF8D || object_id == 0xF97) {
+    return 6;
   }
 
   // RupeeFloor (0xF92 = ASM 0x212) reads the two words at obj1DD6 and

--- a/src/zelda3/dungeon/object_parser.h
+++ b/src/zelda3/dungeon/object_parser.h
@@ -180,6 +180,7 @@ class ObjectParser {
    * @brief Get tile count for subtype 3 objects
    *
    * Different subtype 3 objects have different tile counts:
+   * - PrisonCell aliases (0xF8D/0xF97): 6 tiles from literal obj1488
    * - BigKeyLock (0xF98): 4 tiles (one closed 2x2 block)
    * - BombableFloor (0xFC7): 32 tiles (two non-contiguous 4x4 states)
    * - Chest/OpenChest (0xF99/0xF9A): 8/4 tiles (stateful/fixed 2x2)

--- a/src/zelda3/dungeon/room.cc
+++ b/src/zelda3/dungeon/room.cc
@@ -1352,10 +1352,11 @@ void Room::RenderObjectsToBackground() {
   ObjectDrawer drawer(rom_, room_id_, current_gfx16_.data());
   drawer.SetAllowTrackCornerAliases(RoomUsesTrackCornerAliases(tile_objects_));
   drawer.SetBG1RevealMaskSource(gfx::BG1RevealMaskSource::kBG2Objects);
-  // NOTE: BothBG routines (ceiling corners, merged stairs, prison cells) are
-  // handled by DrawRoutineRegistry's draws_to_both_bgs flag. The room object
-  // stream is split here as primary -> BG2 overlay -> BG1 overlay, while the
-  // layout pass is rendered separately by RoomLayout::Draw.
+  // NOTE: Routines that explicitly write both tilemaps (ceiling corners and
+  // merged stairs) are handled by DrawRoutineRegistry's draws_to_both_bgs
+  // flag. The room object stream is split here as primary -> BG2 overlay ->
+  // BG1 overlay, while the layout pass is rendered separately by
+  // RoomLayout::Draw.
 
   // Clear object buffers before rendering
   // IMPORTANT: Fill with 255 (transparent color key) so objects overlay correctly

--- a/test/README.md
+++ b/test/README.md
@@ -502,7 +502,7 @@ The dungeon object parity test suite validates that the editor's drawing pipelin
 | `ParityAllRoutineIdsInBounds` | All routine IDs index within the draw routines array |
 | `ParityPaletteOffsetBanks` | Palettes 2-7 map to correct 16-color SDL banks |
 | `ParityPitMaskObjectsIdentified` | Water/pit overlay objects flagged correctly |
-| `ParityBothBGRoutinesCorrect` | Dual-layer routines (corners, prison cells) have draws_to_both_bgs |
+| `ParityBothBGRoutinesCorrect` | Explicit dual-layer routines are flagged; target-only routines (including prison cells) are not |
 | `ParityWaterObjectsLayerCorrect` | Water overlay objects route to BG2 |
 | `ParityType3WaterFaceRoutines` | Water face objects use expected routines (94/95/96) |
 | `ParitySubtype1TileCountsComplete` | All subtype 1 objects have non-zero tile counts |

--- a/test/integration/zelda3/dungeon_object_rom_validation_test.cc
+++ b/test/integration/zelda3/dungeon_object_rom_validation_test.cc
@@ -629,7 +629,8 @@ TEST_F(DungeonObjectRomValidationTest, Subtype3PrisonCellParserMatchesRom) {
     SCOPED_TRACE(id);
     auto parsed_or = parser.ParseObject(static_cast<int16_t>(id));
     ASSERT_TRUE(parsed_or.ok());
-    EXPECT_EQ(parsed_or->size(), 8u);
+    EXPECT_EQ(parsed_or->size(), 6u)
+        << "RoomDraw_PrisonCell loads the six words at literal obj1488";
   }
 }
 

--- a/test/unit/zelda3/dungeon/object_dimensions_test.cc
+++ b/test/unit/zelda3/dungeon/object_dimensions_test.cc
@@ -181,7 +181,7 @@ TEST_F(ObjectDimensionTableTest, SomariaPathBaseDimensionsAreSingleTile) {
 
   // The intervening prison-cell object and later table/rock object are not
   // RoomDraw_SomariaLine entries.
-  EXPECT_EQ(table.GetBaseDimensions(0xF8D), std::make_pair(10, 4));
+  EXPECT_EQ(table.GetBaseDimensions(0xF8D), std::make_pair(16, 4));
   EXPECT_EQ(table.GetBaseDimensions(0xF94), std::make_pair(4, 3));
 }
 
@@ -280,6 +280,39 @@ TEST_F(ObjectDimensionTableTest, BigKeyLockUsesFixedTwoByTwoBounds) {
         ObjectDrawer(rom_.get(), 0).CalculateObjectDimensions(object);
     EXPECT_EQ(legacy_width, 16);
     EXPECT_EQ(legacy_height, 16);
+  }
+}
+
+TEST_F(ObjectDimensionTableTest, PrisonCellUsesFixedSixteenByFourBounds) {
+  auto& table = ObjectDimensionTable::Get();
+  ASSERT_TRUE(table.LoadFromRom(rom_.get()).ok());
+
+  for (int object_id : {0xF8D, 0xF97}) {
+    SCOPED_TRACE(::testing::Message() << "object=0x" << std::hex << object_id);
+    for (uint8_t size : {uint8_t{0}, uint8_t{7}, uint8_t{15}}) {
+      auto [width, height] = table.GetDimensions(object_id, size);
+      EXPECT_EQ(width, 16);
+      EXPECT_EQ(height, 4);
+
+      const auto selection = table.GetSelectionBounds(object_id, size);
+      EXPECT_EQ(selection.offset_x, 0);
+      EXPECT_EQ(selection.offset_y, 0);
+      EXPECT_EQ(selection.width, 16);
+      EXPECT_EQ(selection.height, 4);
+
+      const RoomObject object(object_id, 0, 0, size, 0);
+      auto geometry = ObjectGeometry::Get().MeasureByObjectId(object);
+      ASSERT_TRUE(geometry.ok());
+      EXPECT_EQ(geometry->min_x_tiles, 0);
+      EXPECT_EQ(geometry->min_y_tiles, 0);
+      EXPECT_EQ(geometry->width_tiles, 16);
+      EXPECT_EQ(geometry->height_tiles, 4);
+
+      auto [legacy_width, legacy_height] =
+          ObjectDrawer(rom_.get(), 0).CalculateObjectDimensions(object);
+      EXPECT_EQ(legacy_width, 128);
+      EXPECT_EQ(legacy_height, 32);
+    }
   }
 }
 

--- a/test/unit/zelda3/dungeon/object_drawer_registry_replay_test.cc
+++ b/test/unit/zelda3/dungeon/object_drawer_registry_replay_test.cc
@@ -3198,7 +3198,7 @@ TEST(ObjectDrawerMaskPropagationTest,
 }
 
 TEST(ObjectDrawerRegistryReplayTest,
-     PrisonCellDrawsToBothBuffersWhenMarkedBothBG) {
+     PrisonCellDrawsOnlyToObjectStreamTargetLayer) {
   ScopedCustomObjectsFlag disable_custom(false);
 
   Rom rom;
@@ -3219,27 +3219,31 @@ TEST(ObjectDrawerRegistryReplayTest,
 
   // PrisonCell maps to routine 97. ZScream "0x20D" corresponds to 0xF8D in
   // our decoded Type 3 ID space (0xF80 + 0x0D).
-  RoomObject cell(0x0F8D, /*x=*/2, /*y=*/2, /*size=*/0, /*layer=*/0);
-  cell.tiles_loaded_ = true;
-  cell.tiles_.clear();
-  for (int i = 0; i < 6; ++i) {
-    cell.tiles_.push_back(gfx::TileInfo(static_cast<uint16_t>(i), /*pal=*/2,
-                                        false, false, false));
-  }
-
   gfx::PaletteGroup palette_group;
-  ASSERT_TRUE(drawer.DrawObject(cell, bg1, bg2, palette_group).ok());
+  for (const auto layer :
+       {RoomObject::LayerType::BG1, RoomObject::LayerType::BG2}) {
+    SCOPED_TRACE(static_cast<int>(layer));
+    RoomObject cell(0x0F8D, /*x=*/2, /*y=*/2, /*size=*/0,
+                    static_cast<int>(layer));
+    cell.tiles_loaded_ = true;
+    cell.tiles_.clear();
+    for (int i = 0; i < 6; ++i) {
+      cell.tiles_.push_back(gfx::TileInfo(static_cast<uint16_t>(i), /*pal=*/2,
+                                          /*vertical=*/false,
+                                          /*horizontal=*/true, /*over=*/false));
+    }
 
-  const int px = cell.x_ * 8;
-  const int py = cell.y_ * 8;
-  const int idx = py * bg1.bitmap().width() + px;
-  ASSERT_GE(idx, 0);
-  ASSERT_LT(idx, static_cast<int>(bg1.bitmap().size()));
-
-  // Routine 97 is marked draws_to_both_bgs=true in the registry, so ObjectDrawer
-  // should execute it once for BG1 and once for BG2.
-  EXPECT_NE(bg1.bitmap().data()[idx], 255);
-  EXPECT_NE(bg2.bitmap().data()[idx], 255);
+    std::vector<ObjectDrawer::TileTrace> trace;
+    drawer.SetTraceCollector(&trace, /*trace_only=*/true);
+    ASSERT_TRUE(drawer.DrawObject(cell, bg1, bg2, palette_group).ok());
+    ASSERT_EQ(trace.size(), 48u);
+    for (const auto& write : trace) {
+      EXPECT_EQ(write.layer, static_cast<uint8_t>(layer));
+      EXPECT_NE(write.flags & 0x1, 0)
+          << "USDASM ORA #$4000 must not toggle an existing H-flip off";
+    }
+    drawer.ClearTraceCollector();
+  }
 }
 
 TEST(ObjectDrawerCannonHoleTest,

--- a/test/unit/zelda3/dungeon/object_drawing_comprehensive_test.cc
+++ b/test/unit/zelda3/dungeon/object_drawing_comprehensive_test.cc
@@ -97,6 +97,8 @@ int ExpectedSubtype3TileCount(int id) {
     return 20;
   if (id == 0xF82)
     return 28;
+  if (id == 0xF8D || id == 0xF97)
+    return 6;
   if (id == 0xF92)
     return 2;
   if (id == 0xF96)

--- a/test/unit/zelda3/dungeon/object_drawing_comprehensive_test.cc
+++ b/test/unit/zelda3/dungeon/object_drawing_comprehensive_test.cc
@@ -1078,7 +1078,6 @@ TEST_F(ObjectDrawingComprehensiveTest, ParityBothBGRoutinesCorrect) {
       35,  // k4x4Corner_BothBG
       36,  // kWeirdCornerBottom_BothBG
       37,  // kWeirdCornerTop_BothBG
-      97,  // kPrisonCell
   };
 
   for (int rid : bothbg_routines) {
@@ -1087,7 +1086,7 @@ TEST_F(ObjectDrawingComprehensiveTest, ParityBothBGRoutinesCorrect) {
   }
 
   // Verify some non-BothBG routines are NOT flagged
-  std::vector<int> non_bothbg = {0, 1, 3, 4, 5, 6, 16, 38, 39};
+  std::vector<int> non_bothbg = {0, 1, 3, 4, 5, 6, 16, 38, 39, 97};
   for (int rid : non_bothbg) {
     EXPECT_FALSE(reg.RoutineDrawsToBothBGs(rid))
         << "Routine " << rid << " should NOT have draws_to_both_bgs flag";

--- a/test/unit/zelda3/dungeon/room_object_rom_parity_test.cc
+++ b/test/unit/zelda3/dungeon/room_object_rom_parity_test.cc
@@ -50,6 +50,7 @@ constexpr int kSubtype2Base = 0x83F0;
 constexpr int kSubtype3Base = 0x84F0;
 constexpr int kTileDataBase = 0x1B52;
 constexpr int kBombableFloorOpenTileOffset = 0x05BA;
+constexpr int kPrisonCellTileOffset = 0x1488;
 // Oracle of Secrets relocates this room-specific behavior from vanilla room
 // 0x65 to room 0xAD. Keep the preview test keyed to the current room supplied
 // to the drawer rather than baking in the vanilla room number.
@@ -395,9 +396,8 @@ TEST_P(RoomObjectRomParityTest,
 //      verify the routine selects the expected sub-range of parsed tiles.
 //
 // Routine bodies referenced (special_routines.cc):
-//   - DrawPrisonCell (97) at 1077-1135: 5 cols x 4 rows x 2 sides per BG;
-//     reads tiles[0..3] (row-indexed); registered draws_to_both_bgs=true so
-//     ObjectDrawer dispatches the routine twice (BG1, then BG2).
+//   - DrawPrisonCell (97): sparse 16x4 target-layer pattern matching the long
+//     tilemap writes at RoomDraw_PrisonCell ($019C44); reads tiles[0..5].
 //   - DrawBigKeyLock (92): column-major 2x2 tiles[0..3] when closed; no tile
 //     writes when the corresponding shared chest/lock room-event slot is set.
 //   - DrawBombableFloor (93): four 2x2 quadrants from tiles[0..15], or the
@@ -407,18 +407,16 @@ TEST_P(RoomObjectRomParityTest,
 TEST_P(RoomObjectRomParityTest, PrisonCellParserMatchesRawRomWords) {
   SCOPED_TRACE(::yaze::test::TestRomManager::GetRomRoleName(GetParam()));
   ObjectParser parser(rom_.get());
+  const auto expected = DecodeTilesFromRom(
+      *rom_, kTileDataBase + kPrisonCellTileOffset, /*count=*/6);
   for (int id : {0xF8D, 0xF97}) {
     SCOPED_TRACE(absl::StrFormat("object 0x%03X (PrisonCell)", id));
-    const int addr = Subtype3TileDataAddr(*rom_, id);
-    const auto expected = DecodeTilesFromRom(*rom_, addr, /*count=*/8);
 
     auto parsed_or = parser.ParseObject(static_cast<int16_t>(id));
     ASSERT_TRUE(parsed_or.ok()) << parsed_or.status();
     const auto& parsed = parsed_or.value();
-    ASSERT_EQ(parsed.size(), 8u)
-        << "PrisonCell parses 8 tiles via the subtype-3 default; routine "
-           "consumes tiles[0..3] but the >=6 early-return guard means parsing "
-           "below 6 would clip the routine to a no-op.";
+    ASSERT_EQ(parsed.size(), 6u)
+        << "Both PrisonCell aliases consume the six words at literal obj1488.";
 
     for (size_t i = 0; i < expected.size(); ++i) {
       SCOPED_TRACE(absl::StrFormat("tile idx=%zu", i));
@@ -477,59 +475,67 @@ TEST_P(RoomObjectRomParityTest, BombableFloorParserMatchesRawRomWords) {
   }
 }
 
-TEST_P(RoomObjectRomParityTest, PrisonCellDrawerWritesSymmetricBarsBothBGs) {
+TEST_P(RoomObjectRomParityTest,
+       PrisonCellDrawerMatchesSparseTargetLayerUsdasmWrites) {
   SCOPED_TRACE(::yaze::test::TestRomManager::GetRomRoleName(GetParam()));
-  // Use 0xF97 (PrisonCell second variant); 0xF8D shares the same routine.
-  // Origin chosen so the mirror offset (base_x + 9 - col) stays in-bounds.
+  // Origin chosen so the full x..x+15 span stays in-bounds.
   const int base_x = 5;
   const int base_y = 7;
-  const auto trace = ReplayRomObjectTrace(rom_.get(), 0xF97, base_x, base_y,
-                                          /*size=*/0);
+  const auto rom_tiles =
+      DecodeTilesFromRom(*rom_, kTileDataBase + kPrisonCellTileOffset, 6);
 
-  const auto bg1 = FilterByLayer(trace, RoomObject::LayerType::BG1);
-  const auto bg2 = FilterByLayer(trace, RoomObject::LayerType::BG2);
-  // Routine draws 5 cols * 4 rows * 2 sides = 40 writes per BG.
-  // PrisonCell is registered draws_to_both_bgs=true, so ObjectDrawer dispatches
-  // the routine twice with secondary_bg=nullptr each time -> 40+40 = 80.
-  ASSERT_EQ(bg1.size(), 40u) << "PrisonCell BG1 trace must cover 5x4x2 writes";
-  ASSERT_EQ(bg2.size(), 40u) << "PrisonCell BG2 trace must mirror BG1 writes";
-
-  // Read tiles parsed from ROM so we can compare tile_id.
-  const int addr = Subtype3TileDataAddr(*rom_, 0xF97);
-  const auto rom_tiles = DecodeTilesFromRom(*rom_, addr, 8);
-
-  // Routine ordering: outer col 0..4, inner row 0..3, emit (left bar, right
-  // bar) per (col,row). tile_idx = row.
-  size_t idx = 0;
+  struct ExpectedWrite {
+    int tile_index;
+    int x_offset;
+    int y_offset;
+    bool force_horizontal_mirror;
+  };
+  std::vector<ExpectedWrite> expected;
+  expected.reserve(48);
   for (int col = 0; col < 5; ++col) {
-    for (int row = 0; row < 4; ++row) {
-      SCOPED_TRACE(absl::StrFormat("col=%d row=%d", col, row));
-      ASSERT_LT(idx + 1, bg1.size());
+    expected.push_back({1, 2 + col, 0, false});
+    expected.push_back({1, 9 + col, 0, false});
+    expected.push_back({2, 2 + col, 1, false});
+    expected.push_back({2, 9 + col, 1, true});
+    expected.push_back({4, 2 + col, 2, false});
+    expected.push_back({4, 9 + col, 2, true});
+    expected.push_back({5, 2 + col, 3, false});
+    expected.push_back({5, 9 + col, 3, true});
+  }
+  expected.push_back({0, 0, 0, false});
+  expected.push_back({0, 15, 0, true});
+  for (int x_offset : {1, 7, 8, 14}) {
+    expected.push_back({1, x_offset, 0, false});
+  }
+  expected.push_back({3, 1, 2, false});
+  expected.push_back({3, 14, 2, true});
 
-      // Left bar at (base_x + col, base_y + row).
-      EXPECT_EQ(bg1[idx].x_tile, base_x + col);
-      EXPECT_EQ(bg1[idx].y_tile, base_y + row);
-      EXPECT_EQ(bg1[idx].tile_id, rom_tiles[row].id_);
-      EXPECT_EQ(bg2[idx].x_tile, base_x + col);
-      EXPECT_EQ(bg2[idx].y_tile, base_y + row);
-      EXPECT_EQ(bg2[idx].tile_id, rom_tiles[row].id_);
-      ++idx;
+  for (int object_id : {0xF8D, 0xF97}) {
+    SCOPED_TRACE(absl::StrFormat("object=0x%03X", object_id));
+    const auto trace =
+        ReplayRomObjectTrace(rom_.get(), object_id, base_x, base_y, /*size=*/0);
+    const auto bg1 = FilterByLayer(trace, RoomObject::LayerType::BG1);
+    const auto bg2 = FilterByLayer(trace, RoomObject::LayerType::BG2);
+    ASSERT_EQ(bg1.size(), 48u);
+    EXPECT_TRUE(bg2.empty())
+        << "RoomDraw_PrisonCell writes only to the $BF-selected tilemap";
 
-      // Right bar at (base_x + 9 - col, base_y + row), horizontally mirrored.
-      EXPECT_EQ(bg1[idx].x_tile, base_x + 9 - col);
-      EXPECT_EQ(bg1[idx].y_tile, base_y + row);
-      EXPECT_EQ(bg1[idx].tile_id, rom_tiles[row].id_);
-      EXPECT_TRUE(bg1[idx].flags & 0x1)
-          << "right bar must have horizontal_mirror set";
-      EXPECT_EQ(bg2[idx].x_tile, base_x + 9 - col);
-      EXPECT_EQ(bg2[idx].y_tile, base_y + row);
-      EXPECT_EQ(bg2[idx].tile_id, rom_tiles[row].id_);
-      EXPECT_TRUE(bg2[idx].flags & 0x1)
-          << "right bar BG2 mirror must also have horizontal_mirror set";
-      ++idx;
+    ASSERT_EQ(expected.size(), bg1.size());
+    for (size_t i = 0; i < expected.size(); ++i) {
+      SCOPED_TRACE(absl::StrFormat("write=%zu", i));
+      const auto& write = bg1[i];
+      const auto& want = expected[i];
+      const auto& tile = rom_tiles[want.tile_index];
+      EXPECT_EQ(write.x_tile, base_x + want.x_offset);
+      EXPECT_EQ(write.y_tile, base_y + want.y_offset);
+      EXPECT_EQ(write.tile_id, tile.id_);
+      EXPECT_EQ((write.flags & 0x1) != 0,
+                want.force_horizontal_mirror || tile.horizontal_mirror_);
+      EXPECT_EQ((write.flags & 0x2) != 0, tile.vertical_mirror_);
+      EXPECT_EQ((write.flags & 0x4) != 0, tile.over_);
+      EXPECT_EQ((write.flags >> 3) & 0x7, tile.palette_);
     }
   }
-  EXPECT_EQ(idx, bg1.size());
 }
 
 TEST_P(RoomObjectRomParityTest, BigKeyLockDrawerMatchesRoomEventState) {


### PR DESCRIPTION
## Summary

- match `RoomDraw_PrisonCell` (`$019C44-$019CC5`) with its exact sparse 48-write, 16x4 layout
- route prison cells only to the current object-stream tilemap and force the USDASM `ORA #$4000` mirror writes
- load literal `obj1488` for both `0xF8D` and `0xF97`, then align selection/legacy dimensions and active docs
- replace the old self-consistency checks with ROM-backed tile, coordinate, flag, layer, alias, and geometry coverage

## Context

The room `0x080` investigation exposed the existing routine as a dense 10x4 dual-BG approximation. A proposed Mesen PNG pair was rejected before commit after PPU inspection proved its 16-pixel delta came from animated tile `$18D`, not F98. No invalid visual fixture or ROM artifact is included here.

## Verification

- `cmake --build build/presets/mac-ai --target yaze_test_unit yaze_test_integration --parallel 8`
- `cmake --build build/presets/mac-ai --target yaze_test_rom_dependent --parallel 8`
- focused prison-cell/parser/layer filters: 14 passed, 2 expected skips without an expanded ROM
- full `ObjectDimensionTableTest.*:ObjectGeometryTest.*`: 42 passed
- vanilla ROM-dependent prison-cell parser validation: 1 passed
- changed-file `clang-format --dry-run --Werror` and `git diff --check`
- pre-push build/format/change-aware validation passed

Refs #115
