### PR TITLE
fix(dungeon): simulate chest and lock room-event slots

### DIFF
--- a/src/zelda3/dungeon/dungeon_validator.cc
+++ b/src/zelda3/dungeon/dungeon_validator.cc
@@ -66,9 +66,12 @@ ValidationResult DungeonValidator::ValidateRoom(const Room& room) {
   // shared index, so a chest after a lock reuses an earlier event slot.
   // Validate the encoded stream order (primary, BG2 overlay, BG1 overlay), not
   // the editor vector order, which may interleave objects from those lists.
-  size_t stateful_room_event_count = 0;
+  size_t chest_slot_index = 0;
+  size_t shared_event_slot_index = 0;
   bool saw_big_key_lock = false;
   int first_chest_after_lock = -1;
+  int first_out_of_range_object = -1;
+  size_t first_out_of_range_slot = 0;
   for (uint8_t list_index = 0; list_index < 3; ++list_index) {
     for (const auto& obj : room.GetTileObjects()) {
       if (!UsesRoomObjectStream(obj) || obj.GetLayerValue() != list_index) {
@@ -76,13 +79,26 @@ ValidationResult DungeonValidator::ValidateRoom(const Room& room) {
       }
 
       if (obj.id_ == kBigKeyLockObjectId) {
+        if (shared_event_slot_index >= kMaxStatefulRoomEventSlots &&
+            first_out_of_range_object < 0) {
+          first_out_of_range_object = obj.id_;
+          first_out_of_range_slot = shared_event_slot_index;
+        }
         saw_big_key_lock = true;
-        ++stateful_room_event_count;
+        ++shared_event_slot_index;
       } else if (IsStatefulChest(obj.id_)) {
-        ++stateful_room_event_count;
+        if (chest_slot_index >= kMaxStatefulRoomEventSlots &&
+            first_out_of_range_object < 0) {
+          first_out_of_range_object = obj.id_;
+          first_out_of_range_slot = chest_slot_index;
+        }
         if (saw_big_key_lock && first_chest_after_lock < 0) {
           first_chest_after_lock = obj.id_;
         }
+        ++chest_slot_index;
+        // RoomDraw_Chest and RoomDraw_BigChest advance the chest-only $0496
+        // index, then copy its next value into shared index $0498.
+        shared_event_slot_index = chest_slot_index;
       }
     }
   }
@@ -94,11 +110,12 @@ ValidationResult DungeonValidator::ValidateRoom(const Room& room) {
         "room-state slot conflicts.",
         first_chest_after_lock));
   }
-  if (stateful_room_event_count > kMaxStatefulRoomEventSlots) {
+  if (first_out_of_range_object >= 0) {
     result.warnings.push_back(absl::StrFormat(
-        "Room uses %zu stateful chest/lock slots; the engine supports at most "
-        "%zu.",
-        stateful_room_event_count, kMaxStatefulRoomEventSlots));
+        "Stateful object 0x%03X accesses room-event slot %zu; RoomFlagMask "
+        "only defines slots 0-%zu.",
+        first_out_of_range_object, first_out_of_range_slot,
+        kMaxStatefulRoomEventSlots - 1));
   }
 
   // Check bounds

