### PR TITLE
test(dungeon): refresh right-palette room goldens

### DIFF
--- a/test/integration/zelda3/dungeon_room_regression_fixtures.h
+++ b/test/integration/zelda3/dungeon_room_regression_fixtures.h
@@ -37,7 +37,8 @@ struct DungeonRoomRegressionFixture {
 
 // Fixed vanilla-room fixtures (US 1.0). Room ids verified via
 // DungeonRoomRegressionFixturesTest.ScanAllRoomsForFixtureCandidates.
-// Golden checksums recorded 2026-06-28 via YAZE_RECORD_DUNGEON_ROOM_FIXTURES=1.
+// Golden checksums regenerated 2026-07-22 after the USDASM-correct Left/Right
+// dungeon palette-slot mapping fix (62f954b68).
 inline constexpr DungeonRoomRegressionFixture kDungeonRoomRegressionFixtures[] =
     {
         {
@@ -50,10 +51,10 @@ inline constexpr DungeonRoomRegressionFixture kDungeonRoomRegressionFixtures[] =
                 "streams with BG2 overlay platform objects 0x033/0x034/0x071.",
             .required_object_id = 0x108,
             .expected_layer_merge_id = 6,
-            .composite_checksum = 3925581144764392225ull,
-            .object_bg1_checksum = 13831736980008890945ull,
-            .object_bg2_checksum = 3151175755251988992ull,
-            .layout_bg1_checksum = 5628238167289212587ull,
+            .composite_checksum = 5018637587913985457ull,
+            .object_bg1_checksum = 7942374673971519889ull,
+            .object_bg2_checksum = 16314113468206397296ull,
+            .layout_bg1_checksum = 16155382640141831219ull,
             .composite_non_backdrop_pixels = 262144,
             .object_bg1_non_backdrop_pixels = 262144,
             .object_bg2_non_backdrop_pixels = 262144,
@@ -68,10 +69,10 @@ inline constexpr DungeonRoomRegressionFixture kDungeonRoomRegressionFixtures[] =
                      "streams.",
             .required_object_id = 0x034,
             .expected_layer_merge_id = 6,
-            .composite_checksum = 154053754431283302ull,
-            .object_bg1_checksum = 124322299965229508ull,
-            .object_bg2_checksum = 12015621994152001693ull,
-            .layout_bg1_checksum = 5270035654940668381ull,
+            .composite_checksum = 7186032506148411670ull,
+            .object_bg1_checksum = 12203971081140519348ull,
+            .object_bg2_checksum = 4665773132931031645ull,
+            .layout_bg1_checksum = 14374714413720404755ull,
             .composite_non_backdrop_pixels = 262144,
             .object_bg1_non_backdrop_pixels = 262144,
             .object_bg2_non_backdrop_pixels = 262144,
@@ -85,10 +86,10 @@ inline constexpr DungeonRoomRegressionFixture kDungeonRoomRegressionFixtures[] =
                      "wall/corner objects with no moving-water effect.",
             .required_object_id = 0x100,
             .expected_layer_merge_id = 0,
-            .composite_checksum = 15098288716652967704ull,
-            .object_bg1_checksum = 2924072550631335041ull,
-            .object_bg2_checksum = 275146388502860235ull,
-            .layout_bg1_checksum = 1100323173258158507ull,
+            .composite_checksum = 7928503047124983480ull,
+            .object_bg1_checksum = 10501821798088277057ull,
+            .object_bg2_checksum = 14741702422515376347ull,
+            .layout_bg1_checksum = 3904745168084633499ull,
             .composite_non_backdrop_pixels = 262144,
             .object_bg1_non_backdrop_pixels = 262144,
             .object_bg2_non_backdrop_pixels = 262144,
@@ -104,10 +105,10 @@ inline constexpr DungeonRoomRegressionFixture kDungeonRoomRegressionFixtures[] =
             .expected_layer_merge_id = 4,
             // FF1 now honors the inactive room-0x065 bombed-floor state, so
             // the default room render correctly omits the big light beam.
-            .composite_checksum = 7101433555545613415ull,
-            .object_bg1_checksum = 3344402020867724551ull,
-            .object_bg2_checksum = 10195791645045441415ull,
-            .layout_bg1_checksum = 8945647139078008391ull,
+            .composite_checksum = 2251720105443116807ull,
+            .object_bg1_checksum = 38343009025063977ull,
+            .object_bg2_checksum = 9908005591592637895ull,
+            .layout_bg1_checksum = 6452462266518031539ull,
             .composite_non_backdrop_pixels = 208440,
             .object_bg1_non_backdrop_pixels = 262144,
             .object_bg2_non_backdrop_pixels = 262144,
@@ -123,10 +124,10 @@ inline constexpr DungeonRoomRegressionFixture kDungeonRoomRegressionFixtures[] =
             .expected_layer_merge_id = 0,
             // Room 0x004 contains six F92 rupee-floor objects. Their
             // USDASM-accurate sparse five-by-eight pattern changes BG1.
-            .composite_checksum = 5477542344832277612ull,
-            .object_bg1_checksum = 16713002165790269043ull,
+            .composite_checksum = 11931349271745880540ull,
+            .object_bg1_checksum = 3494573777721387843ull,
             .object_bg2_checksum = 11028269878064776067ull,
-            .layout_bg1_checksum = 17333734306328304163ull,
+            .layout_bg1_checksum = 8128105348724780643ull,
             .composite_non_backdrop_pixels = 262144,
             .object_bg1_non_backdrop_pixels = 262144,
             .object_bg2_non_backdrop_pixels = 262144,

--- a/test/integration/zelda3/dungeon_room_regression_fixtures_test.cc
+++ b/test/integration/zelda3/dungeon_room_regression_fixtures_test.cc
@@ -64,11 +64,11 @@ struct RoomLayerFingerprints {
 constexpr int kRoom001ObjectOverlapX = 45;
 constexpr int kRoom001ObjectOverlapY = 120;
 constexpr int kRoom001ObjectOverlapIndex = 61485;
-constexpr uint8_t kRoom001ObjectOverlapBg1Pixel = 33;
-constexpr uint8_t kRoom001ObjectOverlapBg2Pixel = 34;
+constexpr uint8_t kRoom001ObjectOverlapBg1Pixel = 41;
+constexpr uint8_t kRoom001ObjectOverlapBg2Pixel = 42;
 constexpr uint8_t kRoom001ObjectOverlapBg1Priority = 1;
 constexpr uint8_t kRoom001ObjectOverlapBg2Priority = 0;
-constexpr uint8_t kRoom001ObjectOverlapCompositePixel = 33;
+constexpr uint8_t kRoom001ObjectOverlapCompositePixel = 41;
 
 #if defined(YAZE_HAS_VISUAL_DIFF_ENGINE)
 constexpr size_t kCanonicalUsRomSize = 0x100000;
@@ -311,8 +311,8 @@ TEST_F(DungeonRoomRegressionFixturesTest,
   // Broad checksums catch drift but do not explain *where* compositing changed.
   // Pin one sparse golden overlap pixel from room 0x001, which exercises
   // primary, BG2-overlay, and BG1-overlay object streams. The sampled pixel is
-  // BG1 high-priority object pixel 33 over BG2 low-priority object pixel 34,
-  // so SNES Mode 1 compositing must leave palette index 33 on top.
+  // BG1 high-priority object pixel 0x29 over BG2 low-priority object pixel
+  // 0x2A, so SNES Mode 1 compositing must leave palette index 0x29 on top.
   Room room(0x001, &rom_, &game_data_);
   room.LoadRoomGraphics();
   room.LoadObjects();


### PR DESCRIPTION
## What
- Refresh the five ROM-backed dungeon room layer/composite fingerprints after the corrected Right-palette slot mapping.
- Update the room `0x001` sparse overlap sample from palette indices `33/34` to `41/42` while preserving the same BG1-over-BG2 priority winner.
- Record the regeneration date and implementation provenance alongside the fixtures.

## Why
The renderer fix in `62f954b68` (merged by PR #116 as `ae766ddfa`) corrected how destination graphics blocks map to the SNES runtime slot counter. The existing renderer-derived goldens still described the prior reversed mapping, so they failed even though the corrected output agrees with the independently captured Mesen palette diagnostic.

## Impact
Test-only change. Production rendering behavior is unchanged by this PR; it restores useful regression coverage for the already-merged palette mapping fix.

## Root cause
`InitializeTilesets` loads destination blocks `0..7` while `$0F` counts down from runtime slot `7..0`. The old implementation treated the destination block number as the runtime slot. Correctly reversing that relationship sets bit 3 for the affected nonzero 3bpp pixels, shifting the pinned room `0x001` values by `+8` and changing the affected full-room fingerprints.

## Provenance
The fixture values were regenerated from the canonical US 1.0 ROM with `YAZE_RECORD_DUNGEON_ROOM_FIXTURES=1` after `62f954b68`. The committed values exactly match a fresh recording. The mapping itself is grounded by the USDASM-based unit tests and the independent Mesen room `0x012` carpet pixel baseline.

## Checks
- `CCACHE_DISABLE=1 cmake --build build/presets/mac-test-golden-noccache --target yaze_test_unit yaze_test_integration -j2`
- `RoomGraphicsPaletteTest.CopyRoomGraphicsToBuffer_ShiftsRightPaletteBlocks`
- `RoomGraphicsPaletteTest.CopyRoomGraphicsToBuffer_UsesEntranceMainGroupForRightPaletteSlots`
- `DungeonRoomRegressionFixturesTest.*` — 10 passed, 2 opt-in discovery/recording tests skipped
- `git diff --check origin/master..HEAD`
- `CCACHE_DISABLE=1 scripts/pre-push.sh --build-dir build/presets/mac-test-golden-noccache`

