### PR TITLE
fix(palette): normalize widget color values

### DIFF
--- a/src/app/gui/widgets/palette_editor_widget.cc
+++ b/src/app/gui/widgets/palette_editor_widget.cc
@@ -305,9 +305,7 @@ void PaletteEditorWidget::DrawColorPicker() {
   ImGui::Text(tr("SNES BGR555: 0x%04X"), original_color.snes());
 
   if (gui::ThemedButton("Reset to Original")) {
-    editing_color_ =
-        ImVec4(original_color.rgb().x / 255.0f, original_color.rgb().y / 255.0f,
-               original_color.rgb().z / 255.0f, 1.0f);
+    editing_color_ = gui::ConvertSnesColorToImVec4(original_color);
     // Also reset the actual palette color
     palette[selected_color_index_] = original_color;
     dungeon_pal_group[current_palette_id_] = palette;
@@ -349,7 +347,7 @@ void PaletteEditorWidget::DrawDungeonRenderPalette() {
       }
     }
 
-    ImVec4 display_color = color.rgb();
+    ImVec4 display_color = gui::ConvertSnesColorToImVec4(color);
     ImGui::PushID(i);
     if (!editable) {
       ImGui::PushStyleVar(ImGuiStyleVar_Alpha, 0.25f);
@@ -379,7 +377,7 @@ void PaletteEditorWidget::DrawDungeonRenderPalette() {
       if (status.ok()) {
         selected_color_index_ = i;
         editing_color_index_ = i;
-        temp_color_ = dropped_color.rgb();
+        temp_color_ = gui::ConvertSnesColorToImVec4(dropped_color);
         editing_color_ = temp_color_;
       } else {
         LOG_ERROR("PaletteEditorWidget", "Failed to apply dropped color: %s",
@@ -665,7 +663,7 @@ void PaletteEditorWidget::DrawPaletteGrid(gfx::SnesPalette& palette, int cols) {
       ImGui::SameLine();
 
     auto color = palette[i];
-    ImVec4 display_color = color.rgb();
+    ImVec4 display_color = gui::ConvertSnesColorToImVec4(color);
 
     ImGui::PushID(i);
     const bool clicked = ImGui::ColorButton("##color", display_color,
@@ -685,7 +683,7 @@ void PaletteEditorWidget::DrawPaletteGrid(gfx::SnesPalette& palette, int cols) {
     if (AcceptImGuiColorDrop(&palette[i], swatch_min, swatch_max)) {
       selected_color_index_ = i;
       editing_color_index_ = i;
-      temp_color_ = palette[i].rgb();
+      temp_color_ = gui::ConvertSnesColorToImVec4(palette[i]);
       editing_color_ = temp_color_;
       if (on_palette_changed_) {
         on_palette_changed_(
@@ -784,7 +782,7 @@ void PaletteEditorWidget::DrawROMPaletteSelector() {
       if (i > 0)
         ImGui::SameLine();
       auto color = preview_palette[i];
-      ImVec4 display_color = color.rgb();
+      ImVec4 display_color = gui::ConvertSnesColorToImVec4(color);
       ImGui::ColorButton(("##preview" + std::to_string(i)).c_str(),
                          display_color, ImGuiColorEditFlags_NoTooltip,
                          ImVec2(20, 20));
@@ -794,7 +792,7 @@ void PaletteEditorWidget::DrawROMPaletteSelector() {
 
 void PaletteEditorWidget::DrawColorEditControls(gfx::SnesColor& color,
                                                 int color_index) {
-  ImVec4 rgba = color.rgb();
+  ImVec4 rgba = gui::ConvertSnesColorToImVec4(color);
 
   ImGui::PushID(color_index);
 
@@ -843,7 +841,8 @@ void PaletteEditorWidget::DrawPaletteAnalysis(const gfx::SnesPalette& palette) {
     if (ImGui::TreeNode("Duplicate Colors")) {
       for (const auto& [snes_color, count] : color_frequency) {
         if (count > 1) {
-          ImVec4 display_color = gfx::SnesColor(snes_color).rgb();
+          ImVec4 display_color =
+              gui::ConvertSnesColorToImVec4(gfx::SnesColor(snes_color));
           ImGui::ColorButton(("##dup" + std::to_string(snes_color)).c_str(),
                              display_color, ImGuiColorEditFlags_NoTooltip,
                              ImVec2(16, 16));
@@ -885,7 +884,7 @@ void PaletteEditorWidget::DrawPaletteAnalysis(const gfx::SnesPalette& palette) {
   float max_brightness = 0.0f;
 
   for (int i = 0; i < static_cast<int>(palette.size()); i++) {
-    ImVec4 color = palette[i].rgb();
+    ImVec4 color = gui::ConvertSnesColorToImVec4(palette[i]);
     float brightness = (color.x + color.y + color.z) / 3.0f;
     total_brightness += brightness;
     min_brightness = std::min(min_brightness, brightness);

--- a/test/unit/snes_color_test.cc
+++ b/test/unit/snes_color_test.cc
@@ -2,6 +2,7 @@
 
 #include <gtest/gtest.h>
 
+#include "app/gui/core/color.h"
 #include "imgui/imgui.h"
 
 namespace yaze {
@@ -111,6 +112,20 @@ TEST_F(SnesColorTest, ConstructFromSnesBlack) {
   EXPECT_FLOAT_EQ(rgb.x, 0.0f);
   EXPECT_FLOAT_EQ(rgb.y, 0.0f);
   EXPECT_FLOAT_EQ(rgb.z, 0.0f);
+}
+
+TEST_F(SnesColorTest, ImGuiConversionNormalizesRawRgbComponents) {
+  const SnesColor color(0x7FFF);
+  const ImVec4 raw = color.rgb();
+  const ImVec4 normalized = yaze::gui::ConvertSnesColorToImVec4(color);
+
+  EXPECT_GT(raw.x, 1.0f);
+  EXPECT_GT(raw.y, 1.0f);
+  EXPECT_GT(raw.z, 1.0f);
+  EXPECT_FLOAT_EQ(normalized.x, raw.x / 255.0f);
+  EXPECT_FLOAT_EQ(normalized.y, raw.y / 255.0f);
+  EXPECT_FLOAT_EQ(normalized.z, raw.z / 255.0f);
+  EXPECT_FLOAT_EQ(normalized.w, 1.0f);
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary

- normalize every `SnesColor` passed from `PaletteEditorWidget` into ImGui's `0.0-1.0` color domain
- keep edit/drop/reset state normalized before constructing colors or opening color editors
- compute palette brightness in the same normalized range expected by the progress bar
- add a focused unit test documenting the raw-RGB versus ImGui conversion contract

## Root cause

`gfx::SnesColor::rgb()` intentionally returns channel values in the `0-255` range, while ImGui color widgets and `SnesColor(ImVec4)` expect `0.0-1.0`. Several widget call sites passed the raw values directly, saturating swatches and color editors; brightness analysis could report values up to 255 and saturate its progress bar.

## Impact

Dungeon and ROM palette swatches, drag/drop edit state, duplicate-color previews, direct color controls, and brightness analysis now use the correct normalized values. ROM/SNES color storage remains unchanged.

## Verification

- `yaze_test_unit` target built successfully
- `SnesColorTest.*` and `DungeonEditorPaletteRefreshTest.*`: 23/23 passed
- `clang-format --dry-run --Werror` passed for both changed files
- `git diff --check` passed
- source audit confirms no raw `.rgb()` use remains in `palette_editor_widget.cc`
- independent code review found no blockers

## Notes

The repository pre-push smoke filter `PanelManagerPolicyTest.*` currently selects 0 tests; the 23 focused tests above were run directly and passed.
