### PR TITLE
fix(dungeon): draw active switches as 2x2 objects

### DIFF
--- a/src/zelda3/dungeon/draw_routines/draw_routine_registry.cc
+++ b/src/zelda3/dungeon/draw_routines/draw_routine_registry.cc
@@ -366,8 +366,8 @@ void DrawRoutineRegistry::BuildObjectMapping() {
   object_to_routine_map_[0x11C] = 16;
   object_to_routine_map_[0x11D] = 28;
   object_to_routine_map_[0x11E] = 4;
-  object_to_routine_map_[0x11F] = 25;
-  object_to_routine_map_[0x120] = 25;
+  object_to_routine_map_[0x11F] = DrawRoutineIds::kSingle2x2;
+  object_to_routine_map_[0x120] = DrawRoutineIds::kSingle2x2;
   object_to_routine_map_[0x121] = 28;
   object_to_routine_map_[0x122] = 98;
   object_to_routine_map_[0x123] = 30;

--- a/src/zelda3/dungeon/object_dimensions.cc
+++ b/src/zelda3/dungeon/object_dimensions.cc
@@ -287,8 +287,6 @@ ObjectDimensionTable::SelectionBounds ObjectDimensionTable::GetSelectionBounds(
   switch (object_id) {
     // Offset +3 (1x1 solid +3)
     case 0x34:
-    case 0x11F:
-    case 0x120:
       bounds.offset_x = 3;
       break;
 
@@ -834,9 +832,9 @@ void ObjectDimensionTable::InitializeDefaults() {
   dimensions_[0x11D] = {2, 3, Dir::Horizontal, 4, false};
   // 0x11E: Single 2x2
   dimensions_[0x11E] = {2, 2, Dir::Horizontal, 2, false};
-  // 0x11F-0x120: Star switch / Torch (1x1 +3)
-  dimensions_[0x11F] = {4, 1, Dir::Horizontal, 1, false};
-  dimensions_[0x120] = {4, 1, Dir::Horizontal, 1, false};
+  // 0x11F-0x120: Enabled star switch / lit torch (fixed 2x2)
+  dimensions_[0x11F] = {2, 2, Dir::None, 0, false};
+  dimensions_[0x120] = {2, 2, Dir::None, 0, false};
   // 0x121: 2x3 pillar (repeated)
   dimensions_[0x121] = {2, 3, Dir::Horizontal, 4, false};
 

--- a/src/zelda3/dungeon/object_parser.cc
+++ b/src/zelda3/dungeon/object_parser.cc
@@ -500,6 +500,10 @@ int ObjectParser::GetSubtype2TileCount(int16_t object_id) const {
   if (object_id >= 0x110 && object_id <= 0x117) {
     return 12;
   }
+  // Enabled star switch and lit torch are fixed 2x2 patterns.
+  if (object_id == 0x11F || object_id == 0x120) {
+    return 4;
+  }
   // 4x4 fixed patterns (stairs/altars/walls)
   if (object_id == 0x11C || object_id == 0x124 || object_id == 0x125 ||
       object_id == 0x129 || (object_id >= 0x12D && object_id <= 0x133) ||

--- a/test/unit/zelda3/dungeon/object_dimensions_test.cc
+++ b/test/unit/zelda3/dungeon/object_dimensions_test.cc
@@ -185,6 +185,30 @@ TEST_F(ObjectDimensionTableTest, SomariaPathBaseDimensionsAreSingleTile) {
   EXPECT_EQ(table.GetBaseDimensions(0xF94), std::make_pair(4, 3));
 }
 
+TEST_F(ObjectDimensionTableTest,
+       EnabledStarSwitchAndLitTorchUseAnchoredTwoByTwoBounds) {
+  auto& table = ObjectDimensionTable::Get();
+  ASSERT_TRUE(table.LoadFromRom(rom_.get()).ok());
+
+  for (int16_t object_id : {int16_t{0x11F}, int16_t{0x120}}) {
+    SCOPED_TRACE(::testing::Message()
+                 << "object_id=0x" << std::hex << object_id);
+
+    EXPECT_EQ(table.GetBaseDimensions(object_id), std::make_pair(2, 2));
+    EXPECT_EQ(table.GetDimensions(object_id, 0), std::make_pair(2, 2));
+
+    const auto selection = table.GetSelectionBounds(object_id, 0);
+    EXPECT_EQ(selection.offset_x, 0);
+    EXPECT_EQ(selection.offset_y, 0);
+    EXPECT_EQ(selection.width, 2);
+    EXPECT_EQ(selection.height, 2);
+
+    const RoomObject object(object_id, 0, 0, 0, 0);
+    EXPECT_EQ(ObjectDrawer(rom_.get(), 0).CalculateObjectDimensions(object),
+              std::make_pair(16, 16));
+  }
+}
+
 TEST_F(ObjectDimensionTableTest, GetDimensionsAccountsForSize) {
   auto& table = ObjectDimensionTable::Get();
   table.LoadFromRom(rom_.get());

--- a/test/unit/zelda3/dungeon/object_drawer_registry_replay_test.cc
+++ b/test/unit/zelda3/dungeon/object_drawer_registry_replay_test.cc
@@ -284,6 +284,33 @@ TEST(ObjectDrawerRegistryReplayTest,
   }
 }
 
+TEST(ObjectDrawerRegistryReplayTest,
+     EnabledStarSwitchAndLitTorchDrawAnchoredTwoByTwo) {
+  ScopedCustomObjectsFlag disable_custom(false);
+
+  constexpr int kX = 12;
+  constexpr int kY = 18;
+  constexpr uint16_t kTileId = 0x0240;
+  const std::vector<SnapshotTileWrite> expected = {
+      {kX, kY, kTileId},
+      {kX, kY + 1, kTileId + 1},
+      {kX + 1, kY, kTileId + 2},
+      {kX + 1, kY + 1, kTileId + 3},
+  };
+
+  for (int16_t object_id : {int16_t{0x11F}, int16_t{0x120}}) {
+    SCOPED_TRACE(::testing::Message()
+                 << "object_id=0x" << std::hex << object_id);
+    const auto trace = ReplayObjectTrace(
+        object_id, kX, kY, /*size=*/0, RoomObject::LayerType::BG1,
+        MakeSequentialTiles(/*count=*/4, kTileId));
+    const auto bg1 = FilterTraceByLayer(trace, RoomObject::LayerType::BG1);
+
+    ExpectTraceMatchesSnapshot(bg1, expected);
+    EXPECT_TRUE(FilterTraceByLayer(trace, RoomObject::LayerType::BG2).empty());
+  }
+}
+
 std::array<uint8_t, 0x10000> MakeOpaqueDoorGfx() {
   std::array<uint8_t, 0x10000> gfx{};
   gfx.fill(1);

--- a/test/unit/zelda3/dungeon/object_drawing_comprehensive_test.cc
+++ b/test/unit/zelda3/dungeon/object_drawing_comprehensive_test.cc
@@ -64,6 +64,9 @@ int ExpectedSubtype2TileCount(int id) {
   if (id >= 0x110 && id <= 0x117) {
     return 12;
   }
+  if (id == 0x11F || id == 0x120) {
+    return 4;
+  }
   if (id == 0x11C || id == 0x124 || id == 0x125 || id == 0x129 ||
       (id >= 0x12D && id <= 0x133) || id == 0x13C || id == 0x13F) {
     return 16;
@@ -400,6 +403,8 @@ TEST_F(ObjectDrawingComprehensiveTest, TileCountLookupTable_SpecialCases) {
       {0xD4, 0, "Wall moved check variant"},
       {0xD5, 0, "Wall moved check variant"},
       {0xD6, 0, "Wall moved check variant"},
+      {0x11F, 4, "Enabled star switch (fixed 2x2 payload)"},
+      {0x120, 4, "Lit torch (fixed 2x2 payload)"},
       // Waterfall47 indexes tile slots 0..14 = 15 tiles
       // (`DrawWaterfall47` in special_routines.cc). The prior 8-tile
       // fallback caused the routine's `TileAtWrapped` lookup to wrap

--- a/test/unit/zelda3/object_parser_test.cc
+++ b/test/unit/zelda3/object_parser_test.cc
@@ -596,9 +596,9 @@ TEST_F(ObjectParserTest,
 // subtype-2 / subtype-3 over-fetch clusters identified by
 // `zelda3-hacking-expert`. These IDs currently take the parser's
 // 8-tile fallback even though their bound routines read fewer tiles
-// (`Rightwards2x2_1to16` reads 4, `Rightwards1x1Solid_1to16_plus3`
-// reads 1, `RightwardsStatue2x3spaced2_1to16` reads 6, `DrawSingle2x2`
-// reads 4). The over-fetch is harmless — the routines reference fixed
+// (`Rightwards2x2_1to16` reads 4, `RightwardsStatue2x3spaced2_1to16`
+// reads 6, `DrawSingle2x2` reads 4). The over-fetch is harmless — the
+// routines reference fixed
 // indices below their span and ignore the trailing slots — so this
 // test does NOT mirror the parser's tile-count table; it pins the
 // audit's id→routine mapping at the registry level so a future
@@ -624,13 +624,6 @@ TEST_F(ObjectParserTest, OverFetchClusterIdsRouteToAuditedRoutines) {
                  << "id=0x" << std::hex << id << " expects routine 28");
     EXPECT_EQ(registry.GetRoutineIdForObject(id), 28);
   }
-  // Subtype-2: routine 25 is `Rightwards1x1Solid_1to16_plus3`
-  // (reads tiles[0]).
-  for (int id : {0x11F, 0x120}) {
-    SCOPED_TRACE(::testing::Message()
-                 << "id=0x" << std::hex << id << " expects routine 25");
-    EXPECT_EQ(registry.GetRoutineIdForObject(id), 25);
-  }
   // Subtype-3: routine 110 is `DrawSingle2x2` (reads tiles[0..3]).
   // Cluster scoped to IDs explicitly mapped in the registry; the
   // initial audit listed a broader set, but registry diff showed the
@@ -646,6 +639,24 @@ TEST_F(ObjectParserTest, OverFetchClusterIdsRouteToAuditedRoutines) {
     SCOPED_TRACE(::testing::Message()
                  << "id=0x" << std::hex << id << " expects routine 39");
     EXPECT_EQ(registry.GetRoutineIdForObject(id), 39);
+  }
+}
+
+TEST_F(ObjectParserTest, EnabledStarSwitchAndLitTorchUseFixedTwoByTwoPayload) {
+  auto& registry = zelda3::DrawRoutineRegistry::Get();
+
+  for (int id : {0x11F, 0x120}) {
+    SCOPED_TRACE(::testing::Message() << "id=0x" << std::hex << id);
+    EXPECT_EQ(registry.GetRoutineIdForObject(id),
+              zelda3::DrawRoutineIds::kSingle2x2);
+
+    const auto subtype = parser_->GetObjectSubtype(id);
+    ASSERT_TRUE(subtype.ok());
+    EXPECT_EQ(subtype->max_tile_count, 4);
+
+    const auto tiles = parser_->ParseObject(id);
+    ASSERT_TRUE(tiles.ok());
+    EXPECT_EQ(tiles->size(), 4u);
   }
 }
 


### PR DESCRIPTION
## Summary
- route subtype-2 objects `0x11F` (enabled star switch) and `0x120` (lit torch) through the fixed `Single2x2` drawer
- load their exact four-word payload instead of the generic eight-tile fallback
- report anchored `2x2` selection/dimension bounds instead of a displaced `4x1` strip
- add parser, dimension, registry, and exact ordered replay coverage

## ROM parity evidence
USDASM maps these objects to `RoomDraw_EnabledStarSwitch` and `RoomDraw_LitTorch`. After their runtime bookkeeping, both render four words through the same column-major pointer order:

`(x,y)`, `(x,y+1)`, `(x+1,y)`, `(x+1,y+1)`.

A read-only `z3ed dungeon-list-objects` census of `oos168.sfc` rooms `0..127` found 69 instances across 23 rooms, so the prior displaced strip affected real Oracle content.

## Verification
- `cmake --build build/presets/mac-test --target yaze_test_unit --parallel 8`
- 9 focused tests passed, covering exact replay, fixed bounds, subtype-2 parser counts/reads, broad dimension parity, and routine registration
- `clang-format --dry-run --Werror --style=file <7 changed files>`
- `git diff --check`
- independent USDASM/code review: no blocking findings
- pre-push build and formatting passed

## Known harness gap
The repository's default pre-push smoke filter is `PanelManagerPolicyTest.*`, which currently selects 0 tests. The explicit 9-test filter above is the meaningful local test gate for this change.
