### PR TITLE
fix(dungeon): preview selected custom object subtype

### DIFF
--- a/src/app/editor/dungeon/dungeon_object_selector.cc
+++ b/src/app/editor/dungeon/dungeon_object_selector.cc
@@ -522,8 +522,10 @@ void DungeonObjectSelector::DrawObjectAssetBrowser() {
                                                     : "thumbnails off"));
             ImGui::Separator();
 
+            const uint8_t preview_size =
+                zelda3::DefaultRoomObjectSizeForPlacement(obj_id);
             uint32_t layout_key = (static_cast<uint32_t>(obj_id) << 16) |
-                                  static_cast<uint32_t>(subtype);
+                                  static_cast<uint32_t>(preview_size);
             const bool can_capture_layout =
                 rom_ && rooms_ && current_room_id_ >= 0 &&
                 current_room_id_ < zelda3::kNumberOfRooms;
@@ -532,7 +534,7 @@ void DungeonObjectSelector::DrawObjectAssetBrowser() {
               zelda3::ObjectTileEditor editor(rom_);
               auto& room_ref = (*rooms_)[current_room_id_];
               auto layout_or = editor.CaptureObjectLayout(
-                  obj_id, room_ref, current_palette_group_);
+                  obj_id, room_ref, current_palette_group_, preview_size);
               if (layout_or.ok()) {
                 layout_cache_[layout_key] = layout_or.value();
               }
