### PR TITLE
fix(dungeon): draw Mario portrait as 4x2

### DIFF
--- a/src/zelda3/dungeon/draw_routines/draw_routine_registry.cc
+++ b/src/zelda3/dungeon/draw_routines/draw_routine_registry.cc
@@ -377,7 +377,7 @@ void DrawRoutineRegistry::BuildObjectMapping() {
   object_to_routine_map_[0x127] = 4;
   object_to_routine_map_[0x128] = 98;
   object_to_routine_map_[0x129] = 16;
-  object_to_routine_map_[0x12A] = 4;
+  object_to_routine_map_[0x12A] = DrawRoutineIds::kWaterHopStairsA;
   object_to_routine_map_[0x12B] = 4;
   object_to_routine_map_[0x12C] = 99;
   object_to_routine_map_[0x12D] = 83;

--- a/src/zelda3/dungeon/object_dimensions.cc
+++ b/src/zelda3/dungeon/object_dimensions.cc
@@ -852,8 +852,9 @@ void ObjectDimensionTable::InitializeDefaults() {
   dimensions_[0x128] = {4, 5, Dir::None, 0, false};  // Bed variant
   // 0x129: 4x4
   dimensions_[0x129] = {4, 4, Dir::Horizontal, 4, false};
-  // 0x12A-0x12B: Rightwards 2x2 (repeatable)
-  dimensions_[0x12A] = {2, 2, Dir::Horizontal, 2, false};
+  // 0x12A: Mario portrait (fixed 4x2)
+  dimensions_[0x12A] = {4, 2, Dir::None, 0, false};
+  // 0x12B: Rightwards 2x2 (repeatable)
   dimensions_[0x12B] = {2, 2, Dir::Horizontal, 2, false};
   // 0x134: Rightwards 2x2 (repeatable)
   dimensions_[0x134] = {2, 2, Dir::Horizontal, 2, false};

--- a/test/unit/zelda3/dungeon/object_dimensions_test.cc
+++ b/test/unit/zelda3/dungeon/object_dimensions_test.cc
@@ -209,6 +209,31 @@ TEST_F(ObjectDimensionTableTest,
   }
 }
 
+TEST_F(ObjectDimensionTableTest, MarioPortraitUsesAnchoredFourByTwoBounds) {
+  auto& table = ObjectDimensionTable::Get();
+  ASSERT_TRUE(table.LoadFromRom(rom_.get()).ok());
+
+  EXPECT_EQ(table.GetBaseDimensions(0x12A), std::make_pair(4, 2));
+  EXPECT_EQ(table.GetDimensions(0x12A, 0), std::make_pair(4, 2));
+
+  const auto selection = table.GetSelectionBounds(0x12A, 0);
+  EXPECT_EQ(selection.offset_x, 0);
+  EXPECT_EQ(selection.offset_y, 0);
+  EXPECT_EQ(selection.width, 4);
+  EXPECT_EQ(selection.height, 2);
+
+  const RoomObject object(0x12A, 0, 0, 0, 0);
+  const auto geometry = ObjectGeometry::Get().MeasureByObjectId(object);
+  ASSERT_TRUE(geometry.ok());
+  EXPECT_EQ(geometry->min_x_tiles, 0);
+  EXPECT_EQ(geometry->min_y_tiles, 0);
+  EXPECT_EQ(geometry->width_tiles, 4);
+  EXPECT_EQ(geometry->height_tiles, 2);
+
+  EXPECT_EQ(ObjectDrawer(rom_.get(), 0).CalculateObjectDimensions(object),
+            std::make_pair(32, 16));
+}
+
 TEST_F(ObjectDimensionTableTest, GetDimensionsAccountsForSize) {
   auto& table = ObjectDimensionTable::Get();
   table.LoadFromRom(rom_.get());

--- a/test/unit/zelda3/dungeon/object_drawer_registry_replay_test.cc
+++ b/test/unit/zelda3/dungeon/object_drawer_registry_replay_test.cc
@@ -311,6 +311,23 @@ TEST(ObjectDrawerRegistryReplayTest,
   }
 }
 
+TEST(ObjectDrawerRegistryReplayTest,
+     MarioPortraitDrawsAnchoredFourByTwoRowMajor) {
+  ScopedCustomObjectsFlag disable_custom(false);
+
+  constexpr int kX = 14;
+  constexpr int kY = 20;
+  constexpr uint16_t kTileId = 0x0260;
+  const auto trace = ReplayObjectTrace(
+      /*object_id=*/0x12A, kX, kY, /*size=*/0, RoomObject::LayerType::BG1,
+      MakeSequentialTiles(/*count=*/8, kTileId));
+  const auto bg1 = FilterTraceByLayer(trace, RoomObject::LayerType::BG1);
+
+  ExpectTraceMatchesSnapshot(
+      bg1, MakeRowMajorSnapshot(kX, kY, /*width=*/4, /*height=*/2, kTileId));
+  EXPECT_TRUE(FilterTraceByLayer(trace, RoomObject::LayerType::BG2).empty());
+}
+
 std::array<uint8_t, 0x10000> MakeOpaqueDoorGfx() {
   std::array<uint8_t, 0x10000> gfx{};
   gfx.fill(1);

--- a/test/unit/zelda3/object_parser_test.cc
+++ b/test/unit/zelda3/object_parser_test.cc
@@ -611,8 +611,7 @@ TEST_F(ObjectParserTest, OverFetchClusterIdsRouteToAuditedRoutines) {
   auto& registry = zelda3::DrawRoutineRegistry::Get();
 
   // Subtype-2: routine 4 is `Rightwards2x2_1to16` (reads tiles[0..3]).
-  for (int id :
-       {0x118, 0x119, 0x11A, 0x11B, 0x11E, 0x127, 0x12A, 0x12B, 0x134}) {
+  for (int id : {0x118, 0x119, 0x11A, 0x11B, 0x11E, 0x127, 0x12B, 0x134}) {
     SCOPED_TRACE(::testing::Message()
                  << "id=0x" << std::hex << id << " expects routine 4");
     EXPECT_EQ(registry.GetRoutineIdForObject(id), 4);
@@ -640,6 +639,20 @@ TEST_F(ObjectParserTest, OverFetchClusterIdsRouteToAuditedRoutines) {
                  << "id=0x" << std::hex << id << " expects routine 39");
     EXPECT_EQ(registry.GetRoutineIdForObject(id), 39);
   }
+}
+
+TEST_F(ObjectParserTest, MarioPortraitUsesFullFourByTwoPayload) {
+  auto& registry = zelda3::DrawRoutineRegistry::Get();
+  EXPECT_EQ(registry.GetRoutineIdForObject(0x12A),
+            zelda3::DrawRoutineIds::kWaterHopStairsA);
+
+  const auto subtype = parser_->GetObjectSubtype(0x12A);
+  ASSERT_TRUE(subtype.ok());
+  EXPECT_EQ(subtype->max_tile_count, 8);
+
+  const auto tiles = parser_->ParseObject(0x12A);
+  ASSERT_TRUE(tiles.ok());
+  EXPECT_EQ(tiles->size(), 8u);
 }
 
 TEST_F(ObjectParserTest, EnabledStarSwitchAndLitTorchUseFixedTwoByTwoPayload) {


### PR DESCRIPTION
## Summary
- map subtype-2 object `0x12A` (Mario portrait) to the existing fixed, single-layer 4x2 row-major draw routine
- give the portrait anchored 4x2 selection and legacy pixel dimensions while leaving `0x12B` repeatable
- pin registry, parser payload, geometry, write order, and BG-layer behavior with focused tests

## Canonical evidence
- USDASM subtype-2 routine table `$0184C4` routes `0x12A` to `RoomDraw_PortraitOfMario`
- `$019B48` selects one pass through `$01B220`, which writes offsets `+000,+002,+004,+006,+080,+082,+084,+086`: one anchored 4x2 row-major stamp
- tile data `obj0F92` through the next object `obj0FA2` is 16 bytes / eight Tile8 words
- the reused `kWaterHopStairsA` implementation already models that shared fixed path, consumes eight tiles, and writes only the active background

## Oracle of Secrets impact sample
Using the current local `oos168.sfc` and z3ed across rooms 0-127 found 12 instances in 10 rooms:

`41(2), 42(2), 72, 81, 101, 102, 103, 104, 106, 110`

Rooms above 127 were not included because the available z3ed build cannot materialize them for this ROM.

## Verification
- `cmake --build build/presets/mac-test --target yaze_test_unit --parallel 8`
- 7 focused unit tests passed:
  - Mario portrait parser payload
  - exact 4x2 row-major registry replay and no BG2 writes
  - fixed selection/object geometry
  - broad selection-vs-geometry parity sweep
  - subtype-2 routing/coverage and registry completeness
- `git diff --check`
- `clang-format --dry-run --Werror --style=file ...`
- `scripts/pre-push.sh --build-dir build/presets/mac-test`

Note: the pre-push harness's default `PanelManagerPolicyTest.*` smoke filter currently matches 0 tests; the seven explicit focused tests above are the meaningful unit gate for this patch.
