### PR TITLE
fix(dungeon): canonicalize room object sizes

### DIFF
--- a/src/app/editor/dungeon/dungeon_object_selector.cc
+++ b/src/app/editor/dungeon/dungeon_object_selector.cc
@@ -36,6 +36,8 @@ namespace yaze::editor {
 
 namespace {
 
+constexpr int kPersistedCustomSubtypeSlots = 16;
+
 float GetObjectGridItemSize(int density) {
   switch (density) {
     case 0:
@@ -106,12 +108,19 @@ void DrawFallbackPreviewTile(ImDrawList* draw_list, ImVec2 top_left,
 
 }  // namespace
 
+bool DungeonObjectSelector::IsRepresentableChestObjectId(int object_id) {
+  return object_id == 0xF99 || object_id == 0xF9A || object_id == 0xFB1 ||
+         object_id == 0xFB2 || object_id == 0xFF5;
+}
+
 ImU32 DungeonObjectSelector::GetObjectTypeColor(int object_id) {
   const auto& theme = AgentUI::GetTheme();
 
   // Type 3 objects (0xF80-0xFFF) - Special room features
   if (object_id >= 0xF80) {
-    if (object_id >= 0xF80 && object_id <= 0xF8F) {
+    if (IsRepresentableChestObjectId(object_id)) {
+      return ImGui::GetColorU32(theme.item_color);  // Gold for chests
+    } else if (object_id >= 0xF80 && object_id <= 0xF8F) {
       return ImGui::ColorConvertFloat4ToU32(
           theme.selection_secondary);  // Light blue for layer indicators
     } else if (object_id >= 0xF90 && object_id <= 0xF9F) {
@@ -123,7 +132,7 @@ ImU32 DungeonObjectSelector::GetObjectTypeColor(int object_id) {
     }
   }
 
-  // Type 2 objects (0x100-0x141) - Torches, blocks, switches
+  // Type 2 objects (0x100-0x13F) - Torches, blocks, switches
   if (object_id >= 0x100 && object_id < 0x200) {
     if (object_id >= 0x100 && object_id <= 0x10F) {
       return ImGui::GetColorU32(theme.status_warning);  // Torches
@@ -139,13 +148,11 @@ ImU32 DungeonObjectSelector::GetObjectTypeColor(int object_id) {
     }
   }
 
-  // Type 1 objects (0x00-0xFF) - Base room objects
+  // Type 1 objects (0x00-0xF7) - Base room objects
   if (object_id >= 0x10 && object_id <= 0x1F) {
     return ImGui::GetColorU32(theme.dungeon_object_wall);  // Gray for walls
   } else if (object_id >= 0x20 && object_id <= 0x2F) {
     return ImGui::GetColorU32(theme.dungeon_object_floor);  // Brown for floors
-  } else if (object_id == 0xF9 || object_id == 0xFA) {
-    return ImGui::GetColorU32(theme.item_color);  // Gold for chests
   } else if (object_id >= 0x17 && object_id <= 0x1E) {
     return ImGui::GetColorU32(theme.dungeon_object_floor);  // Brown for doors
   } else if (object_id == 0x2F || object_id == 0x2B) {
@@ -164,7 +171,9 @@ ImU32 DungeonObjectSelector::GetObjectTypeColor(int object_id) {
 std::string DungeonObjectSelector::GetObjectTypeSymbol(int object_id) {
   // Type 3 objects (0xF80-0xFFF) - Special room features
   if (object_id >= 0xF80) {
-    if (object_id >= 0xF80 && object_id <= 0xF8F) {
+    if (IsRepresentableChestObjectId(object_id)) {
+      return "C";
+    } else if (object_id >= 0xF80 && object_id <= 0xF8F) {
       return "L";  // Layer
     } else if (object_id >= 0xF90 && object_id <= 0xF9F) {
       return "D";  // Door indicator
@@ -173,7 +182,7 @@ std::string DungeonObjectSelector::GetObjectTypeSymbol(int object_id) {
     }
   }
 
-  // Type 2 objects (0x100-0x141) - Torches, blocks, switches
+  // Type 2 objects (0x100-0x13F) - Torches, blocks, switches
   if (object_id >= 0x100 && object_id < 0x200) {
     if (object_id >= 0x100 && object_id <= 0x10F) {
       return "*";  // Torch (flame)
@@ -188,13 +197,11 @@ std::string DungeonObjectSelector::GetObjectTypeSymbol(int object_id) {
     }
   }
 
-  // Type 1 objects (0x00-0xFF) - Base room objects
+  // Type 1 objects (0x00-0xF7) - Base room objects
   if (object_id >= 0x10 && object_id <= 0x1F) {
     return "|";  // Wall
   } else if (object_id >= 0x20 && object_id <= 0x2F) {
     return "_";  // Floor
-  } else if (object_id == 0xF9 || object_id == 0xFA) {
-    return "C";  // Chest
   } else if (object_id >= 0x17 && object_id <= 0x1E) {
     return "+";  // Door
   } else if (object_id == 0x2F || object_id == 0x2B) {
@@ -209,12 +216,18 @@ std::string DungeonObjectSelector::GetObjectTypeSymbol(int object_id) {
 }
 
 void DungeonObjectSelector::SelectObject(int obj_id, int subtype) {
+  if (subtype >= kPersistedCustomSubtypeSlots) {
+    return;
+  }
+
   selected_object_id_ = obj_id;
 
   // Create and update preview object
-  uint8_t size = 0x12;
+  uint8_t size = zelda3::DefaultRoomObjectSizeForPlacement(obj_id);
   if (subtype >= 0) {
-    size = static_cast<uint8_t>(subtype & 0x1F);
+    // Oracle custom objects use the explicitly selected size as a subtype.
+    size =
+        zelda3::CanonicalRoomObjectSize(obj_id, static_cast<uint8_t>(subtype));
   }
   preview_object_ = zelda3::RoomObject(obj_id, 0, 0, size, 0);
   preview_object_.SetRom(rom_);
@@ -234,26 +247,28 @@ void DungeonObjectSelector::SelectObject(int obj_id, int subtype) {
 void DungeonObjectSelector::DrawObjectAssetBrowser() {
   const auto& theme = AgentUI::GetTheme();
 
-  // Object ranges: Type 1 (0x00-0xFF), Type 2 (0x100-0x141), Type 3 (0xF80-0xFFF)
+  // Object ranges supported by the room-object stream codec.
   struct ObjectRange {
     int start;
     int end;
     const char* label;
   };
   static const ObjectRange ranges[] = {
-      {0x00, 0xFF, "Type 1"},
-      {0x100, 0x141, "Type 2"},
+      {0x00, 0xF7, "Type 1"},
+      {0x100, 0x13F, "Type 2"},
       {0xF80, 0xFFF, "Type 3"},
   };
 
   // Total object count
   int total_objects =
-      (0xFF - 0x00 + 1) + (0x141 - 0x100 + 1) + (0xFFF - 0xF80 + 1);
+      (0xF7 - 0x00 + 1) + (0x13F - 0x100 + 1) + (0xFFF - 0xF80 + 1);
 
   EnsureCustomObjectsInitialized();
   auto& obj_manager = zelda3::CustomObjectManager::Get();
   const int custom_count =
-      obj_manager.GetSubtypeCount(0x31) + obj_manager.GetSubtypeCount(0x32);
+      std::min(obj_manager.GetSubtypeCount(0x31),
+               kPersistedCustomSubtypeSlots) +
+      std::min(obj_manager.GetSubtypeCount(0x32), kPersistedCustomSubtypeSlots);
 
   // Row 1: search input, full-width since this is the most-used control.
   ImGui::SetNextItemWidth(-1.0f);
@@ -398,7 +413,9 @@ void DungeonObjectSelector::DrawObjectAssetBrowser() {
           selected_object_id_ = obj_id;
 
           // Create and update preview object
-          preview_object_ = zelda3::RoomObject(obj_id, 0, 0, 0x12, 0);
+          preview_object_ = zelda3::RoomObject(
+              obj_id, 0, 0, zelda3::DefaultRoomObjectSizeForPlacement(obj_id),
+              0);
           preview_object_.SetRom(rom_);
           if (game_data_ &&
               current_palette_group_id_ <
@@ -416,8 +433,9 @@ void DungeonObjectSelector::DrawObjectAssetBrowser() {
         }
         const bool item_visible = ImGui::IsItemVisible();
         ImVec2 button_pos = ImGui::GetItemRectMin();
-        gui::BeginRoomObjectDragSource(static_cast<uint16_t>(obj_id),
-                                       current_room_id_, 0, 0, 0x12);
+        gui::BeginRoomObjectDragSource(
+            static_cast<uint16_t>(obj_id), current_room_id_, 0, 0,
+            zelda3::DefaultRoomObjectSizeForPlacement(obj_id));
         // Draw object preview on the button; fall back to styled placeholder
         ImDrawList* draw_list = ImGui::GetWindowDrawList();
 
@@ -576,7 +594,7 @@ bool DungeonObjectSelector::MatchesObjectFilter(int obj_id, int filter_type) {
     case 2:  // Floors
       return obj_id >= 0x20 && obj_id <= 0x2F;
     case 3:  // Chests
-      return obj_id == 0xF9 || obj_id == 0xFA;
+      return IsRepresentableChestObjectId(obj_id);
     case 4:  // Doors
       return obj_id >= 0x17 && obj_id <= 0x1E;
     case 5:  // Decorations
@@ -664,7 +682,8 @@ void DungeonObjectSelector::EnsureCustomObjectsInitialized() {
 }
 
 zelda3::RoomObject DungeonObjectSelector::MakePreviewObject(int obj_id) const {
-  zelda3::RoomObject obj(obj_id, 0, 0, 0x12, 0);
+  zelda3::RoomObject obj(obj_id, 0, 0,
+                         zelda3::DefaultRoomObjectSizeForPlacement(obj_id), 0);
   obj.SetRom(rom_);
   obj.EnsureTilesLoaded();
   return obj;
@@ -825,14 +844,18 @@ void DungeonObjectSelector::DrawNewCustomObjectDialog() {
     bool valid = true;
     std::string error_msg;
 
-    if (create_filename_[0] == '\0') {
+    auto& mgr = zelda3::CustomObjectManager::Get();
+    const int subtype_count = mgr.GetSubtypeCount(create_object_id_);
+    if (subtype_count >= kPersistedCustomSubtypeSlots) {
+      valid = false;
+      error_msg = "Object group already uses all 16 persisted subtype slots";
+    } else if (create_filename_[0] == '\0') {
       valid = false;
       error_msg = "Filename cannot be empty";
     } else if (!rooms_ || current_room_id_ < 0) {
       valid = false;
       error_msg = "Load a room first (needed for tile graphics)";
     } else {
-      auto& mgr = zelda3::CustomObjectManager::Get();
       if (mgr.GetBasePath().empty()) {
         valid = false;
         error_msg = "Custom objects folder not configured in project";
@@ -975,7 +998,8 @@ void DungeonObjectSelector::DrawCustomObjectWorkshopPopup(float item_size) {
       if (!MatchesObjectFilter(obj_id, object_type_filter_)) {
         continue;
       }
-      int subtype_count = obj_manager.GetSubtypeCount(obj_id);
+      const int subtype_count = std::min(obj_manager.GetSubtypeCount(obj_id),
+                                         kPersistedCustomSubtypeSlots);
       for (int subtype = 0; subtype < subtype_count; ++subtype) {
         std::string base_name = zelda3::GetObjectName(obj_id);
         std::string subtype_name =
@@ -990,8 +1014,8 @@ void DungeonObjectSelector::DrawCustomObjectWorkshopPopup(float item_size) {
 
         ImGui::PushID(obj_id * 1000 + subtype);
 
-        bool is_selected = (selected_object_id_ == obj_id &&
-                            (preview_object_.size_ & 0x1F) == subtype);
+        bool is_selected =
+            (selected_object_id_ == obj_id && preview_object_.size_ == subtype);
         ImVec2 button_size(item_size, item_size);
 
         if (ImGui::Selectable("", is_selected, 0, button_size)) {
@@ -1000,15 +1024,17 @@ void DungeonObjectSelector::DrawCustomObjectWorkshopPopup(float item_size) {
         }
         const bool item_visible = ImGui::IsItemVisible();
         ImVec2 button_pos = ImGui::GetItemRectMin();
-        gui::BeginRoomObjectDragSource(static_cast<uint16_t>(obj_id),
-                                       current_room_id_, 0, 0,
-                                       static_cast<uint8_t>(subtype & 0x1F));
+        gui::BeginRoomObjectDragSource(
+            static_cast<uint16_t>(obj_id), current_room_id_, 0, 0,
+            zelda3::CanonicalRoomObjectSize(obj_id,
+                                            static_cast<uint8_t>(subtype)));
         ImDrawList* draw_list = ImGui::GetWindowDrawList();
 
         bool rendered = false;
         if (item_visible && enable_object_previews_) {
           auto temp_obj = MakePreviewObject(obj_id);
-          temp_obj.size_ = subtype;
+          temp_obj.size_ = zelda3::CanonicalRoomObjectSize(
+              obj_id, static_cast<uint8_t>(subtype));
           rendered = DrawObjectPreview(temp_obj, button_pos, item_size);
         }
 

--- a/src/app/editor/dungeon/dungeon_object_selector.h
+++ b/src/app/editor/dungeon/dungeon_object_selector.h
@@ -105,6 +105,14 @@ class DungeonObjectSelector {
   bool object_previews_enabled_for_testing() const {
     return enable_object_previews_;
   }
+  int selected_object_id_for_testing() const { return selected_object_id_; }
+  bool matches_object_filter_for_testing(int obj_id, int filter_type) {
+    return MatchesObjectFilter(obj_id, filter_type);
+  }
+  std::string object_type_symbol_for_testing(int object_id) {
+    return GetObjectTypeSymbol(object_id);
+  }
+  static bool IsRepresentableChestObjectId(int object_id);
 
  private:
   bool MatchesObjectFilter(int obj_id, int filter_type);

--- a/src/app/editor/dungeon/interaction/tile_object_handler.cc
+++ b/src/app/editor/dungeon/interaction/tile_object_handler.cc
@@ -651,14 +651,25 @@ void TileObjectHandler::UpdateObjectsId(int room_id,
   auto* room = GetRoom(room_id);
   if (!room || indices.empty())
     return;
+
+  auto& objects = room->GetTileObjects();
+  const bool has_change =
+      std::any_of(indices.begin(), indices.end(), [&](size_t index) {
+        return index < objects.size() && objects[index].id_ != new_id;
+      });
+  if (!has_change) {
+    return;
+  }
   if (ctx_)
     ctx_->NotifyMutation(MutationDomain::kTileObjects);
 
-  auto& objects = room->GetTileObjects();
   for (size_t index : indices) {
-    if (index < objects.size()) {
+    if (index < objects.size() && objects[index].id_ != new_id) {
+      const uint8_t canonical_size =
+          zelda3::CanonicalRoomObjectSize(new_id, objects[index].size_);
       // Use the setter so derived flags + tile caches stay coherent.
       objects[index].set_id(new_id);
+      objects[index].set_size(canonical_size);
     }
   }
   NotifyChange(room);
@@ -670,13 +681,32 @@ void TileObjectHandler::UpdateObjectsSize(int room_id,
   auto* room = GetRoom(room_id);
   if (!room || indices.empty())
     return;
+
+  auto& objects = room->GetTileObjects();
+  const bool has_change =
+      std::any_of(indices.begin(), indices.end(), [&](size_t index) {
+        if (index >= objects.size() ||
+            !zelda3::IsRoomObjectSizeEditable(objects[index].id_)) {
+          return false;
+        }
+        return objects[index].size_ !=
+               zelda3::CanonicalRoomObjectSize(objects[index].id_, new_size);
+      });
+  if (!has_change) {
+    return;
+  }
   if (ctx_)
     ctx_->NotifyMutation(MutationDomain::kTileObjects);
 
-  auto& objects = room->GetTileObjects();
   for (size_t index : indices) {
-    if (index < objects.size()) {
-      objects[index].size_ = new_size;
+    if (index < objects.size() &&
+        zelda3::IsRoomObjectSizeEditable(objects[index].id_)) {
+      const uint8_t canonical_size =
+          zelda3::CanonicalRoomObjectSize(objects[index].id_, new_size);
+      if (objects[index].size_ == canonical_size) {
+        continue;
+      }
+      objects[index].size_ = canonical_size;
       objects[index].tiles_loaded_ = false;
     }
   }
@@ -919,14 +949,32 @@ void TileObjectHandler::ResizeObjects(int room_id,
   auto* room = GetRoom(room_id);
   if (!room || indices.empty())
     return;
+  auto& objects = room->GetTileObjects();
+  const auto resized_size = [&](const zelda3::RoomObject& object) {
+    const int requested_size = static_cast<int>(object.size_) + delta;
+    return zelda3::CanonicalRoomObjectSize(
+        object.id_, static_cast<uint8_t>(std::clamp(requested_size, 0, 255)));
+  };
+  const bool has_change =
+      std::any_of(indices.begin(), indices.end(), [&](size_t index) {
+        return index < objects.size() &&
+               zelda3::IsRoomObjectSizeEditable(objects[index].id_) &&
+               objects[index].size_ != resized_size(objects[index]);
+      });
+  if (!has_change) {
+    return;
+  }
   if (ctx_)
     ctx_->NotifyMutation(MutationDomain::kTileObjects);
-  auto& objects = room->GetTileObjects();
+
   for (size_t index : indices) {
-    if (index < objects.size()) {
-      int new_size =
-          std::clamp(static_cast<int>(objects[index].size_) + delta, 0, 15);
-      objects[index].size_ = static_cast<uint8_t>(new_size);
+    if (index < objects.size() &&
+        zelda3::IsRoomObjectSizeEditable(objects[index].id_)) {
+      const uint8_t new_size = resized_size(objects[index]);
+      if (objects[index].size_ == new_size) {
+        continue;
+      }
+      objects[index].size_ = new_size;
       objects[index].tiles_loaded_ = false;
     }
   }

--- a/src/zelda3/dungeon/room_object.cc
+++ b/src/zelda3/dungeon/room_object.cc
@@ -1,5 +1,7 @@
 #include "room_object.h"
 
+#include <algorithm>
+
 #include "absl/status/status.h"
 #include "absl/strings/str_format.h"
 #include "util/log.h"
@@ -332,6 +334,31 @@ RoomObject::ObjectBytes RoomObject::EncodeObjectToBytes() const {
   }
 
   return bytes;
+}
+
+bool IsRoomObjectSizeEditable(int object_id) {
+  return object_id >= 0x000 && object_id <= 0x0F7;
+}
+
+uint8_t CanonicalRoomObjectSize(int object_id, uint8_t requested_size) {
+  if (IsRoomObjectSizeEditable(object_id)) {
+    return std::min<uint8_t>(requested_size, 15);
+  }
+  if (object_id >= 0x100 && object_id <= 0x13F) {
+    return 0;
+  }
+  if (object_id >= 0xF80 && object_id <= 0xFFF) {
+    return static_cast<uint8_t>(((object_id & 0x03) << 2) |
+                                ((object_id >> 2) & 0x03));
+  }
+  return requested_size;
+}
+
+uint8_t DefaultRoomObjectSizeForPlacement(int object_id) {
+  if (IsRoomObjectSizeEditable(object_id)) {
+    return 2;
+  }
+  return CanonicalRoomObjectSize(object_id, 0);
 }
 
 absl::Status ValidateRoomObjectStreamEntryForSave(const RoomObject& object) {

--- a/src/zelda3/dungeon/room_object.h
+++ b/src/zelda3/dungeon/room_object.h
@@ -241,6 +241,13 @@ class RoomObject {
   void InvalidateTileCache();
 };
 
+// Room-object size is persisted only for Type 1 objects. Type 2 has no size
+// field, while Type 3 reuses those bits as part of the object ID; its canonical
+// value mirrors DecodeObjectFromBytes rather than the ID's raw low nibble.
+bool IsRoomObjectSizeEditable(int object_id);
+uint8_t CanonicalRoomObjectSize(int object_id, uint8_t requested_size);
+uint8_t DefaultRoomObjectSizeForPlacement(int object_id);
+
 // Validates that an ordinary room-object stream entry can be encoded without
 // changing its identity or colliding with the stream's list/door markers.
 // Torches and pushable blocks use separate tables; callers must exclude them

--- a/test/unit/editor/dungeon_object_selector_palette_test.cc
+++ b/test/unit/editor/dungeon_object_selector_palette_test.cc
@@ -75,6 +75,82 @@ TEST(DungeonObjectSelectorPaletteTest, ObjectPreviewsDefaultOn) {
   EXPECT_TRUE(selector.object_previews_enabled_for_testing());
 }
 
+TEST(DungeonObjectSelectorSizeTest,
+     ProgrammaticSelectionUsesPersistedSizeSemantics) {
+  DungeonObjectSelector selector;
+
+  selector.SelectObject(0x01);
+  EXPECT_EQ(selector.GetPreviewObject().size(), 2);
+
+  selector.SelectObject(0x02, -2);
+  EXPECT_EQ(selector.GetPreviewObject().id_, 0x02);
+  EXPECT_EQ(selector.GetPreviewObject().size(), 2);
+
+  selector.SelectObject(0x100);
+  EXPECT_EQ(selector.GetPreviewObject().size(), 0);
+
+  selector.SelectObject(0xF99);
+  EXPECT_EQ(selector.GetPreviewObject().size(), 0x06);
+}
+
+TEST(DungeonObjectSelectorSizeTest, CanonicalHelpersRespectCodecBoundaries) {
+  EXPECT_TRUE(zelda3::IsRoomObjectSizeEditable(0x000));
+  EXPECT_TRUE(zelda3::IsRoomObjectSizeEditable(0x0F7));
+  EXPECT_FALSE(zelda3::IsRoomObjectSizeEditable(0x0F8));
+  EXPECT_FALSE(zelda3::IsRoomObjectSizeEditable(0x100));
+
+  EXPECT_EQ(zelda3::CanonicalRoomObjectSize(0x0F7, 0xFF), 0x0F);
+  EXPECT_EQ(zelda3::CanonicalRoomObjectSize(0x100, 0x0A), 0);
+  EXPECT_EQ(zelda3::CanonicalRoomObjectSize(0x13F, 0x0A), 0);
+  EXPECT_EQ(zelda3::CanonicalRoomObjectSize(0xF80, 0), 0);
+  EXPECT_EQ(zelda3::CanonicalRoomObjectSize(0xF99, 0), 0x06);
+  EXPECT_EQ(zelda3::CanonicalRoomObjectSize(0xFFF, 0), 0x0F);
+
+  EXPECT_EQ(zelda3::DefaultRoomObjectSizeForPlacement(0x0F7), 2);
+  EXPECT_EQ(zelda3::DefaultRoomObjectSizeForPlacement(0x100), 0);
+  EXPECT_EQ(zelda3::DefaultRoomObjectSizeForPlacement(0xF99), 0x06);
+}
+
+TEST(DungeonObjectSelectorSizeTest,
+     UnpersistableOracleSubtypeLeavesSelectionAndPreviewUnchanged) {
+  DungeonObjectSelector selector;
+  int callback_count = 0;
+  selector.SetObjectSelectedCallback(
+      [&](const zelda3::RoomObject&) { ++callback_count; });
+
+  selector.SelectObject(0x31, 0x0C);
+  ASSERT_TRUE(selector.IsObjectLoaded());
+  ASSERT_EQ(selector.selected_object_id_for_testing(), 0x31);
+  ASSERT_EQ(selector.GetPreviewObject().id_, 0x31);
+  EXPECT_EQ(selector.GetPreviewObject().size(), 0x0C);
+  EXPECT_EQ(callback_count, 1);
+
+  selector.SelectObject(0x32, 0x12);
+
+  EXPECT_EQ(selector.selected_object_id_for_testing(), 0x31);
+  EXPECT_EQ(selector.GetPreviewObject().id_, 0x31);
+  EXPECT_EQ(selector.GetPreviewObject().size(), 0x0C);
+  EXPECT_EQ(callback_count, 1);
+}
+
+TEST(DungeonObjectSelectorSizeTest,
+     ChestCategoryUsesRepresentableType3ObjectIds) {
+  DungeonObjectSelector selector;
+
+  for (int object_id : {0xF99, 0xF9A, 0xFB1, 0xFB2, 0xFF5}) {
+    EXPECT_TRUE(DungeonObjectSelector::IsRepresentableChestObjectId(object_id));
+    EXPECT_TRUE(selector.matches_object_filter_for_testing(object_id, 3));
+    EXPECT_EQ(selector.object_type_symbol_for_testing(object_id), "C");
+  }
+
+  for (int object_id : {0xF9, 0xFA, 0xF98, 0xFB0}) {
+    EXPECT_FALSE(
+        DungeonObjectSelector::IsRepresentableChestObjectId(object_id));
+    EXPECT_FALSE(selector.matches_object_filter_for_testing(object_id, 3));
+    EXPECT_NE(selector.object_type_symbol_for_testing(object_id), "C");
+  }
+}
+
 }  // namespace
 }  // namespace editor
 }  // namespace yaze

--- a/test/unit/editor/tile_object_handler_test.cc
+++ b/test/unit/editor/tile_object_handler_test.cc
@@ -634,6 +634,56 @@ TEST_F(TileObjectHandlerTest, ResizeMultipleObjects) {
   EXPECT_EQ(objects[2].size_, 9);  // 7 + 2
 }
 
+TEST_F(TileObjectHandlerTest, ResizeSkipsFixedSizeObjects) {
+  AddTestObjects({CreateTestObject(5, 5, 0x00, 0x100),
+                  CreateTestObject(10, 10, 0x06, 0xF99)});
+  rooms_[0].ClearSaveDirtyState();
+  mutation_count_ = 0;
+  invalidate_count_ = 0;
+
+  handler_.ResizeObjects(0, {0, 1}, 1);
+
+  const auto& objects = rooms_[0].GetTileObjects();
+  EXPECT_EQ(objects[0].size_, 0);
+  EXPECT_EQ(objects[1].size_, 0x06);
+  EXPECT_EQ(mutation_count_, 0);
+  EXPECT_EQ(invalidate_count_, 0);
+  EXPECT_FALSE(rooms_[0].object_stream_dirty());
+}
+
+TEST_F(TileObjectHandlerTest, ResizeMixedSelectionChangesOnlyType1) {
+  AddTestObjects({CreateTestObject(5, 5, 0x03, 0x01),
+                  CreateTestObject(10, 10, 0x00, 0x100),
+                  CreateTestObject(15, 15, 0x06, 0xF99)});
+  rooms_[0].ClearSaveDirtyState();
+  mutation_count_ = 0;
+  invalidate_count_ = 0;
+
+  handler_.ResizeObjects(0, {0, 1, 2}, 1);
+
+  const auto& objects = rooms_[0].GetTileObjects();
+  EXPECT_EQ(objects[0].size_, 0x04);
+  EXPECT_EQ(objects[1].size_, 0);
+  EXPECT_EQ(objects[2].size_, 0x06);
+  EXPECT_EQ(mutation_count_, 1);
+  EXPECT_EQ(invalidate_count_, 1);
+  EXPECT_TRUE(rooms_[0].object_stream_dirty());
+}
+
+TEST_F(TileObjectHandlerTest, ResizeAtType1LimitIsNoOp) {
+  AddTestObjects({CreateTestObject(5, 5, 0x0F, 0x01)});
+  rooms_[0].ClearSaveDirtyState();
+  mutation_count_ = 0;
+  invalidate_count_ = 0;
+
+  handler_.ResizeObjects(0, {0}, 1);
+
+  EXPECT_EQ(rooms_[0].GetTileObjects()[0].size_, 0x0F);
+  EXPECT_EQ(mutation_count_, 0);
+  EXPECT_EQ(invalidate_count_, 0);
+  EXPECT_FALSE(rooms_[0].object_stream_dirty());
+}
+
 // ============================================================================
 // Property Update Tests
 // ============================================================================
@@ -656,6 +706,56 @@ TEST_F(TileObjectHandlerTest, UpdateObjectSize) {
   const auto& objects = rooms_[0].GetTileObjects();
   EXPECT_EQ(objects[0].size_, 0x0A);
   EXPECT_FALSE(objects[0].tiles_loaded_);
+}
+
+TEST_F(TileObjectHandlerTest, UpdateObjectSizeClampsType1) {
+  AddTestObjects({CreateTestObject(5, 5, 0x00, 0x01)});
+
+  handler_.UpdateObjectsSize(0, {0}, 0xFF);
+
+  EXPECT_EQ(rooms_[0].GetTileObjects()[0].size_, 0x0F);
+}
+
+TEST_F(TileObjectHandlerTest, UpdateObjectSizeSkipsFixedSizeObject) {
+  AddTestObjects({CreateTestObject(5, 5, 0x00, 0x100)});
+  rooms_[0].ClearSaveDirtyState();
+  mutation_count_ = 0;
+  invalidate_count_ = 0;
+
+  handler_.UpdateObjectsSize(0, {0}, 0x0A);
+
+  EXPECT_EQ(rooms_[0].GetTileObjects()[0].size_, 0);
+  EXPECT_EQ(mutation_count_, 0);
+  EXPECT_EQ(invalidate_count_, 0);
+  EXPECT_FALSE(rooms_[0].object_stream_dirty());
+}
+
+TEST_F(TileObjectHandlerTest, UpdateObjectIdCanonicalizesFixedSizeFamily) {
+  AddTestObjects({CreateTestObject(5, 5, 0x07, 0x01)});
+
+  handler_.UpdateObjectsId(0, {0}, 0x100);
+
+  const auto& object = rooms_[0].GetTileObjects()[0];
+  EXPECT_EQ(object.id_, 0x100);
+  EXPECT_EQ(object.size_, 0);
+
+  handler_.UpdateObjectsId(0, {0}, 0xF99);
+  EXPECT_EQ(object.id_, 0xF99);
+  EXPECT_EQ(object.size_, 0x06);
+}
+
+TEST_F(TileObjectHandlerTest, UpdateObjectIdWithSameIdIsNoOp) {
+  AddTestObjects({CreateTestObject(5, 5, 0x07, 0x01)});
+  rooms_[0].ClearSaveDirtyState();
+  mutation_count_ = 0;
+  invalidate_count_ = 0;
+
+  handler_.UpdateObjectsId(0, {0}, 0x01);
+
+  EXPECT_EQ(rooms_[0].GetTileObjects()[0].size_, 0x07);
+  EXPECT_EQ(mutation_count_, 0);
+  EXPECT_EQ(invalidate_count_, 0);
+  EXPECT_FALSE(rooms_[0].object_stream_dirty());
 }
 
 TEST_F(TileObjectHandlerTest, UpdateObjectLayer) {


### PR DESCRIPTION
## Summary
- model persisted object size semantics explicitly: Type 1 clamps to `0..15`, Type 2 is fixed at `0`, and Type 3 derives size bits from its ID
- replace ordinary selector/drag/preview size `0x12` with canonical family-specific defaults
- restrict selector IDs to codec-safe ranges and repair the chest category to use representable Type 3 chest IDs
- cap Oracle custom objects at the 16 persisted subtype slots and reject unpersistable selection without changing current state
- make fixed-size and unchanged resize/property mutations true no-ops; canonicalize size when an ID crosses object families

## Verification
- built `yaze_test_unit` (smallest existing target containing `tile_object_handler_test`)
- ran an exact focused filter only: 11 tests from 2 suites, 11 passed
- full-file `clang-format --dry-run --Werror` passed for all changed C/C++ files
- `git diff --check` passed
- independent source review completed; subtype alias and chest taxonomy findings were fixed

## Integration
- #148 is merged
- branch was merged with current `master` to run the full hosted CI matrix on the exact integrated head
- #150 remains stacked behind this PR

## Deferred UI follow-ups
- custom workshop thumbnail capture is addressed by #150
- fixed-size Size fields/buttons remain visible even though backend mutation is safely disabled
- legacy `DungeonObjectEditor` resize/default paths remain unchanged