@@ -725,7 +727,9 @@ bool DungeonObjectSelector::GetOrCreatePreview(const zelda3::RoomObject& object,
 
   // Check if already in cache
   // Key: (object_id << 32) | (subtype << 16) | (blockset << 8) | palette
-  int subtype = object.size_ & 0x1F;
+  const uint8_t preview_size =
+      zelda3::CanonicalRoomObjectSize(object.id_, object.size());
+  int subtype = preview_size & 0x1F;
   uint64_t cache_key = (static_cast<uint64_t>(object.id_) << 32) |
                        (static_cast<uint64_t>(subtype) << 16) |
                        (static_cast<uint64_t>(cached_preview_blockset_) << 8) |
@@ -742,8 +746,8 @@ bool DungeonObjectSelector::GetOrCreatePreview(const zelda3::RoomObject& object,
   const uint8_t* gfx_data = room.get_gfx_buffer().data();
 
   zelda3::ObjectTileEditor editor(rom_);
-  auto layout_or =
-      editor.CaptureObjectLayout(object.id_, room, current_palette_group_);
+  auto layout_or = editor.CaptureObjectLayout(
+      object.id_, room, current_palette_group_, preview_size);
   if (!layout_or.ok()) {
     return false;
   }

--- a/src/zelda3/dungeon/object_tile_editor.cc
+++ b/src/zelda3/dungeon/object_tile_editor.cc
@@ -199,6 +199,13 @@ ObjectTileEditor::ObjectTileEditor(Rom* rom) : rom_(rom) {}
 
 absl::StatusOr<ObjectTileLayout> ObjectTileEditor::CaptureObjectLayout(
     int16_t object_id, const Room& room, const gfx::PaletteGroup& palette) {
+  return CaptureObjectLayout(object_id, room, palette,
+                             DefaultRoomObjectSizeForPlacement(object_id));
+}
+
+absl::StatusOr<ObjectTileLayout> ObjectTileEditor::CaptureObjectLayout(
+    int16_t object_id, const Room& room, const gfx::PaletteGroup& palette,
+    uint8_t object_size) {
   if (!rom_ || !rom_->is_loaded()) {
     return absl::FailedPreconditionError("ROM not loaded");
   }
@@ -210,10 +217,10 @@ absl::StatusOr<ObjectTileLayout> ObjectTileEditor::CaptureObjectLayout(
   // dropped tile writes at negative tile coordinates because
   // DrawRoutineUtils::WriteTile8 short-circuits via IsValidTilePosition
   // before invoking the trace hook.
-  constexpr uint8_t kPreviewSizeByte = 0x12;
+  const uint8_t preview_size = CanonicalRoomObjectSize(object_id, object_size);
   auto [anchor_x, anchor_y] =
-      ObjectGeometry::Get().ResolveAnchor(object_id, kPreviewSizeByte);
-  RoomObject obj(object_id, anchor_x, anchor_y, kPreviewSizeByte, 0);
+      ObjectGeometry::Get().ResolveAnchor(object_id, preview_size);
+  RoomObject obj(object_id, anchor_x, anchor_y, preview_size, 0);
   obj.SetRom(rom_);
   obj.EnsureTilesLoaded();
 

--- a/src/zelda3/dungeon/object_tile_editor.h
+++ b/src/zelda3/dungeon/object_tile_editor.h
@@ -80,6 +80,9 @@ class ObjectTileEditor {
   // Capture: run object draw in trace_only mode, build editable layout
   absl::StatusOr<ObjectTileLayout> CaptureObjectLayout(
       int16_t object_id, const Room& room, const gfx::PaletteGroup& palette);
+  absl::StatusOr<ObjectTileLayout> CaptureObjectLayout(
+      int16_t object_id, const Room& room, const gfx::PaletteGroup& palette,
+      uint8_t object_size);
 
   // Render: draw layout to preview bitmap using room's gfx buffer
   absl::Status RenderLayoutToBitmap(const ObjectTileLayout& layout,

--- a/test/unit/zelda3/dungeon/object_tile_editor_test.cc
+++ b/test/unit/zelda3/dungeon/object_tile_editor_test.cc
@@ -1,5 +1,6 @@
 #include "zelda3/dungeon/object_tile_editor.h"
 
+#include <chrono>
 #include <filesystem>
 #include <fstream>
 #include <vector>
@@ -75,11 +76,11 @@ TEST(ObjectTileEditorTest, CaptureLayoutBoundsMatchObjectGeometry) {
     SCOPED_TRACE(::testing::Message()
                  << "object_id=0x" << std::hex << object_id);
 
-    // size_byte = 0x12 matches CaptureObjectLayout's hardcoded preview
-    // size. ObjectGeometry::MeasureByObjectId uses the same size_byte
-    // path internally, so the bounds it returns should equal what
-    // CaptureObjectLayout produces from the trace.
-    RoomObject geom_obj(object_id, 0, 0, 0x12, 0);
+    // The compatibility overload uses the canonical placement default for
+    // each object family. ObjectGeometry must measure the same persisted size
+    // that CaptureObjectLayout uses for its trace.
+    RoomObject geom_obj(object_id, 0, 0,
+                        DefaultRoomObjectSizeForPlacement(object_id), 0);
     auto geom_or = ObjectGeometry::Get().MeasureByObjectId(geom_obj);
     ASSERT_TRUE(geom_or.ok());
 
@@ -90,6 +91,75 @@ TEST(ObjectTileEditorTest, CaptureLayoutBoundsMatchObjectGeometry) {
     EXPECT_EQ(layout_or->bounds_height, geom_or->height_tiles)
         << "CaptureObjectLayout bounds height must match ObjectGeometry";
   }
+}
+
+TEST(ObjectTileEditorTest, CaptureLayoutUsesRequestedOracleCustomSubtype) {
+  const bool old_custom_objects_flag =
+      core::FeatureFlags::get().kEnableCustomObjects;
+  const auto old_custom_object_state =
+      CustomObjectManager::Get().SnapshotState();
+  core::FeatureFlags::get().kEnableCustomObjects = true;
+
+  const auto unique_suffix =
+      std::chrono::steady_clock::now().time_since_epoch().count();
+  const std::filesystem::path temp_base =
+      std::filesystem::temp_directory_path() /
+      ("yaze_test_custom_preview_subtypes_" + std::to_string(unique_suffix));
+  std::filesystem::create_directories(temp_base);
+  struct Cleanup {
+    bool old_custom_objects_flag;
+    CustomObjectManager::State old_custom_object_state;
+    std::filesystem::path temp_base;
+    ~Cleanup() {
+      core::FeatureFlags::get().kEnableCustomObjects = old_custom_objects_flag;
+      CustomObjectManager::Get().RestoreState(old_custom_object_state);
+      std::filesystem::remove_all(temp_base);
+    }
+  } cleanup{old_custom_objects_flag, old_custom_object_state, temp_base};
+
+  const auto write_object = [&](const std::string& filename,
+                                const std::vector<uint16_t>& tile_words) {
+    std::ofstream file(temp_base / filename, std::ios::binary);
+    const uint16_t header = static_cast<uint16_t>(tile_words.size());
+    file.put(static_cast<char>(header & 0xFF));
+    file.put(static_cast<char>((header >> 8) & 0xFF));
+    for (uint16_t tile_word : tile_words) {
+      file.put(static_cast<char>(tile_word & 0xFF));
+      file.put(static_cast<char>((tile_word >> 8) & 0xFF));
+    }
+    file.put(0);
+    file.put(0);
+  };
+
+  write_object("subtype_zero.bin", {0x0011});
+  write_object("subtype_one.bin", {0x0022, 0x0033});
+
+  auto& manager = CustomObjectManager::Get();
+  manager.Initialize(temp_base.string());
+  manager.SetObjectFileMap({{0x31, {"subtype_zero.bin", "subtype_one.bin"}}});
+
+  Rom rom;
+  ASSERT_TRUE(rom.LoadFromData(std::vector<uint8_t>(0x200000, 0)).ok());
+
+  Room room(/*room_id=*/0, &rom, /*game_data=*/nullptr);
+  gfx::PaletteGroup palette;
+  ObjectTileEditor editor(&rom);
+
+  auto subtype_zero = editor.CaptureObjectLayout(
+      /*object_id=*/0x31, room, palette, /*object_size=*/0);
+  auto subtype_one = editor.CaptureObjectLayout(
+      /*object_id=*/0x31, room, palette, /*object_size=*/1);
+
+  ASSERT_TRUE(subtype_zero.ok()) << subtype_zero.status();
+  ASSERT_TRUE(subtype_one.ok()) << subtype_one.status();
+  EXPECT_TRUE(subtype_zero->is_custom);
+  EXPECT_TRUE(subtype_one->is_custom);
+  EXPECT_EQ(subtype_zero->custom_filename, "subtype_zero.bin");
+  EXPECT_EQ(subtype_one->custom_filename, "subtype_one.bin");
+  EXPECT_EQ(subtype_zero->cells.size(), 1u);
+  EXPECT_EQ(subtype_one->cells.size(), 2u);
+  EXPECT_EQ(subtype_zero->bounds_width, 1);
+  EXPECT_EQ(subtype_one->bounds_width, 2);
 }
 
 TEST(ObjectTileLayoutTest, FromTracesEmptyInput) {


### PR DESCRIPTION
## Summary
- add a subtype/size-aware `ObjectTileEditor::CaptureObjectLayout` path
- keep the existing overload source-compatible while using canonical family defaults
- pass the selected object's canonical persisted size into selector/workshop preview capture
- key preview and tooltip layout caches with the same canonical size used for capture
- prove Oracle custom object `0x31` subtypes 0 and 1 resolve different files and layouts

## Verification
- built `yaze_test_unit` (only existing target containing `object_tile_editor_test.cc`)
- ran exact focused filters only: 8 tests from 2 suites, 8 passed
- full-file `clang-format --dry-run --Werror` passed for all four changed files
- `git diff --check` passed
- independent source review: no blocking findings

## Hosted CI
- retargeted to `master` after #149 merged
- full hosted CI gates the exact master diff at head `85bf98f13de89be40f13a34d92eae5c6a245880f`

## Deferred
- `ObjectTileEditorPanel::OpenForObject` remains ID-only and therefore opens canonical default size
- no ImGui-level texture/cache integration test; backend subtype-specific layouts are covered
- direct custom lookup coverage uses `0x31`; existing tests retain corner-alias coverage
