### PR TITLE
fix(dungeon): classify stateful chest usage

### DIFF
--- a/src/app/editor/dungeon/selectors/object_selector_content.cc
+++ b/src/app/editor/dungeon/selectors/object_selector_content.cc
@@ -27,6 +27,7 @@
 #include "zelda3/dungeon/dungeon_limits.h"
 #include "zelda3/dungeon/dungeon_object_editor.h"
 #include "zelda3/dungeon/dungeon_validator.h"
+#include "zelda3/dungeon/object_layer_semantics.h"
 #include "zelda3/dungeon/room_object.h"
 
 namespace yaze {
@@ -317,7 +318,8 @@ void ObjectSelectorContent::DrawInteractionSummary() {
     size_t door_count = room.GetDoors().size();
     int chest_count = 0;
     for (const auto& obj : room.GetTileObjects()) {
-      if (obj.id_ >= 0xF9 && obj.id_ <= 0xFD) {
+      if (zelda3::UsesRoomObjectStream(obj) &&
+          zelda3::IsStatefulChestObjectId(obj.id_)) {
         chest_count++;
       }
     }

--- a/src/cli/handlers/tools/dungeon_doctor_commands.cc
+++ b/src/cli/handlers/tools/dungeon_doctor_commands.cc
@@ -8,7 +8,9 @@
 #include "cli/handlers/tools/diagnostic_types.h"
 #include "rom/rom.h"
 #include "zelda3/dungeon/dungeon_validator.h"
+#include "zelda3/dungeon/object_layer_semantics.h"
 #include "zelda3/dungeon/room.h"
+#include "zelda3/dungeon/room_object.h"
 
 namespace yaze::cli {
 
@@ -103,7 +105,8 @@ RoomDiagnostic DiagnoseRoom(Rom* rom, int room_id) {
 
   // Count chests
   for (const auto& obj : room.GetTileObjects()) {
-    if (obj.id_ >= 0xF9 && obj.id_ <= 0xFD) {
+    if (zelda3::UsesRoomObjectStream(obj) &&
+        zelda3::IsStatefulChestObjectId(obj.id_)) {
       diag.chest_count++;
     }
   }

--- a/src/zelda3/dungeon/dungeon_validator.cc
+++ b/src/zelda3/dungeon/dungeon_validator.cc
@@ -8,13 +8,7 @@ namespace zelda3 {
 namespace {
 
 constexpr int16_t kBigKeyLockObjectId = 0xF98;
-constexpr int16_t kSmallChestObjectId = 0xF99;
-constexpr int16_t kBigChestObjectId = 0xFB1;
 constexpr size_t kMaxStatefulRoomEventSlots = 6;
-
-bool IsStatefulChest(int16_t object_id) {
-  return object_id == kSmallChestObjectId || object_id == kBigChestObjectId;
-}
 
 }  // namespace
 
@@ -35,30 +29,6 @@ ValidationResult DungeonValidator::ValidateRoom(const Room& room) {
     result.warnings.push_back(
         absl::StrFormat("Too many sprites (%zu > %d). Game limit is strict.",
                         sprite_count, kMaxTotalSprites));
-  }
-
-  // Check chest count (approximate, based on object ID)
-  int chest_count = 0;
-  for (const auto& obj : room.GetTileObjects()) {
-    // Check for Big Chest (0xE4?? No, let's trust standard ranges)
-    // ZScream logic for chests:
-    // 0xF9 = Small Key Chest
-    // 0xFA = Big Key Chest
-    // 0xFB = Map Chest
-    // 0xFC = Compass Chest
-    // 0xFD = Big Chest
-    // But simple chest objects are also common.
-    // Let's count objects in the 0xF9-0xFD range as chests for now.
-    if (obj.id_ >= 0xF9 && obj.id_ <= 0xFD) {
-      chest_count++;
-    }
-  }
-
-  if (chest_count > kMaxChests) {
-    result.errors.push_back(absl::StrFormat(
-        "Too many chests (%d > %d). Item collection flags will conflict.",
-        chest_count, kMaxChests));
-    result.is_valid = false;
   }
 
   // Stateful chests and big-key locks share a six-entry room-event table in
@@ -86,7 +56,7 @@ ValidationResult DungeonValidator::ValidateRoom(const Room& room) {
         }
         saw_big_key_lock = true;
         ++shared_event_slot_index;
-      } else if (IsStatefulChest(obj.id_)) {
+      } else if (IsStatefulChestObjectId(obj.id_)) {
         if (chest_slot_index >= kMaxStatefulRoomEventSlots &&
             first_out_of_range_object < 0) {
           first_out_of_range_object = obj.id_;

--- a/src/zelda3/dungeon/room_object.h
+++ b/src/zelda3/dungeon/room_object.h
@@ -248,6 +248,12 @@ bool IsRoomObjectSizeEditable(int object_id);
 uint8_t CanonicalRoomObjectSize(int object_id, uint8_t requested_size);
 uint8_t DefaultRoomObjectSizeForPlacement(int object_id);
 
+// Stateful small and big chests advance the engine's per-room chest-event
+// index. Fixed-open chest graphics (F9A/FB2) and the FF5 minigame chest do not.
+inline constexpr bool IsStatefulChestObjectId(int object_id) {
+  return object_id == 0xF99 || object_id == 0xFB1;
+}
+
 // Validates that an ordinary room-object stream entry can be encoded without
 // changing its identity or colliding with the stream's list/door markers.
 // Torches and pushable blocks use separate tables; callers must exclude them

--- a/test/unit/zelda3/dungeon/dungeon_validator_test.cc
+++ b/test/unit/zelda3/dungeon/dungeon_validator_test.cc
@@ -196,35 +196,45 @@ TEST(DungeonValidatorTest, RoomAddObjectRejectsOutOfBoundsCoordinates) {
       << "Room should have no objects after an out-of-bounds AddObject";
 }
 
-// Too many chests: 7 objects in ID range 0xF9-0xFD exceeds kMaxChests=6.
-TEST(DungeonValidatorTest, RejectsTooManyChestObjects) {
+TEST(DungeonValidatorTest, DoesNotReportSubtypeOneObjectsAsChests) {
   Rom rom;
   ASSERT_TRUE(rom.LoadFromData(std::vector<uint8_t>(0x200000, 0)).ok());
 
   Room room(/*room_id=*/0, &rom);
-  // Add kMaxChests+1 = 7 chest objects (IDs 0xF9–0xFD cycle).
   for (int i = 0; i < 7; ++i) {
-    const int16_t chest_id = static_cast<int16_t>(0xF9 + (i % 5));
+    const int16_t object_id = static_cast<int16_t>(0xF9 + (i % 5));
     ASSERT_TRUE(
-        room.AddObject(RoomObject(chest_id, /*x=*/i * 4, /*y=*/0, /*size=*/0,
+        room.AddObject(RoomObject(object_id, /*x=*/i * 4, /*y=*/0, /*size=*/0,
                                   /*layer=*/0))
             .ok());
   }
 
-  DungeonValidator validator;
-  const auto result = validator.ValidateRoom(room);
+  const auto result = DungeonValidator().ValidateRoom(room);
 
+  // These IDs are independently rejected by the room-object codec, but they
+  // must not also produce the old, misleading chest-limit error.
   EXPECT_FALSE(result.is_valid);
-  bool found_chest_err = false;
-  for (const auto& err : result.errors) {
-    if (err.find("Too many chests") != std::string::npos) {
-      found_chest_err = true;
-      break;
-    }
+  EXPECT_FALSE(HasErrorContaining(result, "Too many chests"));
+  EXPECT_FALSE(HasWarningContaining(result, "room-event slot"));
+}
+
+TEST(DungeonValidatorTest, SpecialTableChestIdsDoNotConsumeEventSlots) {
+  Rom rom;
+  ASSERT_TRUE(rom.LoadFromData(std::vector<uint8_t>(0x200000, 0)).ok());
+
+  Room room(/*room_id=*/0, &rom);
+  for (int i = 0; i < 7; ++i) {
+    RoomObject object(/*id=*/0xF99, /*x=*/i * 4, /*y=*/0, /*size=*/0,
+                      /*layer=*/0);
+    object.set_options(ObjectOption::Torch);
+    ASSERT_TRUE(room.AddObject(object).ok());
   }
-  EXPECT_TRUE(found_chest_err)
-      << "Expected chest overflow error, got: "
-      << (result.errors.empty() ? "(none)" : result.errors[0]);
+
+  const auto result = DungeonValidator().ValidateRoom(room);
+
+  EXPECT_TRUE(result.is_valid);
+  EXPECT_TRUE(result.errors.empty());
+  EXPECT_TRUE(result.warnings.empty());
 }
 
 TEST(DungeonValidatorTest, AcceptsStatefulChestsBeforeBigKeyLocks) {

--- a/test/unit/zelda3/dungeon/room_object_encoding_test.cc
+++ b/test/unit/zelda3/dungeon/room_object_encoding_test.cc
@@ -15,6 +15,16 @@ namespace yaze {
 namespace zelda3 {
 namespace {
 
+TEST(RoomObjectEncodingTest, ClassifiesOnlyStatefulChestObjects) {
+  for (const int object_id : {0xF99, 0xFB1}) {
+    EXPECT_TRUE(IsStatefulChestObjectId(object_id));
+  }
+  for (const int object_id :
+       {0xF98, 0xF9A, 0xFB2, 0xFF5, 0x0F9, 0x0FA, 0x0FB, 0x0FC, 0x0FD}) {
+    EXPECT_FALSE(IsStatefulChestObjectId(object_id));
+  }
+}
+
 // ============================================================================
 // Object Type Detection Tests
 // ============================================================================


### PR DESCRIPTION
## Dependency

#154 is merged; this PR now targets `master` as a single atomic commit.

## Summary

- centralize runtime stateful-chest classification on object IDs `0xF99` and `0xFB1`
- remove the legacy `0xF9..0xFD` range heuristic that reported misleading chest/event findings for subtype-one objects the codec cannot save
- make the validator, object-selector usage chip, and `dungeon-doctor` count the same room-stream objects
- preserve the existing advisory policy for room-event slot overflow

## Root cause

Three call sites approximated chests as every ID from `0xF9` through `0xFD`. Those values are legacy/subtype-one IDs, while the actual stateful room chests are subtype-three IDs `0xF99` and `0xFB1`. The UI and doctor also did not consistently require the room-object stream, allowing special-table objects to inflate usage counts.

## Impact

Dungeon authors no longer receive a fake chest-capacity error for unrelated legacy objects, and all three diagnostics agree on which objects consume stateful chest slots. Fixed-open and minigame chest visuals remain excluded.

## Verification

- `DungeonValidatorTest.*`: 18/18 passed
- `RoomObjectEncodingTest.StatefulChestClassifierMatchesRuntimeObjects`: 1/1 passed
- pre-push `yaze_test_unit` build passed with `YAZE_FORCE_BUNDLED_ABSL=ON` build directory
- pre-push formatting passed for all 6 changed C++ files
- vanilla/OOS `dungeon-doctor` results unchanged: vanilla 296 valid / 0 warn / 0 error; OOS 294 valid / 2 warn / 0 error
- two independent code reviews found no blocking issues

## Notes

The repository pre-push smoke filter `PanelManagerPolicyTest.*` currently selects 0 tests; the focused validator/classifier tests above were run directly and passed.
