### PR TITLE
feat(editor): add explicit restored-backup discard

### DIFF
--- a/docs/public/overview/getting-started.md
+++ b/docs/public/overview/getting-started.md
@@ -36,8 +36,9 @@ supported features and AI configuration.
   in the current session, inspect it, then use `Save ROM` to commit it. Keep
   **Backup Before Save** enabled so that commit also preserves the ROM version
   it replaces. Autosave remains paused until you either commit with `Save ROM`
-  or choose `Discard Restored Backup` in the ROM Backups popup to reload the
-  unchanged backing ROM.
+  or choose `Discard Restored Backup` in the ROM Backups popup to abandon the
+  staged ROM-buffer edits and reload the unchanged backing ROM. Resolve pending
+  dungeon-room or palette edits before discarding.
 - **Overworld vs. World Map**: the Overworld Editor edits playable areas; Screen
   Editor > Overworld Map edits the pause-menu map art.
 - **Experiment Flags**: Try new features via `File > Options > Experiment Flags`.

--- a/docs/public/overview/getting-started.md
+++ b/docs/public/overview/getting-started.md
@@ -35,8 +35,9 @@ supported features and AI configuration.
   timestamped backup. Use `File > ROM Backups... > Restore` to stage a backup
   in the current session, inspect it, then use `Save ROM` to commit it. Keep
   **Backup Before Save** enabled so that commit also preserves the ROM version
-  it replaces. Autosave remains paused until you explicitly commit or discard
-  the staged restore.
+  it replaces. Autosave remains paused until you either commit with `Save ROM`
+  or choose `Discard Restored Backup` in the ROM Backups popup to reload the
+  unchanged backing ROM.
 - **Overworld vs. World Map**: the Overworld Editor edits playable areas; Screen
   Editor > Overworld Map edits the pause-menu map art.
 - **Experiment Flags**: Try new features via `File > Options > Experiment Flags`.

