### PR TITLE
fix(dungeon): disable fixed-size resize controls

### DIFF
--- a/docs/internal/architecture/dungeon_interaction_architecture.md
+++ b/docs/internal/architecture/dungeon_interaction_architecture.md
@@ -127,7 +127,7 @@ Handles tile object (RoomObject) manipulation.
 void MoveObjects(int room_id, const std::vector<size_t>& indices, int dx, int dy);
 std::vector<size_t> DuplicateObjects(int room_id, const std::vector<size_t>& indices, int dx, int dy);
 void DeleteObjects(int room_id, std::vector<size_t> indices);
-void ResizeObjects(int room_id, const std::vector<size_t>& indices, int delta);
+bool ResizeObjects(int room_id, const std::vector<size_t>& indices, int delta);
 void PlaceObjectAt(int room_id, const RoomObject& object, int x, int y);
 
 // Property updates

--- a/src/app/editor/dungeon/interaction/tile_object_handler.cc
+++ b/src/app/editor/dungeon/interaction/tile_object_handler.cc
@@ -364,8 +364,7 @@ bool TileObjectHandler::HandleMouseWheel(float delta) {
     return false;
 
   int resize_delta = (delta > 0.0f) ? 1 : -1;
-  ResizeObjects(ctx_->current_room_id, indices, resize_delta);
-  return true;
+  return ResizeObjects(ctx_->current_room_id, indices, resize_delta);
 }
 
 void TileObjectHandler::DrawGhostPreview() {
@@ -943,12 +942,12 @@ void TileObjectHandler::MoveBackward(int room_id,
   NotifyChange(room);
 }
 
-void TileObjectHandler::ResizeObjects(int room_id,
+bool TileObjectHandler::ResizeObjects(int room_id,
                                       const std::vector<size_t>& indices,
                                       int delta) {
   auto* room = GetRoom(room_id);
   if (!room || indices.empty())
-    return;
+    return false;
   auto& objects = room->GetTileObjects();
   const auto resized_size = [&](const zelda3::RoomObject& object) {
     const int requested_size = static_cast<int>(object.size_) + delta;
@@ -962,7 +961,7 @@ void TileObjectHandler::ResizeObjects(int room_id,
                objects[index].size_ != resized_size(objects[index]);
       });
   if (!has_change) {
-    return;
+    return false;
   }
   if (ctx_)
     ctx_->NotifyMutation(MutationDomain::kTileObjects);
@@ -979,6 +978,7 @@ void TileObjectHandler::ResizeObjects(int room_id,
     }
   }
   NotifyChange(room);
+  return true;
 }
 
 bool TileObjectHandler::PlaceObjectAt(int room_id,

--- a/src/app/editor/dungeon/interaction/tile_object_handler.h
+++ b/src/app/editor/dungeon/interaction/tile_object_handler.h
@@ -109,8 +109,9 @@ class TileObjectHandler : public BaseEntityHandler {
 
   /**
    * @brief Resize objects by a delta.
+   * @return true if at least one editable object changed size.
    */
-  void ResizeObjects(int room_id, const std::vector<size_t>& indices,
+  bool ResizeObjects(int room_id, const std::vector<size_t>& indices,
                      int delta);
 
   /**

--- a/src/app/editor/dungeon/workspace/dungeon_workbench_content.cc
+++ b/src/app/editor/dungeon/workspace/dungeon_workbench_content.cc
@@ -2398,6 +2398,8 @@ void DungeonWorkbenchContent::DrawInspectorShelfSelection(
           has_special_layer_object = true;
         }
       }
+      const bool has_editable_size =
+          workbench::HasEditableRoomObjectSize(objects, selection_copy);
 
       workbench::DrawInspectorSectionHeader(ICON_MD_OPEN_WITH " Bulk Edit");
 
@@ -2476,11 +2478,17 @@ void DungeonWorkbenchContent::DrawInspectorShelfSelection(
 
       ImGui::Spacing();
       ImGui::TextDisabled(tr("Size"));
+      if (!has_editable_size) {
+        ImGui::BeginDisabled();
+      }
       if (ImGui::SmallButton(ICON_MD_REMOVE "##BulkSizeDec"))
         tile_handler.ResizeObjects(room_id, selection_copy, -1);
       ImGui::SameLine();
       if (ImGui::SmallButton(ICON_MD_ADD "##BulkSizeInc"))
         tile_handler.ResizeObjects(room_id, selection_copy, 1);
+      if (!has_editable_size) {
+        ImGui::EndDisabled();
+      }
 
       ImGui::Spacing();
       if (ImGui::SmallButton(ICON_MD_CONTENT_COPY " Duplicate##BulkDup"))
@@ -2582,10 +2590,18 @@ void DungeonWorkbenchContent::DrawInspectorShelfSelection(
           // Size
           gui::LayoutHelpers::PropertyRow("Size", [&]() {
             uint8_t size = obj.size_ & 0x0F;
+            const bool size_editable =
+                zelda3::IsRoomObjectSizeEditable(obj.id_);
+            if (!size_editable) {
+              ImGui::BeginDisabled();
+            }
             if (auto res = gui::InputHexByteEx("##SelObjSize", &size, 0x0F,
                                                60.0f, true);
-                res.ShouldApply()) {
+                size_editable && res.ShouldApply()) {
               interaction.SetObjectSize(idx, size);
+            }
+            if (!size_editable) {
+              ImGui::EndDisabled();
             }
           });
 

--- a/src/app/editor/dungeon/workspace/dungeon_workbench_inspector_helpers.cc
+++ b/src/app/editor/dungeon/workspace/dungeon_workbench_inspector_helpers.cc
@@ -6,6 +6,15 @@
 
 namespace yaze::editor::workbench {
 
+bool HasEditableRoomObjectSize(std::span<const zelda3::RoomObject> objects,
+                               std::span<const size_t> selected_indices) {
+  return std::any_of(
+      selected_indices.begin(), selected_indices.end(), [&](size_t index) {
+        return index < objects.size() &&
+               zelda3::IsRoomObjectSizeEditable(objects[index].id_);
+      });
+}
+
 void DrawInspectorSectionHeader(const char* label) {
   ImGui::SeparatorText(label);
 }

--- a/src/app/editor/dungeon/workspace/dungeon_workbench_inspector_helpers.h
+++ b/src/app/editor/dungeon/workspace/dungeon_workbench_inspector_helpers.h
@@ -1,9 +1,16 @@
 #ifndef YAZE_APP_EDITOR_DUNGEON_WORKSPACE_DUNGEON_WORKBENCH_INSPECTOR_HELPERS_H
 #define YAZE_APP_EDITOR_DUNGEON_WORKSPACE_DUNGEON_WORKBENCH_INSPECTOR_HELPERS_H
 
+#include <cstddef>
+#include <span>
+
 #include "imgui/imgui.h"
+#include "zelda3/dungeon/room_object.h"
 
 namespace yaze::editor::workbench {
+
+bool HasEditableRoomObjectSize(std::span<const zelda3::RoomObject> objects,
+                               std::span<const size_t> selected_indices);
 
 void DrawInspectorSectionHeader(const char* label);
 

--- a/test/unit/editor/dungeon_workbench_content_test.cc
+++ b/test/unit/editor/dungeon_workbench_content_test.cc
@@ -13,6 +13,7 @@
 #include "absl/status/status.h"
 #include "app/editor/dungeon/dungeon_project_labels.h"
 #include "app/editor/dungeon/workspace/dungeon_pit_damage_view_model.h"
+#include "app/editor/dungeon/workspace/dungeon_workbench_inspector_helpers.h"
 #include "core/project.h"
 #include "imgui/imgui.h"
 #include "zelda3/dungeon/pit_damage_table.h"
@@ -147,6 +148,22 @@ TEST(DungeonWorkbenchContentLayoutTest,
       699.0f, kMinCanvasWidth, kMinSidebarWidth, kSplitterWidth, true, true);
   EXPECT_FALSE(hide_both.show_left);
   EXPECT_FALSE(hide_both.show_right);
+}
+
+TEST(DungeonWorkbenchContentObjectSizeTest,
+     SizeControlsEnableOnlyWhenSelectionContainsEditableObject) {
+  const std::vector<zelda3::RoomObject> objects = {
+      zelda3::RoomObject(0x100, 5, 5, 0, 0),
+      zelda3::RoomObject(0xF99, 10, 10, 0x06, 0),
+      zelda3::RoomObject(0x001, 15, 15, 3, 0),
+  };
+  const std::vector<size_t> fixed_only = {0, 1};
+  const std::vector<size_t> mixed = {0, 1, 2};
+  const std::vector<size_t> invalid = {objects.size()};
+
+  EXPECT_FALSE(workbench::HasEditableRoomObjectSize(objects, fixed_only));
+  EXPECT_TRUE(workbench::HasEditableRoomObjectSize(objects, mixed));
+  EXPECT_FALSE(workbench::HasEditableRoomObjectSize(objects, invalid));
 }
 
 TEST(DungeonWorkbenchContentLayoutTest,

--- a/test/unit/editor/tile_object_handler_test.cc
+++ b/test/unit/editor/tile_object_handler_test.cc
@@ -588,7 +588,7 @@ TEST_F(TileObjectHandlerTest,
 TEST_F(TileObjectHandlerTest, ResizeObjectsIncrements) {
   AddTestObjects({CreateTestObject(5, 5, 0x05, 0x01)});
 
-  handler_.ResizeObjects(0, {0}, 1);
+  EXPECT_TRUE(handler_.ResizeObjects(0, {0}, 1));
 
   const auto& objects = rooms_[0].GetTileObjects();
   EXPECT_EQ(objects[0].size_, 6);
@@ -641,7 +641,7 @@ TEST_F(TileObjectHandlerTest, ResizeSkipsFixedSizeObjects) {
   mutation_count_ = 0;
   invalidate_count_ = 0;
 
-  handler_.ResizeObjects(0, {0, 1}, 1);
+  EXPECT_FALSE(handler_.ResizeObjects(0, {0, 1}, 1));
 
   const auto& objects = rooms_[0].GetTileObjects();
   EXPECT_EQ(objects[0].size_, 0);
@@ -659,7 +659,7 @@ TEST_F(TileObjectHandlerTest, ResizeMixedSelectionChangesOnlyType1) {
   mutation_count_ = 0;
   invalidate_count_ = 0;
 
-  handler_.ResizeObjects(0, {0, 1, 2}, 1);
+  EXPECT_TRUE(handler_.ResizeObjects(0, {0, 1, 2}, 1));
 
   const auto& objects = rooms_[0].GetTileObjects();
   EXPECT_EQ(objects[0].size_, 0x04);
@@ -676,12 +676,69 @@ TEST_F(TileObjectHandlerTest, ResizeAtType1LimitIsNoOp) {
   mutation_count_ = 0;
   invalidate_count_ = 0;
 
-  handler_.ResizeObjects(0, {0}, 1);
+  EXPECT_FALSE(handler_.ResizeObjects(0, {0}, 1));
 
   EXPECT_EQ(rooms_[0].GetTileObjects()[0].size_, 0x0F);
   EXPECT_EQ(mutation_count_, 0);
   EXPECT_EQ(invalidate_count_, 0);
   EXPECT_FALSE(rooms_[0].object_stream_dirty());
+}
+
+TEST_F(TileObjectHandlerTest, MouseWheelDoesNotConsumeFixedSizeOnlySelection) {
+  AddTestObjects({CreateTestObject(5, 5, 0x00, 0x100),
+                  CreateTestObject(10, 10, 0x06, 0xF99)});
+  selection_.SelectObject(0);
+  selection_.SelectObject(1, ObjectSelection::SelectionMode::Add);
+  rooms_[0].ClearSaveDirtyState();
+  mutation_count_ = 0;
+  invalidate_count_ = 0;
+
+  EXPECT_FALSE(handler_.HandleMouseWheel(1.0f));
+
+  const auto& objects = rooms_[0].GetTileObjects();
+  EXPECT_EQ(objects[0].size_, 0);
+  EXPECT_EQ(objects[1].size_, 0x06);
+  EXPECT_EQ(mutation_count_, 0);
+  EXPECT_EQ(invalidate_count_, 0);
+  EXPECT_FALSE(rooms_[0].object_stream_dirty());
+}
+
+TEST_F(TileObjectHandlerTest, MouseWheelDoesNotConsumeType1AtSizeLimit) {
+  AddTestObjects({CreateTestObject(5, 5, 0x0F, 0x01)});
+  selection_.SelectObject(0);
+  rooms_[0].ClearSaveDirtyState();
+  mutation_count_ = 0;
+  invalidate_count_ = 0;
+
+  EXPECT_FALSE(handler_.HandleMouseWheel(1.0f));
+
+  EXPECT_EQ(rooms_[0].GetTileObjects()[0].size_, 0x0F);
+  EXPECT_EQ(mutation_count_, 0);
+  EXPECT_EQ(invalidate_count_, 0);
+  EXPECT_FALSE(rooms_[0].object_stream_dirty());
+}
+
+TEST_F(TileObjectHandlerTest,
+       MouseWheelConsumesMixedSelectionWhenEditableObjectChanges) {
+  AddTestObjects({CreateTestObject(5, 5, 0x03, 0x01),
+                  CreateTestObject(10, 10, 0x00, 0x100),
+                  CreateTestObject(15, 15, 0x06, 0xF99)});
+  selection_.SelectObject(0);
+  selection_.SelectObject(1, ObjectSelection::SelectionMode::Add);
+  selection_.SelectObject(2, ObjectSelection::SelectionMode::Add);
+  rooms_[0].ClearSaveDirtyState();
+  mutation_count_ = 0;
+  invalidate_count_ = 0;
+
+  EXPECT_TRUE(handler_.HandleMouseWheel(1.0f));
+
+  const auto& objects = rooms_[0].GetTileObjects();
+  EXPECT_EQ(objects[0].size_, 0x04);
+  EXPECT_EQ(objects[1].size_, 0);
+  EXPECT_EQ(objects[2].size_, 0x06);
+  EXPECT_EQ(mutation_count_, 1);
+  EXPECT_EQ(invalidate_count_, 1);
+  EXPECT_TRUE(rooms_[0].object_stream_dirty());
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary
- make `TileObjectHandler::ResizeObjects` report whether an editable object actually changed
- stop consuming the canvas wheel event for fixed-only, boundary, invalid, or otherwise no-op resize attempts
- disable bulk size buttons when a selection has no editable Type 1 object
- render the single-object Size field disabled/read-only for fixed Type 2/3 objects
- keep mixed selections enabled while changing Type 1 objects only
- update the interaction architecture contract

## Verification
- built `yaze_test_unit`; no full suite was run locally
- exact focused filter: 8 tests from 2 suites, 8 passed
- full-file `clang-format --dry-run --Werror` passed
- `git diff --check` passed
- independent source review: no blocking findings
- full hosted CI now gates the exact master-based diff

## Residual
- no ImGui screenshot test; eligibility logic and mutation behavior are unit-tested
- no full undo-manager integration test, though mutation/invalidation/dirty hooks are covered
