### PR TITLE
fix(dungeon): reject unsafe room object encodings

### DIFF
--- a/src/zelda3/dungeon/dungeon_validator.cc
+++ b/src/zelda3/dungeon/dungeon_validator.cc
@@ -103,13 +103,17 @@ ValidationResult DungeonValidator::ValidateRoom(const Room& room) {
 
   // Check bounds
   for (const auto& obj : room.GetTileObjects()) {
-    const int layer = static_cast<int>(obj.GetLayerValue());
-    if (layer < 0 || layer > 2) {
-      result.errors.push_back(absl::StrFormat(
-          "Object 0x%02X has invalid layer %d", obj.id_, layer));
-      result.is_valid = false;
+    if (UsesRoomObjectStream(obj)) {
+      const absl::Status status = ValidateRoomObjectStreamEntryForSave(obj);
+      if (!status.ok()) {
+        result.errors.emplace_back(std::string(status.message()));
+        result.is_valid = false;
+      }
+      continue;
     }
-    if (UsesSpecialLayerSelector(obj) && layer > 1) {
+
+    const int layer = static_cast<int>(obj.GetLayerValue());
+    if (layer > 1) {
       result.errors.push_back(absl::StrFormat(
           "Special-table object 0x%02X has invalid layer selector %d; "
           "expected upper/BG1 (0) or lower/BG2 (1)",

--- a/src/zelda3/dungeon/room.cc
+++ b/src/zelda3/dungeon/room.cc
@@ -27,6 +27,7 @@
 #include "zelda3/dungeon/dungeon_torch_codec.h"
 #include "zelda3/dungeon/editor_dungeon_state.h"
 #include "zelda3/dungeon/object_drawer.h"
+#include "zelda3/dungeon/object_layer_semantics.h"
 #include "zelda3/dungeon/palette_debug.h"
 #include "zelda3/dungeon/pit_damage_table.h"
 #include "zelda3/dungeon/room_layer_manager.h"
@@ -2023,6 +2024,12 @@ absl::Status Room::SaveObjects(const DungeonStreamLayout* layout) {
   }
   if (!object_stream_dirty()) {
     return absl::OkStatus();
+  }
+
+  for (const auto& object : tile_objects_) {
+    if (UsesRoomObjectStream(object)) {
+      RETURN_IF_ERROR(ValidateRoomObjectStreamEntryForSave(object));
+    }
   }
 
   const auto& rom_data = rom()->vector();

--- a/src/zelda3/dungeon/room_object.cc
+++ b/src/zelda3/dungeon/room_object.cc
@@ -247,13 +247,13 @@ int RoomObject::DetermineObjectType(uint8_t b1, uint8_t b3) {
     return 2;
   }
 
-  // Type 3: Objects with ID >= 0xF00
+  // Type 3: Representable object IDs 0xF80-0xFFF
   // These have b3 >= 0xF8 (top nibble is 0xF)
   if (b3 >= 0xF8) {
     return 3;
   }
 
-  // Type 1: Standard objects (ID 0x00-0xFF)
+  // Type 1: Representable object IDs 0x000-0x0F7
   return 1;
 }
 
@@ -313,17 +313,17 @@ RoomObject::ObjectBytes RoomObject::EncodeObjectToBytes() const {
 
   // Determine type based on object ID
   if (id_ >= 0x100 && id_ < 0x200) {
-    // Type 2: 111111xx xxxxyyyy yyiiiiii
+    // Type 2: 111111xx xxxxyyyy yyiiiiii (representable IDs 0x100-0x13F)
     bytes.b1 = 0xFC | ((x_ & 0x30) >> 4);
     bytes.b2 = ((x_ & 0x0F) << 4) | ((y_ & 0x3C) >> 2);
     bytes.b3 = ((y_ & 0x03) << 6) | (id_ & 0x3F);
   } else if (id_ >= 0xF00) {
-    // Type 3: xxxxxxii yyyyyyii 11111iii
+    // Type 3: xxxxxxii yyyyyyii 11111iii (representable IDs 0xF80-0xFFF)
     bytes.b1 = (x_ << 2) | (id_ & 0x03);
     bytes.b2 = (y_ << 2) | ((id_ >> 2) & 0x03);
     bytes.b3 = (id_ >> 4) & 0xFF;
   } else {
-    // Type 1: xxxxxxss yyyyyyss iiiiiiii
+    // Type 1: xxxxxxss yyyyyyss iiiiiiii (representable IDs 0x000-0x0F7)
     uint8_t clamped_size = size_ > 15 ? 15 : size_;
     bytes.b1 = (x_ << 2) | ((clamped_size >> 2) & 0x03);
     bytes.b2 = (y_ << 2) | (clamped_size & 0x03);
@@ -331,6 +331,75 @@ RoomObject::ObjectBytes RoomObject::EncodeObjectToBytes() const {
   }
 
   return bytes;
+}
+
+absl::Status ValidateRoomObjectStreamEntryForSave(const RoomObject& object) {
+  const int layer = object.GetLayerValue();
+  if (layer > 2) {
+    return absl::InvalidArgumentError(absl::StrFormat(
+        "Room object 0x%03X has invalid stream list index %d; expected 0..2",
+        object.id_, layer));
+  }
+  if (object.x_ > 63 || object.y_ > 63) {
+    return absl::InvalidArgumentError(absl::StrFormat(
+        "Room object 0x%03X has out-of-range coordinates (%d, %d); "
+        "expected 0..63",
+        object.id_, object.x_, object.y_));
+  }
+
+  int expected_type = 0;
+  if (object.id_ >= 0x000 && object.id_ <= 0x0F7) {
+    expected_type = 1;
+  } else if (object.id_ >= 0x100 && object.id_ <= 0x13F) {
+    expected_type = 2;
+  } else if (object.id_ >= 0xF80 && object.id_ <= 0xFFF) {
+    expected_type = 3;
+  } else {
+    return absl::InvalidArgumentError(absl::StrFormat(
+        "Room object ID 0x%03X is not representable without aliasing; "
+        "expected 0x000..0x0F7, 0x100..0x13F, or 0xF80..0xFFF",
+        object.id_));
+  }
+
+  // Type 1/3 encode X in the upper six bits of byte 1. X=63 therefore
+  // produces the Type 2 discriminator (0xFC..0xFF) and decodes as another
+  // object family.
+  if (expected_type != 2 && object.x_ == 63) {
+    return absl::InvalidArgumentError(absl::StrFormat(
+        "Room object 0x%03X at x=63 collides with the Type 2 discriminator",
+        object.id_));
+  }
+
+  const RoomObject::ObjectBytes encoded = object.EncodeObjectToBytes();
+  if ((encoded.b1 == 0xFF && encoded.b2 == 0xFF) ||
+      (encoded.b1 == 0xF0 && encoded.b2 == 0xFF)) {
+    return absl::InvalidArgumentError(absl::StrFormat(
+        "Room object 0x%03X encodes with reserved stream-control prefix "
+        "0x%02X 0x%02X",
+        object.id_, encoded.b1, encoded.b2));
+  }
+
+  const int encoded_type =
+      RoomObject::DetermineObjectType(encoded.b1, encoded.b3);
+  if (encoded_type != expected_type) {
+    return absl::InvalidArgumentError(absl::StrFormat(
+        "Room object 0x%03X encodes with Type %d discriminator, expected "
+        "Type %d",
+        object.id_, encoded_type, expected_type));
+  }
+
+  const RoomObject decoded = RoomObject::DecodeObjectFromBytes(
+      encoded.b1, encoded.b2, encoded.b3,
+      static_cast<uint8_t>(object.GetLayerValue()));
+  if (decoded.id_ != object.id_ || decoded.x_ != object.x_ ||
+      decoded.y_ != object.y_) {
+    return absl::InvalidArgumentError(absl::StrFormat(
+        "Room object 0x%03X at (%d, %d) aliases to 0x%03X at (%d, %d) "
+        "after encoding",
+        object.id_, object.x_, object.y_, decoded.id_, decoded.x_, decoded.y_));
+  }
+
+  return absl::OkStatus();
 }
 
 }  // namespace zelda3

--- a/src/zelda3/dungeon/room_object.cc
+++ b/src/zelda3/dungeon/room_object.cc
@@ -41,7 +41,8 @@ bool IsAllBgsObjectId(int object_id) {
   // Keep this list in sync with DecodeObjectFromBytes behavior and any
   // special-cased BothBG handling in ObjectDrawer.
   const int id = object_id;
-  if ((id >= 0x03 && id <= 0x04) ||  // USDASM: Rightwards2x4spaced4_1to16 writes to both tilemaps
+  // USDASM: Rightwards2x4spaced4_1to16 writes to both tilemaps.
+  if ((id >= 0x03 && id <= 0x04) ||
       (id >= 0x63 && id <= 0x64) ||  // Routine 9 objects
       // Routine 17 (Acute Diagonals)
       id == 0x0C || id == 0x0D || id == 0x10 || id == 0x11 || id == 0x14 ||

--- a/src/zelda3/dungeon/room_object.h
+++ b/src/zelda3/dungeon/room_object.h
@@ -5,6 +5,7 @@
 #include <string>
 #include <vector>
 
+#include "absl/status/status.h"
 #include "absl/strings/str_format.h"
 #include "app/gfx/types/snes_tile.h"
 #include "rom/rom.h"
@@ -121,9 +122,9 @@ class RoomObject {
   };
 
   // Decode object from 3-byte ROM format
-  // Type1: xxxxxxss yyyyyyss iiiiiiii (ID 0x00-0xFF)
-  // Type2: 111111xx xxxxyyyy yyiiiiii (ID 0x100-0x1FF)
-  // Type3: xxxxxxii yyyyyyii 11111iii (ID 0xF00-0xFFF)
+  // Type1: xxxxxxss yyyyyyss iiiiiiii (ID 0x000-0x0F7)
+  // Type2: 111111xx xxxxyyyy yyiiiiii (ID 0x100-0x13F)
+  // Type3: xxxxxxii yyyyyyii 11111iii (ID 0xF80-0xFFF)
   static RoomObject DecodeObjectFromBytes(uint8_t b1, uint8_t b2, uint8_t b3,
                                           uint8_t layer);
 
@@ -239,6 +240,12 @@ class RoomObject {
   void RefreshDerivedFlagsFromId();
   void InvalidateTileCache();
 };
+
+// Validates that an ordinary room-object stream entry can be encoded without
+// changing its identity or colliding with the stream's list/door markers.
+// Torches and pushable blocks use separate tables; callers must exclude them
+// with UsesRoomObjectStream().
+absl::Status ValidateRoomObjectStreamEntryForSave(const RoomObject& object);
 
 // USDASM (LoadAndBuildRoom): three room-object lists separated by $FFFF after the
 // floor/layout header. `RoomObject::layer_` stores that list index (0, 1, 2) for

--- a/test/unit/zelda3/dungeon/dungeon_save_test.cc
+++ b/test/unit/zelda3/dungeon/dungeon_save_test.cc
@@ -356,6 +356,32 @@ TEST_F(DungeonSaveTest, SaveObjects_FitsInSpace) {
   EXPECT_TRUE(status.ok()) << status.message();
 }
 
+TEST_F(DungeonSaveTest,
+       SaveObjects_InvalidObjectFailsWithoutRomMutationAndStaysDirty) {
+  room_->AddTileObject(RoomObject(/*id=*/0x140, /*x=*/10, /*y=*/10,
+                                  /*size=*/0, /*layer=*/0));
+  const auto before = rom_->vector();
+
+  const auto status = room_->SaveObjects();
+
+  EXPECT_EQ(status.code(), absl::StatusCode::kInvalidArgument);
+  EXPECT_EQ(rom_->vector(), before);
+  EXPECT_TRUE(room_->object_stream_dirty());
+}
+
+TEST_F(DungeonSaveTest,
+       SaveObjects_StreamMarkerCollisionFailsWithoutRomMutationAndStaysDirty) {
+  room_->AddTileObject(RoomObject(/*id=*/0x010, /*x=*/60, /*y=*/63,
+                                  /*size=*/3, /*layer=*/0));
+  const auto before = rom_->vector();
+
+  const auto status = room_->SaveObjects();
+
+  EXPECT_EQ(status.code(), absl::StatusCode::kInvalidArgument);
+  EXPECT_EQ(rom_->vector(), before);
+  EXPECT_TRUE(room_->object_stream_dirty());
+}
+
 TEST_F(DungeonSaveTest, SaveObjects_TooLarge) {
   // Add MANY objects to exceed 256 bytes
   // Each object encodes to 3 bytes.

--- a/test/unit/zelda3/dungeon/dungeon_validator_test.cc
+++ b/test/unit/zelda3/dungeon/dungeon_validator_test.cc
@@ -24,6 +24,16 @@ bool HasWarningContaining(const ValidationResult& result,
   return false;
 }
 
+bool HasErrorContaining(const ValidationResult& result,
+                        std::string_view needle) {
+  for (const auto& error : result.errors) {
+    if (error.find(needle) != std::string::npos) {
+      return true;
+    }
+  }
+  return false;
+}
+
 TEST(DungeonValidatorTest, AcceptsBothBgObjectsInOverlayStreams) {
   Rom rom;
   ASSERT_TRUE(rom.LoadFromData(std::vector<uint8_t>(0x200000, 0)).ok());
@@ -51,8 +61,8 @@ TEST(DungeonValidatorTest, AcceptsMoreThan128ObjectsInOverlayStream) {
 
   Room room(/*room_id=*/0, &rom);
   for (int i = 0; i < 129; ++i) {
-    ASSERT_TRUE(room.AddObject(RoomObject(/*id=*/0x21, /*x=*/i % 64,
-                                          /*y=*/(i / 64) % 64,
+    ASSERT_TRUE(room.AddObject(RoomObject(/*id=*/0x21, /*x=*/i % 63,
+                                          /*y=*/(i / 63) % 64,
                                           /*size=*/0, /*layer=*/2))
                     .ok());
   }
@@ -99,6 +109,42 @@ TEST(DungeonValidatorTest, AcceptsValidRoomWithNormalObject) {
 
   DungeonValidator validator;
   const auto result = validator.ValidateRoom(room);
+
+  EXPECT_TRUE(result.is_valid);
+  EXPECT_TRUE(result.errors.empty());
+}
+
+TEST(DungeonValidatorTest, RejectsUnrepresentableRoomStreamObject) {
+  Rom rom;
+  ASSERT_TRUE(rom.LoadFromData(std::vector<uint8_t>(0x200000, 0)).ok());
+
+  Room room(/*room_id=*/0, &rom);
+  ASSERT_TRUE(
+      room.AddObject(RoomObject(/*id=*/0x140, /*x=*/4, /*y=*/4, /*size=*/0,
+                                /*layer=*/0))
+          .ok());
+
+  const auto result = DungeonValidator().ValidateRoom(room);
+
+  EXPECT_FALSE(result.is_valid);
+  EXPECT_TRUE(HasErrorContaining(result, "not representable"));
+}
+
+TEST(DungeonValidatorTest, ExemptsSpecialTableObjectsFromRoomStreamCodec) {
+  Rom rom;
+  ASSERT_TRUE(rom.LoadFromData(std::vector<uint8_t>(0x200000, 0)).ok());
+
+  Room room(/*room_id=*/0, &rom);
+  RoomObject torch(/*id=*/0x150, /*x=*/4, /*y=*/4, /*size=*/0,
+                   /*layer=*/0);
+  torch.set_options(ObjectOption::Torch);
+  ASSERT_TRUE(room.AddObject(torch).ok());
+  RoomObject block(/*id=*/0x0E00, /*x=*/8, /*y=*/8, /*size=*/0,
+                   /*layer=*/1);
+  block.set_options(ObjectOption::Block);
+  ASSERT_TRUE(room.AddObject(block).ok());
+
+  const auto result = DungeonValidator().ValidateRoom(room);
 
   EXPECT_TRUE(result.is_valid);
   EXPECT_TRUE(result.errors.empty());

--- a/test/unit/zelda3/dungeon/room_object_encoding_test.cc
+++ b/test/unit/zelda3/dungeon/room_object_encoding_test.cc
@@ -5,6 +5,8 @@
 // correctly for all three object types (Type1, Type2, Type3) based on
 // ZScream's proven implementation.
 
+#include <string>
+
 #include <gtest/gtest.h>
 
 #include "zelda3/dungeon/room_object.h"
@@ -51,6 +53,93 @@ TEST(RoomObjectEncodingTest, MapRoomObjectListIndexToDrawLayer) {
   EXPECT_EQ(MapRoomObjectListIndexToDrawLayer(1), RoomObject::LayerType::BG2);
   EXPECT_EQ(MapRoomObjectListIndexToDrawLayer(2), RoomObject::LayerType::BG3);
   EXPECT_EQ(MapRoomObjectListIndexToDrawLayer(99), RoomObject::LayerType::BG3);
+}
+
+TEST(RoomObjectEncodingTest, SaveGuardAcceptsRepresentableIdBoundaries) {
+  for (const int16_t id : {int16_t{0x000}, int16_t{0x0F7}, int16_t{0x100},
+                           int16_t{0x13F}, int16_t{0xF80}, int16_t{0xFFF}}) {
+    const RoomObject object(id, /*x=*/62, /*y=*/63, /*size=*/15,
+                            /*layer=*/2);
+
+    const auto status = ValidateRoomObjectStreamEntryForSave(object);
+
+    EXPECT_TRUE(status.ok()) << "id=" << id << ": " << status.message();
+  }
+}
+
+TEST(RoomObjectEncodingTest, SaveGuardRejectsAliasedIdRanges) {
+  for (const int16_t id : {int16_t{0x0F8}, int16_t{0x140}, int16_t{0x200},
+                           int16_t{0xF00}, int16_t{0xF7F}}) {
+    const RoomObject object(id, /*x=*/10, /*y=*/20, /*size=*/0,
+                            /*layer=*/0);
+
+    const auto status = ValidateRoomObjectStreamEntryForSave(object);
+
+    EXPECT_EQ(status.code(), absl::StatusCode::kInvalidArgument) << "id=" << id;
+    EXPECT_NE(status.message().find("not representable"), std::string::npos)
+        << status.message();
+  }
+}
+
+TEST(RoomObjectEncodingTest, SaveGuardRejectsNonType2X63Discriminator) {
+  for (const int16_t id : {int16_t{0x010}, int16_t{0xF99}}) {
+    const RoomObject object(id, /*x=*/63, /*y=*/20, /*size=*/0,
+                            /*layer=*/0);
+
+    const auto status = ValidateRoomObjectStreamEntryForSave(object);
+
+    EXPECT_EQ(status.code(), absl::StatusCode::kInvalidArgument);
+    EXPECT_NE(status.message().find("Type 2 discriminator"), std::string::npos)
+        << status.message();
+  }
+
+  const RoomObject type2(/*id=*/0x100, /*x=*/63, /*y=*/59, /*size=*/0,
+                         /*layer=*/0);
+  EXPECT_TRUE(ValidateRoomObjectStreamEntryForSave(type2).ok());
+}
+
+TEST(RoomObjectEncodingTest, SaveGuardRejectsStreamControlPrefixes) {
+  const RoomObject list_terminator(/*id=*/0x100, /*x=*/63, /*y=*/60,
+                                   /*size=*/0, /*layer=*/0);
+  const RoomObject type1_door_marker(/*id=*/0x010, /*x=*/60, /*y=*/63,
+                                     /*size=*/3, /*layer=*/0);
+  const RoomObject type3_door_marker(/*id=*/0xF8C, /*x=*/60, /*y=*/63,
+                                     /*size=*/0, /*layer=*/0);
+
+  for (const RoomObject* object :
+       {&list_terminator, &type1_door_marker, &type3_door_marker}) {
+    const auto status = ValidateRoomObjectStreamEntryForSave(*object);
+
+    EXPECT_EQ(status.code(), absl::StatusCode::kInvalidArgument);
+    EXPECT_NE(status.message().find("reserved stream-control prefix"),
+              std::string::npos)
+        << status.message();
+  }
+}
+
+TEST(RoomObjectEncodingTest, SaveGuardRejectsInvalidLayerAndCoordinates) {
+  RoomObject invalid_layer(/*id=*/0x010, /*x=*/10, /*y=*/20, /*size=*/0,
+                           /*layer=*/0);
+  invalid_layer.layer_ = static_cast<RoomObject::LayerType>(3);
+  EXPECT_EQ(ValidateRoomObjectStreamEntryForSave(invalid_layer).code(),
+            absl::StatusCode::kInvalidArgument);
+
+  const RoomObject invalid_x(/*id=*/0x010, /*x=*/64, /*y=*/20, /*size=*/0,
+                             /*layer=*/0);
+  EXPECT_EQ(ValidateRoomObjectStreamEntryForSave(invalid_x).code(),
+            absl::StatusCode::kInvalidArgument);
+
+  const RoomObject invalid_y(/*id=*/0x010, /*x=*/10, /*y=*/64, /*size=*/0,
+                             /*layer=*/0);
+  EXPECT_EQ(ValidateRoomObjectStreamEntryForSave(invalid_y).code(),
+            absl::StatusCode::kInvalidArgument);
+}
+
+TEST(RoomObjectEncodingTest, SaveGuardDoesNotRejectLossySizeField) {
+  const RoomObject object(/*id=*/0x010, /*x=*/10, /*y=*/20, /*size=*/0xFF,
+                          /*layer=*/0);
+
+  EXPECT_TRUE(ValidateRoomObjectStreamEntryForSave(object).ok());
 }
 
 // Type 1 Object Encoding/Decoding Tests

--- a/test/unit/zelda3/dungeon/room_object_encoding_test.cc
+++ b/test/unit/zelda3/dungeon/room_object_encoding_test.cc
@@ -37,7 +37,8 @@ TEST(RoomObjectEncodingTest, DetermineObjectTypeType3) {
   // Type3: b3 >= 0xF8 AND b1 < 0xFC (Type 2 takes precedence when b1 >= 0xFC)
   EXPECT_EQ(RoomObject::DetermineObjectType(0x28, 0xF8), 3);
   EXPECT_EQ(RoomObject::DetermineObjectType(0x50, 0xF9), 3);
-  EXPECT_EQ(RoomObject::DetermineObjectType(0xFB, 0xFF), 3);  // b1 < 0xFC, so Type 3
+  EXPECT_EQ(RoomObject::DetermineObjectType(0xFB, 0xFF),
+            3);  // b1 < 0xFC, so Type 3
 }
 
 TEST(RoomObjectEncodingTest, DetermineObjectTypeBoundaryCollision) {


### PR DESCRIPTION
## Summary
- reject room-object IDs and coordinates that cannot survive the 3-byte dungeon stream codec
- reject Type 2 discriminator and `FF FF` / `F0 FF` stream-control collisions before ROM writes
- apply the same validation in `DungeonValidator` while exempting torch/block special-table objects
- preserve the room dirty flag and ROM bytes when validation fails

## Why
The unchecked encoder can otherwise silently alias IDs (for example `0x140`) or emit bytes that the loader interprets as a list terminator or door marker. This makes those failures explicit before any object-stream mutation.

## Verification
- built `yaze_test_unit` with bundled Abseil (`YAZE_FORCE_BUNDLED_ABSL=ON`)
- focused filter only: 13 tests from 3 suites, 13 passed
- `git clang-format --diff HEAD -- <changed files>` produced no changes
- `git diff --check` passed

## Deferred
- canonical size semantics and resize UI restrictions
- checked encoder API for all callers
- full in-place stream transactionality