--- a/src/app/editor/editor_manager.cc
+++ b/src/app/editor/editor_manager.cc
@@ -5885,6 +5885,7 @@ absl::Status EditorManager::RestoreRomBackup(const std::string& backup_path) {
   if (!original_filename.empty()) {
     restored_rom.set_filename(original_filename);
   }
+  RETURN_IF_ERROR(rom_lifecycle_.CheckRomOpenPolicy(&restored_rom));
   // Normal ROM backups do not copy the active `.labels` sidecar. Preserve the
   // session's loaded and in-memory resource labels instead of replacing them
   // with the usually-empty `<backup>.labels` lookup from LoadFromFile().

--- a/src/app/editor/editor_manager.cc
+++ b/src/app/editor/editor_manager.cc
@@ -5877,8 +5877,8 @@ absl::Status EditorManager::RestoreRomBackup(const std::string& backup_path) {
 
   // Load the backup away from the live session. Backups may legitimately have
   // a different size when they predate a ROM expansion or shrink. Reusing the
-  // transactional ROM-replacement path keeps the prior ROM and editor assets
-  // recoverable if reloading the backup fails partway through.
+  // ROM-replacement path restores the prior ROM bytes and backing identity if
+  // rebuilding assets fails partway through.
   Rom restored_rom;
   RETURN_IF_ERROR(rom_file_manager_.LoadRom(&restored_rom, backup_path));
 
@@ -5913,14 +5913,22 @@ absl::Status EditorManager::DiscardPendingRomBackupRestore() {
     return absl::FailedPreconditionError("No restored backup is staged");
   }
 
+  const size_t session_index = GetCurrentSessionIndex();
+  if (PendingDungeonRoomCountForSession(session_index) > 0 ||
+      gfx::PaletteManager::Get().HasUnsavedChanges(&session->game_data)) {
+    return absl::FailedPreconditionError(
+        "Resolve pending dungeon-room or palette edits before discarding the "
+        "restored backup");
+  }
+
   const std::string backing_path = session->rom.filename();
   if (backing_path.empty()) {
     return absl::FailedPreconditionError("ROM has no backing file to reload");
   }
 
-  // Reload into scratch storage so any file or asset-loading failure leaves the
-  // staged restore intact. Resource labels are session work, not part of normal
-  // ROM backups, so preserve them across the byte-level discard.
+  // Load into scratch storage before touching the live session so file I/O
+  // failures preserve the staged ROM. Resource labels are session work, not
+  // part of normal ROM backups, so preserve them across the byte-level discard.
   const project::ResourceLabelManager resource_labels =
       *session->rom.resource_label();
   Rom backing_rom;

--- a/src/app/editor/editor_manager.cc
+++ b/src/app/editor/editor_manager.cc
@@ -5843,6 +5843,14 @@ std::vector<RomFileManager::BackupEntry> EditorManager::GetRomBackups() const {
   return rom_lifecycle_.GetRomBackups(GetCurrentRom());
 }
 
+bool EditorManager::IsRomBackupRestorePending() const {
+  if (!session_coordinator_) {
+    return false;
+  }
+  const auto* session = session_coordinator_->GetActiveRomSession();
+  return session != nullptr && session->backup_restore_pending;
+}
+
 absl::Status EditorManager::RestoreRomBackup(const std::string& backup_path) {
   auto* rom = GetCurrentRom();
   if (!rom) {
@@ -5892,6 +5900,39 @@ absl::Status EditorManager::RestoreRomBackup(const std::string& backup_path) {
   return absl::OkStatus();
 }
 
+absl::Status EditorManager::DiscardPendingRomBackupRestore() {
+  if (!session_coordinator_) {
+    return absl::FailedPreconditionError("No session coordinator");
+  }
+  auto* session = session_coordinator_->GetActiveRomSession();
+  if (!session || !session->rom.is_loaded()) {
+    return absl::FailedPreconditionError("No ROM loaded");
+  }
+  if (!session->backup_restore_pending) {
+    return absl::FailedPreconditionError("No restored backup is staged");
+  }
+
+  const std::string backing_path = session->rom.filename();
+  if (backing_path.empty()) {
+    return absl::FailedPreconditionError("ROM has no backing file to reload");
+  }
+
+  // Reload into scratch storage so any file or asset-loading failure leaves the
+  // staged restore intact. Resource labels are session work, not part of normal
+  // ROM backups, so preserve them across the byte-level discard.
+  const project::ResourceLabelManager resource_labels =
+      *session->rom.resource_label();
+  Rom backing_rom;
+  RETURN_IF_ERROR(rom_file_manager_.LoadRom(&backing_rom, backing_path));
+  *backing_rom.resource_label() = resource_labels;
+  RETURN_IF_ERROR(
+      ReplaceActiveSessionRom(std::move(backing_rom), backing_path));
+
+  session->backup_restore_pending = false;
+  session->rom.ClearDirty();
+  return absl::OkStatus();
+}
+
 absl::Status EditorManager::PruneRomBackups() {
   return rom_lifecycle_.PruneRomBackups(GetCurrentRom());
 }
@@ -5927,6 +5968,13 @@ void EditorManager::DuplicateCurrentSession() {
 
 void EditorManager::CloseCurrentSession() {
   if (!session_coordinator_) {
+    return;
+  }
+
+  if (!session_coordinator_->HasMultipleSessions()) {
+    // Preserve the coordinator's existing warning without offering a
+    // "Close Without Saving" action that cannot close the final session.
+    session_coordinator_->CloseCurrentSession();
     return;
   }
 

--- a/src/app/editor/editor_manager.h
+++ b/src/app/editor/editor_manager.h
@@ -211,7 +211,9 @@ class EditorManager : public ISessionConfigurator, public IEditorSwitcher {
   }
   bool IsRomHashMismatch() const { return rom_lifecycle_.IsRomHashMismatch(); }
   std::vector<editor::RomFileManager::BackupEntry> GetRomBackups() const;
+  bool IsRomBackupRestorePending() const;
   absl::Status RestoreRomBackup(const std::string& backup_path);
+  absl::Status DiscardPendingRomBackupRestore();
   absl::Status PruneRomBackups();
   void ConfirmRomWrite();
   void CancelRomWriteConfirm();

--- a/src/app/editor/shell/feedback/popup_manager.cc
+++ b/src/app/editor/shell/feedback/popup_manager.cc
@@ -447,8 +447,9 @@ void PopupManager::DrawRomBackupManagerPopup() {
   if (editor_manager_->IsRomBackupRestorePending()) {
     Separator();
     TextWrapped(
-        tr("A restored backup is staged in this session. Save ROM to "
-           "commit it, or discard it to reload the backing ROM."));
+        tr("A restored backup is staged in this session. Save ROM to commit "
+           "it. Discard reloads the backing ROM and abandons staged ROM-buffer "
+           "edits; resolve pending dungeon-room or palette edits first."));
     if (Button(ICON_MD_UNDO " Discard Restored Backup")) {
       auto status = editor_manager_->DiscardPendingRomBackupRestore();
       if (!status.ok()) {

--- a/src/app/editor/shell/feedback/popup_manager.cc
+++ b/src/app/editor/shell/feedback/popup_manager.cc
@@ -444,6 +444,26 @@ void PopupManager::DrawRomBackupManagerPopup() {
   Separator();
   TextWrapped(tr("Backup folder: %s"), backup_dir.c_str());
 
+  if (editor_manager_->IsRomBackupRestorePending()) {
+    Separator();
+    TextWrapped(
+        tr("A restored backup is staged in this session. Save ROM to "
+           "commit it, or discard it to reload the backing ROM."));
+    if (Button(ICON_MD_UNDO " Discard Restored Backup")) {
+      auto status = editor_manager_->DiscardPendingRomBackupRestore();
+      if (!status.ok()) {
+        if (auto* toast = editor_manager_->toast_manager()) {
+          toast->Show(absl::StrFormat("Discard failed: %s", status.message()),
+                      ToastType::kError);
+        }
+      } else if (auto* toast = editor_manager_->toast_manager()) {
+        toast->Show("Restored backup discarded; reloaded ROM from disk",
+                    ToastType::kSuccess);
+      }
+    }
+    Separator();
+  }
+
   if (Button(ICON_MD_DELETE_SWEEP " Prune Backups")) {
     auto status = editor_manager_->PruneRomBackups();
     if (!status.ok()) {

--- a/test/unit/editor/editor_manager_rom_write_policy_test.cc
+++ b/test/unit/editor/editor_manager_rom_write_policy_test.cc
@@ -10,6 +10,7 @@
 
 #include "absl/status/status.h"
 #include "absl/strings/str_format.h"
+#include "app/editor/dungeon/dungeon_editor_v2.h"
 #include "app/editor/editor_manager.h"
 #include "app/gfx/backend/null_renderer.h"
 #include "core/features.h"
@@ -640,6 +641,68 @@ TEST(EditorManagerBackupRestoreTest,
   EXPECT_EQ(manager->GetCurrentRomHash(), backing_hash);
   EXPECT_EQ(active_rom->resource_label()->GetLabel("rooms", "0"),
             "In-memory room label");
+}
+
+TEST(EditorManagerBackupRestoreTest,
+     DiscardPendingRomBackupRestoreRejectsPendingDungeonRoom) {
+  FeatureFlagsGuard guard;
+  ScopedImGuiContext imgui;
+
+  auto renderer = std::make_unique<gfx::NullRenderer>();
+  auto manager = std::make_unique<EditorManager>();
+  manager->Initialize(renderer.get(), "");
+  manager->SetAssetLoadMode(AssetLoadMode::kLazy);
+  manager->user_settings().prefs().backup_before_save = true;
+
+  const auto temp_dir =
+      MakeTempFilePath("yaze_backup_restore_discard_pending_room");
+  ScopedDirectoryCleanup cleanup{temp_dir};
+  ASSERT_TRUE(std::filesystem::create_directories(temp_dir));
+  const auto rom_path = temp_dir / "oracle-copy.sfc";
+  WriteTestRom(rom_path, "DISCARD PENDING ROOM");
+
+  ASSERT_OK(manager->OpenRomOrProject(rom_path.string()));
+  DisableRomWritesForTest();
+  Rom* const active_rom = manager->GetCurrentRom();
+  ASSERT_NE(active_rom, nullptr);
+
+  constexpr uint32_t kPcOffset = 0x1234;
+  constexpr uint8_t kOriginal = 0x00;
+  constexpr uint8_t kEdited = 0xA5;
+  ASSERT_OK(active_rom->WriteByte(kPcOffset, kEdited));
+  ASSERT_OK(manager->SaveRom());
+
+  const auto backups = manager->GetRomBackups();
+  ASSERT_EQ(backups.size(), 1u);
+  ASSERT_OK(manager->RestoreRomBackup(backups.front().path));
+
+  auto* const session = manager->session_coordinator()->GetActiveRomSession();
+  ASSERT_NE(session, nullptr);
+  ASSERT_TRUE(session->backup_restore_pending);
+  const std::string staged_hash = manager->GetCurrentRomHash();
+
+  auto* const dungeon =
+      manager->GetCurrentEditorSet()->GetEditorAs<DungeonEditorV2>(
+          EditorType::kDungeon);
+  ASSERT_NE(dungeon, nullptr);
+  dungeon->rooms()[0].SetPalette(0x2A);
+  ASSERT_EQ(dungeon->PendingRoomCount(), 1);
+
+  const auto discard_status = manager->DiscardPendingRomBackupRestore();
+
+  EXPECT_EQ(discard_status.code(), absl::StatusCode::kFailedPrecondition)
+      << discard_status;
+  EXPECT_NE(std::string(discard_status.message())
+                .find("pending dungeon-room or palette edits"),
+            std::string::npos);
+  EXPECT_EQ(manager->GetCurrentRom(), active_rom);
+  ASSERT_TRUE(active_rom->ReadByte(kPcOffset).ok());
+  EXPECT_EQ(*active_rom->ReadByte(kPcOffset), kOriginal);
+  EXPECT_EQ(manager->GetCurrentRomHash(), staged_hash);
+  EXPECT_TRUE(active_rom->dirty());
+  EXPECT_TRUE(session->backup_restore_pending);
+  EXPECT_EQ(dungeon->PendingRoomCount(), 1);
+  EXPECT_EQ(ReadByteAt(rom_path, kPcOffset), kEdited);
 }
 
 TEST(EditorManagerBackupRestoreTest,

--- a/test/unit/editor/editor_manager_rom_write_policy_test.cc
+++ b/test/unit/editor/editor_manager_rom_write_policy_test.cc
@@ -517,6 +517,60 @@ TEST(EditorManagerBackupRestoreTest,
 }
 
 TEST(EditorManagerBackupRestoreTest,
+     RestoreRejectsProjectBuildOutputBackingPath) {
+  FeatureFlagsGuard guard;
+  ScopedImGuiContext imgui;
+
+  auto renderer = std::make_unique<gfx::NullRenderer>();
+  auto manager = std::make_unique<EditorManager>();
+  manager->Initialize(renderer.get(), "");
+  manager->SetAssetLoadMode(AssetLoadMode::kLazy);
+  manager->user_settings().prefs().backup_before_save = true;
+
+  const auto temp_dir = MakeTempFilePath("yaze_backup_restore_build_output");
+  ScopedDirectoryCleanup cleanup{temp_dir};
+  ASSERT_TRUE(std::filesystem::create_directories(temp_dir));
+  const auto dev_rom_path = temp_dir / "oracle-dev.sfc";
+  const auto build_rom_path = temp_dir / "oracle-build.sfc";
+  WriteTestRom(dev_rom_path, "RESTORE DEV");
+  WriteTestRom(build_rom_path, "RESTORE BUILD");
+
+  ASSERT_OK(manager->OpenRomOrProject(build_rom_path.string()));
+  DisableRomWritesForTest();
+  Rom* const active_rom = manager->GetCurrentRom();
+  ASSERT_NE(active_rom, nullptr);
+
+  constexpr uint32_t kPcOffset = 0x1234;
+  constexpr uint8_t kEdited = 0xA5;
+  ASSERT_OK(active_rom->WriteByte(kPcOffset, kEdited));
+  ASSERT_OK(manager->SaveRom());
+
+  const auto backups = manager->GetRomBackups();
+  ASSERT_EQ(backups.size(), 1u);
+
+  auto* project = manager->GetCurrentProject();
+  ASSERT_NE(project, nullptr);
+  project->name = "Backup Restore Build Output";
+  project->filepath = (temp_dir / "project.yaze").string();
+  project->rom_filename = dev_rom_path.filename().string();
+  project->build_target = build_rom_path.filename().string();
+  project->rom_metadata.write_policy = project::RomWritePolicy::kWarn;
+
+  const auto restore_status = manager->RestoreRomBackup(backups.front().path);
+
+  EXPECT_EQ(restore_status.code(), absl::StatusCode::kFailedPrecondition)
+      << restore_status;
+  EXPECT_NE(std::string(restore_status.message()).find("build output"),
+            std::string::npos);
+  EXPECT_EQ(manager->GetCurrentRom(), active_rom);
+  ASSERT_TRUE(active_rom->ReadByte(kPcOffset).ok());
+  EXPECT_EQ(*active_rom->ReadByte(kPcOffset), kEdited);
+  EXPECT_FALSE(active_rom->dirty());
+  EXPECT_FALSE(manager->IsRomBackupRestorePending());
+  EXPECT_EQ(ReadByteAt(build_rom_path, kPcOffset), kEdited);
+}
+
+TEST(EditorManagerBackupRestoreTest,
      DiscardPendingRomBackupRestoreReloadsBackingWithoutWriting) {
   FeatureFlagsGuard guard;
   ScopedImGuiContext imgui;

--- a/test/unit/editor/editor_manager_rom_write_policy_test.cc
+++ b/test/unit/editor/editor_manager_rom_write_policy_test.cc
@@ -516,6 +516,181 @@ TEST(EditorManagerBackupRestoreTest,
   EXPECT_TRUE(active_rom->dirty());
 }
 
+TEST(EditorManagerBackupRestoreTest,
+     DiscardPendingRomBackupRestoreReloadsBackingWithoutWriting) {
+  FeatureFlagsGuard guard;
+  ScopedImGuiContext imgui;
+
+  auto renderer = std::make_unique<gfx::NullRenderer>();
+  auto manager = std::make_unique<EditorManager>();
+  manager->Initialize(renderer.get(), "");
+  manager->SetAssetLoadMode(AssetLoadMode::kLazy);
+  manager->user_settings().prefs().backup_before_save = true;
+
+  const auto temp_dir = MakeTempFilePath("yaze_backup_restore_discard");
+  ScopedDirectoryCleanup cleanup{temp_dir};
+  ASSERT_TRUE(std::filesystem::create_directories(temp_dir));
+  const auto rom_path = temp_dir / "oracle-copy.sfc";
+  WriteTestRom(rom_path, "RESTORE DISCARD");
+  {
+    std::ofstream labels(rom_path.string() + ".labels",
+                         std::ios::out | std::ios::trunc);
+    ASSERT_TRUE(labels.is_open());
+    labels << "[rooms]\n0=On-disk room label\n";
+    ASSERT_TRUE(labels.good());
+  }
+
+  ASSERT_OK(manager->OpenRomOrProject(rom_path.string()));
+  DisableRomWritesForTest();
+  Rom* const active_rom = manager->GetCurrentRom();
+  ASSERT_NE(active_rom, nullptr);
+  active_rom->resource_label()->EditLabel("rooms", "0", "In-memory room label");
+
+  constexpr uint32_t kPcOffset = 0x1234;
+  constexpr uint8_t kOriginal = 0x00;
+  constexpr uint8_t kEdited = 0xA5;
+  ASSERT_OK(active_rom->WriteByte(kPcOffset, kEdited));
+  ASSERT_OK(manager->SaveRom());
+  const std::string backing_hash = manager->GetCurrentRomHash();
+  const size_t session_id = manager->GetCurrentSessionId();
+
+  const auto no_restore_status = manager->DiscardPendingRomBackupRestore();
+  EXPECT_EQ(no_restore_status.code(), absl::StatusCode::kFailedPrecondition)
+      << no_restore_status;
+  EXPECT_EQ(ReadByteAt(rom_path, kPcOffset), kEdited);
+
+  const auto backups = manager->GetRomBackups();
+  ASSERT_EQ(backups.size(), 1u);
+  ASSERT_OK(manager->RestoreRomBackup(backups.front().path));
+  ASSERT_TRUE(active_rom->ReadByte(kPcOffset).ok());
+  EXPECT_EQ(*active_rom->ReadByte(kPcOffset), kOriginal);
+  EXPECT_EQ(ReadByteAt(rom_path, kPcOffset), kEdited);
+  EXPECT_NE(manager->GetCurrentRomHash(), backing_hash);
+
+  auto* const session = manager->session_coordinator()->GetActiveRomSession();
+  ASSERT_NE(session, nullptr);
+  ASSERT_TRUE(session->backup_restore_pending);
+  ASSERT_TRUE(active_rom->dirty());
+
+  ASSERT_OK(manager->DiscardPendingRomBackupRestore());
+
+  EXPECT_EQ(manager->GetCurrentRom(), active_rom);
+  EXPECT_EQ(manager->GetCurrentSessionId(), session_id);
+  EXPECT_EQ(active_rom->filename(),
+            std::filesystem::absolute(rom_path).string());
+  ASSERT_TRUE(active_rom->ReadByte(kPcOffset).ok());
+  EXPECT_EQ(*active_rom->ReadByte(kPcOffset), kEdited);
+  EXPECT_EQ(ReadByteAt(rom_path, kPcOffset), kEdited);
+  EXPECT_FALSE(active_rom->dirty());
+  EXPECT_FALSE(session->backup_restore_pending);
+  EXPECT_EQ(manager->GetCurrentRomHash(), backing_hash);
+  EXPECT_EQ(active_rom->resource_label()->GetLabel("rooms", "0"),
+            "In-memory room label");
+}
+
+TEST(EditorManagerBackupRestoreTest,
+     DiscardPendingRomBackupRestoreFailureKeepsStagedState) {
+  FeatureFlagsGuard guard;
+  ScopedImGuiContext imgui;
+
+  auto renderer = std::make_unique<gfx::NullRenderer>();
+  auto manager = std::make_unique<EditorManager>();
+  manager->Initialize(renderer.get(), "");
+  manager->SetAssetLoadMode(AssetLoadMode::kLazy);
+  manager->user_settings().prefs().backup_before_save = true;
+
+  const auto temp_dir = MakeTempFilePath("yaze_backup_restore_discard_failure");
+  ScopedDirectoryCleanup cleanup{temp_dir};
+  ASSERT_TRUE(std::filesystem::create_directories(temp_dir));
+  const auto rom_path = temp_dir / "oracle-copy.sfc";
+  const auto moved_rom_path = temp_dir / "oracle-copy-moved.sfc";
+  WriteTestRom(rom_path, "DISCARD FAILURE");
+
+  ASSERT_OK(manager->OpenRomOrProject(rom_path.string()));
+  DisableRomWritesForTest();
+  Rom* const active_rom = manager->GetCurrentRom();
+  ASSERT_NE(active_rom, nullptr);
+
+  constexpr uint32_t kPcOffset = 0x1234;
+  constexpr uint8_t kOriginal = 0x00;
+  constexpr uint8_t kEdited = 0xA5;
+  ASSERT_OK(active_rom->WriteByte(kPcOffset, kEdited));
+  ASSERT_OK(manager->SaveRom());
+
+  const auto backups = manager->GetRomBackups();
+  ASSERT_EQ(backups.size(), 1u);
+  ASSERT_OK(manager->RestoreRomBackup(backups.front().path));
+  auto* const session = manager->session_coordinator()->GetActiveRomSession();
+  ASSERT_NE(session, nullptr);
+  ASSERT_TRUE(session->backup_restore_pending);
+  const std::string staged_hash = manager->GetCurrentRomHash();
+  const std::string staged_title = active_rom->title();
+  const size_t staged_size = active_rom->size();
+
+  std::filesystem::rename(rom_path, moved_rom_path);
+  const auto discard_status = manager->DiscardPendingRomBackupRestore();
+
+  EXPECT_FALSE(discard_status.ok()) << discard_status;
+  EXPECT_EQ(manager->GetCurrentRom(), active_rom);
+  EXPECT_EQ(active_rom->filename(),
+            std::filesystem::absolute(rom_path).string());
+  ASSERT_TRUE(active_rom->ReadByte(kPcOffset).ok());
+  EXPECT_EQ(*active_rom->ReadByte(kPcOffset), kOriginal);
+  EXPECT_EQ(active_rom->title(), staged_title);
+  EXPECT_EQ(active_rom->size(), staged_size);
+  EXPECT_EQ(manager->GetCurrentRomHash(), staged_hash);
+  EXPECT_TRUE(active_rom->dirty());
+  EXPECT_TRUE(session->backup_restore_pending);
+  EXPECT_EQ(ReadByteAt(moved_rom_path, kPcOffset), kEdited);
+}
+
+TEST(EditorManagerBackupRestoreTest,
+     SingleSessionCloseDoesNotOfferImpossibleRestoreDiscard) {
+  FeatureFlagsGuard guard;
+  ScopedImGuiContext imgui;
+
+  auto renderer = std::make_unique<gfx::NullRenderer>();
+  auto manager = std::make_unique<EditorManager>();
+  manager->Initialize(renderer.get(), "");
+  manager->SetAssetLoadMode(AssetLoadMode::kLazy);
+  manager->user_settings().prefs().backup_before_save = true;
+
+  const auto temp_dir = MakeTempFilePath("yaze_backup_restore_single_close");
+  ScopedDirectoryCleanup cleanup{temp_dir};
+  ASSERT_TRUE(std::filesystem::create_directories(temp_dir));
+  const auto rom_path = temp_dir / "oracle-copy.sfc";
+  WriteTestRom(rom_path, "RESTORE CLOSE");
+
+  ASSERT_OK(manager->OpenRomOrProject(rom_path.string()));
+  DisableRomWritesForTest();
+  Rom* const active_rom = manager->GetCurrentRom();
+  ASSERT_NE(active_rom, nullptr);
+
+  constexpr uint32_t kPcOffset = 0x1234;
+  constexpr uint8_t kOriginal = 0x00;
+  constexpr uint8_t kEdited = 0xA5;
+  ASSERT_OK(active_rom->WriteByte(kPcOffset, kEdited));
+  ASSERT_OK(manager->SaveRom());
+
+  const auto backups = manager->GetRomBackups();
+  ASSERT_EQ(backups.size(), 1u);
+  ASSERT_OK(manager->RestoreRomBackup(backups.front().path));
+  auto* const session = manager->session_coordinator()->GetActiveRomSession();
+  ASSERT_NE(session, nullptr);
+  ASSERT_TRUE(session->backup_restore_pending);
+
+  manager->CloseCurrentSession();
+
+  EXPECT_EQ(manager->GetActiveSessionCount(), 1u);
+  EXPECT_FALSE(manager->HasPendingUnsavedSessionAction());
+  EXPECT_EQ(manager->GetCurrentRom(), active_rom);
+  ASSERT_TRUE(active_rom->ReadByte(kPcOffset).ok());
+  EXPECT_EQ(*active_rom->ReadByte(kPcOffset), kOriginal);
+  EXPECT_TRUE(active_rom->dirty());
+  EXPECT_TRUE(session->backup_restore_pending);
+  EXPECT_EQ(ReadByteAt(rom_path, kPcOffset), kEdited);
+}
+
 TEST(EditorManagerRomWritePolicyTest,
      SaveRomBlocksOnHashMismatchWhenPolicyBlock) {
   FeatureFlagsGuard guard;

--- a/test/unit/editor/editor_manager_rom_write_policy_test.cc
+++ b/test/unit/editor/editor_manager_rom_write_policy_test.cc
@@ -16,6 +16,8 @@
 #include "app/editor/dungeon/ui/window/overlay_manager_panel.h"
 #include "app/editor/editor_manager.h"
 #include "app/gfx/backend/null_renderer.h"
+#include "app/gfx/types/snes_palette.h"
+#include "app/gfx/util/palette_manager.h"
 #include "core/features.h"
 #include "rom/snes.h"
 #include "testing.h"
@@ -72,6 +74,11 @@ namespace {
 struct FeatureFlagsGuard {
   core::FeatureFlags::Flags prev = core::FeatureFlags::get();
   ~FeatureFlagsGuard() { core::FeatureFlags::get() = prev; }
+};
+
+struct PaletteManagerGuard {
+  PaletteManagerGuard() { gfx::PaletteManager::Get().ResetForTesting(); }
+  ~PaletteManagerGuard() { gfx::PaletteManager::Get().ResetForTesting(); }
 };
 
 struct ScopedFileCleanup {
@@ -969,6 +976,77 @@ TEST(EditorManagerBackupRestoreTest,
   EXPECT_TRUE(active_rom->dirty());
   EXPECT_TRUE(session->backup_restore_pending);
   EXPECT_EQ(dungeon->PendingRoomCount(), 1);
+  EXPECT_EQ(ReadByteAt(rom_path, kPcOffset), kEdited);
+}
+
+TEST(EditorManagerBackupRestoreTest,
+     DiscardPendingRomBackupRestoreRejectsPendingPaletteWrite) {
+  FeatureFlagsGuard guard;
+  PaletteManagerGuard palette_guard;
+  ScopedImGuiContext imgui;
+
+  auto renderer = std::make_unique<gfx::NullRenderer>();
+  auto manager = std::make_unique<EditorManager>();
+  manager->Initialize(renderer.get(), "");
+  manager->SetAssetLoadMode(AssetLoadMode::kLazy);
+  manager->user_settings().prefs().backup_before_save = true;
+
+  const auto temp_dir =
+      MakeTempFilePath("yaze_backup_restore_discard_pending_palette");
+  ScopedDirectoryCleanup cleanup{temp_dir};
+  ASSERT_TRUE(std::filesystem::create_directories(temp_dir));
+  const auto rom_path = temp_dir / "oracle-copy.sfc";
+  WriteTestRom(rom_path, "DISCARD PENDING PALETTE");
+
+  ASSERT_OK(manager->OpenRomOrProject(rom_path.string()));
+  DisableRomWritesForTest();
+  Rom* const active_rom = manager->GetCurrentRom();
+  ASSERT_NE(active_rom, nullptr);
+
+  constexpr uint32_t kPcOffset = 0x1234;
+  constexpr uint8_t kOriginal = 0x00;
+  constexpr uint8_t kEdited = 0xA5;
+  ASSERT_OK(active_rom->WriteByte(kPcOffset, kEdited));
+  ASSERT_OK(manager->SaveRom());
+
+  const auto backups = manager->GetRomBackups();
+  ASSERT_EQ(backups.size(), 1u);
+  ASSERT_OK(manager->RestoreRomBackup(backups.front().path));
+
+  auto* const session = manager->session_coordinator()->GetActiveRomSession();
+  ASSERT_NE(session, nullptr);
+  ASSERT_TRUE(session->backup_restore_pending);
+  const std::string staged_hash = manager->GetCurrentRomHash();
+
+  auto* const game_data = manager->GetCurrentGameData();
+  ASSERT_NE(game_data, nullptr);
+  auto* const group = game_data->palette_groups.get_group("dungeon_main");
+  ASSERT_NE(group, nullptr);
+  group->clear();
+  gfx::SnesPalette palette;
+  palette.AddColor(gfx::SnesColor(0x0100));
+  group->AddPalette(palette);
+  gfx::PaletteManager::Get().Initialize(game_data);
+  ASSERT_OK(gfx::PaletteManager::Get().SetColor("dungeon_main", 0, 0,
+                                                gfx::SnesColor(0x1111)));
+  ASSERT_TRUE(gfx::PaletteManager::Get().HasUnsavedChanges(game_data));
+
+  const auto discard_status = manager->DiscardPendingRomBackupRestore();
+
+  EXPECT_EQ(discard_status.code(), absl::StatusCode::kFailedPrecondition)
+      << discard_status;
+  EXPECT_NE(std::string(discard_status.message())
+                .find("pending dungeon-room or palette edits"),
+            std::string::npos);
+  EXPECT_EQ(manager->GetCurrentRom(), active_rom);
+  ASSERT_TRUE(active_rom->ReadByte(kPcOffset).ok());
+  EXPECT_EQ(*active_rom->ReadByte(kPcOffset), kOriginal);
+  EXPECT_EQ(manager->GetCurrentRomHash(), staged_hash);
+  EXPECT_TRUE(active_rom->dirty());
+  EXPECT_TRUE(session->backup_restore_pending);
+  EXPECT_TRUE(gfx::PaletteManager::Get().HasUnsavedChanges(game_data));
+  EXPECT_EQ(gfx::PaletteManager::Get().GetColor("dungeon_main", 0, 0).snes(),
+            0x1111);
   EXPECT_EQ(ReadByteAt(rom_path, kPcOffset), kEdited);
 }
 


### PR DESCRIPTION
## What

- Add an explicit **Discard Restored Backup** action to the ROM Backups popup.
- Reload the active session's unchanged backing ROM through the transactional replacement path while preserving in-memory resource labels.
- Reject discard when dungeon-room or palette model edits are still pending.
- Apply the project ROM-open policy before staging a managed backup restore.
- Route single-session close attempts directly to the existing cannot-close-last-session warning instead of offering an impossible destructive action.
- Document the restore/commit/discard workflow and add focused regression coverage.

## Why

A restored backup is intentionally staged in memory and marked dirty so autosave cannot commit it silently. Previously, the only explicit completion path was **Save ROM**; users had no safe UI action to abandon the staged restore and return to the on-disk ROM.

## Impact

Users can inspect a backup, commit it with **Save ROM**, or explicitly discard it. Discard loads the backing ROM into scratch storage first and then refreshes the stable live session in place, so it safely reloads the backing ROM **without writing to disk**. Failed reloads keep the restored ROM dirty and pending. Pending dungeon-room and palette edits fail closed instead of being lost.

This work was originally stacked on #119. PR #119 is now merged, and this branch has been synchronized with its merge commit before publication.

## Root cause

The backup-restore flow tracked `backup_restore_pending` to pause autosave, but it exposed no inverse operation. Reusing ordinary close/session actions was unsafe because the final session cannot actually be closed, and a direct ROM reload needed the same stable-address editor refresh and rollback guarantees added by #119.

## Checks

- `cmake --build build/presets/mac-test --target yaze_test_quick_unit_editor --parallel 4`
- `yaze_test_quick_unit_editor --gtest_filter='EditorManagerBackupRestoreTest.*'` — 9/9 passed
- `clang-format --dry-run --Werror` on the four changed C++ files
- `git diff --check origin/master..HEAD`
- `YAZE_PREPUSH_BUILD_DIR=build/presets/mac-test scripts/pre-push.sh`
