### PR TITLE
fix(dungeon): refresh on global palette apply

### DIFF
--- a/src/app/editor/dungeon/dungeon_editor_v2.cc
+++ b/src/app/editor/dungeon/dungeon_editor_v2.cc
@@ -1014,10 +1014,6 @@ void DungeonEditorV2::InvalidateDungeonPaletteUsers(
     return;
   }
 
-  if (change.palette_id < 0) {
-    return;
-  }
-
   // Editing palette bytes does not change a room header, so the room's normal
   // property cache cannot detect this dependency change. Mark every cached
   // room that resolves to the edited concrete palette; inactive rooms will

--- a/src/app/editor/dungeon/dungeon_editor_v2.cc
+++ b/src/app/editor/dungeon/dungeon_editor_v2.cc
@@ -100,6 +100,11 @@ DungeonEditorV2::DungeonEditorV2(Rom* rom)
 }
 
 DungeonEditorV2::~DungeonEditorV2() {
+  if (palette_listener_id_ >= 0) {
+    gfx::Arena::Get().UnregisterPaletteListener(palette_listener_id_);
+    palette_listener_id_ = -1;
+  }
+
   // Clear viewer references in panels BEFORE room_viewers_ is destroyed.
   // Panels are owned by WorkspaceWindowManager and outlive this editor, so they need
   // to have their viewer pointers cleared to prevent dangling pointer access.
@@ -894,63 +899,9 @@ absl::Status DungeonEditorV2::Load() {
 
   palette_editor_.SetOnDungeonPaletteChanged(
       [this](gui::DungeonPaletteChange change) {
-        InvalidateDungeonPaletteUsers(change);
-
-        auto apply_palette = [this](DungeonCanvasViewer* viewer) {
-          if (!viewer) {
-            return;
-          }
-          viewer->SetCurrentPaletteId(current_palette_id_);
-          viewer->SetCurrentPaletteGroup(current_palette_group_);
-        };
-
-        if (current_room_id_ >= 0 && current_room_id_ < (int)rooms_.size() &&
-            game_data()) {
-          auto& dungeon_main_pal_group =
-              game_data()->palette_groups.dungeon_main;
-          if (current_palette_id_ >= 0 &&
-              current_palette_id_ <
-                  static_cast<int>(dungeon_main_pal_group.size())) {
-            current_palette_group_id_ = current_palette_id_;
-            current_palette_ = dungeon_main_pal_group[current_palette_id_];
-            if (auto pal_group =
-                    gfx::CreatePaletteGroupFromLargePalette(current_palette_);
-                pal_group.ok()) {
-              current_palette_group_ = pal_group.value();
-              apply_palette(workbench_viewer_.get());
-              apply_palette(workbench_compare_viewer_.get());
-              if (!IsWorkbenchWorkflowEnabled()) {
-                if (auto* existing_viewer =
-                        room_viewers_.Get(current_room_id_)) {
-                  apply_palette(existing_viewer->get());
-                }
-              }
-              if (object_selector_panel_) {
-                object_selector_panel_->SetCurrentPaletteGroup(
-                    current_palette_group_);
-              }
-              if (room_graphics_panel_) {
-                room_graphics_panel_->SetCurrentPaletteGroup(
-                    current_palette_group_);
-              }
-            }
-          }
-        }
-
-        bool rendered_current_room = false;
-        for (int i = 0; i < active_rooms_.Size; i++) {
-          int room_id = active_rooms_[i];
-          if (room_id >= 0 && room_id < (int)rooms_.size()) {
-            rooms_[room_id].RenderRoomGraphics();
-            rendered_current_room |= room_id == current_room_id_;
-          }
-        }
-
-        if (!rendered_current_room && current_room_id_ >= 0 &&
-            current_room_id_ < static_cast<int>(rooms_.size())) {
-          rooms_[current_room_id_].RenderRoomGraphics();
-        }
+        HandleDungeonPaletteChanged(change);
       });
+  RegisterPaletteListener();
 
   // Oracle of Secrets: load editor-authored water fill zones (best-effort).
   ReloadWaterFillZones();
@@ -968,9 +919,96 @@ absl::Status DungeonEditorV2::Load() {
   return absl::OkStatus();
 }
 
+void DungeonEditorV2::RegisterPaletteListener() {
+  if (palette_listener_id_ >= 0) {
+    return;
+  }
+
+  palette_listener_id_ = gfx::Arena::Get().RegisterPaletteListener(
+      [this](const std::string& group_name, int palette_index) {
+        HandleArenaPaletteChanged(group_name, palette_index);
+      });
+}
+
+void DungeonEditorV2::HandleArenaPaletteChanged(const std::string& group_name,
+                                                int palette_index) {
+  if (!gfx::PaletteManager::Get().IsManaging(game_data_)) {
+    return;
+  }
+
+  if (group_name == "hud") {
+    HandleDungeonPaletteChanged({static_cast<int>(current_palette_id_),
+                                 gui::DungeonRenderPaletteSource::kHud});
+  } else if (group_name == "dungeon_main") {
+    HandleDungeonPaletteChanged(
+        {palette_index, gui::DungeonRenderPaletteSource::kDungeonMain});
+  }
+}
+
+void DungeonEditorV2::HandleDungeonPaletteChanged(
+    gui::DungeonPaletteChange change) {
+  InvalidateDungeonPaletteUsers(change);
+
+  auto apply_palette = [this](DungeonCanvasViewer* viewer) {
+    if (!viewer) {
+      return;
+    }
+    viewer->SetCurrentPaletteId(current_palette_id_);
+    viewer->SetCurrentPaletteGroup(current_palette_group_);
+  };
+
+  if (current_room_id_ >= 0 &&
+      current_room_id_ < static_cast<int>(rooms_.size()) && game_data()) {
+    auto& dungeon_main_pal_group = game_data()->palette_groups.dungeon_main;
+    if (current_palette_id_ <
+        static_cast<uint64_t>(dungeon_main_pal_group.size())) {
+      current_palette_group_id_ = current_palette_id_;
+      current_palette_ = dungeon_main_pal_group[current_palette_id_];
+      if (auto pal_group =
+              gfx::CreatePaletteGroupFromLargePalette(current_palette_);
+          pal_group.ok()) {
+        current_palette_group_ = pal_group.value();
+        apply_palette(workbench_viewer_.get());
+        apply_palette(workbench_compare_viewer_.get());
+        if (!IsWorkbenchWorkflowEnabled()) {
+          if (auto* existing_viewer = room_viewers_.Get(current_room_id_)) {
+            apply_palette(existing_viewer->get());
+          }
+        }
+        if (object_selector_panel_) {
+          object_selector_panel_->SetCurrentPaletteGroup(
+              current_palette_group_);
+        }
+        if (room_graphics_panel_) {
+          room_graphics_panel_->SetCurrentPaletteGroup(current_palette_group_);
+        }
+        if (object_tile_editor_panel_) {
+          object_tile_editor_panel_->SetCurrentPaletteGroup(
+              current_palette_group_);
+        }
+      }
+    }
+  }
+
+  bool rendered_current_room = false;
+  for (int i = 0; i < active_rooms_.Size; i++) {
+    int room_id = active_rooms_[i];
+    if (room_id >= 0 && room_id < static_cast<int>(rooms_.size())) {
+      rooms_[room_id].RenderRoomGraphics();
+      rendered_current_room |= room_id == current_room_id_;
+    }
+  }
+
+  if (!rendered_current_room && current_room_id_ >= 0 &&
+      current_room_id_ < static_cast<int>(rooms_.size())) {
+    rooms_[current_room_id_].RenderRoomGraphics();
+  }
+}
+
 void DungeonEditorV2::InvalidateDungeonPaletteUsers(
     gui::DungeonPaletteChange change) {
-  if (change.source == gui::DungeonRenderPaletteSource::kHud) {
+  if (change.source == gui::DungeonRenderPaletteSource::kHud ||
+      change.palette_id < 0) {
     rooms_.ForEachMaterialized(
         [](int, zelda3::Room& room) { room.MarkGraphicsDirty(); });
     return;

--- a/src/app/editor/dungeon/dungeon_editor_v2.h
+++ b/src/app/editor/dungeon/dungeon_editor_v2.h
@@ -43,6 +43,7 @@ namespace yaze {
 namespace editor {
 
 class CustomCollisionPanel;
+class DungeonEditorPaletteRefreshTestPeer;
 class DungeonEditorV2RegularEntranceTestPeer;
 class DungeonEditorV2ReloadTestPeer;
 class DungeonEditorV2SpawnPointTestPeer;
@@ -249,6 +250,7 @@ class DungeonEditorV2 : public Editor {
   const std::deque<int>& GetRecentRooms() const { return recent_rooms_; }
 
  private:
+  friend class DungeonEditorPaletteRefreshTestPeer;
   friend class DungeonEditorV2RegularEntranceTestPeer;
   friend class DungeonEditorV2ReloadTestPeer;
   friend class DungeonEditorV2SpawnPointTestPeer;
@@ -291,6 +293,10 @@ class DungeonEditorV2 : public Editor {
 
   // Sync all sub-panels to the current room configuration
   void SyncPanelsToRoom(int room_id);
+  void HandleDungeonPaletteChanged(gui::DungeonPaletteChange change);
+  void HandleArenaPaletteChanged(const std::string& group_name,
+                                 int palette_index);
+  void RegisterPaletteListener();
   void InvalidateDungeonPaletteUsers(gui::DungeonPaletteChange change);
   uint8_t ResolveSelectedEntranceBlocksetForRoom(int room_id) const;
   void ApplyEntranceRenderContext(int room_id);
@@ -359,6 +365,7 @@ class DungeonEditorV2 : public Editor {
   gfx::PaletteGroup current_palette_group_;
   uint64_t current_palette_id_ = 0;
   uint64_t current_palette_group_id_ = 0;
+  int palette_listener_id_ = -1;
 
   // Components - these do all the work
   DungeonRoomLoader room_loader_;

--- a/test/unit/editor/dungeon_editor_palette_refresh_test.cc
+++ b/test/unit/editor/dungeon_editor_palette_refresh_test.cc
@@ -36,6 +36,21 @@ void SeedPaletteGroup(gfx::PaletteGroup* group, int palette_count,
 
 }  // namespace
 
+class DungeonEditorPaletteRefreshTestPeer {
+ public:
+  static void RegisterPaletteListener(DungeonEditorV2* editor) {
+    editor->RegisterPaletteListener();
+  }
+
+  static void SetCurrentPaletteId(DungeonEditorV2* editor, int palette_id) {
+    editor->current_palette_id_ = palette_id;
+  }
+
+  static const gfx::SnesPalette& CurrentPalette(const DungeonEditorV2& editor) {
+    return editor.current_palette_;
+  }
+};
+
 class DungeonEditorPaletteRefreshTest : public ::testing::Test {
  protected:
   void SetUp() override {
@@ -220,6 +235,104 @@ TEST_F(DungeonEditorPaletteRefreshTest,
   EXPECT_EQ(unrelated_before.r, unrelated_after.r);
   EXPECT_EQ(unrelated_before.g, unrelated_after.g);
   EXPECT_EQ(unrelated_before.b, unrelated_after.b);
+}
+
+TEST_F(DungeonEditorPaletteRefreshTest,
+       ApplyPreviewChangesRefreshesAllMaterializedDungeonRooms) {
+  auto& current_room = editor_->rooms()[0];
+  current_room.SetPalette(5);  // Resolves to dungeon palette 3.
+  auto& cached_room = editor_->rooms()[1];
+  cached_room.SetPalette(6);  // Resolves to dungeon palette 2.
+
+  RenderToCleanState(current_room);
+  RenderToCleanState(cached_room);
+
+  constexpr int kDungeonDisplayIndex = 33;
+  constexpr int kDungeonColorIndex = 0;
+  const gfx::SnesColor edited_color(0x7C00);
+  const SDL_Color before =
+      ReadSurfacePaletteColor(current_room, kDungeonDisplayIndex);
+
+  DungeonEditorPaletteRefreshTestPeer::SetCurrentPaletteId(editor_.get(), 3);
+  DungeonEditorPaletteRefreshTestPeer::RegisterPaletteListener(editor_.get());
+
+  auto& palette_manager = gfx::PaletteManager::Get();
+  ASSERT_TRUE(palette_manager
+                  .SetColor("dungeon_main", 3, kDungeonColorIndex, edited_color)
+                  .ok());
+  ASSERT_FALSE(current_room.IsCompositeDirty());
+  ASSERT_FALSE(cached_room.IsCompositeDirty());
+
+  ASSERT_TRUE(palette_manager.ApplyPreviewChanges().ok());
+
+  EXPECT_TRUE(current_room.IsCompositeDirty());
+  EXPECT_TRUE(cached_room.IsCompositeDirty());
+  const SDL_Color after =
+      ReadSurfacePaletteColor(current_room, kDungeonDisplayIndex);
+  EXPECT_NE(before.r, after.r);
+  ExpectSurfaceColor(after, edited_color);
+  EXPECT_EQ(
+      DungeonEditorPaletteRefreshTestPeer::CurrentPalette(*editor_)[0].snes(),
+      edited_color.snes());
+}
+
+TEST_F(DungeonEditorPaletteRefreshTest,
+       ApplyPreviewChangesRefreshesSharedHudPaletteUsers) {
+  auto& current_room = editor_->rooms()[0];
+  current_room.SetPalette(5);
+  auto& cached_room = editor_->rooms()[1];
+  cached_room.SetPalette(6);
+
+  RenderToCleanState(current_room);
+  RenderToCleanState(cached_room);
+
+  constexpr int kHudDisplayIndex = 17;
+  const gfx::SnesColor edited_color(0x03E0);
+  const SDL_Color before =
+      ReadSurfacePaletteColor(current_room, kHudDisplayIndex);
+
+  DungeonEditorPaletteRefreshTestPeer::SetCurrentPaletteId(editor_.get(), 3);
+  DungeonEditorPaletteRefreshTestPeer::RegisterPaletteListener(editor_.get());
+
+  auto& palette_manager = gfx::PaletteManager::Get();
+  ASSERT_TRUE(
+      palette_manager.SetColor("hud", 0, kHudDisplayIndex, edited_color).ok());
+  ASSERT_FALSE(current_room.IsCompositeDirty());
+  ASSERT_FALSE(cached_room.IsCompositeDirty());
+
+  ASSERT_TRUE(palette_manager.ApplyPreviewChanges().ok());
+
+  EXPECT_TRUE(current_room.IsCompositeDirty());
+  EXPECT_TRUE(cached_room.IsCompositeDirty());
+  const SDL_Color after =
+      ReadSurfacePaletteColor(current_room, kHudDisplayIndex);
+  EXPECT_NE(before.g, after.g);
+  ExpectSurfaceColor(after, edited_color);
+}
+
+TEST_F(DungeonEditorPaletteRefreshTest,
+       PaletteNotificationFromInactiveSessionIsIgnored) {
+  auto& room = editor_->rooms()[0];
+  room.SetPalette(5);
+  RenderToCleanState(room);
+
+  DungeonEditorPaletteRefreshTestPeer::RegisterPaletteListener(editor_.get());
+
+  Rom other_rom;
+  ASSERT_TRUE(other_rom.LoadFromData(std::vector<uint8_t>(0x200000, 0)).ok());
+  zelda3::GameData other_game_data(&other_rom);
+  SeedPaletteGroup(&other_game_data.palette_groups.dungeon_main,
+                   /*palette_count=*/1, /*color_count=*/90,
+                   /*seed=*/0x0300);
+
+  auto& palette_manager = gfx::PaletteManager::Get();
+  palette_manager.Initialize(&other_game_data);
+  ASSERT_TRUE(
+      palette_manager.SetColor("dungeon_main", 0, 0, gfx::SnesColor(0x001F))
+          .ok());
+  ASSERT_TRUE(palette_manager.ApplyPreviewChanges().ok());
+
+  EXPECT_FALSE(room.IsCompositeDirty());
 }
 
 TEST_F(DungeonEditorPaletteRefreshTest,


### PR DESCRIPTION
## Summary
- refresh dungeon rooms when global Arena palette edits are applied
- ignore notifications belonging to another active GameData session
- update dungeon viewers and palette-dependent tool panels from one shared handler
- invalidate all materialized rooms for HUD or whole-group dungeon palette changes

## Verification
- `cmake --build build/presets/mac-test --target yaze_test_unit --parallel 8`
- `build/presets/mac-test/bin/Debug/yaze_test_unit --gtest_filter='DungeonEditorPaletteRefreshTest.*'` (9 passed)
- `YAZE_PREPUSH_SMOKE_FILTER='WorkspaceWindowManagerPolicyTest.*' scripts/pre-push.sh --build-dir build/presets/mac-test`
- `git diff --check`
- `git clang-format --diff origin/master -- ...`

## Review notes
Independent strict review found no blocking issues. Remaining non-blocking follow-up: a placement ghost already active during a palette edit may keep its old preview colors until reselected.
