### PR TITLE
fix(dungeon): persist door interaction edits

### DIFF
--- a/src/app/editor/dungeon/interaction/door_interaction_handler.cc
+++ b/src/app/editor/dungeon/interaction/door_interaction_handler.cc
@@ -89,6 +89,21 @@ void DoorInteractionHandler::HandleRelease() {
     return;
   }
 
+  auto& doors = room->GetDoors();
+  if (*selected_door_index_ >= doors.size()) {
+    is_dragging_ = false;
+    return;
+  }
+
+  // HandleClick primes drag state so a selected door can move immediately, but
+  // a plain click must not canonicalize distinct ROM positions that share the
+  // same visual snap slot.
+  if (drag_current_pos_.x == drag_start_pos_.x &&
+      drag_current_pos_.y == drag_start_pos_.y) {
+    is_dragging_ = false;
+    return;
+  }
+
   int drag_x = static_cast<int>(drag_current_pos_.x);
   int drag_y = static_cast<int>(drag_current_pos_.y);
 
@@ -100,19 +115,18 @@ void DoorInteractionHandler::HandleRelease() {
         drag_x, drag_y, direction);
 
     if (zelda3::DoorPositionManager::IsValidPosition(position, direction)) {
-      ctx_->NotifyMutation(MutationDomain::kDoors);
-
-      auto& doors = room->GetDoors();
-      if (*selected_door_index_ < doors.size()) {
-        doors[*selected_door_index_].position = position;
-        doors[*selected_door_index_].direction = direction;
+      auto& door = doors[*selected_door_index_];
+      if (door.position != position || door.direction != direction) {
+        ctx_->NotifyMutation(MutationDomain::kDoors);
+        door.position = position;
+        door.direction = direction;
 
         // Re-encode bytes for ROM storage
-        auto [b1, b2] = doors[*selected_door_index_].EncodeBytes();
-        doors[*selected_door_index_].byte1 = b1;
-        doors[*selected_door_index_].byte2 = b2;
+        auto [b1, b2] = door.EncodeBytes();
+        door.byte1 = b1;
+        door.byte2 = b2;
 
-        room->MarkObjectsDirty();
+        room->MarkObjectStreamDirty();
         ctx_->NotifyInvalidateCache(MutationDomain::kDoors);
       }
     }
@@ -582,7 +596,7 @@ bool DoorInteractionHandler::NudgeSelected(int delta_x, int delta_y) {
   auto [b1, b2] = door.EncodeBytes();
   door.byte1 = b1;
   door.byte2 = b2;
-  room->MarkObjectsDirty();
+  room->MarkObjectStreamDirty();
   ctx_->NotifyInvalidateCache(MutationDomain::kDoors);
   ctx_->NotifyEntityChanged();
   return true;
@@ -612,7 +626,7 @@ bool DoorInteractionHandler::MutateDoorType(size_t index,
   door.byte1 = b1;
   door.byte2 = b2;
 
-  room->MarkObjectsDirty();
+  room->MarkObjectStreamDirty();
   ctx_->NotifyInvalidateCache(MutationDomain::kDoors);
   ctx_->NotifyEntityChanged();
   return true;

--- a/src/app/editor/dungeon/interaction/interaction_coordinator.cc
+++ b/src/app/editor/dungeon/interaction/interaction_coordinator.cc
@@ -685,7 +685,7 @@ bool InteractionCoordinator::NudgeSelectedEntities(
   }
 
   if (doors_changed) {
-    room->MarkObjectsDirty();
+    room->MarkObjectStreamDirty();
     if (defer_drag_notifications) {
       entity_group_drag_doors_changed_ = true;
     } else {

--- a/test/unit/editor/interaction_coordinator_test.cc
+++ b/test/unit/editor/interaction_coordinator_test.cc
@@ -311,6 +311,7 @@ TEST_F(InteractionCoordinatorTest, NudgeSelectedDoorMovesAlongDoorAxisOnly) {
   const auto [expected_b1, expected_b2] = moved.EncodeBytes();
   EXPECT_EQ(moved.byte1, expected_b1);
   EXPECT_EQ(moved.byte2, expected_b2);
+  EXPECT_TRUE(rooms_[0].object_stream_dirty());
 }
 
 TEST_F(InteractionCoordinatorTest, SelectEntitiesInRectCapturesMixedEntities) {
@@ -366,6 +367,7 @@ TEST_F(InteractionCoordinatorTest, NudgeSelectedMovesMixedEntitySelection) {
   EXPECT_EQ(rooms_[0].GetPotItems()[0].GetPixelX(), 88);
   EXPECT_EQ(rooms_[0].GetPotItems()[0].GetPixelY(), 96);
   EXPECT_GT(invalidation_count_, 0);
+  EXPECT_TRUE(rooms_[0].object_stream_dirty());
   EXPECT_TRUE(rooms_[0].sprites_dirty());
   EXPECT_TRUE(rooms_[0].pot_items_dirty());
 }

--- a/test/unit/editor/sprite_door_handler_test.cc
+++ b/test/unit/editor/sprite_door_handler_test.cc
@@ -360,6 +360,8 @@ TEST_F(DoorInteractionHandlerTest,
   door.type = zelda3::DoorType::NormalDoor;
   door.direction = zelda3::DoorDirection::North;
   rooms_[0].AddDoor(door);
+  rooms_[0].ClearObjectStreamDirty();
+  ASSERT_FALSE(rooms_[0].object_stream_dirty());
 
   const int mutations_before = mutation_count_;
   const int invalidations_before = invalidate_count_;
@@ -383,6 +385,7 @@ TEST_F(DoorInteractionHandlerTest,
 
   EXPECT_EQ(mutation_count_, mutations_before + 1);
   EXPECT_EQ(invalidate_count_, invalidations_before + 1);
+  EXPECT_TRUE(rooms_[0].object_stream_dirty());
 }
 
 TEST_F(DoorInteractionHandlerTest, MutateDoorTypeNoOpWhenTypeUnchanged) {
@@ -391,11 +394,15 @@ TEST_F(DoorInteractionHandlerTest, MutateDoorTypeNoOpWhenTypeUnchanged) {
   door.type = zelda3::DoorType::SmallKeyDoor;
   door.direction = zelda3::DoorDirection::East;
   rooms_[0].AddDoor(door);
+  rooms_[0].ClearObjectStreamDirty();
 
   const int mutations_before = mutation_count_;
+  const int invalidations_before = invalidate_count_;
 
   EXPECT_FALSE(handler_.MutateDoorType(0, zelda3::DoorType::SmallKeyDoor));
   EXPECT_EQ(mutation_count_, mutations_before);
+  EXPECT_EQ(invalidate_count_, invalidations_before);
+  EXPECT_FALSE(rooms_[0].object_stream_dirty());
 }
 
 TEST_F(DoorInteractionHandlerTest, MutateDoorTypeRejectsOutOfRangeIndex) {
@@ -422,6 +429,82 @@ TEST_F(DoorInteractionHandlerTest,
   const auto hit = handler_.GetEntityAtPosition(hit_x, hit_y);
   ASSERT_TRUE(hit.has_value());
   EXPECT_EQ(*hit, 0u);
+}
+
+TEST_F(DoorInteractionHandlerTest,
+       DragReleaseMovesDoorAndMarksObjectStreamDirty) {
+  zelda3::Room::Door door;
+  door.position = 0;
+  door.type = zelda3::DoorType::NormalDoor;
+  door.direction = zelda3::DoorDirection::North;
+  auto [byte1, byte2] = door.EncodeBytes();
+  door.byte1 = byte1;
+  door.byte2 = byte2;
+  rooms_[0].AddDoor(door);
+  rooms_[0].ClearObjectStreamDirty();
+
+  const auto [door_x, door_y, door_w, door_h] =
+      rooms_[0].GetDoors()[0].GetEditorBounds();
+  ASSERT_TRUE(handler_.HandleClick(door_x + door_w / 2, door_y + door_h / 2));
+
+  handler_.HandleDrag(ImVec2(30.0f * 8.0f, static_cast<float>(door_y)),
+                      ImVec2(0.0f, 0.0f));
+  handler_.HandleRelease();
+
+  const auto& moved = rooms_[0].GetDoors()[0];
+  EXPECT_EQ(moved.position, 1);
+  EXPECT_EQ(moved.direction, zelda3::DoorDirection::North);
+  const auto [expected_b1, expected_b2] = moved.EncodeBytes();
+  EXPECT_EQ(moved.byte1, expected_b1);
+  EXPECT_EQ(moved.byte2, expected_b2);
+  EXPECT_TRUE(rooms_[0].object_stream_dirty());
+  EXPECT_EQ(mutation_count_, 1);
+  EXPECT_EQ(invalidate_count_, 1);
+}
+
+TEST_F(DoorInteractionHandlerTest,
+       ClickReleaseWithoutMovementDoesNotMutateOrMarkDirty) {
+  zelda3::Room::Door door;
+  // South positions 9-11 share moving-axis snap slots with 6-8. A plain click
+  // must preserve the original ROM position instead of canonicalizing it.
+  door.position = 9;
+  door.type = zelda3::DoorType::NormalDoor;
+  door.direction = zelda3::DoorDirection::South;
+  auto [byte1, byte2] = door.EncodeBytes();
+  door.byte1 = byte1;
+  door.byte2 = byte2;
+  rooms_[0].AddDoor(door);
+  rooms_[0].ClearObjectStreamDirty();
+
+  const auto [door_x, door_y, door_w, door_h] =
+      rooms_[0].GetDoors()[0].GetEditorBounds();
+  ASSERT_TRUE(handler_.HandleClick(door_x + door_w / 2, door_y + door_h / 2));
+
+  handler_.HandleRelease();
+
+  EXPECT_EQ(rooms_[0].GetDoors()[0].position, 9);
+  EXPECT_EQ(rooms_[0].GetDoors()[0].direction, zelda3::DoorDirection::South);
+  EXPECT_FALSE(rooms_[0].object_stream_dirty());
+  EXPECT_EQ(mutation_count_, 0);
+  EXPECT_EQ(invalidate_count_, 0);
+}
+
+TEST_F(DoorInteractionHandlerTest, NudgeMarksObjectStreamDirty) {
+  zelda3::Room::Door door;
+  door.position = 1;
+  door.type = zelda3::DoorType::NormalDoor;
+  door.direction = zelda3::DoorDirection::North;
+  auto [byte1, byte2] = door.EncodeBytes();
+  door.byte1 = byte1;
+  door.byte2 = byte2;
+  rooms_[0].AddDoor(door);
+  rooms_[0].ClearObjectStreamDirty();
+  handler_.SelectDoor(0);
+
+  ASSERT_TRUE(handler_.NudgeSelected(1, 0));
+
+  EXPECT_EQ(rooms_[0].GetDoors()[0].position, 2);
+  EXPECT_TRUE(rooms_[0].object_stream_dirty());
 }
 
 TEST_F(DoorInteractionHandlerTest, PairBadgeClickNavigatesToNeighborDoor) {


### PR DESCRIPTION
## Summary
- mark door drags, nudges, mixed-selection moves, and type changes as object-stream save-dirty
- keep plain click/release clean and preserve distinct ROM door positions that share a visual snap slot
- add focused regression coverage for dirty-state and no-op behavior

This fixes a data-loss path where edited doors rendered correctly but were skipped by Save Room/File Save because persistence gates object/door writes on `object_stream_dirty()`.

Contributes to #115.

## Verification
- `cmake --build build/presets/mac-test --config Debug --target yaze_test_unit --parallel 8`
- `build/presets/mac-test/bin/Debug/yaze_test_unit '--gtest_filter=DoorInteractionHandlerTest.*:InteractionCoordinatorTest.NudgeSelectedDoorMovesAlongDoorAxisOnly:InteractionCoordinatorTest.NudgeSelectedMovesMixedEntitySelection' --gtest_brief=1` — 19/19 passed
- `clang-format --dry-run --Werror` on all four changed C++ files
- independent read-only diff review: no remaining findings
