### PR TITLE
fix(dungeon): guard canonical room-object sizes on save

### DIFF
--- a/src/cli/handlers/game/dungeon_edit_commands.cc
+++ b/src/cli/handlers/game/dungeon_edit_commands.cc
@@ -505,10 +505,6 @@ absl::Status DungeonPlaceObjectCommandHandler::Execute(
   if (!y_or.ok()) {
     return y_or.status();
   }
-  auto size_or = GetOptionalInt(parser, "size", 0);
-  if (!size_or.ok()) {
-    return size_or.status();
-  }
   auto layer_or = GetOptionalInt(parser, "layer", 0);
   if (!layer_or.ok()) {
     return layer_or.status();
@@ -516,7 +512,16 @@ absl::Status DungeonPlaceObjectCommandHandler::Execute(
 
   int x = x_or.value();
   int y = y_or.value();
-  int size = size_or.value();
+  // Preserve the command's legacy omitted Type 1 size of zero while deriving
+  // the fixed, ID-backed size required by Type 2/3 stream entries.
+  int size = zelda3::CanonicalRoomObjectSize(object_id, 0);
+  if (parser.GetString("size").has_value()) {
+    auto size_or = parser.GetInt("size");
+    if (!size_or.ok()) {
+      return size_or.status();
+    }
+    size = size_or.value();
+  }
   int layer = layer_or.value();
   bool do_write = parser.HasFlag("write");
 
@@ -532,6 +537,13 @@ absl::Status DungeonPlaceObjectCommandHandler::Execute(
   }
   if (size < 0 || size > 0xFF) {
     return absl::InvalidArgumentError("Size must be 0-255");
+  }
+  const uint8_t canonical_size =
+      zelda3::CanonicalRoomObjectSize(object_id, static_cast<uint8_t>(size));
+  if (size != canonical_size) {
+    return absl::InvalidArgumentError(absl::StrFormat(
+        "Size %d is not encodable for object 0x%03X; expected %d", size,
+        object_id, canonical_size));
   }
 
   std::optional<ObjectSaveManifestContext> manifest_context;

--- a/src/zelda3/dungeon/dungeon_object_editor.cc
+++ b/src/zelda3/dungeon/dungeon_object_editor.cc
@@ -19,6 +19,16 @@
 namespace yaze {
 namespace zelda3 {
 
+namespace {
+
+bool IsRepresentableRoomObjectId(int object_id) {
+  return (object_id >= 0x000 && object_id <= 0x0F7) ||
+         (object_id >= 0x100 && object_id <= 0x13F) ||
+         (object_id >= 0xF80 && object_id <= 0xFFF);
+}
+
+}  // namespace
+
 DungeonObjectEditor::DungeonObjectEditor(Rom* rom) : rom_(rom) {}
 
 absl::Status DungeonObjectEditor::InitializeEditor() {
@@ -40,7 +50,8 @@ absl::Status DungeonObjectEditor::InitializeEditor() {
   editing_state_.current_mode = Mode::kSelect;
   editing_state_.current_layer = 0;
   editing_state_.current_object_type = 0x10;  // Default to wall
-  editing_state_.preview_size = kDefaultObjectSize;
+  editing_state_.preview_size =
+      DefaultRoomObjectSizeForPlacement(editing_state_.current_object_type);
 
   // Initialize empty room
   owned_room_ = std::make_unique<Room>(0, rom_);
@@ -141,9 +152,11 @@ absl::Status DungeonObjectEditor::InsertObject(int x, int y, int object_type,
   }
 
   // Validate parameters
-  // Object IDs can be up to 12-bit (0xFFF) to support Type 3 objects
-  if (object_type < 0 || object_type > 0xFFF) {
-    return absl::InvalidArgumentError("Invalid object type");
+  if (!IsRepresentableRoomObjectId(object_type)) {
+    return absl::InvalidArgumentError(absl::StrFormat(
+        "Object ID 0x%03X is not representable; expected 0x000..0x0F7, "
+        "0x100..0x13F, or 0xF80..0xFFF",
+        object_type));
   }
 
   if (size < kMinObjectSize || size > kMaxObjectSize) {
@@ -166,8 +179,12 @@ absl::Status DungeonObjectEditor::InsertObject(int x, int y, int object_type,
     return status;
   }
 
-  // Create new object
-  RoomObject new_object(object_type, x, y, size, layer);
+  // Create new object with the family-specific canonical size. Type 1 owns a
+  // four-bit size field, Type 2 has no size field, and Type 3 derives those
+  // bits from its ID.
+  const uint8_t canonical_size =
+      CanonicalRoomObjectSize(object_type, static_cast<uint8_t>(size));
+  RoomObject new_object(object_type, x, y, canonical_size, layer);
   new_object.SetRom(rom_);
   new_object.EnsureTilesLoaded();
 
@@ -370,6 +387,17 @@ absl::Status DungeonObjectEditor::ResizeObject(size_t object_index,
     return absl::InvalidArgumentError("Invalid object size");
   }
 
+  auto& object = current_room_->GetTileObject(object_index);
+  if (!IsRoomObjectSizeEditable(object.id_)) {
+    return absl::OkStatus();
+  }
+
+  const uint8_t canonical_size =
+      CanonicalRoomObjectSize(object.id_, static_cast<uint8_t>(new_size));
+  if (object.size() == canonical_size) {
+    return absl::OkStatus();
+  }
+
   // Create undo point
   auto status = CreateUndoPoint();
   if (!status.ok()) {
@@ -377,15 +405,9 @@ absl::Status DungeonObjectEditor::ResizeObject(size_t object_index,
   }
 
   // Resize the object
-  auto& object = current_room_->GetTileObject(object_index);
-  const bool changed = object.size() != new_size;
-  if (changed) {
-    current_room_->MarkSaveDirtyForTileObject(object);
-  }
-  object.set_size(new_size);
-  if (changed) {
-    current_room_->MarkSaveDirtyForTileObject(object);
-  }
+  current_room_->MarkSaveDirtyForTileObject(object);
+  object.set_size(canonical_size);
+  current_room_->MarkSaveDirtyForTileObject(object);
 
   // Notify callbacks
   if (object_changed_callback_) {
@@ -538,6 +560,23 @@ absl::Status DungeonObjectEditor::BatchResizeObjects(
     return absl::InvalidArgumentError("Invalid object size");
   }
 
+  const uint8_t requested_size = static_cast<uint8_t>(new_size);
+  bool change_needed = false;
+  for (size_t index : indices) {
+    if (index >= current_room_->GetTileObjectCount()) {
+      continue;
+    }
+    const auto& object = current_room_->GetTileObject(index);
+    if (IsRoomObjectSizeEditable(object.id_) &&
+        object.size() != CanonicalRoomObjectSize(object.id_, requested_size)) {
+      change_needed = true;
+      break;
+    }
+  }
+  if (!change_needed) {
+    return absl::OkStatus();
+  }
+
   // Create undo point
   auto status = CreateUndoPoint();
   if (!status.ok()) {
@@ -549,16 +588,18 @@ absl::Status DungeonObjectEditor::BatchResizeObjects(
       continue;
 
     auto& object = current_room_->GetTileObject(index);
-    // Only Type 1 objects typically support arbitrary sizing, but we allow it
-    // for all here as the validation logic might vary.
-    const bool changed = object.size() != new_size;
-    if (changed) {
-      current_room_->MarkSaveDirtyForTileObject(object);
+    if (!IsRoomObjectSizeEditable(object.id_)) {
+      continue;
     }
-    object.set_size(new_size);
-    if (changed) {
-      current_room_->MarkSaveDirtyForTileObject(object);
+
+    const uint8_t canonical_size =
+        CanonicalRoomObjectSize(object.id_, requested_size);
+    if (object.size() == canonical_size) {
+      continue;
     }
+    current_room_->MarkSaveDirtyForTileObject(object);
+    object.set_size(canonical_size);
+    current_room_->MarkSaveDirtyForTileObject(object);
 
     if (object_changed_callback_) {
       object_changed_callback_(index, object);
@@ -675,10 +716,20 @@ absl::Status DungeonObjectEditor::ChangeObjectType(size_t object_index,
     return absl::OutOfRangeError("Object index out of range");
   }
 
-  // Object IDs can be up to 12-bit (0xFFF) to support Type 3 objects
-  if (new_type < 0 || new_type > 0xFFF) {
-    return absl::InvalidArgumentError("Invalid object type");
+  if (!IsRepresentableRoomObjectId(new_type)) {
+    return absl::InvalidArgumentError(absl::StrFormat(
+        "Object ID 0x%03X is not representable; expected 0x000..0x0F7, "
+        "0x100..0x13F, or 0xF80..0xFFF",
+        new_type));
   }
+
+  auto& object = current_room_->GetTileObject(object_index);
+  if (object.id_ == new_type) {
+    return absl::OkStatus();
+  }
+
+  const uint8_t canonical_size =
+      CanonicalRoomObjectSize(new_type, object.size());
 
   // Create undo point
   auto status = CreateUndoPoint();
@@ -686,15 +737,10 @@ absl::Status DungeonObjectEditor::ChangeObjectType(size_t object_index,
     return status;
   }
 
-  auto& object = current_room_->GetTileObject(object_index);
-  const bool changed = object.id_ != new_type;
-  if (changed) {
-    current_room_->MarkSaveDirtyForTileObject(object);
-  }
+  current_room_->MarkSaveDirtyForTileObject(object);
   object.set_id(static_cast<int16_t>(new_type));
-  if (changed) {
-    current_room_->MarkSaveDirtyForTileObject(object);
-  }
+  object.set_size(canonical_size);
+  current_room_->MarkSaveDirtyForTileObject(object);
 
   if (object_changed_callback_) {
     object_changed_callback_(object_index, object);
@@ -1215,9 +1261,10 @@ void DungeonObjectEditor::SetCurrentLayer(int layer) {
 }
 
 void DungeonObjectEditor::SetCurrentObjectType(int object_type) {
-  // Object IDs can be up to 12-bit (0xFFF) to support Type 3 objects
-  if (object_type >= 0 && object_type <= 0xFFF) {
+  if (IsRepresentableRoomObjectId(object_type)) {
     editing_state_.current_object_type = object_type;
+    editing_state_.preview_size =
+        CanonicalRoomObjectSize(object_type, editing_state_.preview_size);
     UpdatePreviewObject();
   }
 }
@@ -1324,7 +1371,10 @@ int DungeonObjectEditor::SnapToGrid(int coordinate) {
 }
 
 void DungeonObjectEditor::UpdatePreviewObject() {
-  if (editing_state_.current_mode == Mode::kInsert) {
+  if (editing_state_.current_mode == Mode::kInsert &&
+      IsRepresentableRoomObjectId(editing_state_.current_object_type)) {
+    editing_state_.preview_size = CanonicalRoomObjectSize(
+        editing_state_.current_object_type, editing_state_.preview_size);
     preview_object_ =
         RoomObject(editing_state_.current_object_type, editing_state_.preview_x,
                    editing_state_.preview_y, editing_state_.preview_size,
@@ -1333,6 +1383,7 @@ void DungeonObjectEditor::UpdatePreviewObject() {
     preview_object_->EnsureTilesLoaded();
     preview_visible_ = true;
   } else {
+    preview_object_.reset();
     preview_visible_ = false;
   }
 }
@@ -1637,7 +1688,7 @@ void DungeonObjectEditor::DrawPropertyUI() {
       gui::SectionHeader(ICON_MD_PALETTE, "Appearance", theme.text_info);
       if (gui::BeginPropertyTable("##AppearanceProps")) {
         // Size (for Type 1 objects only)
-        if (obj.id_ < 0x100) {
+        if (IsRoomObjectSizeEditable(obj.id_)) {
           ImGui::TableNextRow();
           ImGui::TableNextColumn();
           ImGui::Text("Size");
@@ -1645,12 +1696,7 @@ void DungeonObjectEditor::DrawPropertyUI() {
           int size = obj.size();
           ImGui::SetNextItemWidth(-1);
           if (ImGui::SliderInt("##Size", &size, 0, 15, "0x%02X")) {
-            current_room_->MarkSaveDirtyForTileObject(obj);
-            obj.set_size(size);
-            current_room_->MarkSaveDirtyForTileObject(obj);
-            if (object_changed_callback_) {
-              object_changed_callback_(obj_idx, obj);
-            }
+            (void)ResizeObject(obj_idx, size);
           }
         }
 
@@ -1664,12 +1710,7 @@ void DungeonObjectEditor::DrawPropertyUI() {
         if (ImGui::InputInt("##ID", &id, 1, 16,
                             ImGuiInputTextFlags_CharsHexadecimal)) {
           if (id >= 0 && id <= 0xFFF && obj.id_ != id) {
-            current_room_->MarkSaveDirtyForTileObject(obj);
-            obj.set_id(static_cast<int16_t>(id));
-            current_room_->MarkSaveDirtyForTileObject(obj);
-            if (object_changed_callback_) {
-              object_changed_callback_(obj_idx, obj);
-            }
+            (void)ChangeObjectType(obj_idx, id);
           }
         }
 
@@ -1761,15 +1802,18 @@ void DungeonObjectEditor::DrawPropertyUI() {
 
     bool has_room_stream_object = false;
     bool has_special_table_object = false;
+    bool has_editable_size_object = false;
     for (size_t index : selection_state_.selected_objects) {
       if (index >= current_room_->GetTileObjectCount()) {
         continue;
       }
-      if (UsesRoomObjectStream(current_room_->GetTileObject(index))) {
+      const auto& object = current_room_->GetTileObject(index);
+      if (UsesRoomObjectStream(object)) {
         has_room_stream_object = true;
       } else {
         has_special_table_object = true;
       }
+      has_editable_size_object |= IsRoomObjectSizeEditable(object.id_);
     }
 
     if (has_special_table_object) {
@@ -1808,12 +1852,15 @@ void DungeonObjectEditor::DrawPropertyUI() {
 
     // ========== Batch Size ==========
     gui::SectionHeader(ICON_MD_ASPECT_RATIO, "Batch Size", theme.text_info);
-    static int batch_size = 0x12;
+    static int batch_size = 0x02;
     ImGui::SetNextItemWidth(-1);
+    ImGui::BeginDisabled(!has_editable_size_object);
     if (ImGui::InputInt("##BatchSize", &batch_size, 1, 16,
                         ImGuiInputTextFlags_CharsHexadecimal)) {
+      batch_size = std::clamp(batch_size, 0, 15);
       BatchResizeObjects(selection_state_.selected_objects, batch_size);
     }
+    ImGui::EndDisabled();
 
     ImGui::Spacing();
 

--- a/src/zelda3/dungeon/dungeon_object_editor.h
+++ b/src/zelda3/dungeon/dungeon_object_editor.h
@@ -66,7 +66,7 @@ class DungeonObjectEditor {
     bool is_editing_position = false;
     int preview_x = 0;
     int preview_y = 0;
-    int preview_size = 0x12;  // Default size
+    int preview_size = 0x02;  // Canonical default Type 1 size
   };
 
   // Editor configuration
@@ -107,7 +107,7 @@ class DungeonObjectEditor {
   absl::Status ClearRoom();
 
   // Object manipulation
-  absl::Status InsertObject(int x, int y, int object_type, int size = 0x12,
+  absl::Status InsertObject(int x, int y, int object_type, int size = 0x02,
                             int layer = 0);
   absl::Status DeleteObject(size_t object_index);
   absl::Status DeleteSelectedObjects();
@@ -286,7 +286,6 @@ class DungeonObjectEditor {
   // Constants
   static constexpr int kMinObjectSize = 0x00;
   static constexpr int kMaxObjectSize = 0xFF;
-  static constexpr int kDefaultObjectSize = 0x12;
   static constexpr int kMinLayer = 0;
   static constexpr int kMaxLayer = 2;
 

--- a/src/zelda3/dungeon/room_object.cc
+++ b/src/zelda3/dungeon/room_object.cc
@@ -389,6 +389,20 @@ absl::Status ValidateRoomObjectStreamEntryForSave(const RoomObject& object) {
         object.id_));
   }
 
+  const uint8_t canonical_size =
+      CanonicalRoomObjectSize(object.id_, object.size_);
+  if (object.size_ != canonical_size) {
+    if (expected_type == 1) {
+      return absl::InvalidArgumentError(
+          absl::StrFormat("Room object 0x%03X has noncanonical size 0x%02X; "
+                          "Type 1 size must be 0x00..0x0F",
+                          object.id_, object.size_));
+    }
+    return absl::InvalidArgumentError(absl::StrFormat(
+        "Room object 0x%03X has noncanonical size 0x%02X; expected 0x%02X",
+        object.id_, object.size_, canonical_size));
+  }
+
   // Type 1/3 encode X in the upper six bits of byte 1. X=63 therefore
   // produces the Type 2 discriminator (0xFC..0xFF) and decodes as another
   // object family.

--- a/test/unit/cli/dungeon_edit_commands_test.cc
+++ b/test/unit/cli/dungeon_edit_commands_test.cc
@@ -426,6 +426,75 @@ TEST(DungeonEditCommandsTest, PlaceObjectRejectsInvalidSize) {
   ExpectInvalidArgument(status, "Invalid integer for '--size'");
 }
 
+TEST(DungeonEditCommandsTest, PlaceObjectPreservesOmittedType1Size) {
+  Rom rom;
+  InitializeDescribeRoomObjectsRom(&rom);
+  const std::vector<uint8_t> before = rom.vector();
+
+  handlers::DungeonPlaceObjectCommandHandler handler;
+  std::string output;
+  const auto status = handler.Run(
+      {"--room=0x00", "--id=0x031", "--x=1", "--y=2", "--format=json"}, &rom,
+      &output);
+
+  ASSERT_TRUE(status.ok()) << status;
+  const auto result = nlohmann::json::parse(output);
+  const auto& placement = result.at("Place Object");
+  EXPECT_EQ(placement.at("size"), 0);
+  EXPECT_EQ(placement.at("preflight_status"), "success");
+  EXPECT_EQ(rom.vector(), before);
+}
+
+TEST(DungeonEditCommandsTest, PlaceObjectDefaultsOmittedType2Size) {
+  Rom rom;
+  InitializeDescribeRoomObjectsRom(&rom);
+  const std::vector<uint8_t> before = rom.vector();
+
+  handlers::DungeonPlaceObjectCommandHandler handler;
+  std::string output;
+  const auto status = handler.Run(
+      {"--room=0x00", "--id=0x100", "--x=1", "--y=2", "--format=json"}, &rom,
+      &output);
+
+  ASSERT_TRUE(status.ok()) << status;
+  const auto result = nlohmann::json::parse(output);
+  const auto& placement = result.at("Place Object");
+  EXPECT_EQ(placement.at("size"), 0);
+  EXPECT_EQ(placement.at("preflight_status"), "success");
+  EXPECT_EQ(rom.vector(), before);
+}
+
+TEST(DungeonEditCommandsTest, PlaceObjectDefaultsOmittedType3Size) {
+  Rom rom;
+  InitializeDescribeRoomObjectsRom(&rom);
+  const std::vector<uint8_t> before = rom.vector();
+
+  handlers::DungeonPlaceObjectCommandHandler handler;
+  std::string output;
+  const auto status = handler.Run(
+      {"--room=0x00", "--id=0xF99", "--x=1", "--y=2", "--format=json"}, &rom,
+      &output);
+
+  ASSERT_TRUE(status.ok()) << status;
+  const auto result = nlohmann::json::parse(output);
+  const auto& placement = result.at("Place Object");
+  EXPECT_EQ(placement.at("size"), 6);
+  EXPECT_EQ(placement.at("preflight_status"), "success");
+  EXPECT_EQ(rom.vector(), before);
+}
+
+TEST(DungeonEditCommandsTest, PlaceObjectRejectsNoncanonicalFixedSize) {
+  handlers::DungeonPlaceObjectCommandHandler handler;
+  std::string output;
+  const auto status =
+      handler.Run({"--mock-rom", "--room=0x98", "--id=0xF99", "--x=1", "--y=2",
+                   "--size=0", "--format=json"},
+                  nullptr, &output);
+
+  ExpectInvalidArgument(status,
+                        "Size 0 is not encodable for object 0xF99; expected 6");
+}
+
 TEST(DungeonEditCommandsTest, PlaceObjectRejectsRoomIdOutOfRange) {
   handlers::DungeonPlaceObjectCommandHandler handler;
   std::string output;

--- a/test/unit/zelda3/dungeon/dungeon_object_editor_dirty_test.cc
+++ b/test/unit/zelda3/dungeon/dungeon_object_editor_dirty_test.cc
@@ -65,6 +65,117 @@ TEST_F(DungeonObjectEditorDirtyTest, BatchMutatorsMarkObjectStreamDirty) {
   EXPECT_TRUE(room_->object_stream_dirty());
 }
 
+TEST_F(DungeonObjectEditorDirtyTest,
+       ResizeMutatorsSkipFixedSizesAndClampType1Batch) {
+  ASSERT_TRUE(room_->AddObject(RoomObject(0x100, 10, 10, /*size=*/0, 0)).ok());
+  ASSERT_TRUE(
+      room_
+          ->AddObject(RoomObject(0xF99, 15, 15,
+                                 /*size=*/CanonicalRoomObjectSize(0xF99, 0), 0))
+          .ok());
+  room_->ClearSaveDirtyState();
+
+  ASSERT_TRUE(editor_->ResizeObject(2, 9).ok());
+  ASSERT_TRUE(editor_->ResizeObject(3, 9).ok());
+  EXPECT_EQ(room_->GetTileObject(2).size(), 0);
+  EXPECT_EQ(room_->GetTileObject(3).size(), CanonicalRoomObjectSize(0xF99, 0));
+  EXPECT_FALSE(room_->object_stream_dirty());
+
+  ASSERT_TRUE(editor_->ResizeObject(0, 0xFF).ok());
+  EXPECT_EQ(room_->GetTileObject(0).size(), 0x0F);
+  EXPECT_TRUE(room_->object_stream_dirty());
+
+  room_->ClearSaveDirtyState();
+  ASSERT_TRUE(editor_->BatchResizeObjects({1, 2, 3}, 0xFF).ok());
+  EXPECT_EQ(room_->GetTileObject(1).size(), 0x0F);
+  EXPECT_EQ(room_->GetTileObject(2).size(), 0);
+  EXPECT_EQ(room_->GetTileObject(3).size(), CanonicalRoomObjectSize(0xF99, 0));
+  EXPECT_TRUE(room_->object_stream_dirty());
+}
+
+TEST_F(DungeonObjectEditorDirtyTest,
+       ChangeObjectTypeCanonicalizesFixedSizeFamilies) {
+  ASSERT_TRUE(editor_->ResizeObject(0, 7).ok());
+  room_->ClearSaveDirtyState();
+
+  ASSERT_TRUE(editor_->ChangeObjectType(0, 0x100).ok());
+  EXPECT_EQ(room_->GetTileObject(0).id_, 0x100);
+  EXPECT_EQ(room_->GetTileObject(0).size(), 0);
+  EXPECT_TRUE(
+      ValidateRoomObjectStreamEntryForSave(room_->GetTileObject(0)).ok());
+
+  room_->ClearSaveDirtyState();
+  ASSERT_TRUE(editor_->ChangeObjectType(0, 0xF99).ok());
+  EXPECT_EQ(room_->GetTileObject(0).id_, 0xF99);
+  EXPECT_EQ(room_->GetTileObject(0).size(), CanonicalRoomObjectSize(0xF99, 0));
+  EXPECT_TRUE(
+      ValidateRoomObjectStreamEntryForSave(room_->GetTileObject(0)).ok());
+  EXPECT_TRUE(room_->object_stream_dirty());
+}
+
+TEST_F(DungeonObjectEditorDirtyTest, InsertObjectUsesCanonicalFamilyDefaults) {
+  const size_t initial_count = room_->GetTileObjectCount();
+
+  ASSERT_TRUE(editor_->InsertObject(10, 10, 0x23).ok());
+  ASSERT_TRUE(editor_->InsertObject(15, 15, 0x100).ok());
+  ASSERT_TRUE(editor_->InsertObject(20, 20, 0xF99).ok());
+
+  const auto& type1 = room_->GetTileObject(initial_count);
+  EXPECT_EQ(type1.size(), DefaultRoomObjectSizeForPlacement(type1.id_));
+  EXPECT_TRUE(ValidateRoomObjectStreamEntryForSave(type1).ok());
+
+  const auto& type2 = room_->GetTileObject(initial_count + 1);
+  EXPECT_EQ(type2.size(), 0);
+  EXPECT_TRUE(ValidateRoomObjectStreamEntryForSave(type2).ok());
+
+  const auto& type3 = room_->GetTileObject(initial_count + 2);
+  EXPECT_EQ(type3.size(), CanonicalRoomObjectSize(0xF99, 0));
+  EXPECT_TRUE(ValidateRoomObjectStreamEntryForSave(type3).ok());
+}
+
+TEST_F(DungeonObjectEditorDirtyTest,
+       PreviewUsesCanonicalSizeAndRejectsCodecGapId) {
+  EXPECT_EQ(editor_->GetEditingState().current_object_type, 0x10);
+  EXPECT_EQ(editor_->GetEditingState().preview_size,
+            DefaultRoomObjectSizeForPlacement(0x10));
+
+  editor_->SetMode(DungeonObjectEditor::Mode::kInsert);
+  editor_->SetCurrentObjectType(0x100);
+  EXPECT_EQ(editor_->GetEditingState().preview_size, 0);
+
+  editor_->SetCurrentObjectType(0xF99);
+  EXPECT_EQ(editor_->GetEditingState().preview_size,
+            CanonicalRoomObjectSize(0xF99, 0));
+
+  editor_->SetCurrentObjectType(0x140);
+  EXPECT_EQ(editor_->GetEditingState().current_object_type, 0xF99);
+  EXPECT_EQ(editor_->GetEditingState().preview_size,
+            CanonicalRoomObjectSize(0xF99, 0));
+}
+
+TEST_F(DungeonObjectEditorDirtyTest,
+       InsertAndTypeChangeRejectCodecGapIdsWithoutMutation) {
+  const size_t initial_count = room_->GetTileObjectCount();
+  const int16_t initial_id = room_->GetTileObject(0).id_;
+  const uint8_t initial_size = room_->GetTileObject(0).size();
+  room_->ClearSaveDirtyState();
+
+  for (const int invalid_id : {0x0F8, 0x0FF, 0x140, 0xF7F}) {
+    const auto insert_status =
+        editor_->InsertObject(10, 10, invalid_id, /*size=*/2, /*layer=*/0);
+    EXPECT_EQ(insert_status.code(), absl::StatusCode::kInvalidArgument)
+        << "id=" << invalid_id;
+    EXPECT_EQ(room_->GetTileObjectCount(), initial_count);
+
+    const auto change_status = editor_->ChangeObjectType(0, invalid_id);
+    EXPECT_EQ(change_status.code(), absl::StatusCode::kInvalidArgument)
+        << "id=" << invalid_id;
+    EXPECT_EQ(room_->GetTileObject(0).id_, initial_id);
+    EXPECT_EQ(room_->GetTileObject(0).size(), initial_size);
+    EXPECT_FALSE(room_->object_stream_dirty());
+  }
+}
+
 TEST_F(DungeonObjectEditorDirtyTest, AlignAndDragMarkObjectStreamDirty) {
   ASSERT_TRUE(editor_->AddToSelection(0).ok());
   ASSERT_TRUE(editor_->AddToSelection(1).ok());

--- a/test/unit/zelda3/dungeon/dungeon_save_test.cc
+++ b/test/unit/zelda3/dungeon/dungeon_save_test.cc
@@ -382,6 +382,36 @@ TEST_F(DungeonSaveTest,
   EXPECT_TRUE(room_->object_stream_dirty());
 }
 
+TEST_F(DungeonSaveTest,
+       SaveObjects_NoncanonicalSizesFailWithoutRomMutationAndStayDirty) {
+  const struct {
+    int16_t id;
+    uint8_t size;
+  } test_cases[] = {
+      {/*id=*/0x010, /*size=*/16},
+      {/*id=*/0x100, /*size=*/1},
+      {/*id=*/0xF99, /*size=*/0},
+  };
+
+  for (const auto& test_case : test_cases) {
+    room_->GetTileObjects().clear();
+    room_->ClearObjectStreamDirty();
+    room_->AddTileObject(RoomObject(test_case.id, /*x=*/10, /*y=*/10,
+                                    test_case.size, /*layer=*/0));
+    const auto before = rom_->vector();
+
+    const auto status = room_->SaveObjects();
+
+    EXPECT_EQ(status.code(), absl::StatusCode::kInvalidArgument)
+        << "id=" << test_case.id
+        << " size=" << static_cast<int>(test_case.size);
+    EXPECT_NE(status.message().find("noncanonical size"), std::string::npos)
+        << status.message();
+    EXPECT_EQ(rom_->vector(), before);
+    EXPECT_TRUE(room_->object_stream_dirty());
+  }
+}
+
 TEST_F(DungeonSaveTest, SaveObjects_TooLarge) {
   // Add MANY objects to exceed 256 bytes
   // Each object encodes to 3 bytes.

--- a/test/unit/zelda3/dungeon/dungeon_validator_test.cc
+++ b/test/unit/zelda3/dungeon/dungeon_validator_test.cc
@@ -34,6 +34,11 @@ bool HasErrorContaining(const ValidationResult& result,
   return false;
 }
 
+RoomObject MakeCanonicalRoomObject(int16_t id, uint8_t x, uint8_t y,
+                                   uint8_t layer) {
+  return RoomObject(id, x, y, CanonicalRoomObjectSize(id, 0), layer);
+}
+
 TEST(DungeonValidatorTest, AcceptsBothBgObjectsInOverlayStreams) {
   Rom rom;
   ASSERT_TRUE(rom.LoadFromData(std::vector<uint8_t>(0x200000, 0)).ok());
@@ -130,16 +135,34 @@ TEST(DungeonValidatorTest, RejectsUnrepresentableRoomStreamObject) {
   EXPECT_TRUE(HasErrorContaining(result, "not representable"));
 }
 
+TEST(DungeonValidatorTest, RejectsNoncanonicalRoomStreamObjectSizes) {
+  Rom rom;
+  ASSERT_TRUE(rom.LoadFromData(std::vector<uint8_t>(0x200000, 0)).ok());
+
+  for (const auto [id, size] : {std::pair<int16_t, uint8_t>{0x010, 16},
+                                std::pair<int16_t, uint8_t>{0x100, 1},
+                                std::pair<int16_t, uint8_t>{0xF99, 0}}) {
+    Room room(/*room_id=*/0, &rom);
+    room.AddTileObject(RoomObject(id, /*x=*/4, /*y=*/4, size, /*layer=*/0));
+
+    const auto result = DungeonValidator().ValidateRoom(room);
+
+    EXPECT_FALSE(result.is_valid);
+    EXPECT_TRUE(HasErrorContaining(result, "noncanonical size"))
+        << "id=" << id << " size=" << static_cast<int>(size);
+  }
+}
+
 TEST(DungeonValidatorTest, ExemptsSpecialTableObjectsFromRoomStreamCodec) {
   Rom rom;
   ASSERT_TRUE(rom.LoadFromData(std::vector<uint8_t>(0x200000, 0)).ok());
 
   Room room(/*room_id=*/0, &rom);
-  RoomObject torch(/*id=*/0x150, /*x=*/4, /*y=*/4, /*size=*/0,
+  RoomObject torch(/*id=*/0x150, /*x=*/4, /*y=*/4, /*size=*/0xFF,
                    /*layer=*/0);
   torch.set_options(ObjectOption::Torch);
   ASSERT_TRUE(room.AddObject(torch).ok());
-  RoomObject block(/*id=*/0x0E00, /*x=*/8, /*y=*/8, /*size=*/0,
+  RoomObject block(/*id=*/0x0E00, /*x=*/8, /*y=*/8, /*size=*/0xFF,
                    /*layer=*/1);
   block.set_options(ObjectOption::Block);
   ASSERT_TRUE(room.AddObject(block).ok());
@@ -211,13 +234,13 @@ TEST(DungeonValidatorTest, AcceptsStatefulChestsBeforeBigKeyLocks) {
   Room room(/*room_id=*/0, &rom);
   for (int i = 0; i < 4; ++i) {
     const int16_t chest_id = i % 2 == 0 ? 0xF99 : 0xFB1;
-    ASSERT_TRUE(room.AddObject(RoomObject(chest_id, /*x=*/i * 4, /*y=*/0,
-                                          /*size=*/0, /*layer=*/0))
+    ASSERT_TRUE(room.AddObject(MakeCanonicalRoomObject(chest_id, /*x=*/i * 4,
+                                                       /*y=*/0, /*layer=*/0))
                     .ok());
   }
   for (int i = 0; i < 2; ++i) {
-    ASSERT_TRUE(room.AddObject(RoomObject(0xF98, /*x=*/i * 4, /*y=*/8,
-                                          /*size=*/0, /*layer=*/2))
+    ASSERT_TRUE(room.AddObject(MakeCanonicalRoomObject(0xF98, /*x=*/i * 4,
+                                                       /*y=*/8, /*layer=*/2))
                     .ok());
   }
 
@@ -234,11 +257,11 @@ TEST(DungeonValidatorTest, WarnsForEachStatefulChestVariantAfterLock) {
 
   for (const int16_t chest_id : {int16_t{0xF99}, int16_t{0xFB1}}) {
     Room room(/*room_id=*/0, &rom);
-    ASSERT_TRUE(room.AddObject(RoomObject(0xF98, /*x=*/0, /*y=*/0,
-                                          /*size=*/0, /*layer=*/0))
+    ASSERT_TRUE(room.AddObject(MakeCanonicalRoomObject(0xF98, /*x=*/0, /*y=*/0,
+                                                       /*layer=*/0))
                     .ok());
-    ASSERT_TRUE(room.AddObject(RoomObject(chest_id, /*x=*/8, /*y=*/0,
-                                          /*size=*/0, /*layer=*/0))
+    ASSERT_TRUE(room.AddObject(MakeCanonicalRoomObject(chest_id, /*x=*/8,
+                                                       /*y=*/0, /*layer=*/0))
                     .ok());
 
     const auto result = DungeonValidator().ValidateRoom(room);
@@ -257,12 +280,12 @@ TEST(DungeonValidatorTest, UsesEncodedListOrderForRoomEventWarnings) {
   // The chest is first in the editor vector, but list 1 is encoded after the
   // list-0 lock. A raw vector scan would miss this ordering hazard.
   ASSERT_TRUE(invalid_room
-                  .AddObject(RoomObject(0xF99, /*x=*/8, /*y=*/0,
-                                        /*size=*/0, /*layer=*/1))
+                  .AddObject(MakeCanonicalRoomObject(0xF99, /*x=*/8, /*y=*/0,
+                                                     /*layer=*/1))
                   .ok());
   ASSERT_TRUE(invalid_room
-                  .AddObject(RoomObject(0xF98, /*x=*/0, /*y=*/0,
-                                        /*size=*/0, /*layer=*/0))
+                  .AddObject(MakeCanonicalRoomObject(0xF98, /*x=*/0, /*y=*/0,
+                                                     /*layer=*/0))
                   .ok());
 
   const auto invalid_result = DungeonValidator().ValidateRoom(invalid_room);
@@ -276,12 +299,12 @@ TEST(DungeonValidatorTest, UsesEncodedListOrderForRoomEventWarnings) {
   // Conversely, raw vector order has the lock first, but the primary-list
   // chest is encoded before the list-2 lock and must remain valid.
   ASSERT_TRUE(valid_room
-                  .AddObject(RoomObject(0xF98, /*x=*/0, /*y=*/0,
-                                        /*size=*/0, /*layer=*/2))
+                  .AddObject(MakeCanonicalRoomObject(0xF98, /*x=*/0, /*y=*/0,
+                                                     /*layer=*/2))
                   .ok());
   ASSERT_TRUE(valid_room
-                  .AddObject(RoomObject(0xF99, /*x=*/8, /*y=*/0,
-                                        /*size=*/0, /*layer=*/0))
+                  .AddObject(MakeCanonicalRoomObject(0xF99, /*x=*/8, /*y=*/0,
+                                                     /*layer=*/0))
                   .ok());
 
   const auto valid_result = DungeonValidator().ValidateRoom(valid_room);
@@ -296,13 +319,14 @@ TEST(DungeonValidatorTest, FixedOpenChestsDoNotConsumeRoomEventSlots) {
   ASSERT_TRUE(rom.LoadFromData(std::vector<uint8_t>(0x200000, 0)).ok());
 
   Room room(/*room_id=*/0, &rom);
-  ASSERT_TRUE(room.AddObject(RoomObject(0xF98, /*x=*/0, /*y=*/0,
-                                        /*size=*/0, /*layer=*/0))
+  ASSERT_TRUE(room.AddObject(MakeCanonicalRoomObject(0xF98, /*x=*/0, /*y=*/0,
+                                                     /*layer=*/0))
                   .ok());
   for (int i = 0; i < 8; ++i) {
     const int16_t open_chest_id = i % 2 == 0 ? 0xF9A : 0xFB2;
-    ASSERT_TRUE(room.AddObject(RoomObject(open_chest_id, /*x=*/i * 4,
-                                          /*y=*/8, /*size=*/0, /*layer=*/0))
+    ASSERT_TRUE(room.AddObject(MakeCanonicalRoomObject(open_chest_id,
+                                                       /*x=*/i * 4, /*y=*/8,
+                                                       /*layer=*/0))
                     .ok());
   }
 
@@ -319,13 +343,13 @@ TEST(DungeonValidatorTest, WarnsWhenRoomEventConsumersExceedSixSlots) {
 
   Room room(/*room_id=*/0, &rom);
   for (int i = 0; i < 4; ++i) {
-    ASSERT_TRUE(room.AddObject(RoomObject(0xF99, /*x=*/i * 4, /*y=*/0,
-                                          /*size=*/0, /*layer=*/0))
+    ASSERT_TRUE(room.AddObject(MakeCanonicalRoomObject(0xF99, /*x=*/i * 4,
+                                                       /*y=*/0, /*layer=*/0))
                     .ok());
   }
   for (int i = 0; i < 3; ++i) {
-    ASSERT_TRUE(room.AddObject(RoomObject(0xF98, /*x=*/i * 4, /*y=*/8,
-                                          /*size=*/0, /*layer=*/0))
+    ASSERT_TRUE(room.AddObject(MakeCanonicalRoomObject(0xF98, /*x=*/i * 4,
+                                                       /*y=*/8, /*layer=*/0))
                     .ok());
   }
 

--- a/test/unit/zelda3/dungeon/room_object_encoding_test.cc
+++ b/test/unit/zelda3/dungeon/room_object_encoding_test.cc
@@ -59,8 +59,10 @@ TEST(RoomObjectEncodingTest, MapRoomObjectListIndexToDrawLayer) {
 TEST(RoomObjectEncodingTest, SaveGuardAcceptsRepresentableIdBoundaries) {
   for (const int16_t id : {int16_t{0x000}, int16_t{0x0F7}, int16_t{0x100},
                            int16_t{0x13F}, int16_t{0xF80}, int16_t{0xFFF}}) {
-    const RoomObject object(id, /*x=*/62, /*y=*/63, /*size=*/15,
-                            /*layer=*/2);
+    const RoomObject object(
+        id, /*x=*/62, /*y=*/63,
+        /*size=*/CanonicalRoomObjectSize(id, /*requested_size=*/15),
+        /*layer=*/2);
 
     const auto status = ValidateRoomObjectStreamEntryForSave(object);
 
@@ -84,8 +86,10 @@ TEST(RoomObjectEncodingTest, SaveGuardRejectsAliasedIdRanges) {
 
 TEST(RoomObjectEncodingTest, SaveGuardRejectsNonType2X63Discriminator) {
   for (const int16_t id : {int16_t{0x010}, int16_t{0xF99}}) {
-    const RoomObject object(id, /*x=*/63, /*y=*/20, /*size=*/0,
-                            /*layer=*/0);
+    const RoomObject object(
+        id, /*x=*/63, /*y=*/20,
+        /*size=*/CanonicalRoomObjectSize(id, /*requested_size=*/0),
+        /*layer=*/0);
 
     const auto status = ValidateRoomObjectStreamEntryForSave(object);
 
@@ -105,7 +109,7 @@ TEST(RoomObjectEncodingTest, SaveGuardRejectsStreamControlPrefixes) {
   const RoomObject type1_door_marker(/*id=*/0x010, /*x=*/60, /*y=*/63,
                                      /*size=*/3, /*layer=*/0);
   const RoomObject type3_door_marker(/*id=*/0xF8C, /*x=*/60, /*y=*/63,
-                                     /*size=*/0, /*layer=*/0);
+                                     /*size=*/3, /*layer=*/0);
 
   for (const RoomObject* object :
        {&list_terminator, &type1_door_marker, &type3_door_marker}) {
@@ -136,11 +140,45 @@ TEST(RoomObjectEncodingTest, SaveGuardRejectsInvalidLayerAndCoordinates) {
             absl::StatusCode::kInvalidArgument);
 }
 
-TEST(RoomObjectEncodingTest, SaveGuardDoesNotRejectLossySizeField) {
-  const RoomObject object(/*id=*/0x010, /*x=*/10, /*y=*/20, /*size=*/0xFF,
-                          /*layer=*/0);
+TEST(RoomObjectEncodingTest, SaveGuardAcceptsCanonicalSizeBoundaries) {
+  for (const RoomObject object :
+       {RoomObject(/*id=*/0x010, /*x=*/10, /*y=*/20, /*size=*/0,
+                   /*layer=*/0),
+        RoomObject(/*id=*/0x0F7, /*x=*/10, /*y=*/20, /*size=*/15,
+                   /*layer=*/0),
+        RoomObject(/*id=*/0x100, /*x=*/10, /*y=*/20, /*size=*/0,
+                   /*layer=*/0),
+        RoomObject(/*id=*/0xF80, /*x=*/10, /*y=*/20, /*size=*/0,
+                   /*layer=*/0),
+        RoomObject(/*id=*/0xFFF, /*x=*/10, /*y=*/20, /*size=*/15,
+                   /*layer=*/0)}) {
+    EXPECT_TRUE(ValidateRoomObjectStreamEntryForSave(object).ok())
+        << "id=" << object.id_ << " size=" << static_cast<int>(object.size_);
+  }
+}
 
-  EXPECT_TRUE(ValidateRoomObjectStreamEntryForSave(object).ok());
+TEST(RoomObjectEncodingTest, SaveGuardRejectsNoncanonicalSizes) {
+  const struct {
+    int16_t id;
+    uint8_t size;
+  } test_cases[] = {
+      {/*id=*/0x010, /*size=*/16}, {/*id=*/0x010, /*size=*/0xFF},
+      {/*id=*/0x100, /*size=*/1},  {/*id=*/0x13F, /*size=*/15},
+      {/*id=*/0xF99, /*size=*/0},  {/*id=*/0xFFF, /*size=*/14},
+  };
+
+  for (const auto& test_case : test_cases) {
+    const RoomObject object(test_case.id, /*x=*/10, /*y=*/20, test_case.size,
+                            /*layer=*/0);
+
+    const auto status = ValidateRoomObjectStreamEntryForSave(object);
+
+    EXPECT_EQ(status.code(), absl::StatusCode::kInvalidArgument)
+        << "id=" << test_case.id
+        << " size=" << static_cast<int>(test_case.size);
+    EXPECT_NE(status.message().find("noncanonical size"), std::string::npos)
+        << status.message();
+  }
 }
 
 // Type 1 Object Encoding/Decoding Tests


### PR DESCRIPTION
## Summary

- reject noncanonical Type 1, Type 2, and Type 3 sizes before room-object encoding or ROM mutation
- keep failed saves atomic and dirty so the editor can recover safely
- canonicalize the active Selection Inspector and legacy `DungeonObjectEditor` insert, resize, preview, and ID-change paths
- reject room-object codec-gap IDs before editor mutation
- preserve z3ed's omitted Type 1 size of `0`, derive omitted fixed-family sizes, and reject explicit noncanonical sizes

## Why

Only Type 1 objects persist an editable size. Type 2 stores no size, while Type 3 derives the apparent size bits from its ID. Allowing noncanonical in-memory values can silently lose state or alias an object during stream encoding. The save guard fails before writes, while the editor and CLI changes prevent normal workflows from creating those invalid states.

## Verification

- `cmake --build build/presets/mac-test --config Debug --target yaze_test_unit --parallel 8`
- focused unit filter: **42/42 passed** across `RoomObjectEncodingTest.SaveGuard*`, `DungeonValidatorTest.*`, the three atomic `DungeonSaveTest` cases, `DungeonObjectEditorDirtyTest.*`, and seven `dungeon-place-object` regressions
- `clang-format --dry-run --Werror` on the five follow-up files
- `git diff --check 22448f97..HEAD`
- full hosted CI now gates the exact master diff after retargeting and synchronization

## Remaining automated gaps

- no ImGui-driven property-field integration test
- no fixed-family z3ed `--write` readback test; the immutable dry-run/preflight and existing COW write path are covered