--- a/test/unit/zelda3/dungeon/dungeon_validator_test.cc
+++ b/test/unit/zelda3/dungeon/dungeon_validator_test.cc
@@ -357,8 +357,97 @@ TEST(DungeonValidatorTest, WarnsWhenRoomEventConsumersExceedSixSlots) {
 
   EXPECT_TRUE(result.is_valid);
   EXPECT_TRUE(result.errors.empty());
-  EXPECT_TRUE(HasWarningContaining(result, "engine supports at most 6"));
+  EXPECT_TRUE(HasWarningContaining(result, "0xF98 accesses room-event slot 6"));
+  EXPECT_TRUE(
+      HasWarningContaining(result, "RoomFlagMask only defines slots 0-5"));
   EXPECT_FALSE(HasWarningContaining(result, "appears after big-key lock"));
+}
+
+TEST(DungeonValidatorTest,
+     ResynchronizedSharedIndexDoesNotUseRawConsumerCount) {
+  Rom rom;
+  ASSERT_TRUE(rom.LoadFromData(std::vector<uint8_t>(0x200000, 0)).ok());
+
+  Room room(/*room_id=*/0, &rom);
+  // Six locks consume shared slots 0..5. The following chest uses chest-only
+  // slot 0 and resets the shared index to 1; five more locks then use 1..5.
+  for (int i = 0; i < 6; ++i) {
+    ASSERT_TRUE(room.AddObject(MakeCanonicalRoomObject(0xF98, /*x=*/i * 4,
+                                                       /*y=*/0, /*layer=*/0))
+                    .ok());
+  }
+  ASSERT_TRUE(room.AddObject(MakeCanonicalRoomObject(0xF99, /*x=*/0, /*y=*/8,
+                                                     /*layer=*/0))
+                  .ok());
+  for (int i = 0; i < 5; ++i) {
+    ASSERT_TRUE(room.AddObject(MakeCanonicalRoomObject(0xF98, /*x=*/i * 4,
+                                                       /*y=*/16, /*layer=*/0))
+                    .ok());
+  }
+
+  const auto result = DungeonValidator().ValidateRoom(room);
+
+  EXPECT_TRUE(result.is_valid);
+  EXPECT_TRUE(result.errors.empty());
+  EXPECT_TRUE(HasWarningContaining(result, "appears after big-key lock"));
+  EXPECT_FALSE(
+      HasWarningContaining(result, "RoomFlagMask only defines slots 0-5"));
+}
+
+TEST(DungeonValidatorTest, AlternatingConsumersUseChestAndSharedIndices) {
+  Rom rom;
+  ASSERT_TRUE(rom.LoadFromData(std::vector<uint8_t>(0x200000, 0)).ok());
+
+  Room room(/*room_id=*/0, &rom);
+  // Each chest uses its chest-only slot and resynchronizes the shared index,
+  // so these twelve consumers only access slots 0..5.
+  for (int i = 0; i < 6; ++i) {
+    ASSERT_TRUE(room.AddObject(MakeCanonicalRoomObject(0xF98, /*x=*/i * 4,
+                                                       /*y=*/0, /*layer=*/0))
+                    .ok());
+    const int16_t chest_id = i % 2 == 0 ? 0xF99 : 0xFB1;
+    ASSERT_TRUE(
+        room.AddObject(MakeCanonicalRoomObject(chest_id, /*x=*/i * 4, /*y=*/8,
+                                               /*layer=*/0))
+            .ok());
+  }
+
+  const auto result = DungeonValidator().ValidateRoom(room);
+
+  EXPECT_TRUE(result.is_valid);
+  EXPECT_TRUE(result.errors.empty());
+  EXPECT_TRUE(HasWarningContaining(result, "appears after big-key lock"));
+  EXPECT_FALSE(
+      HasWarningContaining(result, "RoomFlagMask only defines slots 0-5"));
+}
+
+TEST(DungeonValidatorTest, RoomId1AStillCountsStatefulChests) {
+  Rom rom;
+  ASSERT_TRUE(rom.LoadFromData(std::vector<uint8_t>(0x200000, 0)).ok());
+
+  Room room(/*room_id=*/0x1A, &rom);
+  ASSERT_TRUE(room.AddObject(MakeCanonicalRoomObject(0xF98, /*x=*/0, /*y=*/0,
+                                                     /*layer=*/0))
+                  .ok());
+  // RoomDraw_Chest compares direct-page $10 (game MODE) with $1A, not the
+  // dungeon room ID at $A0. Room $001A receives no special treatment.
+  for (int i = 0; i < 7; ++i) {
+    const int16_t chest_id = i % 2 == 0 ? 0xF99 : 0xFB1;
+    ASSERT_TRUE(
+        room.AddObject(MakeCanonicalRoomObject(chest_id, /*x=*/i * 4, /*y=*/8,
+                                               /*layer=*/0))
+            .ok());
+  }
+
+  const auto result = DungeonValidator().ValidateRoom(room);
+
+  EXPECT_TRUE(result.is_valid);
+  EXPECT_TRUE(result.errors.empty());
+  EXPECT_TRUE(
+      HasWarningContaining(result, "0xF99 appears after big-key lock 0xF98"));
+  EXPECT_TRUE(HasWarningContaining(result, "0xF99 accesses room-event slot 6"));
+  EXPECT_TRUE(
+      HasWarningContaining(result, "RoomFlagMask only defines slots 0-5"));
 }
 
 }  // namespace


### PR DESCRIPTION
## What changed

- simulate the engine's separate chest (`$0496`) and shared room-event (`$0498`) slot indices in `DungeonValidator`
- synchronize the shared index after F99/FB1 chests, matching runtime behavior
- retain encoded primary/BG2/BG1 stream order and the advisory chest-after-lock warning
- report the first exact out-of-range object and slot instead of using a raw combined consumer count

## Why

The validator previously counted F98 locks and F99/FB1 chests as one monotonically increasing total. The game does not: chests advance their own index and then copy it into the shared index. That mismatch could warn on sequences that the runtime safely resynchronizes.

## Verification

- `DungeonValidatorTest.*`: 17/17 passed
- repository pre-push build completed with bundled Abseil
- pre-commit and pre-push formatting checks passed
- two independent code reviews found no blocking issues

The bundled-Abseil build was used because this machine has conflicting Intel `/usr/local` and ARM `/opt/homebrew` Abseil installations; that local toolchain issue is unrelated to this diff.
