### PR TITLE
fix(dungeon): plan exact Oracle save writes

### DIFF
--- a/src/app/editor/dungeon/dungeon_editor_v2_persistence.cc
+++ b/src/app/editor/dungeon/dungeon_editor_v2_persistence.cc
@@ -215,16 +215,59 @@ std::vector<std::pair<uint32_t, uint32_t>> CollectDirtyPotItemWriteRanges(
 
 absl::StatusOr<std::vector<std::pair<uint32_t, uint32_t>>>
 CollectDirtyChestWriteRanges(const Rom* rom, const DungeonRoomStore& rooms) {
+  ASSIGN_OR_RETURN(
+      zelda3::ChestSavePlan plan,
+      zelda3::BuildChestSavePlan(
+          rom, static_cast<int>(rooms.size()),
+          [&rooms](int room_id) { return rooms.GetIfMaterialized(room_id); }));
+  return plan.write_ranges();
+}
+
+std::vector<std::pair<uint32_t, uint32_t>> CollectDirtyWaterFillWriteRanges(
+    const Rom* rom, const DungeonRoomStore& rooms) {
+  std::vector<std::pair<uint32_t, uint32_t>> ranges;
+  if (rom == nullptr || !rom->is_loaded() ||
+      zelda3::kWaterFillTableEnd > static_cast<int>(rom->size())) {
+    return ranges;
+  }
   bool any_dirty = false;
-  rooms.ForEachMaterialized([&](int, const zelda3::Room& room) {
-    if (room.chests_dirty()) {
+  rooms.ForEachMaterialized([&any_dirty](int, const zelda3::Room& room) {
+    if (room.water_fill_dirty()) {
       any_dirty = true;
     }
   });
-  if (!any_dirty) {
-    return std::vector<std::pair<uint32_t, uint32_t>>{};
+  if (any_dirty) {
+    ranges.emplace_back(zelda3::kWaterFillTableStart,
+                        zelda3::kWaterFillTableEnd);
   }
-  return zelda3::GetChestTableWriteRanges(rom);
+  return ranges;
+}
+
+std::vector<std::pair<uint32_t, uint32_t>>
+CollectDirtyCustomCollisionWriteRanges(const Rom* rom,
+                                       const DungeonRoomStore& rooms) {
+  std::vector<std::pair<uint32_t, uint32_t>> ranges;
+  const int pointer_table_size = zelda3::kNumberOfRooms * 3;
+  if (rom == nullptr || !rom->is_loaded() ||
+      zelda3::kCustomCollisionRoomPointers + pointer_table_size >
+          static_cast<int>(rom->size()) ||
+      zelda3::kCustomCollisionDataSoftEnd > static_cast<int>(rom->size())) {
+    return ranges;
+  }
+  bool any_dirty = false;
+  rooms.ForEachMaterialized([&any_dirty](int, const zelda3::Room& room) {
+    if (room.custom_collision_dirty()) {
+      any_dirty = true;
+    }
+  });
+  if (any_dirty) {
+    ranges.emplace_back(
+        zelda3::kCustomCollisionRoomPointers,
+        zelda3::kCustomCollisionRoomPointers + pointer_table_size);
+    ranges.emplace_back(zelda3::kCustomCollisionDataPosition,
+                        zelda3::kCustomCollisionDataSoftEnd);
+  }
+  return ranges;
 }
 
 absl::Status SaveAllPotItemsForProject(const project::YazeProject* project,
@@ -307,13 +350,44 @@ absl::Status ValidateDungeonEntranceSavePreflight(
 }
 
 absl::Status ValidateChestManifestConflicts(const project::YazeProject* project,
-                                            Rom* rom,
-                                            const DungeonRoomStore& rooms,
+                                            const zelda3::ChestSavePlan& plan,
                                             absl::string_view save_scope,
                                             ToastManager* toast_manager) {
-  ASSIGN_OR_RETURN(const auto ranges, CollectDirtyChestWriteRanges(rom, rooms));
+  const auto ranges = plan.write_ranges();
   if (ranges.empty() || project == nullptr ||
       !project->hack_manifest.loaded()) {
+    return absl::OkStatus();
+  }
+  return ValidateHackManifestSaveConflicts(
+      project->hack_manifest, project->rom_metadata.write_policy, ranges,
+      save_scope, "DungeonEditorV2", toast_manager);
+}
+
+absl::Status ValidateWaterFillManifestConflicts(
+    const project::YazeProject* project, const Rom* rom,
+    const DungeonRoomStore& rooms, absl::string_view save_scope,
+    ToastManager* toast_manager) {
+  if (project == nullptr || !project->hack_manifest.loaded()) {
+    return absl::OkStatus();
+  }
+  const auto ranges = CollectDirtyWaterFillWriteRanges(rom, rooms);
+  if (ranges.empty()) {
+    return absl::OkStatus();
+  }
+  return ValidateHackManifestSaveConflicts(
+      project->hack_manifest, project->rom_metadata.write_policy, ranges,
+      save_scope, "DungeonEditorV2", toast_manager);
+}
+
+absl::Status ValidateCustomCollisionManifestConflicts(
+    const project::YazeProject* project, const Rom* rom,
+    const DungeonRoomStore& rooms, absl::string_view save_scope,
+    ToastManager* toast_manager) {
+  if (project == nullptr || !project->hack_manifest.loaded()) {
+    return absl::OkStatus();
+  }
+  const auto ranges = CollectDirtyCustomCollisionWriteRanges(rom, rooms);
+  if (ranges.empty()) {
     return absl::OkStatus();
   }
   return ValidateHackManifestSaveConflicts(
@@ -436,7 +510,18 @@ absl::Status DungeonEditorV2::Save() {
   }
 
   const auto& flags = core::FeatureFlags::get().dungeon;
+  std::optional<zelda3::ChestSavePlan> chest_save_plan;
 
+  if (flags.kSaveCollision) {
+    RETURN_IF_ERROR(ValidateCustomCollisionManifestConflicts(
+        dependencies_.project, rom_, rooms_, "custom collision",
+        dependencies_.toast_manager));
+  }
+  if (flags.kSaveWaterFillZones) {
+    RETURN_IF_ERROR(ValidateWaterFillManifestConflicts(
+        dependencies_.project, rom_, rooms_, "water fill zones",
+        dependencies_.toast_manager));
+  }
   if (flags.kSaveEntrances) {
     RETURN_IF_ERROR(ValidateDungeonEntranceSavePreflight(
         dependencies_.project, rom_, entrances_, spawn_points_,
@@ -444,9 +529,15 @@ absl::Status DungeonEditorV2::Save() {
   }
 
   if (flags.kSaveChests) {
+    ASSIGN_OR_RETURN(auto plan, zelda3::BuildChestSavePlan(
+                                    rom_, static_cast<int>(rooms_.size()),
+                                    [this](int room_id) {
+                                      return rooms_.GetIfMaterialized(room_id);
+                                    }));
     RETURN_IF_ERROR(ValidateChestManifestConflicts(
-        dependencies_.project, rom_, rooms_, "chest table",
+        dependencies_.project, plan, "chest table",
         dependencies_.toast_manager));
+    chest_save_plan = std::move(plan);
   }
   if (flags.kSavePotItems) {
     RETURN_IF_ERROR(ValidatePotItemManifestConflicts(
@@ -541,8 +632,8 @@ absl::Status DungeonEditorV2::Save() {
   }
 
   if (flags.kSaveChests) {
-    auto status = zelda3::SaveAllChests(
-        rom_, static_cast<int>(rooms_.size()),
+    auto status = zelda3::ApplyChestSavePlan(
+        rom_, *chest_save_plan,
         [this](int room_id) { return rooms_.GetIfMaterialized(room_id); });
     if (!status.ok()) {
       LOG_ERROR("DungeonEditorV2", "Failed to save chests: %s",
@@ -644,49 +735,25 @@ std::vector<std::pair<uint32_t, uint32_t>> DungeonEditorV2::CollectWriteRanges()
   // Include it in write-range reporting whenever we have dirty water fill data,
   // even if no rooms are currently loaded (SaveWaterFillZones() is room-indexed
   // and independent of room loading state).
-  if (flags.kSaveWaterFillZones &&
-      zelda3::kWaterFillTableEnd <= static_cast<int>(rom_data.size())) {
-    bool any_dirty = false;
-    rooms_.ForEachMaterialized([&](int, const zelda3::Room& room) {
-      if (room.water_fill_dirty()) {
-        any_dirty = true;
-      }
-    });
-    if (any_dirty) {
-      ranges.emplace_back(zelda3::kWaterFillTableStart,
-                          zelda3::kWaterFillTableEnd);
-    }
+  if (flags.kSaveWaterFillZones) {
+    auto water_fill_ranges = CollectDirtyWaterFillWriteRanges(rom_, rooms_);
+    ranges.insert(ranges.end(), water_fill_ranges.begin(),
+                  water_fill_ranges.end());
   }
 
   // Custom collision writes update the pointer table and append blobs into the
   // expanded collision region. SaveAllCollision() is room-indexed, so include
   // these ranges whenever any room has dirty custom collision data.
   if (flags.kSaveCollision) {
-    const int ptrs_size = zelda3::kNumberOfRooms * 3;
-    const bool has_ptr_table =
-        (zelda3::kCustomCollisionRoomPointers + ptrs_size <=
-         static_cast<int>(rom_data.size()));
-    const bool has_data_region = (zelda3::kCustomCollisionDataSoftEnd <=
-                                  static_cast<int>(rom_data.size()));
-    if (has_ptr_table && has_data_region) {
-      bool any_dirty = false;
-      rooms_.ForEachMaterialized([&](int, const zelda3::Room& room) {
-        if (room.custom_collision_dirty()) {
-          any_dirty = true;
-        }
-      });
-      if (any_dirty) {
-        ranges.emplace_back(zelda3::kCustomCollisionRoomPointers,
-                            zelda3::kCustomCollisionRoomPointers + ptrs_size);
-        ranges.emplace_back(zelda3::kCustomCollisionDataPosition,
-                            zelda3::kCustomCollisionDataSoftEnd);
-      }
-    }
+    auto collision_ranges =
+        CollectDirtyCustomCollisionWriteRanges(rom_, rooms_);
+    ranges.insert(ranges.end(), collision_ranges.begin(),
+                  collision_ranges.end());
   }
 
-  // Chests use one global fixed-capacity table. A dirty room may change the
-  // runtime byte length and any slot inside the live pointer target, so report
-  // both complete write ranges before serializers clear dirty state.
+  // Chests use one global fixed-capacity table. Report only the exact byte
+  // deltas from the same planner used by the serializer so unrelated protected
+  // bytes inside the live table do not block a safe edit.
   if (flags.kSaveChests) {
     auto chest_ranges = CollectDirtyChestWriteRanges(rom_, rooms_);
     if (chest_ranges.ok()) {
@@ -828,6 +895,19 @@ absl::Status DungeonEditorV2::SaveRoom(int room_id) {
     }
 
     const auto& flags = core::FeatureFlags::get().dungeon;
+    std::optional<zelda3::ChestSavePlan> chest_save_plan;
+    if (flags.kSaveCollision) {
+      RETURN_IF_ERROR(ValidateCustomCollisionManifestConflicts(
+          dependencies_.project, rom_, rooms_,
+          absl::StrFormat("custom collision for room 0x%03X", room_id),
+          dependencies_.toast_manager));
+    }
+    if (flags.kSaveWaterFillZones) {
+      RETURN_IF_ERROR(ValidateWaterFillManifestConflicts(
+          dependencies_.project, rom_, rooms_,
+          absl::StrFormat("water fill zones for room 0x%03X", room_id),
+          dependencies_.toast_manager));
+    }
     if (flags.kSaveEntrances) {
       RETURN_IF_ERROR(ValidateDungeonEntranceSavePreflight(
           dependencies_.project, rom_, entrances_, spawn_points_,
@@ -837,10 +917,16 @@ absl::Status DungeonEditorV2::SaveRoom(int room_id) {
           dependencies_.toast_manager));
     }
     if (flags.kSaveChests) {
+      ASSIGN_OR_RETURN(
+          auto plan, zelda3::BuildChestSavePlan(
+                         rom_, static_cast<int>(rooms_.size()), [this](int id) {
+                           return rooms_.GetIfMaterialized(id);
+                         }));
       RETURN_IF_ERROR(ValidateChestManifestConflicts(
-          dependencies_.project, rom_, rooms_,
+          dependencies_.project, plan,
           absl::StrFormat("chest table for room 0x%03X", room_id),
           dependencies_.toast_manager));
+      chest_save_plan = std::move(plan);
     }
     if (flags.kSavePotItems) {
       RETURN_IF_ERROR(ValidatePotItemManifestConflicts(
@@ -888,8 +974,8 @@ absl::Status DungeonEditorV2::SaveRoom(int room_id) {
       RETURN_IF_ERROR(SaveWaterFillZones(rom_, rooms_));
     }
     if (flags.kSaveChests) {
-      RETURN_IF_ERROR(zelda3::SaveAllChests(
-          rom_, static_cast<int>(rooms_.size()),
+      RETURN_IF_ERROR(zelda3::ApplyChestSavePlan(
+          rom_, *chest_save_plan,
           [this](int id) { return rooms_.GetIfMaterialized(id); }));
     }
     if (flags.kSavePotItems) {

--- a/src/zelda3/dungeon/README.md
+++ b/src/zelda3/dungeon/README.md
@@ -84,9 +84,10 @@ Chest persistence treats the global 168-record table as an ordered physical
 stream rather than regrouping it by room. One-for-one dirty-room edits reuse
 their existing occurrences, untouched and unknown-room records keep their raw
 bytes and relative order, removals compact the live stream, and growth appends
-in room-ID order. Capacity and manifest conflicts are checked before writes;
-the runtime length and full live pointer target are declared as possible write
-ranges while the pointer operand remains read-only.
+in room-ID order. Capacity and manifest conflicts are checked before writes
+from the same validated save plan used for serialization. Only contiguous byte
+runs that actually change, plus the runtime length when needed, are declared
+and written; the live pointer operand remains read-only.
 
 ## Key Files & Components
 

--- a/src/zelda3/dungeon/room.cc
+++ b/src/zelda3/dungeon/room.cc
@@ -11,6 +11,7 @@
 #include <string>
 #include <unordered_map>
 #include <unordered_set>
+#include <utility>
 #include <vector>
 
 #include "absl/strings/str_cat.h"
@@ -20,6 +21,7 @@
 #include "app/platform/sdl_compat.h"
 #include "rom/rom.h"
 #include "rom/snes.h"
+#include "rom/transaction.h"
 #include "rom/write_fence.h"
 #include "util/log.h"
 #include "zelda3/dungeon/dungeon_block_codec.h"
@@ -3513,6 +3515,200 @@ void AppendEditedChestRecord(std::vector<uint8_t>* bytes, int room_id,
   AppendChestRecord(bytes, word, chest.id);
 }
 
+void AppendChangedChestRuns(uint32_t pc, absl::Span<const uint8_t> expected,
+                            absl::Span<const uint8_t> replacement,
+                            std::vector<ChestWriteRun>* writes) {
+  size_t cursor = 0;
+  while (cursor < replacement.size()) {
+    if (replacement[cursor] == expected[cursor]) {
+      ++cursor;
+      continue;
+    }
+    const size_t begin = cursor;
+    do {
+      ++cursor;
+    } while (cursor < replacement.size() &&
+             replacement[cursor] != expected[cursor]);
+
+    ChestWriteRun run;
+    run.pc = pc + static_cast<uint32_t>(begin);
+    run.expected_bytes.assign(expected.begin() + begin,
+                              expected.begin() + cursor);
+    run.replacement_bytes.assign(replacement.begin() + begin,
+                                 replacement.begin() + cursor);
+    if (!writes->empty() && writes->back().end() == run.pc) {
+      writes->back().expected_bytes.insert(writes->back().expected_bytes.end(),
+                                           run.expected_bytes.begin(),
+                                           run.expected_bytes.end());
+      writes->back().replacement_bytes.insert(
+          writes->back().replacement_bytes.end(), run.replacement_bytes.begin(),
+          run.replacement_bytes.end());
+    } else {
+      writes->push_back(std::move(run));
+    }
+  }
+}
+
+void SortAndCoalesceChestRuns(std::vector<ChestWriteRun>* writes) {
+  std::sort(writes->begin(), writes->end(),
+            [](const ChestWriteRun& lhs, const ChestWriteRun& rhs) {
+              return lhs.pc < rhs.pc;
+            });
+  std::vector<ChestWriteRun> merged;
+  merged.reserve(writes->size());
+  for (ChestWriteRun& write : *writes) {
+    if (!merged.empty() && merged.back().end() == write.pc) {
+      merged.back().expected_bytes.insert(merged.back().expected_bytes.end(),
+                                          write.expected_bytes.begin(),
+                                          write.expected_bytes.end());
+      merged.back().replacement_bytes.insert(
+          merged.back().replacement_bytes.end(),
+          write.replacement_bytes.begin(), write.replacement_bytes.end());
+      continue;
+    }
+    merged.push_back(std::move(write));
+  }
+  *writes = std::move(merged);
+}
+
+std::vector<uint8_t> EncodeChestRoomState(int room_id, const Room& room) {
+  std::vector<uint8_t> bytes;
+  bytes.reserve(room.GetChests().size() * kChestTableRecordSize);
+  for (const chest_data& chest : room.GetChests()) {
+    AppendEditedChestRecord(&bytes, room_id, chest);
+  }
+  return bytes;
+}
+
+absl::StatusOr<ChestSavePlan> BuildChestSavePlanImpl(
+    const Rom* rom, int room_count,
+    const std::function<const Room*(int)>& room_lookup) {
+  if (rom == nullptr || !rom->is_loaded()) {
+    return absl::InvalidArgumentError("ROM not loaded");
+  }
+  const auto& rom_data = rom->vector();
+  if (kChestsLengthPointer + 1 >= static_cast<int>(rom_data.size()) ||
+      kChestsDataPointer1 + 2 >= static_cast<int>(rom_data.size())) {
+    return absl::OutOfRangeError("Chest pointers out of range");
+  }
+
+  ChestSavePlan plan;
+  plan.room_limit = std::min(room_count, kNumberOfRooms);
+  std::vector<const Room*> dirty_rooms(kNumberOfRooms, nullptr);
+  for (int room_id = 0; room_id < plan.room_limit; ++room_id) {
+    const Room* room = room_lookup(room_id);
+    if (room != nullptr && room->chests_dirty()) {
+      dirty_rooms[room_id] = room;
+      plan.any_dirty = true;
+      plan.dirty_rooms.push_back(
+          ChestDirtyRoomState{room_id, EncodeChestRoomState(room_id, *room)});
+    }
+  }
+  if (!plan.any_dirty) {
+    return plan;
+  }
+
+  ASSIGN_OR_RETURN(auto potential_ranges, GetChestTableWriteRanges(rom));
+  plan.data_pc = potential_ranges[1].first;
+  std::copy_n(rom_data.begin() + kChestsDataPointer1,
+              plan.pointer_operand.size(), plan.pointer_operand.begin());
+  plan.original_byte_length =
+      static_cast<uint16_t>((rom_data[kChestsLengthPointer + 1] << 8) |
+                            rom_data[kChestsLengthPointer]);
+  plan.original_capacity_bytes.assign(
+      rom_data.begin() + plan.data_pc,
+      rom_data.begin() + plan.data_pc + kChestTableCapacityBytes);
+  if (plan.original_byte_length > kChestTableCapacityBytes ||
+      (plan.original_byte_length % kChestTableRecordSize) != 0) {
+    return absl::FailedPreconditionError(absl::StrFormat(
+        "Chest table byte length %d is invalid (capacity %d)",
+        static_cast<int>(plan.original_byte_length), kChestTableCapacityBytes));
+  }
+
+  const auto physical_records = ParsePhysicalRomChests(
+      rom_data, static_cast<int>(plan.data_pc), plan.original_byte_length);
+  if (physical_records.size() !=
+      static_cast<size_t>(plan.original_byte_length / kChestTableRecordSize)) {
+    return absl::OutOfRangeError("Chest data region is truncated");
+  }
+
+  std::vector<size_t> old_counts(kNumberOfRooms, 0);
+  for (const PhysicalChestRecord& record : physical_records) {
+    if (record.room_id() < kNumberOfRooms) {
+      ++old_counts[record.room_id()];
+    }
+  }
+
+  size_t final_record_count = physical_records.size();
+  for (int room_id = 0; room_id < plan.room_limit; ++room_id) {
+    if (dirty_rooms[room_id] == nullptr) {
+      continue;
+    }
+    final_record_count -= old_counts[room_id];
+    final_record_count += dirty_rooms[room_id]->GetChests().size();
+  }
+  if (final_record_count > static_cast<size_t>(kChestTableCapacityRecords)) {
+    return absl::ResourceExhaustedError(absl::StrFormat(
+        "Chest table has %d records; capacity is %d",
+        static_cast<int>(final_record_count), kChestTableCapacityRecords));
+  }
+
+  std::vector<uint8_t> replacement_bytes;
+  replacement_bytes.reserve(final_record_count * kChestTableRecordSize);
+  std::vector<size_t> seen_counts(kNumberOfRooms, 0);
+  for (const PhysicalChestRecord& record : physical_records) {
+    const uint16_t room_id = record.room_id();
+    const Room* dirty_room =
+        room_id < kNumberOfRooms ? dirty_rooms[room_id] : nullptr;
+    if (dirty_room == nullptr) {
+      AppendChestRecord(&replacement_bytes, record.word, record.item);
+      continue;
+    }
+
+    const size_t occurrence = seen_counts[room_id]++;
+    const auto& replacements = dirty_room->GetChests();
+    if (occurrence < replacements.size()) {
+      AppendEditedChestRecord(&replacement_bytes, room_id,
+                              replacements[occurrence]);
+    }
+  }
+
+  // Growth has no existing physical slot. Append extras in room-ID order so
+  // repeated saves are deterministic while every pre-existing record keeps its
+  // relative position.
+  for (int room_id = 0; room_id < plan.room_limit; ++room_id) {
+    const Room* dirty_room = dirty_rooms[room_id];
+    if (dirty_room == nullptr) {
+      continue;
+    }
+    const auto& replacements = dirty_room->GetChests();
+    for (size_t i = seen_counts[room_id]; i < replacements.size(); ++i) {
+      AppendEditedChestRecord(&replacement_bytes, room_id, replacements[i]);
+    }
+  }
+
+  if (replacement_bytes.size() != final_record_count * kChestTableRecordSize) {
+    return absl::InternalError("Chest save plan size mismatch");
+  }
+
+  const std::array<uint8_t, 2> expected_length = {
+      static_cast<uint8_t>(plan.original_byte_length & 0xFF),
+      static_cast<uint8_t>((plan.original_byte_length >> 8) & 0xFF)};
+  const uint16_t replacement_length =
+      static_cast<uint16_t>(replacement_bytes.size());
+  const std::array<uint8_t, 2> encoded_replacement_length = {
+      static_cast<uint8_t>(replacement_length & 0xFF),
+      static_cast<uint8_t>((replacement_length >> 8) & 0xFF)};
+  AppendChangedChestRuns(kChestsLengthPointer, expected_length,
+                         encoded_replacement_length, &plan.writes);
+  AppendChangedChestRuns(plan.data_pc,
+                         absl::MakeConstSpan(plan.original_capacity_bytes)
+                             .subspan(0, replacement_bytes.size()),
+                         replacement_bytes, &plan.writes);
+  SortAndCoalesceChestRuns(&plan.writes);
+  return plan;
+}
+
 int ReadRoomPotItemAddressPc(const std::vector<uint8_t>& rom_data,
                              int room_id) {
   if (room_id < 0 || room_id >= kNumberOfRooms) {
@@ -3559,130 +3755,101 @@ absl::StatusOr<PhysicalStreamInfo> GetPotItemStreamInfo(
 
 }  // namespace
 
-template <typename RoomLookup>
-absl::Status SaveAllChestsImpl(Rom* rom, int room_count,
-                               RoomLookup&& room_lookup) {
+absl::StatusOr<ChestSavePlan> BuildChestSavePlan(
+    const Rom* rom, int room_count,
+    const std::function<const Room*(int)>& room_lookup) {
+  return BuildChestSavePlanImpl(rom, room_count, room_lookup);
+}
+
+absl::StatusOr<std::vector<std::pair<uint32_t, uint32_t>>>
+GetDirtyChestWriteRanges(const Rom* rom, int room_count,
+                         const std::function<const Room*(int)>& room_lookup) {
+  ASSIGN_OR_RETURN(ChestSavePlan plan,
+                   BuildChestSavePlan(rom, room_count, room_lookup));
+  return plan.write_ranges();
+}
+
+absl::Status ApplyChestSavePlan(
+    Rom* rom, const ChestSavePlan& plan,
+    const std::function<const Room*(int)>& room_lookup) {
   if (rom == nullptr || !rom->is_loaded()) {
     return absl::InvalidArgumentError("ROM not loaded");
   }
-  const auto& rom_data = rom->vector();
-  if (kChestsLengthPointer + 1 >= static_cast<int>(rom_data.size()) ||
-      kChestsDataPointer1 + 2 >= static_cast<int>(rom_data.size())) {
-    return absl::OutOfRangeError("Chest pointers out of range");
-  }
-  const int room_limit = std::min(room_count, kNumberOfRooms);
-  std::vector<const Room*> dirty_rooms(kNumberOfRooms, nullptr);
-  bool any_dirty = false;
-  for (int room_id = 0; room_id < room_limit; ++room_id) {
-    const Room* room = room_lookup(room_id);
-    if (room != nullptr && room->chests_dirty()) {
-      dirty_rooms[room_id] = room;
-      any_dirty = true;
+  if (!plan.any_dirty) {
+    ASSIGN_OR_RETURN(ChestSavePlan canonical_plan,
+                     BuildChestSavePlan(rom, plan.room_limit, room_lookup));
+    if (canonical_plan != plan) {
+      return absl::FailedPreconditionError(
+          "Chest save plan does not match canonical serialization");
     }
-  }
-  if (!any_dirty) {
     return absl::OkStatus();
   }
 
-  ASSIGN_OR_RETURN(auto write_ranges, GetChestTableWriteRanges(rom));
-
-  const int byte_length = (rom_data[kChestsLengthPointer + 1] << 8) |
-                          rom_data[kChestsLengthPointer];
-  if (byte_length < 0 || byte_length > kChestTableCapacityBytes ||
-      (byte_length % kChestTableRecordSize) != 0) {
+  const auto& rom_data = rom->vector();
+  if (kChestsLengthPointer + 1 >= static_cast<int>(rom_data.size()) ||
+      kChestsDataPointer1 + 2 >= static_cast<int>(rom_data.size()) ||
+      plan.data_pc > rom_data.size() ||
+      plan.original_capacity_bytes.size() > rom_data.size() - plan.data_pc) {
     return absl::FailedPreconditionError(
-        absl::StrFormat("Chest table byte length %d is invalid (capacity %d)",
-                        byte_length, kChestTableCapacityBytes));
+        "Chest save plan source is no longer addressable");
   }
-  const int cpos = static_cast<int>(write_ranges[1].first);
-  const auto physical_records =
-      ParsePhysicalRomChests(rom_data, cpos, byte_length);
-  if (physical_records.size() !=
-      static_cast<size_t>(byte_length / kChestTableRecordSize)) {
-    return absl::OutOfRangeError("Chest data region is truncated");
+  if (!std::equal(plan.pointer_operand.begin(), plan.pointer_operand.end(),
+                  rom_data.begin() + kChestsDataPointer1)) {
+    return absl::FailedPreconditionError(
+        "Chest save plan is stale: data pointer changed");
   }
-
-  std::vector<size_t> old_counts(kNumberOfRooms, 0);
-  for (const PhysicalChestRecord& record : physical_records) {
-    if (record.room_id() < kNumberOfRooms) {
-      ++old_counts[record.room_id()];
+  const uint16_t current_length =
+      static_cast<uint16_t>((rom_data[kChestsLengthPointer + 1] << 8) |
+                            rom_data[kChestsLengthPointer]);
+  if (current_length != plan.original_byte_length) {
+    return absl::FailedPreconditionError(
+        "Chest save plan is stale: runtime length changed");
+  }
+  if (!std::equal(plan.original_capacity_bytes.begin(),
+                  plan.original_capacity_bytes.end(),
+                  rom_data.begin() + plan.data_pc)) {
+    return absl::FailedPreconditionError(
+        "Chest save plan is stale: table bytes changed");
+  }
+  for (const ChestDirtyRoomState& state : plan.dirty_rooms) {
+    const Room* room = room_lookup(state.room_id);
+    if (room == nullptr || !room->chests_dirty() ||
+        EncodeChestRoomState(state.room_id, *room) != state.encoded_chests) {
+      return absl::FailedPreconditionError(absl::StrFormat(
+          "Chest save plan is stale for room 0x%03X", state.room_id));
     }
   }
-
-  size_t final_record_count = physical_records.size();
-  for (int room_id = 0; room_id < room_limit; ++room_id) {
-    if (dirty_rooms[room_id] == nullptr) {
-      continue;
-    }
-    final_record_count -= old_counts[room_id];
-    final_record_count += dirty_rooms[room_id]->GetChests().size();
-  }
-  if (final_record_count > static_cast<size_t>(kChestTableCapacityRecords)) {
-    return absl::ResourceExhaustedError(absl::StrFormat(
-        "Chest table has %d records; capacity is %d",
-        static_cast<int>(final_record_count), kChestTableCapacityRecords));
+  ASSIGN_OR_RETURN(ChestSavePlan canonical_plan,
+                   BuildChestSavePlan(rom, plan.room_limit, room_lookup));
+  if (canonical_plan != plan) {
+    return absl::FailedPreconditionError(
+        "Chest save plan does not match canonical serialization");
   }
 
-  std::vector<uint8_t> bytes;
-  bytes.reserve(final_record_count * kChestTableRecordSize);
-  std::vector<size_t> seen_counts(kNumberOfRooms, 0);
-  for (const PhysicalChestRecord& record : physical_records) {
-    const uint16_t room_id = record.room_id();
-    const Room* dirty_room =
-        room_id < kNumberOfRooms ? dirty_rooms[room_id] : nullptr;
-    if (dirty_room == nullptr) {
-      AppendChestRecord(&bytes, record.word, record.item);
-      continue;
-    }
-
-    const size_t occurrence = seen_counts[room_id]++;
-    const auto& replacements = dirty_room->GetChests();
-    if (occurrence < replacements.size()) {
-      AppendEditedChestRecord(&bytes, room_id, replacements[occurrence]);
-    }
-  }
-
-  // Growth has no existing physical slot. Append extras in room-ID order so
-  // repeated saves are deterministic while every pre-existing record keeps its
-  // relative position.
-  for (int room_id = 0; room_id < room_limit; ++room_id) {
-    const Room* dirty_room = dirty_rooms[room_id];
-    if (dirty_room == nullptr) {
-      continue;
-    }
-    const auto& replacements = dirty_room->GetChests();
-    for (size_t i = seen_counts[room_id]; i < replacements.size(); ++i) {
-      AppendEditedChestRecord(&bytes, room_id, replacements[i]);
-    }
-  }
-
-  if (bytes.size() != final_record_count * kChestTableRecordSize) {
-    return absl::InternalError("Chest save plan size mismatch");
-  }
-
-  const bool length_changed = byte_length != static_cast<int>(bytes.size());
-  const bool data_changed =
-      !std::equal(bytes.begin(), bytes.end(), rom_data.begin() + cpos);
+  yaze::ScopedRomTransaction transaction(*rom);
   yaze::rom::WriteFence fence;
-  RETURN_IF_ERROR(fence.Allow(write_ranges[0].first, write_ranges[0].second,
-                              "ChestTableLength"));
-  RETURN_IF_ERROR(fence.Allow(write_ranges[1].first, write_ranges[1].second,
-                              "ChestTableData"));
+  for (const ChestWriteRun& write : plan.writes) {
+    RETURN_IF_ERROR(fence.Allow(write.pc, write.end(), "ChestTableExactDelta"));
+  }
   yaze::rom::ScopedWriteFence scope(rom, &fence);
-
-  if (data_changed) {
-    RETURN_IF_ERROR(rom->WriteVector(cpos, bytes));
+  for (const ChestWriteRun& write : plan.writes) {
+    RETURN_IF_ERROR(rom->WriteVector(write.pc, write.replacement_bytes));
   }
-  if (length_changed) {
-    RETURN_IF_ERROR(rom->WriteWord(kChestsLengthPointer,
-                                   static_cast<uint16_t>(bytes.size())));
+  for (const ChestDirtyRoomState& state : plan.dirty_rooms) {
+    const_cast<Room*>(room_lookup(state.room_id))->ClearChestsDirty();
   }
-  for (int room_id = 0; room_id < room_limit; ++room_id) {
-    if (dirty_rooms[room_id] != nullptr) {
-      const_cast<Room*>(dirty_rooms[room_id])->ClearChestsDirty();
-    }
-  }
+  transaction.Commit();
   return absl::OkStatus();
+}
+
+template <typename RoomLookup>
+absl::Status SaveAllChestsImpl(Rom* rom, int room_count,
+                               RoomLookup&& room_lookup) {
+  const std::function<const Room*(int)> lookup =
+      std::forward<RoomLookup>(room_lookup);
+  ASSIGN_OR_RETURN(ChestSavePlan plan,
+                   BuildChestSavePlan(rom, room_count, lookup));
+  return ApplyChestSavePlan(rom, plan, lookup);
 }
 
 absl::Status SaveAllChests(Rom* rom, absl::Span<const Room> rooms) {

--- a/src/zelda3/dungeon/room.h
+++ b/src/zelda3/dungeon/room.h
@@ -3,6 +3,7 @@
 
 #include <yaze.h>
 
+#include <array>
 #include <cstdint>
 #include <functional>
 #include <memory>
@@ -1178,6 +1179,67 @@ absl::Status RelocateSpriteData(Rom* rom, int room_id,
 // only and is deliberately excluded.
 absl::StatusOr<std::vector<std::pair<uint32_t, uint32_t>>>
 GetChestTableWriteRanges(const Rom* rom);
+
+struct ChestWriteRun {
+  uint32_t pc = 0;
+  std::vector<uint8_t> expected_bytes;
+  std::vector<uint8_t> replacement_bytes;
+
+  bool operator==(const ChestWriteRun&) const = default;
+
+  uint32_t end() const {
+    return pc + static_cast<uint32_t>(replacement_bytes.size());
+  }
+};
+
+struct ChestDirtyRoomState {
+  int room_id = 0;
+  std::vector<uint8_t> encoded_chests;
+
+  bool operator==(const ChestDirtyRoomState&) const = default;
+};
+
+// Chest serialization snapshot. It captures both the exact byte runs presented
+// to manifest preflight and the source state required to apply those runs
+// safely after other save domains have run. ApplyChestSavePlan reconstructs
+// and compares the canonical plan before permitting any write.
+struct ChestSavePlan {
+  bool any_dirty = false;
+  int room_limit = 0;
+  uint32_t data_pc = 0;
+  std::array<uint8_t, 3> pointer_operand{};
+  uint16_t original_byte_length = 0;
+  std::vector<uint8_t> original_capacity_bytes;
+  std::vector<ChestWriteRun> writes;
+  std::vector<ChestDirtyRoomState> dirty_rooms;
+
+  bool operator==(const ChestSavePlan&) const = default;
+
+  std::vector<std::pair<uint32_t, uint32_t>> write_ranges() const {
+    std::vector<std::pair<uint32_t, uint32_t>> ranges;
+    ranges.reserve(writes.size());
+    for (const ChestWriteRun& write : writes) {
+      ranges.emplace_back(write.pc, write.end());
+    }
+    return ranges;
+  }
+};
+
+absl::StatusOr<ChestSavePlan> BuildChestSavePlan(
+    const Rom* rom, int room_count,
+    const std::function<const Room*(int)>& room_lookup);
+absl::Status ApplyChestSavePlan(
+    Rom* rom, const ChestSavePlan& plan,
+    const std::function<const Room*(int)>& room_lookup);
+
+// Plan the exact PC ranges changed by the current dirty-room chest state.
+// One-for-one edits return only the affected record bytes; growth/removal may
+// return wider runs plus the two-byte runtime length operand. The same plan is
+// used by manifest preflight and SaveAllChests so protected bytes that are not
+// actually changing do not block an otherwise safe edit.
+absl::StatusOr<std::vector<std::pair<uint32_t, uint32_t>>>
+GetDirtyChestWriteRanges(const Rom* rom, int room_count,
+                         const std::function<const Room*(int)>& room_lookup);
 
 // Aggregate chests from all rooms and write to ROM. Dirty rooms replace their
 // existing occurrences one-for-one in physical-table order. Untouched and

--- a/test/integration/zelda3/dungeon_pot_repack_oos_integration_test.cc
+++ b/test/integration/zelda3/dungeon_pot_repack_oos_integration_test.cc
@@ -40,6 +40,7 @@
 #include "test_utils.h"
 #include "test_utils/dungeon_editor_v2_regular_entrance_test_peer.h"
 #include "util/json.h"
+#include "zelda3/dungeon/custom_collision.h"
 #include "zelda3/dungeon/dungeon_stream_allocator.h"
 #include "zelda3/dungeon/dungeon_validator.h"
 #include "zelda3/dungeon/oracle_rom_safety_preflight.h"
@@ -51,6 +52,10 @@ namespace {
 
 constexpr uint32_t kOracleRoomCount = 296;
 constexpr int kSaveReopenCycles = 50;
+constexpr uint32_t kOracleDungeonMessageIdsStartSnes = 0x07F61D;
+constexpr uint32_t kOracleDungeonMessageIdsEndSnes = 0x07F86D;
+constexpr uint32_t kOracleRoomHeadersStartSnes = 0x228280;
+constexpr uint32_t kOracleRoomHeadersEndSnes = 0x2292B0;
 constexpr std::pair<const char*, const char*> kManifestEnvVars[] = {
     {"YAZE_TEST_HACK_MANIFEST_OOS", "Oracle manifest"},
     {"YAZE_TEST_HACK_MANIFEST", "hack manifest"},
@@ -187,6 +192,64 @@ std::vector<uint8_t> ReadFile(const std::filesystem::path& path) {
   }
   return std::vector<uint8_t>(std::istreambuf_iterator<char>(file),
                               std::istreambuf_iterator<char>());
+}
+
+absl::StatusOr<bool> EnableLegacyV2DungeonMetadataFallback(
+    project::YazeProject* project,
+    const std::filesystem::path& source_manifest_path) {
+  if (project == nullptr || !project->hack_manifest.loaded()) {
+    return absl::FailedPreconditionError("Oracle manifest is not loaded");
+  }
+  if (project->hack_manifest.manifest_version() >= 3) {
+    return false;
+  }
+  if (project->hack_manifest.manifest_version() != 2) {
+    return absl::FailedPreconditionError(
+        "Oracle dungeon metadata fallback requires manifest version 2");
+  }
+
+  const std::vector<uint8_t> manifest_bytes = ReadFile(source_manifest_path);
+  if (manifest_bytes.empty()) {
+    return absl::NotFoundError(
+        absl::StrFormat("Could not read configured Oracle manifest: %s",
+                        source_manifest_path.string()));
+  }
+
+  Json synthetic_manifest =
+      Json::parse(std::string(manifest_bytes.begin(), manifest_bytes.end()));
+  synthetic_manifest["manifest_version"] = 3;
+
+  // Legacy v2 manifests may contain low-half hook addresses. Canonicalize every
+  // protected endpoint before loading the test-local v3 fallback.
+  auto& protected_json = synthetic_manifest["protected_regions"]["regions"];
+  const auto& protected_regions = project->hack_manifest.protected_regions();
+  if (!protected_json.is_array() ||
+      protected_json.size() != protected_regions.size()) {
+    return absl::FailedPreconditionError(
+        "Legacy Oracle protected-region metadata is inconsistent");
+  }
+  for (size_t index = 0; index < protected_regions.size(); ++index) {
+    protected_json[index]["start"] = absl::StrFormat(
+        "0x%06X", PcToSnes(SnesToPc(protected_regions[index].start)));
+    protected_json[index]["end"] = absl::StrFormat(
+        "0x%06X", PcToSnes(SnesToPc(protected_regions[index].end)));
+  }
+
+  synthetic_manifest["editor_managed_regions"] = {
+      {"regions",
+       Json::array(
+           {{{"start",
+              absl::StrFormat("0x%06X", kOracleDungeonMessageIdsStartSnes)},
+             {"end",
+              absl::StrFormat("0x%06X", kOracleDungeonMessageIdsEndSnes)}},
+            {{"start", absl::StrFormat("0x%06X", kOracleRoomHeadersStartSnes)},
+             {"end", absl::StrFormat("0x%06X", kOracleRoomHeadersEndSnes)}}})}};
+  const absl::Status status =
+      project->hack_manifest.LoadFromString(synthetic_manifest.dump());
+  if (!status.ok()) {
+    return status;
+  }
+  return true;
 }
 
 int CountBackupArtifacts(const std::filesystem::path& rom_path) {
@@ -1312,13 +1375,20 @@ TEST_F(DungeonPotRepackOosIntegrationTest,
   expected_sequences[selected_room][0] =
       std::pair<uint8_t, bool>{replacement_item, replacement_size};
 
+  auto planned_chest_ranges = GetDirtyChestWriteRanges(
+      &rom, dungeon_editor->TotalRoomCount(), [&dungeon_editor](int room_id) {
+        return dungeon_editor->rooms().GetIfMaterialized(room_id);
+      });
+  ASSERT_TRUE(planned_chest_ranges.ok())
+      << planned_chest_ranges.status().message();
+  ASSERT_EQ(planned_chest_ranges->size(), 1u);
+  EXPECT_EQ((*planned_chest_ranges)[0],
+            (std::pair<uint32_t, uint32_t>{selected_record_pc + 1u,
+                                           selected_record_pc + 3u}));
   const auto predicted_ranges = dungeon_editor->CollectWriteRanges();
-  EXPECT_NE(std::find(predicted_ranges.begin(), predicted_ranges.end(),
-                      (*chest_ranges)[0]),
-            predicted_ranges.end());
-  EXPECT_NE(std::find(predicted_ranges.begin(), predicted_ranges.end(),
-                      (*chest_ranges)[1]),
-            predicted_ranges.end());
+  EXPECT_EQ(predicted_ranges, *planned_chest_ranges);
+  EXPECT_TRUE(
+      project_.hack_manifest.AnalyzePcWriteRanges(predicted_ranges).empty());
   EXPECT_FALSE(std::any_of(
       predicted_ranges.begin(), predicted_ranges.end(), [](const auto& range) {
         constexpr uint32_t kPointerBegin = kChestsDataPointer1;
@@ -1388,6 +1458,235 @@ TEST_F(DungeonPotRepackOosIntegrationTest,
 }
 
 TEST_F(DungeonPotRepackOosIntegrationTest,
+       PendantHookChestBytesAreBlockedBeforeMutation) {
+  ASSERT_GE(project_.hack_manifest.manifest_version(), 3)
+      << "Pendant-hook chest protection requires manifest version 3";
+
+  constexpr std::array<uint32_t, 2> kPendantHookPcs = {0x00E9E8, 0x00E9F7};
+  DungeonSaveFlagsGuard flags_guard;
+  ConfigureChestOnlySave();
+
+  for (uint32_t protected_pc : kPendantHookPcs) {
+    SCOPED_TRACE(
+        absl::StrFormat("protected chest byte at PC 0x%06X", protected_pc));
+    Rom rom;
+    ASSERT_TRUE(rom.LoadFromFile(temp_rom_path_.string()).ok());
+    auto chest_ranges = GetChestTableWriteRanges(&rom);
+    ASSERT_TRUE(chest_ranges.ok()) << chest_ranges.status().message();
+    const uint32_t chest_data_pc = (*chest_ranges)[1].first;
+    ASSERT_GE(protected_pc, chest_data_pc);
+    ASSERT_LT(protected_pc,
+              chest_data_pc + static_cast<uint32_t>(kChestTableCapacityBytes));
+    ASSERT_EQ((protected_pc - chest_data_pc) % kChestTableRecordSize, 2u)
+        << "Expected each protected pendant hook to overlap a chest item byte";
+
+    const uint32_t record_start =
+        protected_pc - ((protected_pc - chest_data_pc) % kChestTableRecordSize);
+    const uint16_t record_word = static_cast<uint16_t>(
+        rom.data()[record_start] |
+        (static_cast<uint16_t>(rom.data()[record_start + 1]) << 8));
+    const int room_id = record_word & 0x7FFF;
+    ASSERT_LT(room_id, static_cast<int>(kOracleRoomCount));
+
+    size_t occurrence = 0;
+    for (uint32_t pc = chest_data_pc; pc < record_start;
+         pc += kChestTableRecordSize) {
+      const uint16_t word = static_cast<uint16_t>(
+          rom.data()[pc] | (static_cast<uint16_t>(rom.data()[pc + 1]) << 8));
+      if ((word & 0x7FFF) == room_id) {
+        ++occurrence;
+      }
+    }
+
+    auto dungeon_editor = std::make_unique<editor::DungeonEditorV2>(&rom);
+    editor::EditorDependencies dependencies;
+    dependencies.rom = &rom;
+    dependencies.project = &project_;
+    dungeon_editor->SetDependencies(dependencies);
+    Room& room = dungeon_editor->rooms()[room_id];
+    room = LoadRoomFromRom(&rom, room_id);
+    ASSERT_LT(occurrence, room.GetChests().size());
+    room.GetChests()[occurrence].id ^= 0x01u;
+    room.MarkChestsDirty();
+
+    const auto predicted_ranges = dungeon_editor->CollectWriteRanges();
+    ASSERT_EQ(predicted_ranges, (std::vector<std::pair<uint32_t, uint32_t>>{
+                                    {protected_pc, protected_pc + 1u}}));
+    const auto conflicts =
+        project_.hack_manifest.AnalyzePcWriteRanges(predicted_ranges);
+    ASSERT_FALSE(conflicts.empty());
+    EXPECT_EQ(conflicts.front().ownership,
+              core::AddressOwnership::kHookPatched);
+
+    const std::vector<uint8_t> before = rom.vector();
+    const absl::Status status = dungeon_editor->SaveRoom(room_id);
+    EXPECT_EQ(status.code(), absl::StatusCode::kPermissionDenied) << status;
+    EXPECT_EQ(rom.vector(), before);
+    EXPECT_TRUE(room.chests_dirty());
+  }
+}
+
+TEST_F(DungeonPotRepackOosIntegrationTest,
+       ChestRemovalCompactionHonorsPendantProtectedSpan) {
+  ASSERT_GE(project_.hack_manifest.manifest_version(), 3)
+      << "Pendant-hook chest protection requires manifest version 3";
+
+  constexpr uint32_t kPendantProtectedBegin = 0x00E9E8;
+  constexpr uint32_t kPendantProtectedEnd = 0x00E9FF;
+  DungeonSaveFlagsGuard flags_guard;
+  ConfigureChestOnlySave();
+
+  Rom inventory_rom;
+  ASSERT_TRUE(inventory_rom.LoadFromFile(temp_rom_path_.string()).ok());
+  auto chest_ranges = GetChestTableWriteRanges(&inventory_rom);
+  ASSERT_TRUE(chest_ranges.ok()) << chest_ranges.status().message();
+  const uint32_t chest_data_pc = (*chest_ranges)[1].first;
+  const uint32_t chest_data_end =
+      chest_data_pc + ReadChestTableByteLength(inventory_rom);
+  std::array<uint32_t, kOracleRoomCount> last_record_pc{};
+  std::array<bool, kOracleRoomCount> room_seen{};
+  for (uint32_t pc = chest_data_pc; pc < chest_data_end;
+       pc += kChestTableRecordSize) {
+    const uint16_t record_word = static_cast<uint16_t>(
+        inventory_rom.data()[pc] |
+        (static_cast<uint16_t>(inventory_rom.data()[pc + 1]) << 8));
+    const uint16_t room_id = record_word & 0x7FFF;
+    if (room_id < kOracleRoomCount) {
+      room_seen[room_id] = true;
+      last_record_pc[room_id] = pc;
+    }
+  }
+
+  auto ranges_intersect = [](const auto& ranges, uint32_t begin, uint32_t end) {
+    return std::any_of(ranges.begin(), ranges.end(),
+                       [begin, end](const auto& range) {
+                         return range.first < end && begin < range.second;
+                       });
+  };
+  auto plan_last_chest_removal = [&](int room_id)
+      -> absl::StatusOr<std::vector<std::pair<uint32_t, uint32_t>>> {
+    Rom trial_rom;
+    absl::Status load_status = trial_rom.LoadFromFile(temp_rom_path_.string());
+    if (!load_status.ok()) {
+      return load_status;
+    }
+    Room room = LoadRoomFromRom(&trial_rom, room_id);
+    if (room.GetChests().empty()) {
+      return absl::FailedPreconditionError("Room has no chest to remove");
+    }
+    room.GetChests().pop_back();
+    room.MarkChestsDirty();
+    return GetDirtyChestWriteRanges(
+        &trial_rom, static_cast<int>(kOracleRoomCount),
+        [&room, room_id](int requested_room) -> const Room* {
+          return requested_room == room_id ? &room : nullptr;
+        });
+  };
+
+  int blocked_room_id = -1;
+  int safe_room_id = -1;
+  for (int room_id = 0; room_id < static_cast<int>(kOracleRoomCount);
+       ++room_id) {
+    if (!room_seen[room_id]) {
+      continue;
+    }
+    auto planned_ranges = plan_last_chest_removal(room_id);
+    if (!planned_ranges.ok()) {
+      continue;
+    }
+    if (blocked_room_id < 0 &&
+        last_record_pc[room_id] < kPendantProtectedBegin &&
+        ranges_intersect(*planned_ranges, kPendantProtectedBegin,
+                         kPendantProtectedEnd) &&
+        !project_.hack_manifest.AnalyzePcWriteRanges(*planned_ranges).empty()) {
+      blocked_room_id = room_id;
+    }
+    const bool compacts_after_protected_span =
+        last_record_pc[room_id] >= kPendantProtectedEnd &&
+        last_record_pc[room_id] + kChestTableRecordSize < chest_data_end &&
+        std::any_of(
+            planned_ranges->begin(), planned_ranges->end(),
+            [chest_data_pc, chest_data_end,
+             protected_end = kPendantProtectedEnd](const auto& range) {
+              return range.first >= protected_end &&
+                     range.first < chest_data_end &&
+                     chest_data_pc < range.second;
+            });
+    if (safe_room_id < 0 && compacts_after_protected_span &&
+        !ranges_intersect(*planned_ranges, kPendantProtectedBegin,
+                          kPendantProtectedEnd) &&
+        project_.hack_manifest.AnalyzePcWriteRanges(*planned_ranges).empty()) {
+      safe_room_id = room_id;
+    }
+  }
+  ASSERT_GE(blocked_room_id, 0)
+      << "No Oracle chest removal shifted bytes across the pendant span";
+  ASSERT_GE(safe_room_id, 0)
+      << "No Oracle chest removal compacted safely after the pendant span";
+
+  Rom blocked_rom;
+  ASSERT_TRUE(blocked_rom.LoadFromFile(temp_rom_path_.string()).ok());
+  auto blocked_editor = std::make_unique<editor::DungeonEditorV2>(&blocked_rom);
+  editor::EditorDependencies blocked_dependencies;
+  blocked_dependencies.rom = &blocked_rom;
+  blocked_dependencies.project = &project_;
+  blocked_editor->SetDependencies(blocked_dependencies);
+  Room& blocked_room = blocked_editor->rooms()[blocked_room_id];
+  blocked_room = LoadRoomFromRom(&blocked_rom, blocked_room_id);
+  ASSERT_FALSE(blocked_room.GetChests().empty());
+  blocked_room.GetChests().pop_back();
+  blocked_room.MarkChestsDirty();
+  const auto blocked_ranges = blocked_editor->CollectWriteRanges();
+  ASSERT_TRUE(ranges_intersect(blocked_ranges, kPendantProtectedBegin,
+                               kPendantProtectedEnd));
+  ASSERT_FALSE(
+      project_.hack_manifest.AnalyzePcWriteRanges(blocked_ranges).empty());
+  const std::vector<uint8_t> blocked_before = blocked_rom.vector();
+
+  const absl::Status blocked_status = blocked_editor->SaveRoom(blocked_room_id);
+
+  EXPECT_EQ(blocked_status.code(), absl::StatusCode::kPermissionDenied)
+      << blocked_status;
+  EXPECT_EQ(blocked_rom.vector(), blocked_before);
+  EXPECT_TRUE(blocked_room.chests_dirty());
+
+  Rom safe_rom;
+  ASSERT_TRUE(safe_rom.LoadFromFile(temp_rom_path_.string()).ok());
+  auto safe_editor = std::make_unique<editor::DungeonEditorV2>(&safe_rom);
+  editor::EditorDependencies safe_dependencies;
+  safe_dependencies.rom = &safe_rom;
+  safe_dependencies.project = &project_;
+  safe_editor->SetDependencies(safe_dependencies);
+  Room& safe_room = safe_editor->rooms()[safe_room_id];
+  safe_room = LoadRoomFromRom(&safe_rom, safe_room_id);
+  ASSERT_FALSE(safe_room.GetChests().empty());
+  const size_t expected_chest_count = safe_room.GetChests().size() - 1;
+  const uint16_t length_before = ReadChestTableByteLength(safe_rom);
+  safe_room.GetChests().pop_back();
+  safe_room.MarkChestsDirty();
+  const auto safe_ranges = safe_editor->CollectWriteRanges();
+  EXPECT_FALSE(ranges_intersect(safe_ranges, kPendantProtectedBegin,
+                                kPendantProtectedEnd));
+  EXPECT_TRUE(project_.hack_manifest.AnalyzePcWriteRanges(safe_ranges).empty());
+
+  const absl::Status safe_status = safe_editor->SaveRoom(safe_room_id);
+
+  ASSERT_TRUE(safe_status.ok()) << safe_status.message();
+  EXPECT_FALSE(safe_room.chests_dirty());
+  EXPECT_EQ(ReadChestTableByteLength(safe_rom),
+            length_before - kChestTableRecordSize);
+  Rom::SaveSettings save_settings;
+  save_settings.filename = temp_rom_path_.string();
+  ASSERT_TRUE(safe_rom.SaveToFile(save_settings).ok());
+  Rom reopened;
+  ASSERT_TRUE(reopened.LoadFromFile(temp_rom_path_.string()).ok());
+  EXPECT_EQ(LoadRoomFromRom(&reopened, safe_room_id).GetChests().size(),
+            expected_chest_count);
+  RecordProperty("blocked_compaction_room", blocked_room_id);
+  RecordProperty("safe_compaction_room", safe_room_id);
+}
+
+TEST_F(DungeonPotRepackOosIntegrationTest,
        AllRoomHeadersRoundTripByteIdentically) {
   Rom rom;
   ASSERT_TRUE(rom.LoadFromFile(temp_rom_path_.string()).ok());
@@ -1404,7 +1703,7 @@ TEST_F(DungeonPotRepackOosIntegrationTest,
 }
 
 TEST_F(DungeonPotRepackOosIntegrationTest,
-       BlockPolicyRejectsMessageChangeThroughAsmOwnedHeaderBeforeMutation) {
+       DungeonMetadataUsesNativeV3RangesOrLegacyV2Fallback) {
   constexpr int kRoomId = 0;
   Rom rom;
   ASSERT_TRUE(rom.LoadFromFile(temp_rom_path_.string()).ok());
@@ -1424,19 +1723,212 @@ TEST_F(DungeonPotRepackOosIntegrationTest,
 
   Room& room = dungeon_editor->rooms()[kRoomId];
   room = LoadRoomFromRom(&rom, kRoomId);
-  room.SetMessageId(static_cast<uint16_t>(room.message_id() ^ 0x0001u));
+  const uint16_t replacement_message_id =
+      static_cast<uint16_t>(room.message_id() ^ 0x0001u);
+  const uint8_t replacement_palette =
+      static_cast<uint8_t>((room.palette() + 1u) % 72u);
+  room.SetMessageId(replacement_message_id);
+  room.SetPalette(replacement_palette);
   const auto predicted_ranges = dungeon_editor->CollectWriteRanges();
   EXPECT_NE(std::find(predicted_ranges.begin(), predicted_ranges.end(),
                       std::pair<uint32_t, uint32_t>{kMessagesIdDungeon,
                                                     kMessagesIdDungeon + 2}),
             predicted_ranges.end());
-  const std::vector<uint8_t> before = rom.vector();
+
+  const auto header_table_snes = rom.ReadLong(kRoomHeaderPointer);
+  ASSERT_TRUE(header_table_snes.ok()) << header_table_snes.status().message();
+  const uint32_t header_table_pc = SnesToPc(*header_table_snes);
+  const auto header_pointer = rom.ReadWord(header_table_pc + kRoomId * 2u);
+  ASSERT_TRUE(header_pointer.ok()) << header_pointer.status().message();
+  const uint32_t selected_header_pc = SnesToPc(
+      (static_cast<uint32_t>(rom.data()[kRoomHeaderPointerBank]) << 16) |
+      *header_pointer);
+  EXPECT_NE(std::find(predicted_ranges.begin(), predicted_ranges.end(),
+                      std::pair<uint32_t, uint32_t>{selected_header_pc,
+                                                    selected_header_pc + 14u}),
+            predicted_ranges.end());
+
+  const std::vector<std::pair<uint32_t, uint32_t>> metadata_ranges = {
+      {selected_header_pc, selected_header_pc + 14u},
+      {kMessagesIdDungeon, kMessagesIdDungeon + 2u},
+  };
+  const bool native_v3 = project_.hack_manifest.manifest_version() >= 3;
+  const auto initial_conflicts =
+      project_.hack_manifest.AnalyzePcWriteRanges(metadata_ranges);
+  if (native_v3) {
+    EXPECT_TRUE(initial_conflicts.empty())
+        << "Production manifest v3 must directly grant dungeon metadata writes";
+    const std::array<std::pair<uint32_t, uint32_t>, 4> expected_editor_managed =
+        {{
+            {0x07F61D, 0x07F86D},
+            {0x228280, 0x2292B0},
+            {0x258090, 0x258408},
+            {0x258450, 0x25E000},
+        }};
+    const auto& actual_editor_managed =
+        project_.hack_manifest.editor_managed_regions();
+    ASSERT_EQ(actual_editor_managed.size(), expected_editor_managed.size())
+        << "Production v3 editor grants must stay exact";
+    for (size_t index = 0; index < expected_editor_managed.size(); ++index) {
+      EXPECT_EQ(actual_editor_managed[index].start,
+                expected_editor_managed[index].first);
+      EXPECT_EQ(actual_editor_managed[index].end,
+                expected_editor_managed[index].second);
+    }
+  } else {
+    ASSERT_EQ(project_.hack_manifest.manifest_version(), 2);
+    EXPECT_FALSE(initial_conflicts.empty())
+        << "Legacy manifest v2 should require the test-local fallback";
+  }
+
+  auto fallback =
+      EnableLegacyV2DungeonMetadataFallback(&project_, source_manifest_path_);
+  ASSERT_TRUE(fallback.ok()) << fallback.status().message();
+  EXPECT_EQ(*fallback, !native_v3);
+  EXPECT_TRUE(
+      project_.hack_manifest.AnalyzePcWriteRanges(metadata_ranges).empty());
+  EXPECT_EQ(
+      project_.hack_manifest.ClassifyAddress(PcToSnes(selected_header_pc)),
+      core::AddressOwnership::kVanillaSafe);
+  EXPECT_EQ(project_.hack_manifest.ClassifyAddress(
+                PcToSnes(static_cast<uint32_t>(kMessagesIdDungeon))),
+            core::AddressOwnership::kVanillaSafe);
+  EXPECT_EQ(project_.hack_manifest.ClassifyAddress(
+                PcToSnes(static_cast<uint32_t>(kWaterFillTableStart))),
+            core::AddressOwnership::kAsmOwned)
+      << "Dungeon metadata grants must not permit the ASM-owned WaterFill tail";
 
   const absl::Status status = dungeon_editor->SaveRoom(kRoomId);
+  ASSERT_TRUE(status.ok()) << status.message();
+  EXPECT_FALSE(room.header_dirty());
 
-  EXPECT_EQ(status.code(), absl::StatusCode::kPermissionDenied) << status;
-  EXPECT_EQ(rom.vector(), before);
-  EXPECT_TRUE(room.header_dirty());
+  Rom::SaveSettings save_settings;
+  save_settings.filename = temp_rom_path_.string();
+  ASSERT_TRUE(rom.SaveToFile(save_settings).ok());
+  Rom reopened;
+  ASSERT_TRUE(reopened.LoadFromFile(temp_rom_path_.string()).ok());
+  Room reopened_room = LoadRoomFromRom(&reopened, kRoomId);
+  EXPECT_EQ(reopened_room.message_id(), replacement_message_id);
+  EXPECT_EQ(reopened_room.palette(), replacement_palette);
+  RecordProperty(
+      "dungeon_metadata_manifest_path",
+      *fallback ? "legacy-v2-test-fallback" : "production-v3-native");
+}
+
+TEST_F(DungeonPotRepackOosIntegrationTest,
+       ProductionV3PersistsCustomCollisionAndRollsBackWaterFillTail) {
+  ASSERT_GE(project_.hack_manifest.manifest_version(), 3)
+      << "Production custom-collision ownership requires manifest version 3";
+
+  Rom rom;
+  ASSERT_TRUE(rom.LoadFromFile(temp_rom_path_.string()).ok());
+  ASSERT_TRUE(HasCustomCollisionWriteSupport(rom.size()));
+  ASSERT_TRUE(HasWaterFillReservedRegion(rom.size()));
+  project_.rom_metadata.write_policy = project::RomWritePolicy::kBlock;
+
+  int selected_room = -1;
+  for (int room_id = 0; room_id < static_cast<int>(kOracleRoomCount);
+       ++room_id) {
+    auto map = LoadCustomCollisionMap(&rom, room_id);
+    ASSERT_TRUE(map.ok()) << "room 0x" << std::hex << room_id << ": "
+                          << map.status().message();
+    if (!map->has_data) {
+      selected_room = room_id;
+      break;
+    }
+  }
+  ASSERT_GE(selected_room, 0)
+      << "Oracle ROM has no empty custom-collision room for append coverage";
+
+  DungeonSaveFlagsGuard flags_guard;
+  ConfigurePotOnlySave();
+  auto& flags = core::FeatureFlags::get().dungeon;
+  flags.kSavePotItems = false;
+  flags.kSaveCollision = true;
+
+  auto dungeon_editor = std::make_unique<editor::DungeonEditorV2>(&rom);
+  editor::EditorDependencies dependencies;
+  dependencies.rom = &rom;
+  dependencies.project = &project_;
+  dungeon_editor->SetDependencies(dependencies);
+
+  Room& room = dungeon_editor->rooms()[selected_room];
+  room = LoadRoomFromRom(&rom, selected_room);
+  ASSERT_FALSE(room.has_custom_collision());
+  constexpr int kCollisionX = 7;
+  constexpr int kCollisionY = 11;
+  constexpr uint8_t kCollisionTile = 0x08;
+  room.SetCollisionTile(kCollisionX, kCollisionY, kCollisionTile);
+  ASSERT_TRUE(room.custom_collision_dirty());
+
+  const std::vector<uint8_t> water_fill_tail_before(
+      rom.vector().begin() + kWaterFillTableStart,
+      rom.vector().begin() + kWaterFillTableEnd);
+  const auto collision_ranges = dungeon_editor->CollectWriteRanges();
+  EXPECT_NE(std::find(collision_ranges.begin(), collision_ranges.end(),
+                      std::pair<uint32_t, uint32_t>{
+                          kCustomCollisionRoomPointers,
+                          kCustomCollisionRoomPointers + kNumberOfRooms * 3}),
+            collision_ranges.end());
+  EXPECT_NE(
+      std::find(collision_ranges.begin(), collision_ranges.end(),
+                std::pair<uint32_t, uint32_t>{kCustomCollisionDataPosition,
+                                              kCustomCollisionDataSoftEnd}),
+      collision_ranges.end());
+  EXPECT_TRUE(
+      project_.hack_manifest.AnalyzePcWriteRanges(collision_ranges).empty());
+
+  const absl::Status collision_status = dungeon_editor->SaveRoom(selected_room);
+  ASSERT_TRUE(collision_status.ok()) << collision_status.message();
+  EXPECT_FALSE(room.custom_collision_dirty());
+  EXPECT_TRUE(std::equal(water_fill_tail_before.begin(),
+                         water_fill_tail_before.end(),
+                         rom.vector().begin() + kWaterFillTableStart));
+
+  Rom::SaveSettings save_settings;
+  save_settings.filename = temp_rom_path_.string();
+  ASSERT_TRUE(rom.SaveToFile(save_settings).ok());
+  const std::vector<uint8_t> collision_save_bytes = ReadFile(temp_rom_path_);
+  ASSERT_FALSE(collision_save_bytes.empty());
+
+  {
+    Rom reopened;
+    ASSERT_TRUE(reopened.LoadFromFile(temp_rom_path_.string()).ok());
+    auto reopened_map = LoadCustomCollisionMap(&reopened, selected_room);
+    ASSERT_TRUE(reopened_map.ok()) << reopened_map.status().message();
+    EXPECT_TRUE(reopened_map->has_data);
+    EXPECT_EQ(reopened_map->tiles[kCollisionY * 64 + kCollisionX],
+              kCollisionTile);
+    EXPECT_TRUE(std::equal(water_fill_tail_before.begin(),
+                           water_fill_tail_before.end(),
+                           reopened.vector().begin() + kWaterFillTableStart));
+  }
+
+  // Apply Room must reject the ASM-owned WaterFill tail during editor-local
+  // preflight, before either ROM bytes or editor dirty state are mutated.
+  flags.kSaveCollision = false;
+  flags.kSaveWaterFillZones = true;
+  room.SetWaterFillTile(/*x=*/3, /*y=*/5, /*filled=*/true);
+  ASSERT_TRUE(room.water_fill_dirty());
+  const auto water_fill_ranges = dungeon_editor->CollectWriteRanges();
+  ASSERT_EQ(water_fill_ranges,
+            (std::vector<std::pair<uint32_t, uint32_t>>{
+                {kWaterFillTableStart, kWaterFillTableEnd}}));
+  EXPECT_FALSE(
+      project_.hack_manifest.AnalyzePcWriteRanges(water_fill_ranges).empty());
+
+  const auto before_water_fill_attempt = rom.vector();
+  const absl::Status water_fill_status =
+      dungeon_editor->SaveRoom(selected_room);
+  EXPECT_EQ(water_fill_status.code(), absl::StatusCode::kPermissionDenied)
+      << water_fill_status;
+  EXPECT_EQ(rom.vector(), before_water_fill_attempt);
+  EXPECT_TRUE(room.water_fill_dirty());
+  EXPECT_EQ(ReadFile(temp_rom_path_), collision_save_bytes);
+  RecordProperty("custom_collision_room",
+                 absl::StrFormat("0x%03X", selected_room));
+  RecordProperty("water_fill_tail_policy",
+                 "production-v3-direct-apply-preflight-block");
 }
 
 TEST_F(DungeonPotRepackOosIntegrationTest,
@@ -1566,8 +2058,8 @@ TEST_F(DungeonPotRepackOosIntegrationTest,
       edited_chest_room.GetChests()[0].id ^ 0x01u;
   const bool replacement_chest_size = !edited_chest_room.GetChests()[0].size;
   // Oracle uses all 168 records. Keep a 169th record dirty until the first
-  // SaveRoom call so the transaction has to roll back domains written before
-  // the chest serializer reaches its capacity failure.
+  // SaveRoom call to prove capacity planning rejects the whole operation
+  // before any save domain mutates the ROM.
   edited_chest_room.GetChests().push_back(chest_data{0x01, false});
   edited_chest_room.MarkChestsDirty();
 
@@ -1696,12 +2188,6 @@ TEST_F(DungeonPotRepackOosIntegrationTest,
     expect_range(range.first, range.second,
                  "Missing regular entrance range prediction");
   }
-  auto chest_write_ranges = GetChestTableWriteRanges(&rom);
-  ASSERT_TRUE(chest_write_ranges.ok()) << chest_write_ranges.status().message();
-  for (const auto& [begin, end] : *chest_write_ranges) {
-    expect_range(begin, end, "Missing chest-table range prediction");
-  }
-
   const auto header_table_snes = rom.ReadLong(kRoomHeaderPointer);
   ASSERT_TRUE(header_table_snes.ok()) << header_table_snes.status().message();
   const uint32_t header_table_pc = SnesToPc(*header_table_snes);
@@ -1721,59 +2207,38 @@ TEST_F(DungeonPotRepackOosIntegrationTest,
   };
   const auto opted_in_conflicts =
       project_.hack_manifest.AnalyzePcWriteRanges(opted_in_ranges);
-  ASSERT_EQ(opted_in_conflicts.size(), 1u);
-  EXPECT_EQ(opted_in_conflicts[0].ownership, core::AddressOwnership::kAsmOwned);
-  EXPECT_EQ((opted_in_conflicts[0].address >> 16) & 0xFFu, 0x22u);
-  const auto predicted_conflicts =
-      project_.hack_manifest.AnalyzePcWriteRanges(predicted_ranges);
-  ASSERT_EQ(predicted_conflicts.size(), 1u);
-  EXPECT_EQ(predicted_conflicts[0].address, opted_in_conflicts[0].address);
-  EXPECT_EQ(predicted_conflicts[0].ownership, opted_in_conflicts[0].ownership);
-
-  // Keep block policy and add only the two generator-owned metadata ranges to
-  // a test-local copy of the real manifest. This proves the exact override;
-  // the source Oracle manifest and project configuration remain untouched.
-  const std::filesystem::path manifest_path =
-      project_.GetAbsolutePath(project_.hack_manifest_file);
-  const std::vector<uint8_t> manifest_bytes = ReadFile(manifest_path);
-  ASSERT_FALSE(manifest_bytes.empty())
-      << "Could not read configured Oracle manifest: " << manifest_path;
-  Json synthetic_manifest =
-      Json::parse(std::string(manifest_bytes.begin(), manifest_bytes.end()));
-  synthetic_manifest["manifest_version"] = 3;
-  // The legacy v2 Oracle generator emitted one low-half hook address
-  // ($1E7F21). A v3 manifest must canonicalize every protected endpoint before
-  // adding editor exemptions; mirror that required generator migration in this
-  // test-local copy without weakening the production parser.
-  auto& protected_json = synthetic_manifest["protected_regions"]["regions"];
-  const auto& protected_regions = project_.hack_manifest.protected_regions();
-  ASSERT_TRUE(protected_json.is_array());
-  ASSERT_EQ(protected_json.size(), protected_regions.size());
-  for (size_t index = 0; index < protected_regions.size(); ++index) {
-    protected_json[index]["start"] = absl::StrFormat(
-        "0x%06X", PcToSnes(SnesToPc(protected_regions[index].start)));
-    protected_json[index]["end"] = absl::StrFormat(
-        "0x%06X", PcToSnes(SnesToPc(protected_regions[index].end)));
+  const bool native_v3 = project_.hack_manifest.manifest_version() >= 3;
+  if (native_v3) {
+    EXPECT_TRUE(opted_in_conflicts.empty())
+        << "Production manifest v3 must directly grant dungeon metadata writes";
+  } else {
+    ASSERT_EQ(project_.hack_manifest.manifest_version(), 2);
+    ASSERT_EQ(opted_in_conflicts.size(), 1u);
+    EXPECT_EQ(opted_in_conflicts[0].ownership,
+              core::AddressOwnership::kAsmOwned);
+    EXPECT_EQ((opted_in_conflicts[0].address >> 16) & 0xFFu, 0x22u);
   }
-  synthetic_manifest["editor_managed_regions"] = {
-      {"regions", Json::array({{{"start", "0x228280"}, {"end", "0x2292B0"}},
-                               {{"start", "0x07F61D"}, {"end", "0x07F86D"}}})}};
-  const absl::Status synthetic_status =
-      project_.hack_manifest.LoadFromString(synthetic_manifest.dump());
-  ASSERT_TRUE(synthetic_status.ok()) << synthetic_status.message();
+
+  auto fallback =
+      EnableLegacyV2DungeonMetadataFallback(&project_, source_manifest_path_);
+  ASSERT_TRUE(fallback.ok()) << fallback.status().message();
+  EXPECT_EQ(*fallback, !native_v3);
   project_.rom_metadata.write_policy = project::RomWritePolicy::kBlock;
 
   EXPECT_EQ(
       project_.hack_manifest.ClassifyAddress(PcToSnes(selected_header_pc)),
       core::AddressOwnership::kVanillaSafe);
-  EXPECT_EQ(project_.hack_manifest.ClassifyAddress(0x228080),
+  EXPECT_EQ(project_.hack_manifest.ClassifyAddress(
+                PcToSnes(static_cast<uint32_t>(kWaterFillTableStart))),
             core::AddressOwnership::kAsmOwned)
-      << "The exact header exemption must not permit unrelated bank-$22 data";
+      << "Dungeon metadata grants must not permit the ASM-owned WaterFill tail";
   EXPECT_TRUE(
       project_.hack_manifest.AnalyzePcWriteRanges(opted_in_ranges).empty());
   EXPECT_TRUE(
       project_.hack_manifest.AnalyzePcWriteRanges(predicted_ranges).empty());
-  RecordProperty("header_write_policy", "block-exact-editor-managed-regions");
+  RecordProperty("header_write_policy", *fallback
+                                            ? "block-legacy-v2-test-fallback"
+                                            : "block-production-v3-native");
 
   const std::vector<uint8_t> before_failed_save = rom.vector();
   rom::WriteFence failed_save_writes;
@@ -1790,17 +2255,10 @@ TEST_F(DungeonPotRepackOosIntegrationTest,
       << failed_save_status;
   EXPECT_EQ(std::string(failed_save_status.message()),
             "Chest table has 169 records; capacity is 168");
-  EXPECT_NE(std::find_if(failed_save_writes.written_ranges().begin(),
-                         failed_save_writes.written_ranges().end(),
-                         [selected_header_pc](const auto& range) {
-                           return range.first <= selected_header_pc &&
-                                  range.second >= selected_header_pc + 14u;
-                         }),
-            failed_save_writes.written_ranges().end())
-      << "SaveRoomData did not write the complete room header before the late "
-         "chest-capacity failure";
+  EXPECT_TRUE(failed_save_writes.written_ranges().empty())
+      << "Chest-capacity validation must fail before any domain writes";
   EXPECT_EQ(rom.vector(), before_failed_save)
-      << "Late chest-capacity failure did not roll back prior domain writes";
+      << "Chest-capacity failure mutated the ROM";
   EXPECT_TRUE(edited_room.object_stream_dirty());
   EXPECT_TRUE(edited_room.sprites_dirty());
   EXPECT_TRUE(edited_room.header_dirty());
@@ -1818,6 +2276,24 @@ TEST_F(DungeonPotRepackOosIntegrationTest,
   expected_chest_sequences[chest_room_id][0] =
       std::pair<uint8_t, bool>{replacement_chest_item, replacement_chest_size};
 
+  const auto successful_predicted_ranges = dungeon_editor->CollectWriteRanges();
+  auto planned_chest_ranges = GetDirtyChestWriteRanges(
+      &rom, dungeon_editor->TotalRoomCount(), [&dungeon_editor](int room_id) {
+        return dungeon_editor->rooms().GetIfMaterialized(room_id);
+      });
+  ASSERT_TRUE(planned_chest_ranges.ok())
+      << planned_chest_ranges.status().message();
+  ASSERT_FALSE(planned_chest_ranges->empty());
+  for (const auto& range : *planned_chest_ranges) {
+    EXPECT_NE(std::find(successful_predicted_ranges.begin(),
+                        successful_predicted_ranges.end(), range),
+              successful_predicted_ranges.end())
+        << "Missing exact chest delta prediction";
+  }
+  EXPECT_TRUE(
+      project_.hack_manifest.AnalyzePcWriteRanges(successful_predicted_ranges)
+          .empty());
+
   const std::vector<uint8_t> before_save_bytes = rom.vector();
   const absl::Status save_status = dungeon_editor->SaveRoom(selected_room);
   ASSERT_TRUE(save_status.ok()) << save_status.message();
@@ -1834,11 +2310,11 @@ TEST_F(DungeonPotRepackOosIntegrationTest,
     if (before_save_bytes[offset] == rom.vector()[offset]) {
       continue;
     }
-    const bool covered =
-        std::any_of(predicted_ranges.begin(), predicted_ranges.end(),
-                    [offset](const std::pair<uint32_t, uint32_t>& range) {
-                      return range.first <= offset && offset < range.second;
-                    });
+    const bool covered = std::any_of(
+        successful_predicted_ranges.begin(), successful_predicted_ranges.end(),
+        [offset](const std::pair<uint32_t, uint32_t>& range) {
+          return range.first <= offset && offset < range.second;
+        });
     if (!covered) {
       if (uncovered_write_count == 0) {
         first_uncovered_write = offset;
@@ -2010,7 +2486,7 @@ TEST_F(DungeonPotRepackOosIntegrationTest,
         << "Multi-domain save changed ROM bytes during cycle " << cycle;
   }
   RecordProperty("daily_driver_save_reopen_cycles", kSaveReopenCycles);
-  RecordProperty("daily_driver_late_failure_rollback", true);
+  RecordProperty("daily_driver_capacity_failure_pre_mutation", true);
   RecordProperty("daily_driver_cow_retry_after_rollback", true);
   RecordProperty("source_rom_sha256", source_sha_before_);
   RecordProperty("source_manifest_sha256", source_manifest_sha_before_);

--- a/test/unit/editor/dungeon_editor_v2_rom_safety_test.cc
+++ b/test/unit/editor/dungeon_editor_v2_rom_safety_test.cc
@@ -1218,16 +1218,8 @@ TEST(DungeonEditorV2RomSafetyTest,
   flags.kSaveChests = true;
 
   const auto ranges = editor->CollectWriteRanges();
-  EXPECT_NE(std::find(ranges.begin(), ranges.end(),
-                      std::pair<uint32_t, uint32_t>{
-                          zelda3::kChestsLengthPointer,
-                          zelda3::kChestsLengthPointer + 2}),
-            ranges.end());
-  EXPECT_NE(std::find(ranges.begin(), ranges.end(),
-                      std::pair<uint32_t, uint32_t>{
-                          kChestDataPc,
-                          kChestDataPc + zelda3::kChestTableCapacityBytes}),
-            ranges.end());
+  EXPECT_EQ(ranges, (std::vector<std::pair<uint32_t, uint32_t>>{
+                        {kChestDataPc + 2, kChestDataPc + 3}}));
   EXPECT_FALSE(std::any_of(ranges.begin(), ranges.end(), [](const auto& range) {
     constexpr uint32_t kPointerBegin = zelda3::kChestsDataPointer1;
     constexpr uint32_t kPointerEnd = zelda3::kChestsDataPointer1 + 3;
@@ -1828,6 +1820,56 @@ TEST(DungeonEditorV2RomSafetyTest,
 }
 
 TEST(DungeonEditorV2RomSafetyTest,
+     SaveAndSaveRoomBlockProtectedWaterFillBeforeMutation) {
+  Rom rom;
+  ASSERT_TRUE(rom.LoadFromData(std::vector<uint8_t>(0x200000, 0)).ok());
+  auto project = MakeProjectWithManifest(R"json(
+{
+  "manifest_version": 3,
+  "protected_regions": {
+    "total_hooks": 1,
+    "regions": [
+      {
+        "start": "0x25E000",
+        "end": "0x268000",
+        "size": 8192,
+        "hook_count": 1,
+        "module": "WaterFillGuard"
+      }
+    ]
+  }
+}
+)json");
+
+  auto editor = std::make_unique<DungeonEditorV2>(&rom);
+  EditorDependencies dependencies;
+  dependencies.rom = &rom;
+  dependencies.project = &project;
+  editor->SetDependencies(dependencies);
+  auto& room = editor->rooms()[0];
+  room.SetWaterFillTile(/*x=*/1, /*y=*/1, /*filled=*/true);
+
+  DungeonSaveFlagsGuard guard;
+  ConfigureMinimalDungeonSave();
+  auto& flags = core::FeatureFlags::get().dungeon;
+  flags.kSaveObjects = false;
+  flags.kSaveWaterFillZones = true;
+  const auto before = rom.vector();
+
+  const auto save_room_status = editor->SaveRoom(0);
+  EXPECT_EQ(save_room_status.code(), absl::StatusCode::kPermissionDenied)
+      << save_room_status;
+  EXPECT_EQ(rom.vector(), before);
+  EXPECT_TRUE(room.water_fill_dirty());
+
+  const auto save_status = editor->Save();
+  EXPECT_EQ(save_status.code(), absl::StatusCode::kPermissionDenied)
+      << save_status;
+  EXPECT_EQ(rom.vector(), before);
+  EXPECT_TRUE(room.water_fill_dirty());
+}
+
+TEST(DungeonEditorV2RomSafetyTest,
      CollectWriteRangesIncludesCustomCollisionRegionsWhenDirtyAndEnabled) {
   Rom rom;
   ASSERT_TRUE(rom.LoadFromData(std::vector<uint8_t>(0x200000, 0)).ok());
@@ -1854,6 +1896,56 @@ TEST(DungeonEditorV2RomSafetyTest,
             static_cast<uint32_t>(zelda3::kCustomCollisionDataPosition));
   EXPECT_EQ(ranges[1].second,
             static_cast<uint32_t>(zelda3::kCustomCollisionDataSoftEnd));
+}
+
+TEST(DungeonEditorV2RomSafetyTest,
+     SaveAndSaveRoomBlockProtectedCustomCollisionBeforeMutation) {
+  Rom rom;
+  ASSERT_TRUE(rom.LoadFromData(std::vector<uint8_t>(0x200000, 0)).ok());
+  auto project = MakeProjectWithManifest(R"json(
+{
+  "manifest_version": 3,
+  "protected_regions": {
+    "total_hooks": 1,
+    "regions": [
+      {
+        "start": "0x258090",
+        "end": "0x258408",
+        "size": 888,
+        "hook_count": 1,
+        "module": "CollisionGuard"
+      }
+    ]
+  }
+}
+)json");
+
+  auto editor = std::make_unique<DungeonEditorV2>(&rom);
+  EditorDependencies dependencies;
+  dependencies.rom = &rom;
+  dependencies.project = &project;
+  editor->SetDependencies(dependencies);
+  auto& room = editor->rooms()[0];
+  room.SetCollisionTile(/*x=*/0, /*y=*/0, /*tile=*/0x08);
+
+  DungeonSaveFlagsGuard guard;
+  ConfigureMinimalDungeonSave();
+  auto& flags = core::FeatureFlags::get().dungeon;
+  flags.kSaveObjects = false;
+  flags.kSaveCollision = true;
+  const auto before = rom.vector();
+
+  const auto save_room_status = editor->SaveRoom(0);
+  EXPECT_EQ(save_room_status.code(), absl::StatusCode::kPermissionDenied)
+      << save_room_status;
+  EXPECT_EQ(rom.vector(), before);
+  EXPECT_TRUE(room.custom_collision_dirty());
+
+  const auto save_status = editor->Save();
+  EXPECT_EQ(save_status.code(), absl::StatusCode::kPermissionDenied)
+      << save_status;
+  EXPECT_EQ(rom.vector(), before);
+  EXPECT_TRUE(room.custom_collision_dirty());
 }
 
 TEST(DungeonEditorV2RomSafetyTest, UndoSnapshotLeakDetection) {

--- a/test/unit/zelda3/dungeon/dungeon_save_test.cc
+++ b/test/unit/zelda3/dungeon/dungeon_save_test.cc
@@ -9,6 +9,7 @@
 
 #include "rom/rom.h"
 #include "rom/snes.h"
+#include "rom/write_fence.h"
 #include "zelda3/dungeon/dungeon_block_codec.h"
 #include "zelda3/dungeon/dungeon_rom_addresses.h"
 #include "zelda3/dungeon/dungeon_stream_allocator.h"
@@ -1634,6 +1635,304 @@ TEST_F(DungeonSaveTest,
   EXPECT_EQ(rom_->data()[kChestsLengthPointer], 15);
   EXPECT_EQ(rom_->data()[kChestsLengthPointer + 1], 0);
   EXPECT_FALSE(rooms[2].chests_dirty());
+}
+
+TEST_F(DungeonSaveTest,
+       SaveAllChests_OneForOneEditPlansAndWritesOnlyChangedBytes) {
+  SetupChestTable();
+  SeedChestRecords({
+      {2, 0x20, false},
+      {1, 0x10, false},
+      {0x013D, 0x7A, false},
+  });
+  std::vector<Room> rooms(kNumberOfRooms);
+  rooms[2] = Room(2, rom_.get());
+  rooms[2].LoadChests();
+  ASSERT_EQ(rooms[2].GetChests().size(), 1u);
+  rooms[2].GetChests()[0].id = 0x22;
+  rooms[2].GetChests()[0].size = true;
+  rooms[2].MarkChestsDirty();
+
+  auto plan =
+      BuildChestSavePlan(rom_.get(), static_cast<int>(rooms.size()),
+                         [&rooms](int room_id) { return &rooms[room_id]; });
+  ASSERT_TRUE(plan.ok()) << plan.status().message();
+  EXPECT_EQ(plan->write_ranges(), (std::vector<std::pair<uint32_t, uint32_t>>{
+                                      {kChestDataPc + 1, kChestDataPc + 3}}));
+  ASSERT_EQ(plan->writes.size(), 1u);
+  EXPECT_EQ(plan->writes[0].expected_bytes, (std::vector<uint8_t>{0x00, 0x20}));
+  EXPECT_EQ(plan->writes[0].replacement_bytes,
+            (std::vector<uint8_t>{0x80, 0x22}));
+
+  yaze::rom::WriteFence exact_delta_fence;
+  ASSERT_TRUE(
+      exact_delta_fence
+          .Allow(kChestDataPc + 1, kChestDataPc + 3, "OneForOneChestDelta")
+          .ok());
+  yaze::rom::ScopedWriteFence exact_delta_scope(rom_.get(), &exact_delta_fence);
+
+  const auto status = ApplyChestSavePlan(
+      rom_.get(), *plan,
+      [&rooms](int room_id) -> const Room* { return &rooms[room_id]; });
+
+  ASSERT_TRUE(status.ok()) << status.message();
+  EXPECT_EQ(rom_->data()[kChestDataPc + 0], 0x02);
+  EXPECT_EQ(rom_->data()[kChestDataPc + 1], 0x80);
+  EXPECT_EQ(rom_->data()[kChestDataPc + 2], 0x22);
+  EXPECT_FALSE(rooms[2].chests_dirty());
+}
+
+TEST_F(DungeonSaveTest,
+       ApplyChestSavePlan_GrowthWritesOnlyLengthAndNewTailBytes) {
+  SetupChestTable();
+  SeedChestRecords({
+      {1, 0x10, false},
+  });
+  std::vector<Room> rooms(kNumberOfRooms);
+  rooms[0].GetChests().push_back(chest_data{0x42, false});
+  rooms[0].MarkChestsDirty();
+
+  auto plan =
+      BuildChestSavePlan(rom_.get(), static_cast<int>(rooms.size()),
+                         [&rooms](int room_id) { return &rooms[room_id]; });
+  ASSERT_TRUE(plan.ok()) << plan.status().message();
+  EXPECT_EQ(plan->write_ranges(),
+            (std::vector<std::pair<uint32_t, uint32_t>>{
+                {kChestsLengthPointer, kChestsLengthPointer + 1},
+                {kChestDataPc + 5, kChestDataPc + 6},
+            }));
+
+  yaze::rom::WriteFence exact_delta_fence;
+  for (const auto& [begin, end] : plan->write_ranges()) {
+    ASSERT_TRUE(exact_delta_fence.Allow(begin, end, "ChestGrowthDelta").ok());
+  }
+  yaze::rom::ScopedWriteFence exact_delta_scope(rom_.get(), &exact_delta_fence);
+
+  const auto status = ApplyChestSavePlan(
+      rom_.get(), *plan,
+      [&rooms](int room_id) -> const Room* { return &rooms[room_id]; });
+
+  ASSERT_TRUE(status.ok()) << status.message();
+  EXPECT_EQ(rom_->data()[kChestsLengthPointer], 0x06);
+  EXPECT_EQ(rom_->data()[kChestsLengthPointer + 1], 0x00);
+  EXPECT_EQ(rom_->data()[kChestDataPc + 5], 0x42);
+  EXPECT_FALSE(rooms[0].chests_dirty());
+}
+
+TEST_F(DungeonSaveTest,
+       BuildChestSavePlan_LengthBoundaryWritesBothLengthBytes) {
+  SetupChestTable();
+  constexpr int kInitialRecordCount = 85;
+  constexpr uint16_t kInitialByteLength =
+      kInitialRecordCount * kChestTableRecordSize;
+  static_assert(kInitialByteLength == 0x00FF);
+  rom_->mutable_data()[kChestsLengthPointer] = 0xFF;
+  rom_->mutable_data()[kChestsLengthPointer + 1] = 0x00;
+  for (int i = 0; i < kInitialRecordCount; ++i) {
+    const int offset = kChestDataPc + (i * kChestTableRecordSize);
+    rom_->mutable_data()[offset + 0] = 0x01;
+    rom_->mutable_data()[offset + 1] = 0x00;
+    rom_->mutable_data()[offset + 2] = static_cast<uint8_t>(i);
+  }
+  std::vector<Room> rooms(kNumberOfRooms);
+  rooms[0].GetChests().push_back(chest_data{0x42, false});
+  rooms[0].MarkChestsDirty();
+
+  auto plan =
+      BuildChestSavePlan(rom_.get(), static_cast<int>(rooms.size()),
+                         [&rooms](int room_id) { return &rooms[room_id]; });
+
+  ASSERT_TRUE(plan.ok()) << plan.status().message();
+  EXPECT_EQ(plan->write_ranges(),
+            (std::vector<std::pair<uint32_t, uint32_t>>{
+                {kChestsLengthPointer, kChestsLengthPointer + 2},
+                {kChestDataPc + 0x0101, kChestDataPc + 0x0102},
+            }));
+  ASSERT_EQ(plan->writes.size(), 2u);
+  EXPECT_EQ(plan->writes[0].expected_bytes, (std::vector<uint8_t>{0xFF, 0x00}));
+  EXPECT_EQ(plan->writes[0].replacement_bytes,
+            (std::vector<uint8_t>{0x02, 0x01}));
+}
+
+TEST_F(DungeonSaveTest,
+       ApplyChestSavePlan_ShrinkLeavesObsoleteTailUntouchedAndUnwritten) {
+  SetupChestTable();
+  SeedChestRecords({
+      {1, 0x10, false},
+      {2, 0x20, false},
+      {3, 0x30, false},
+  });
+  std::vector<Room> rooms(kNumberOfRooms);
+  rooms[1] = Room(1, rom_.get());
+  rooms[1].LoadChests();
+  rooms[1].GetChests().clear();
+  rooms[1].MarkChestsDirty();
+  const std::array<uint8_t, 3> obsolete_tail = {0x03, 0x00, 0x30};
+
+  auto plan =
+      BuildChestSavePlan(rom_.get(), static_cast<int>(rooms.size()),
+                         [&rooms](int room_id) { return &rooms[room_id]; });
+  ASSERT_TRUE(plan.ok()) << plan.status().message();
+  EXPECT_EQ(plan->write_ranges(),
+            (std::vector<std::pair<uint32_t, uint32_t>>{
+                {kChestsLengthPointer, kChestsLengthPointer + 1},
+                {kChestDataPc, kChestDataPc + 1},
+                {kChestDataPc + 2, kChestDataPc + 4},
+                {kChestDataPc + 5, kChestDataPc + 6},
+            }));
+  for (const auto& [begin, end] : plan->write_ranges()) {
+    EXPECT_TRUE(end <= kChestDataPc + 6 || begin >= kChestDataPc + 9);
+  }
+
+  yaze::rom::WriteFence exact_delta_fence;
+  for (const auto& [begin, end] : plan->write_ranges()) {
+    ASSERT_TRUE(exact_delta_fence.Allow(begin, end, "ChestShrinkDelta").ok());
+  }
+  yaze::rom::ScopedWriteFence exact_delta_scope(rom_.get(), &exact_delta_fence);
+
+  const auto status = ApplyChestSavePlan(
+      rom_.get(), *plan,
+      [&rooms](int room_id) -> const Room* { return &rooms[room_id]; });
+
+  ASSERT_TRUE(status.ok()) << status.message();
+  EXPECT_EQ(rom_->data()[kChestsLengthPointer], 0x06);
+  EXPECT_TRUE(std::equal(obsolete_tail.begin(), obsolete_tail.end(),
+                         rom_->vector().begin() + kChestDataPc + 6));
+  EXPECT_FALSE(rooms[1].chests_dirty());
+}
+
+TEST_F(DungeonSaveTest,
+       ApplyChestSavePlan_LaterFenceFailureRollsBackEarlierRun) {
+  SetupChestTable();
+  SeedChestRecords({
+      {2, 0x20, false},
+      {1, 0x10, false},
+      {0x013D, 0x7A, false},
+  });
+  std::vector<Room> rooms(kNumberOfRooms);
+  rooms[1] = Room(1, rom_.get());
+  rooms[1].LoadChests();
+  rooms[1].GetChests()[0].id = 0x11;
+  rooms[1].MarkChestsDirty();
+  rooms[2] = Room(2, rom_.get());
+  rooms[2].LoadChests();
+  rooms[2].GetChests()[0].id = 0x21;
+  rooms[2].MarkChestsDirty();
+
+  auto plan =
+      BuildChestSavePlan(rom_.get(), static_cast<int>(rooms.size()),
+                         [&rooms](int room_id) { return &rooms[room_id]; });
+  ASSERT_TRUE(plan.ok()) << plan.status().message();
+  ASSERT_EQ(plan->write_ranges(), (std::vector<std::pair<uint32_t, uint32_t>>{
+                                      {kChestDataPc + 2, kChestDataPc + 3},
+                                      {kChestDataPc + 5, kChestDataPc + 6}}));
+
+  rom_->set_dirty(false);
+  const auto before = rom_->vector();
+  yaze::rom::WriteFence first_run_only;
+  ASSERT_TRUE(
+      first_run_only
+          .Allow(kChestDataPc + 2, kChestDataPc + 3, "OnlyFirstChestRun")
+          .ok());
+  absl::Status status;
+  {
+    yaze::rom::ScopedWriteFence scope(rom_.get(), &first_run_only);
+    status = ApplyChestSavePlan(
+        rom_.get(), *plan,
+        [&rooms](int room_id) -> const Room* { return &rooms[room_id]; });
+  }
+
+  EXPECT_EQ(status.code(), absl::StatusCode::kPermissionDenied) << status;
+  EXPECT_EQ(rom_->vector(), before);
+  EXPECT_FALSE(rom_->dirty());
+  EXPECT_TRUE(rooms[1].chests_dirty());
+  EXPECT_TRUE(rooms[2].chests_dirty());
+}
+
+TEST_F(DungeonSaveTest, ApplyChestSavePlan_RejectsStaleTableBeforeMutation) {
+  SetupChestTable();
+  SeedChestRecords({
+      {2, 0x20, false},
+      {1, 0x10, false},
+  });
+  std::vector<Room> rooms(kNumberOfRooms);
+  rooms[2] = Room(2, rom_.get());
+  rooms[2].LoadChests();
+  rooms[2].GetChests()[0].id = 0x21;
+  rooms[2].MarkChestsDirty();
+
+  auto plan =
+      BuildChestSavePlan(rom_.get(), static_cast<int>(rooms.size()),
+                         [&rooms](int room_id) { return &rooms[room_id]; });
+  ASSERT_TRUE(plan.ok()) << plan.status().message();
+
+  rom_->mutable_vector()[kChestDataPc + 4] ^= 0x80;
+  const auto before_apply = rom_->vector();
+  const auto status = ApplyChestSavePlan(
+      rom_.get(), *plan,
+      [&rooms](int room_id) -> const Room* { return &rooms[room_id]; });
+
+  EXPECT_EQ(status.code(), absl::StatusCode::kFailedPrecondition) << status;
+  EXPECT_EQ(rom_->vector(), before_apply);
+  EXPECT_TRUE(rooms[2].chests_dirty());
+}
+
+TEST_F(DungeonSaveTest, ApplyChestSavePlan_RejectsMutatedWriteRun) {
+  SetupChestTable();
+  SeedChestRecords({
+      {2, 0x20, false},
+      {1, 0x10, false},
+  });
+  std::vector<Room> rooms(kNumberOfRooms);
+  rooms[2] = Room(2, rom_.get());
+  rooms[2].LoadChests();
+  rooms[2].GetChests()[0].id = 0x21;
+  rooms[2].MarkChestsDirty();
+
+  auto plan =
+      BuildChestSavePlan(rom_.get(), static_cast<int>(rooms.size()),
+                         [&rooms](int room_id) { return &rooms[room_id]; });
+  ASSERT_TRUE(plan.ok()) << plan.status().message();
+  ASSERT_EQ(plan->writes.size(), 1u);
+  plan->writes[0].pc = kChestDataPc + 0x20;
+  const auto before = rom_->vector();
+
+  const auto status = ApplyChestSavePlan(
+      rom_.get(), *plan,
+      [&rooms](int room_id) -> const Room* { return &rooms[room_id]; });
+
+  EXPECT_EQ(status.code(), absl::StatusCode::kFailedPrecondition) << status;
+  EXPECT_EQ(rom_->vector(), before);
+  EXPECT_TRUE(rooms[2].chests_dirty());
+}
+
+TEST_F(DungeonSaveTest, ApplyChestSavePlan_RejectsCleanPlanAfterNewEdit) {
+  SetupChestTable();
+  SeedChestRecords({
+      {2, 0x20, false},
+      {1, 0x10, false},
+  });
+  std::vector<Room> rooms(kNumberOfRooms);
+  rooms[2] = Room(2, rom_.get());
+  rooms[2].LoadChests();
+
+  auto plan =
+      BuildChestSavePlan(rom_.get(), static_cast<int>(rooms.size()),
+                         [&rooms](int room_id) { return &rooms[room_id]; });
+  ASSERT_TRUE(plan.ok()) << plan.status().message();
+  ASSERT_FALSE(plan->any_dirty);
+
+  rooms[2].GetChests()[0].id = 0x21;
+  rooms[2].MarkChestsDirty();
+  const auto before = rom_->vector();
+
+  const auto status = ApplyChestSavePlan(
+      rom_.get(), *plan,
+      [&rooms](int room_id) -> const Room* { return &rooms[room_id]; });
+
+  EXPECT_EQ(status.code(), absl::StatusCode::kFailedPrecondition) << status;
+  EXPECT_EQ(rom_->vector(), before);
+  EXPECT_TRUE(rooms[2].chests_dirty());
 }
 
 TEST_F(DungeonSaveTest,


### PR DESCRIPTION
## Summary

- build one validated chest-save plan and use its exact changed byte runs for both manifest preflight and serialization
- reject stale or mutated plans before writing, and preserve ROM/editor state atomically when any sparse run fails
- preflight direct WaterFill and custom-collision saves against the hack manifest before any save-domain mutation
- expand the Oracle production-v3 daily-driver gate for native metadata, chest hooks and compaction, custom collision, WaterFill protection, and 50-cycle reopen/readback stability

## Root cause

Chest edits previously declared and rewrote the entire live fixed-capacity table. Oracle's pendant hooks occupy bytes inside that capacity, so an unrelated one-for-one chest edit was either blocked by the manifest or risked touching protected bytes. Direct Apply Room/Apply All paths also reached WaterFill and custom-collision serializers without an editor-local manifest gate.

## Impact

Safe chest edits now write only bytes that actually change (plus changed length bytes). Edits or compaction that intersect Oracle's protected pendant span still fail closed before mutation. Direct WaterFill/custom-collision saves now follow the same fail-closed policy.

## Validation

- 28 focused unit tests passed: chest planning/application plus DungeonEditorV2 manifest safety
- 11 `DungeonPotRepackOosIntegrationTest.*` tests passed against the production v3 fixture from scawful/oracle-of-secrets#113, including 50 reopen cycles
- production fixture hashes remained unchanged:
  - ROM: `d289b2408c3ccc312abeadf274f04f475106034fcab8ebff3f307fd229db4799`
  - manifest: `11efac9d2c95585788d46325dcf3b7bbb61d8a649b1ee896d8b4642b1933d222`
- `clang-format --dry-run --Werror` and `git diff --check` passed
- repository pre-push validation passed

## Draft gate

Keep draft until exact-head CI is terminal green and the Oracle v3 consumer fixture remains reproducible.
