### PR TITLE
fix(dungeon): match BothBG wall size semantics

### DIFF
--- a/src/zelda3/dungeon/draw_routines/downwards_routines.cc
+++ b/src/zelda3/dungeon/draw_routines/downwards_routines.cc
@@ -81,9 +81,32 @@ void DrawDownwards4x2_1to15or26(const DrawContext& ctx) {
 }
 
 void DrawDownwards4x2_1to16_BothBG(const DrawContext& ctx) {
-  // Pattern: Same as above but draws to both BG1 and BG2 (objects 0x63-0x64)
-  DrawDownwards4x2_1to15or26(ctx);
-  // Note: BothBG would require access to both buffers - simplified for now
+  // USDASM $01:8AA4 calls RoomDraw_GetSize_1to16, so the encoded size nibble
+  // is the zero-based repeat count. ObjectDrawer dispatches this routine once
+  // per background because the registry marks it as a BothBG writer.
+  const int count = (ctx.object.size_ & 0x0F) + 1;
+  if (ctx.tiles.size() < 8) {
+    return;
+  }
+
+  for (int s = 0; s < count; ++s) {
+    const int y = ctx.object.y_ + (s * 2);
+    DrawRoutineUtils::WriteTile8(ctx.target_bg, ctx.object.x_, y, ctx.tiles[0]);
+    DrawRoutineUtils::WriteTile8(ctx.target_bg, ctx.object.x_ + 1, y,
+                                 ctx.tiles[1]);
+    DrawRoutineUtils::WriteTile8(ctx.target_bg, ctx.object.x_ + 2, y,
+                                 ctx.tiles[2]);
+    DrawRoutineUtils::WriteTile8(ctx.target_bg, ctx.object.x_ + 3, y,
+                                 ctx.tiles[3]);
+    DrawRoutineUtils::WriteTile8(ctx.target_bg, ctx.object.x_, y + 1,
+                                 ctx.tiles[4]);
+    DrawRoutineUtils::WriteTile8(ctx.target_bg, ctx.object.x_ + 1, y + 1,
+                                 ctx.tiles[5]);
+    DrawRoutineUtils::WriteTile8(ctx.target_bg, ctx.object.x_ + 2, y + 1,
+                                 ctx.tiles[6]);
+    DrawRoutineUtils::WriteTile8(ctx.target_bg, ctx.object.x_ + 3, y + 1,
+                                 ctx.tiles[7]);
+  }
 }
 
 void DrawDownwardsDecor4x2spaced4_1to16(const DrawContext& ctx) {

--- a/src/zelda3/dungeon/object_dimensions.cc
+++ b/src/zelda3/dungeon/object_dimensions.cc
@@ -531,10 +531,9 @@ void ObjectDimensionTable::InitializeDefaults() {
     dimensions_[id].zero_size_override = 26;
   }
 
-  // 0x63-0x64: Downwards 4x2 - GetSize_1to15or26 (BothBG)
+  // 0x63-0x64: Downwards 4x2 - GetSize_1to16 (BothBG)
   for (int id = 0x63; id <= 0x64; id++) {
-    dimensions_[id] = {4, 0, Dir::Vertical, 2, false};
-    dimensions_[id].zero_size_override = 26;
+    dimensions_[id] = {4, 2, Dir::Vertical, 2, false};
   }
   // 0x65-0x66: Downwards Decor 4x2 spaced 4 (6-tile spacing)
   for (int id = 0x65; id <= 0x66; id++) {

--- a/test/unit/zelda3/dungeon/object_dimensions_test.cc
+++ b/test/unit/zelda3/dungeon/object_dimensions_test.cc
@@ -197,6 +197,31 @@ TEST_F(ObjectDimensionTableTest, GetDimensionsAccountsForSize) {
   EXPECT_GT(w0, w5);
 }
 
+TEST_F(ObjectDimensionTableTest,
+       Downwards4x2BothBgUsesUsdasmSizePlusOneDimensions) {
+  auto& table = ObjectDimensionTable::Get();
+  ASSERT_TRUE(table.LoadFromRom(rom_.get()).ok());
+
+  for (int object_id : {0x63, 0x64}) {
+    for (uint8_t size : {uint8_t{0}, uint8_t{3}, uint8_t{15}}) {
+      SCOPED_TRACE(::testing::Message()
+                   << "object_id=0x" << std::hex << object_id
+                   << " size=" << std::dec << static_cast<int>(size));
+
+      const int expected_height = (static_cast<int>(size) + 1) * 2;
+      auto [width, height] = table.GetDimensions(object_id, size);
+      EXPECT_EQ(width, 4);
+      EXPECT_EQ(height, expected_height);
+
+      const auto selection = table.GetSelectionBounds(object_id, size);
+      EXPECT_EQ(selection.offset_x, 0);
+      EXPECT_EQ(selection.offset_y, 0);
+      EXPECT_EQ(selection.width, 4);
+      EXPECT_EQ(selection.height, expected_height);
+    }
+  }
+}
+
 TEST_F(ObjectDimensionTableTest, GetHitTestBoundsReturnsObjectPosition) {
   auto& table = ObjectDimensionTable::Get();
   table.LoadFromRom(rom_.get());

--- a/test/unit/zelda3/dungeon/object_drawer_registry_replay_test.cc
+++ b/test/unit/zelda3/dungeon/object_drawer_registry_replay_test.cc
@@ -1908,6 +1908,38 @@ TEST(ObjectDrawerPillarStrideTest, RightwardsPillar2x4Spaced4Uses6TileStride) {
 }
 
 TEST(ObjectDrawerRegistryReplayTest,
+     Downwards4x2BothBgUsesUsdasmSizePlusOneRows) {
+  ScopedCustomObjectsFlag disable_custom(false);
+
+  constexpr int kX = 10;
+  constexpr int kY = 20;
+  for (uint8_t size : {uint8_t{0}, uint8_t{3}, uint8_t{15}}) {
+    SCOPED_TRACE(::testing::Message() << "size=" << static_cast<int>(size));
+
+    const auto trace = ReplayObjectTrace(
+        /*object_id=*/0x0063, kX, kY, size, RoomObject::LayerType::BG1,
+        MakeSequentialTiles(/*count=*/8));
+    const auto bg1 = FilterTraceByLayer(trace, RoomObject::LayerType::BG1);
+    const auto bg2 = FilterTraceByLayer(trace, RoomObject::LayerType::BG2);
+
+    std::vector<SnapshotTileWrite> expected;
+    const int count = static_cast<int>(size) + 1;
+    expected.reserve(count * 8);
+    for (int block = 0; block < count; ++block) {
+      for (int row = 0; row < 2; ++row) {
+        for (int column = 0; column < 4; ++column) {
+          expected.push_back({kX + column, kY + block * 2 + row,
+                              static_cast<uint16_t>(row * 4 + column)});
+        }
+      }
+    }
+
+    ExpectTraceMatchesSnapshot(bg1, expected);
+    ExpectTraceMatchesSnapshot(bg2, expected);
+  }
+}
+
+TEST(ObjectDrawerRegistryReplayTest,
      DownwardsDecor4x2Spaced4UsesRowMajorTileOrder) {
   ScopedCustomObjectsFlag disable_custom(false);
 


### PR DESCRIPTION
## Status

PR #155 is merged. This PR is now retargeted to `master` as one atomic commit touching four files; the full master-base CI gate has been retriggered.

## Summary

- make routine 9 / objects `0x63-0x64` use USDASM `GetSize_1to16` semantics instead of routine 8's `1-to-15-or-26` rule
- keep fallback dimensions and selection bounds consistent with the corrected renderer
- add independent trace regressions for both backgrounds and dimension coverage for both object aliases

## Root cause

`DrawDownwards4x2_1to16_BothBG` delegated to `DrawDownwards4x2_1to15or26`. At encoded size zero this rendered 26 blocks instead of one; nonzero sizes rendered `N` blocks instead of `N+1`. The legacy dimension table repeated the same wrong zero-size override, so its fallback bounds also disagreed with USDASM.

## Impact

Objects `0x63-0x64` now draw the correct 4x2 block count on BG1 and BG2, including the size-zero and maximum-size boundaries. Fallback hit-test/selection dimensions match the visible result.

## Verification

- Hyrule Historian/USDASM: `$01:8AA4` calls `RoomDraw_GetSize_1to16` and writes eight words to both tilemaps per block
- focused unit run: 24/24 passed (`Downwards4x2BothBg...`, all `ObjectGeometryTest.*`, and all BothBG metadata tests)
- `yaze_test_unit` target built successfully
- `clang-format --dry-run --Werror` passed on all 4 changed files
- `git diff --check` passed
- independent code review found no remaining blockers

## Notes

The repository pre-push smoke filter `PanelManagerPolicyTest.*` currently selects 0 tests; the 24 focused tests above were run directly and passed.
