### PR TITLE
fix(dungeon): guard all pending save domains

### DIFF
--- a/src/app/editor/dungeon/dungeon_editor_v2.cc
+++ b/src/app/editor/dungeon/dungeon_editor_v2.cc
@@ -1187,6 +1187,25 @@ bool DungeonEditorV2::HasPendingRoomChanges() const {
   return PendingRoomCount() > 0;
 }
 
+bool DungeonEditorV2::HasPendingDungeonChanges() const {
+  if (HasPendingRoomChanges()) {
+    return true;
+  }
+  if (std::any_of(entrances_.begin(), entrances_.end(),
+                  [](const zelda3::RoomEntrance& entrance) {
+                    return entrance.dirty();
+                  })) {
+    return true;
+  }
+  if (std::any_of(spawn_points_.begin(), spawn_points_.end(),
+                  [](const zelda3::DungeonSpawnPoint& spawn) {
+                    return spawn.dirty();
+                  })) {
+    return true;
+  }
+  return game_data_ != nullptr && game_data_->pit_damage_table.dirty();
+}
+
 bool DungeonEditorV2::CurrentRoomHasPendingChanges() const {
   if (current_room_id_ < 0 ||
       current_room_id_ >= static_cast<int>(rooms_.size())) {

--- a/src/app/editor/dungeon/dungeon_editor_v2.h
+++ b/src/app/editor/dungeon/dungeon_editor_v2.h
@@ -143,8 +143,11 @@ class DungeonEditorV2 : public Editor {
   void ContributeStatus(StatusBar* status_bar) override;
   absl::Status SaveRoom(int room_id);
   int LoadedRoomCount() const;
+  // Room-specific pending state used by room counts and room-level UI.
   int PendingRoomCount() const;
   bool HasPendingRoomChanges() const;
+  // All dungeon save domains, including global entrance/spawn/pit metadata.
+  bool HasPendingDungeonChanges() const;
   bool CurrentRoomHasPendingChanges() const;
   int TotalRoomCount() const { return static_cast<int>(rooms_.size()); }
 

--- a/src/app/editor/editor_manager.cc
+++ b/src/app/editor/editor_manager.cc
@@ -5959,10 +5959,10 @@ absl::Status EditorManager::DiscardPendingRomBackupRestore() {
   }
 
   const size_t session_index = GetCurrentSessionIndex();
-  if (PendingDungeonRoomCountForSession(session_index) > 0 ||
+  if (HasPendingDungeonChangesForSession(session_index) ||
       gfx::PaletteManager::Get().HasUnsavedChanges(&session->game_data)) {
     return absl::FailedPreconditionError(
-        "Resolve pending dungeon-room or palette edits before discarding the "
+        "Resolve pending dungeon or palette edits before discarding the "
         "restored backup");
   }
 
@@ -6420,12 +6420,32 @@ bool EditorManager::SessionHasPendingRomWork(size_t session_index) const {
       static_cast<RomSession*>(session_coordinator_->GetSession(session_index));
   return session != nullptr &&
          ((session->rom.is_loaded() && session->rom.dirty()) ||
-          PendingDungeonRoomCountForSession(session_index) > 0 ||
+          HasPendingDungeonChangesForSession(session_index) ||
           gfx::PaletteManager::Get().HasUnsavedChanges(&session->game_data));
 }
 
 bool EditorManager::HasAnySessionPendingUnsavedWork() const {
   return ModifiedSessionCount() > 0;
+}
+
+bool EditorManager::HasPendingDungeonChangesForSession(
+    size_t session_index) const {
+  if (!session_coordinator_ ||
+      !session_coordinator_->IsValidSessionIndex(session_index)) {
+    return false;
+  }
+
+  auto* session =
+      static_cast<RomSession*>(session_coordinator_->GetSession(session_index));
+  if (!session) {
+    return false;
+  }
+
+  if (auto* dungeon_editor =
+          session->editors.GetEditorAs<DungeonEditorV2>(EditorType::kDungeon)) {
+    return dungeon_editor->HasPendingDungeonChanges();
+  }
+  return false;
 }
 
 int EditorManager::PendingDungeonRoomCountForSession(
@@ -6487,6 +6507,8 @@ std::string EditorManager::DescribePendingUnsavedWork(
       static_cast<RomSession*>(session_coordinator_->GetSession(session_index));
   const bool rom_dirty =
       session != nullptr && session->rom.is_loaded() && session->rom.dirty();
+  const bool pending_dungeon_changes =
+      HasPendingDungeonChangesForSession(session_index);
   const int pending_rooms = PendingDungeonRoomCountForSession(session_index);
   const size_t pending_palette_colors =
       PendingPaletteColorCountForSession(session_index);
@@ -6499,6 +6521,8 @@ std::string EditorManager::DescribePendingUnsavedWork(
   if (pending_rooms > 0) {
     work.push_back(absl::StrFormat("%d unapplied dungeon room%s", pending_rooms,
                                    pending_rooms == 1 ? "" : "s"));
+  } else if (pending_dungeon_changes) {
+    work.emplace_back("unapplied dungeon metadata");
   }
   if (pending_palette_colors > 0) {
     work.push_back(absl::StrFormat("%zu unapplied palette color%s",

--- a/src/app/editor/editor_manager.h
+++ b/src/app/editor/editor_manager.h
@@ -709,6 +709,7 @@ class EditorManager : public ISessionConfigurator, public IEditorSwitcher {
   bool SessionHasPendingUnsavedWork(size_t session_index) const;
   bool SessionHasPendingRomWork(size_t session_index) const;
   bool HasAnySessionPendingUnsavedWork() const;
+  bool HasPendingDungeonChangesForSession(size_t session_index) const;
   int PendingDungeonRoomCountForSession(size_t session_index) const;
   size_t PendingPaletteColorCountForSession(size_t session_index) const;
   int ModifiedSessionCount() const;

--- a/src/app/editor/shell/feedback/popup_manager.cc
+++ b/src/app/editor/shell/feedback/popup_manager.cc
@@ -449,7 +449,7 @@ void PopupManager::DrawRomBackupManagerPopup() {
     TextWrapped(
         tr("A restored backup is staged in this session. Save ROM to commit "
            "it. Discard reloads the backing ROM and abandons staged ROM-buffer "
-           "edits; resolve pending dungeon-room or palette edits first."));
+           "edits; resolve pending dungeon or palette edits first."));
     if (Button(ICON_MD_UNDO " Discard Restored Backup")) {
       auto status = editor_manager_->DiscardPendingRomBackupRestore();
       if (!status.ok()) {

--- a/src/app/editor/system/session/session_coordinator.cc
+++ b/src/app/editor/system/session/session_coordinator.cc
@@ -1281,7 +1281,7 @@ bool SessionCoordinator::IsSessionModified(size_t index) const {
 
   if (auto* dungeon_editor =
           session->editors.GetEditorAs<DungeonEditorV2>(EditorType::kDungeon)) {
-    return dungeon_editor->HasPendingRoomChanges();
+    return dungeon_editor->HasPendingDungeonChanges();
   }
 
   return false;

--- a/test/unit/editor/dungeon_editor_v2_rom_safety_test.cc
+++ b/test/unit/editor/dungeon_editor_v2_rom_safety_test.cc
@@ -1647,6 +1647,59 @@ TEST(DungeonEditorV2RomSafetyTest, PendingRoomCountTracksRoomDirtyState) {
 }
 
 TEST(DungeonEditorV2RomSafetyTest,
+     HasPendingDungeonChangesTracksRegularEntranceOnly) {
+  Rom rom;
+  ASSERT_TRUE(rom.LoadFromData(std::vector<uint8_t>(0x200000, 0)).ok());
+
+  auto editor = std::make_unique<DungeonEditorV2>(&rom);
+  auto& entrance =
+      DungeonEditorV2RegularEntranceTestPeer::RegularEntrance(*editor, 0);
+  entrance.MarkDirty();
+
+  EXPECT_EQ(editor->PendingRoomCount(), 0);
+  EXPECT_FALSE(editor->HasPendingRoomChanges());
+  EXPECT_TRUE(editor->HasPendingDungeonChanges());
+
+  entrance.ClearDirty();
+  EXPECT_FALSE(editor->HasPendingDungeonChanges());
+}
+
+TEST(DungeonEditorV2RomSafetyTest,
+     HasPendingDungeonChangesTracksDedicatedSpawnOnly) {
+  Rom rom;
+  ASSERT_TRUE(rom.LoadFromData(std::vector<uint8_t>(0x200000, 0)).ok());
+
+  auto editor = std::make_unique<DungeonEditorV2>(&rom);
+  auto& spawn = DungeonEditorV2SpawnPointTestPeer::SpawnPoint(*editor, 0);
+  spawn.MarkDirty();
+
+  EXPECT_EQ(editor->PendingRoomCount(), 0);
+  EXPECT_FALSE(editor->HasPendingRoomChanges());
+  EXPECT_TRUE(editor->HasPendingDungeonChanges());
+
+  spawn.ClearDirty();
+  EXPECT_FALSE(editor->HasPendingDungeonChanges());
+}
+
+TEST(DungeonEditorV2RomSafetyTest,
+     HasPendingDungeonChangesTracksPitDamageTableOnly) {
+  Rom rom;
+  ASSERT_TRUE(rom.LoadFromData(std::vector<uint8_t>(0x200000, 0)).ok());
+  zelda3::GameData game_data(&rom);
+
+  auto editor = std::make_unique<DungeonEditorV2>(&rom);
+  editor->SetGameData(&game_data);
+  game_data.pit_damage_table.MarkDirty();
+
+  EXPECT_EQ(editor->PendingRoomCount(), 0);
+  EXPECT_FALSE(editor->HasPendingRoomChanges());
+  EXPECT_TRUE(editor->HasPendingDungeonChanges());
+
+  game_data.pit_damage_table.ClearDirty();
+  EXPECT_FALSE(editor->HasPendingDungeonChanges());
+}
+
+TEST(DungeonEditorV2RomSafetyTest,
      SaveTransactionRollbackRestoresRoomAndPitDirtyState) {
   Rom rom;
   ASSERT_TRUE(rom.LoadFromData(std::vector<uint8_t>(0x200000, 0)).ok());

--- a/test/unit/editor/editor_manager_rom_write_policy_test.cc
+++ b/test/unit/editor/editor_manager_rom_write_policy_test.cc
@@ -918,7 +918,7 @@ TEST(EditorManagerBackupRestoreTest,
 }
 
 TEST(EditorManagerBackupRestoreTest,
-     DiscardPendingRomBackupRestoreRejectsPendingDungeonRoom) {
+     DiscardPendingRomBackupRestoreRejectsPendingDungeonMetadata) {
   FeatureFlagsGuard guard;
   ScopedImGuiContext imgui;
 
@@ -955,19 +955,23 @@ TEST(EditorManagerBackupRestoreTest,
   ASSERT_TRUE(session->backup_restore_pending);
   const std::string staged_hash = manager->GetCurrentRomHash();
 
+  auto* const game_data = manager->GetCurrentGameData();
+  ASSERT_NE(game_data, nullptr);
+  game_data->pit_damage_table.MarkDirty();
+  ASSERT_TRUE(game_data->pit_damage_table.dirty());
   auto* const dungeon =
       manager->GetCurrentEditorSet()->GetEditorAs<DungeonEditorV2>(
           EditorType::kDungeon);
   ASSERT_NE(dungeon, nullptr);
-  dungeon->rooms()[0].SetPalette(0x2A);
-  ASSERT_EQ(dungeon->PendingRoomCount(), 1);
+  ASSERT_EQ(dungeon->PendingRoomCount(), 0);
+  ASSERT_TRUE(dungeon->HasPendingDungeonChanges());
 
   const auto discard_status = manager->DiscardPendingRomBackupRestore();
 
   EXPECT_EQ(discard_status.code(), absl::StatusCode::kFailedPrecondition)
       << discard_status;
   EXPECT_NE(std::string(discard_status.message())
-                .find("pending dungeon-room or palette edits"),
+                .find("pending dungeon or palette edits"),
             std::string::npos);
   EXPECT_EQ(manager->GetCurrentRom(), active_rom);
   ASSERT_TRUE(active_rom->ReadByte(kPcOffset).ok());
@@ -975,7 +979,8 @@ TEST(EditorManagerBackupRestoreTest,
   EXPECT_EQ(manager->GetCurrentRomHash(), staged_hash);
   EXPECT_TRUE(active_rom->dirty());
   EXPECT_TRUE(session->backup_restore_pending);
-  EXPECT_EQ(dungeon->PendingRoomCount(), 1);
+  EXPECT_TRUE(game_data->pit_damage_table.dirty());
+  EXPECT_TRUE(dungeon->HasPendingDungeonChanges());
   EXPECT_EQ(ReadByteAt(rom_path, kPcOffset), kEdited);
 }
 
@@ -1036,7 +1041,7 @@ TEST(EditorManagerBackupRestoreTest,
   EXPECT_EQ(discard_status.code(), absl::StatusCode::kFailedPrecondition)
       << discard_status;
   EXPECT_NE(std::string(discard_status.message())
-                .find("pending dungeon-room or palette edits"),
+                .find("pending dungeon or palette edits"),
             std::string::npos);
   EXPECT_EQ(manager->GetCurrentRom(), active_rom);
   ASSERT_TRUE(active_rom->ReadByte(kPcOffset).ok());

--- a/test/unit/editor/editor_manager_write_conflict_test.cc
+++ b/test/unit/editor/editor_manager_write_conflict_test.cc
@@ -21,6 +21,7 @@
 #include "core/rom_settings.h"
 #include "rom/rom_diff.h"
 #include "rom/snes.h"
+#include "test_utils/dungeon_editor_v2_regular_entrance_test_peer.h"
 #include "testing.h"
 #include "zelda3/dungeon/custom_object.h"
 #include "zelda3/dungeon/dungeon_rom_addresses.h"
@@ -166,6 +167,19 @@ void MarkCurrentDungeonRoomPending(EditorManager* manager) {
   ASSERT_NE(dungeon, nullptr);
   dungeon->rooms()[0].SetPalette(0x2A);
   EXPECT_EQ(dungeon->PendingRoomCount(), 1);
+}
+
+void MarkCurrentDungeonEntrancePending(EditorManager* manager) {
+  auto* editor_set = manager->GetCurrentEditorSet();
+  ASSERT_NE(editor_set, nullptr);
+  auto* dungeon =
+      editor_set->GetEditorAs<DungeonEditorV2>(EditorType::kDungeon);
+  ASSERT_NE(dungeon, nullptr);
+  auto& entrance =
+      DungeonEditorV2RegularEntranceTestPeer::RegularEntrance(*dungeon, 0);
+  entrance.MarkDirty();
+  EXPECT_EQ(dungeon->PendingRoomCount(), 0);
+  EXPECT_TRUE(dungeon->HasPendingDungeonChanges());
 }
 
 void SeedCurrentDungeonPalette(EditorManager* manager, uint16_t seed) {
@@ -1113,7 +1127,7 @@ TEST(EditorManagerWriteConflictTest,
 }
 
 TEST(EditorManagerWriteConflictTest,
-     SwitchAndCloseSessionDeferWhileCurrentSessionHasPendingDungeonChanges) {
+     SwitchAndCloseSessionDeferWhileCurrentSessionHasPendingDungeonMetadata) {
   ScopedImGuiContext imgui;
 
   auto renderer = std::make_unique<gfx::NullRenderer>();
@@ -1132,7 +1146,8 @@ TEST(EditorManagerWriteConflictTest,
   ASSERT_OK(manager->OpenRomOrProject(rom_b.string()));
   ASSERT_EQ(manager->GetCurrentSessionIndex(), 1u);
 
-  MarkCurrentDungeonRoomPending(manager.get());
+  MarkCurrentDungeonEntrancePending(manager.get());
+  EXPECT_TRUE(manager->session_coordinator()->IsSessionModified(1));
 
   manager->SwitchToSession(0);
   EXPECT_TRUE(manager->HasPendingUnsavedSessionAction());
@@ -1143,7 +1158,7 @@ TEST(EditorManagerWriteConflictTest,
 
   manager->SwitchToSession(1);
   EXPECT_EQ(manager->GetCurrentSessionIndex(), 1u);
-  MarkCurrentDungeonRoomPending(manager.get());
+  MarkCurrentDungeonEntrancePending(manager.get());
 
   manager->session_coordinator()->RequestCloseCurrentSession();
   EXPECT_TRUE(manager->HasPendingUnsavedSessionAction());


### PR DESCRIPTION
## Summary
- add aggregate dungeon pending-state coverage for room edits, regular entrances, dedicated spawn points, and pit-damage membership
- route session modified state and close/switch/open/reload/restore safety guards through the aggregate predicate
- keep `PendingRoomCount()` room-specific while describing metadata-only work accurately
- add focused entrance-only, spawn-only, pit-only, session lifecycle, and backup-restore regressions

This closes a discard/data-loss gap where metadata-only dungeon edits could appear clean and bypass session safety prompts.

Contributes to #115.

## Verification
- `cmake --preset mac-test -DYAZE_FORCE_BUNDLED_ABSL=ON`
- `cmake --build build/presets/mac-test --config RelWithDebInfo --target yaze_test_quick_unit_editor --parallel 8`
- focused aggregate/session/restore filter — 7/7 passed
- `clang-format --dry-run --Werror` on changed C++ files
- independent read-only review: no blocking findings
