### PR TITLE
fix(dungeon): match Big Wall Decor parity

### DIFF
--- a/src/zelda3/dungeon/draw_routines/draw_routine_registry.cc
+++ b/src/zelda3/dungeon/draw_routines/draw_routine_registry.cc
@@ -459,7 +459,7 @@ void DrawRoutineRegistry::BuildObjectMapping() {
   object_to_routine_map_[0xFC8] = 16;
   object_to_routine_map_[0xFC9] = 110;
   object_to_routine_map_[0xFCA] = 110;
-  object_to_routine_map_[0xFCB] = 16;
+  object_to_routine_map_[0xFCB] = DrawRoutineIds::kBigWallDecor;
   object_to_routine_map_[0xFCC] = 16;
   object_to_routine_map_[0xFCD] = 100;
   object_to_routine_map_[0xFCE] = 30;
@@ -498,8 +498,8 @@ void DrawRoutineRegistry::BuildObjectMapping() {
   object_to_routine_map_[0xFF3] = 38;
   object_to_routine_map_[0xFF4] = DrawRoutineIds::kFloorLight;
   object_to_routine_map_[0xFF5] = 110;
-  object_to_routine_map_[0xFF6] = 16;
-  object_to_routine_map_[0xFF7] = 16;
+  object_to_routine_map_[0xFF6] = DrawRoutineIds::kBigWallDecor;
+  object_to_routine_map_[0xFF7] = DrawRoutineIds::kBigWallDecor;
   object_to_routine_map_[0xFF8] = 109;
   object_to_routine_map_[0xFF9] = 30;
   object_to_routine_map_[0xFFA] = 16;

--- a/src/zelda3/dungeon/draw_routines/draw_routine_registry.h
+++ b/src/zelda3/dungeon/draw_routines/draw_routine_registry.h
@@ -84,6 +84,7 @@ constexpr int kDownwardsEdge1x1_1to16plus7 = 122;
 
 // Late special routines.
 constexpr int kFloorLight = 123;
+constexpr int kBigWallDecor = 125;
 
 // Corner routines (19, 35-37, 75-78)
 constexpr int kCorner4x4 = 19;

--- a/src/zelda3/dungeon/draw_routines/special_routines.cc
+++ b/src/zelda3/dungeon/draw_routines/special_routines.cc
@@ -431,6 +431,12 @@ void DrawUtility6x3(const DrawContext& ctx) {
   Draw1x3NRightwards(ctx, /*columns=*/6, /*start_index=*/0);
 }
 
+void DrawBigWallDecor(const DrawContext& ctx) {
+  // ASM: RoomDraw_BigWallDecor ($019A06) calls
+  // RoomDraw_1x3N_rightwards with A=8. The encoded size is not consulted.
+  Draw1x3NRightwards(ctx, /*columns=*/8, /*start_index=*/0);
+}
+
 void DrawUtility3x5(const DrawContext& ctx) {
   // ASM: RoomDraw_Utility3x5 ($01A194) uses:
   // - top row: tiles 0..2
@@ -1907,6 +1913,17 @@ void RegisterSpecialRoutines(std::vector<DrawRoutineInfo>& registry) {
       .base_width = 4,
       .base_height = 4,
       .min_tiles = 16,
+      .category = DrawRoutineInfo::Category::Special,
+  });
+
+  registry.push_back(DrawRoutineInfo{
+      .id = DrawRoutineIds::kBigWallDecor,  // 125
+      .name = "BigWallDecor",
+      .function = DrawBigWallDecor,
+      .draws_to_both_bgs = false,
+      .base_width = 8,
+      .base_height = 3,
+      .min_tiles = 24,
       .category = DrawRoutineInfo::Category::Special,
   });
 

--- a/src/zelda3/dungeon/draw_routines/special_routines.h
+++ b/src/zelda3/dungeon/draw_routines/special_routines.h
@@ -109,6 +109,13 @@ void DrawRightwards3x6(const DrawContext& ctx);
 void DrawUtility6x3(const DrawContext& ctx);
 
 /**
+ * @brief Draw fixed 8x3 big wall decor in column-major order
+ *
+ * ASM: RoomDraw_BigWallDecor ($019A06)
+ */
+void DrawBigWallDecor(const DrawContext& ctx);
+
+/**
  * @brief Draw utility 3x5 pattern (special row pattern)
  *
  * ASM: RoomDraw_Utility3x5 ($01A194)

--- a/src/zelda3/dungeon/object_dimensions.cc
+++ b/src/zelda3/dungeon/object_dimensions.cc
@@ -934,12 +934,13 @@ void ObjectDimensionTable::InitializeDefaults() {
   dimensions_[0xFAA] = {4, 4, Dir::Horizontal, 4, false};
   dimensions_[0xFAD] = {4, 4, Dir::Horizontal, 4, false};
   dimensions_[0xFAE] = {4, 4, Dir::Horizontal, 4, false};
-  dimensions_[0xFCB] = {4, 4, Dir::Horizontal, 4, false};
   dimensions_[0xFCC] = {4, 4, Dir::Horizontal, 4, false};
   dimensions_[0xFD4] = {4, 4, Dir::Horizontal, 4, false};
   dimensions_[0xFE2] = {4, 4, Dir::Horizontal, 4, false};
-  dimensions_[0xFF6] = {4, 4, Dir::Horizontal, 4, false};
-  dimensions_[0xFF7] = {4, 4, Dir::Horizontal, 4, false};
+  // Big wall decor aliases are fixed 8x3 objects; their size nibble is ignored.
+  dimensions_[0xFCB] = {8, 3, Dir::None, 0, false};
+  dimensions_[0xFF6] = {8, 3, Dir::None, 0, false};
+  dimensions_[0xFF7] = {8, 3, Dir::None, 0, false};
   // Utility + archery patterns
   dimensions_[0xFCD] = {6, 3, Dir::None, 0, false};
   dimensions_[0xFDD] = {6, 3, Dir::None, 0, false};

--- a/src/zelda3/dungeon/object_drawer.cc
+++ b/src/zelda3/dungeon/object_drawer.cc
@@ -1416,6 +1416,14 @@ void ObjectDrawer::InitializeDrawRoutines() {
                                        tiles, state);
       };
 
+  ensure_index(DrawRoutineIds::kBigWallDecor);
+  draw_routines_[DrawRoutineIds::kBigWallDecor] =
+      [](ObjectDrawer* self, const RoomObject& obj, gfx::BackgroundBuffer& bg,
+         std::span<const gfx::TileInfo> tiles, const DungeonState* state) {
+        self->DrawUsingRegistryRoutine(DrawRoutineIds::kBigWallDecor, obj, bg,
+                                       tiles, state);
+      };
+
   // Routine 130 - Custom Object (Oracle of Secrets 0x31, 0x32)
   // Uses external binary files instead of ROM tile data.
   // Requires CustomObjectManager initialization and enable_custom_objects flag.
@@ -3192,6 +3200,11 @@ std::pair<int, int> yaze::zelda3::ObjectDrawer::CalculateObjectDimensions(
       // 4 tile8s x 4 tile8s = 32x32 pixels
       width = 32;
       height = 32;
+      break;
+
+    case DrawRoutineIds::kBigWallDecor:
+      width = 64;
+      height = 24;
       break;
 
     default:

--- a/src/zelda3/dungeon/object_parser.cc
+++ b/src/zelda3/dungeon/object_parser.cc
@@ -637,10 +637,14 @@ int ObjectParser::GetSubtype3TileCount(int16_t object_id) const {
   }
   // 4x4 single-pattern objects
   if (object_id == 0xFAA || object_id == 0xFAD || object_id == 0xFAE ||
-      (object_id >= 0xFB4 && object_id <= 0xFB9) || object_id == 0xFCB ||
-      object_id == 0xFCC || object_id == 0xFD4 || object_id == 0xFE2 ||
-      object_id == 0xFF6 || object_id == 0xFF7) {
+      (object_id >= 0xFB4 && object_id <= 0xFB9) || object_id == 0xFCC ||
+      object_id == 0xFD4 || object_id == 0xFE2) {
     return 16;
+  }
+  // Big wall decor aliases: RoomDraw_BigWallDecor calls
+  // RoomDraw_1x3N_rightwards with A=8, consuming 8 columns x 3 rows.
+  if (object_id == 0xFCB || object_id == 0xFF6 || object_id == 0xFF7) {
+    return 24;
   }
   // Turtle Rock pipes: 24 tiles (proven from routine bodies, not just
   // dimensions table). DrawVerticalTurtleRockPipe (0xFBA, 0xFBB at

--- a/test/unit/zelda3/dungeon/draw_routine_mapping_test.cc
+++ b/test/unit/zelda3/dungeon/draw_routine_mapping_test.cc
@@ -710,6 +710,10 @@ TEST_F(DrawRoutineMappingTest, VerifiesSubtype3Mappings) {
   EXPECT_EQ(drawer.GetDrawRoutineId(0xFF4), DrawRoutineIds::kFloorLight);
   EXPECT_EQ(drawer.GetDrawRoutineId(0xFF8),
             DrawRoutineIds::kGanonTriforceFloorDecor);
+  for (int object_id : {0xFCB, 0xFF6, 0xFF7}) {
+    EXPECT_EQ(drawer.GetDrawRoutineId(object_id),
+              DrawRoutineIds::kBigWallDecor);
+  }
 
   const DrawRoutineInfo* floor_light =
       DrawRoutineRegistry::Get().GetRoutineInfo(DrawRoutineIds::kFloorLight);
@@ -718,6 +722,14 @@ TEST_F(DrawRoutineMappingTest, VerifiesSubtype3Mappings) {
   EXPECT_EQ(floor_light->base_height, 8);
   EXPECT_EQ(floor_light->min_tiles, 64);
   EXPECT_FALSE(floor_light->draws_to_both_bgs);
+
+  const DrawRoutineInfo* big_wall_decor =
+      DrawRoutineRegistry::Get().GetRoutineInfo(DrawRoutineIds::kBigWallDecor);
+  ASSERT_NE(big_wall_decor, nullptr);
+  EXPECT_EQ(big_wall_decor->base_width, 8);
+  EXPECT_EQ(big_wall_decor->base_height, 3);
+  EXPECT_EQ(big_wall_decor->min_tiles, 24);
+  EXPECT_FALSE(big_wall_decor->draws_to_both_bgs);
 }
 
 }  // namespace zelda3

--- a/test/unit/zelda3/dungeon/object_dimensions_test.cc
+++ b/test/unit/zelda3/dungeon/object_dimensions_test.cc
@@ -275,6 +275,55 @@ TEST_F(ObjectDimensionTableTest, HammerPegUsesFixedTwoByTwoBounds) {
   }
 }
 
+TEST_F(ObjectDimensionTableTest,
+       BigWallDecorAliasesUseFixedEightByThreeBounds) {
+  auto& table = ObjectDimensionTable::Get();
+  ASSERT_TRUE(table.LoadFromRom(rom_.get()).ok());
+
+  struct DecorCase {
+    int object_id;
+    uint8_t oos_size;
+  };
+  constexpr DecorCase kCases[] = {
+      {0xFCB, 14},
+      {0xFF6, 9},
+      {0xFF7, 13},
+  };
+
+  for (const auto& test_case : kCases) {
+    for (uint8_t size : {uint8_t{0}, test_case.oos_size, uint8_t{15}}) {
+      SCOPED_TRACE(::testing::Message()
+                   << "object_id=0x" << std::hex << test_case.object_id
+                   << " size=" << std::dec << static_cast<int>(size));
+
+      const auto [width, height] =
+          table.GetDimensions(test_case.object_id, size);
+      EXPECT_EQ(width, 8);
+      EXPECT_EQ(height, 3);
+
+      const auto selection =
+          table.GetSelectionBounds(test_case.object_id, size);
+      EXPECT_EQ(selection.offset_x, 0);
+      EXPECT_EQ(selection.offset_y, 0);
+      EXPECT_EQ(selection.width, 8);
+      EXPECT_EQ(selection.height, 3);
+
+      const RoomObject object(test_case.object_id, 0, 0, size, 0);
+      const auto geometry = ObjectGeometry::Get().MeasureByObjectId(object);
+      ASSERT_TRUE(geometry.ok());
+      EXPECT_EQ(geometry->min_x_tiles, 0);
+      EXPECT_EQ(geometry->min_y_tiles, 0);
+      EXPECT_EQ(geometry->width_tiles, 8);
+      EXPECT_EQ(geometry->height_tiles, 3);
+
+      const auto [legacy_width, legacy_height] =
+          ObjectDrawer(rom_.get(), 0).CalculateObjectDimensions(object);
+      EXPECT_EQ(legacy_width, 64);
+      EXPECT_EQ(legacy_height, 24);
+    }
+  }
+}
+
 TEST_F(ObjectDimensionTableTest, BigKeyLockUsesFixedTwoByTwoBounds) {
   auto& table = ObjectDimensionTable::Get();
   ASSERT_TRUE(table.LoadFromRom(rom_.get()).ok());

--- a/test/unit/zelda3/dungeon/object_drawer_registry_replay_test.cc
+++ b/test/unit/zelda3/dungeon/object_drawer_registry_replay_test.cc
@@ -2444,6 +2444,50 @@ TEST(ObjectDrawerRegistryReplayTest, HammerPegDrawsSingleTwoByTwoAtAnchor) {
 }
 
 TEST(ObjectDrawerRegistryReplayTest,
+     BigWallDecorAliasesDrawFixedEightByThreeOnSelectedLayer) {
+  ScopedCustomObjectsFlag disable_custom(false);
+
+  constexpr int kX = 10;
+  constexpr int kY = 12;
+  constexpr uint16_t kFirstTile = 0x0240;
+  struct DecorCase {
+    int16_t object_id;
+    uint8_t oos_size;
+  };
+  constexpr DecorCase kCases[] = {
+      {0x0FCB, 14},
+      {0x0FF6, 9},
+      {0x0FF7, 13},
+  };
+
+  for (const auto& test_case : kCases) {
+    for (uint8_t size : {uint8_t{0}, test_case.oos_size}) {
+      for (const auto layer :
+           {RoomObject::LayerType::BG1, RoomObject::LayerType::BG2}) {
+        SCOPED_TRACE(::testing::Message()
+                     << "object_id=0x" << std::hex << test_case.object_id
+                     << " size=" << std::dec << static_cast<int>(size)
+                     << " layer=" << static_cast<int>(layer));
+
+        const auto trace = ReplayObjectTrace(
+            test_case.object_id, kX, kY, size, layer,
+            MakeSequentialTiles(/*count=*/24,
+                                /*start_tile_id=*/kFirstTile));
+        const auto bg1 = FilterTraceByLayer(trace, RoomObject::LayerType::BG1);
+        const auto bg2 = FilterTraceByLayer(trace, RoomObject::LayerType::BG2);
+        const auto& selected = layer == RoomObject::LayerType::BG1 ? bg1 : bg2;
+        const auto& other = layer == RoomObject::LayerType::BG1 ? bg2 : bg1;
+
+        ExpectTraceMatchesSnapshot(
+            selected, MakeColumnMajorSnapshot(kX, kY, /*width=*/8, /*height=*/3,
+                                              /*start_tile_id=*/kFirstTile));
+        EXPECT_TRUE(other.empty());
+      }
+    }
+  }
+}
+
+TEST(ObjectDrawerRegistryReplayTest,
      VerticalJumpLedgesDrawOneTileForSizePlusEightRows) {
   ScopedCustomObjectsFlag disable_custom(false);
 

--- a/test/unit/zelda3/dungeon/object_drawing_comprehensive_test.cc
+++ b/test/unit/zelda3/dungeon/object_drawing_comprehensive_test.cc
@@ -140,9 +140,13 @@ int ExpectedSubtype3TileCount(int id) {
     return 16;
   }
   if (id == 0xFAA || id == 0xFAD || id == 0xFAE ||
-      (id >= 0xFB4 && id <= 0xFB9) || id == 0xFCB || id == 0xFCC ||
-      id == 0xFD4 || id == 0xFE2 || id == 0xFF6 || id == 0xFF7) {
+      (id >= 0xFB4 && id <= 0xFB9) || id == 0xFCC || id == 0xFD4 ||
+      id == 0xFE2) {
     return 16;
+  }
+  // Big wall decor aliases consume one 8x3 column-major payload.
+  if (id == 0xFCB || id == 0xFF6 || id == 0xFF7) {
+    return 24;
   }
   // Turtle Rock pipes: 24 tiles (matches GetSubtype3TileCount; routine
   // bodies at special_routines.cc:430-441 read tiles[0..23]).

--- a/test/unit/zelda3/object_parser_test.cc
+++ b/test/unit/zelda3/object_parser_test.cc
@@ -493,6 +493,29 @@ TEST_F(ObjectParserTest, TurtleRockPipesProvideTwentyFourTiles) {
   }
 }
 
+TEST_F(ObjectParserTest, BigWallDecorAliasesProvideTwentyFourTiles) {
+  auto& registry = zelda3::DrawRoutineRegistry::Get();
+
+  for (int id : {0xFCB, 0xFF6, 0xFF7}) {
+    SCOPED_TRACE(::testing::Message() << "object_id=0x" << std::hex << id);
+
+    EXPECT_EQ(registry.GetRoutineIdForObject(id),
+              zelda3::DrawRoutineIds::kBigWallDecor);
+
+    const auto subtype = parser_->GetObjectSubtype(id);
+    ASSERT_TRUE(subtype.ok());
+    EXPECT_EQ(subtype->max_tile_count, 24);
+
+    const auto parsed = parser_->ParseObject(id);
+    ASSERT_TRUE(parsed.ok());
+    EXPECT_EQ(parsed->size(), 24u);
+
+    const auto info = parser_->GetObjectDrawInfo(id);
+    EXPECT_EQ(info.tile_count, 24);
+    EXPECT_EQ(info.draw_routine_id, zelda3::DrawRoutineIds::kBigWallDecor);
+  }
+}
+
 TEST_F(ObjectParserTest, HammerPegUsesUsdasmSingle2x2RoutineAndFourTiles) {
   auto& registry = zelda3::DrawRoutineRegistry::Get();
   EXPECT_EQ(registry.GetRoutineIdForObject(0xF96),


### PR DESCRIPTION
## Summary
- route subtype-3 objects `0xFCB`, `0xFF6`, and `0xFF7` through a dedicated Big Wall Decor routine
- match USDASM's fixed 8x3, 24-tile, column-major draw behavior on the selected background
- align parser payloads, geometry, hit-test dimensions, and legacy ObjectDrawer dimensions
- add mapping, parser, dimension, layer, order, and size-invariance coverage

## Canonical basis
USDASM maps all three aliases to `RoomDraw_BigWallDecor`, which loads 8 columns before entering `RoomDraw_1x3N_rightwards`. Each source object-data span is exactly 24 words.

An Oracle of Secrets census found four live objects across rooms `0x000` and `0x121`; their encoded sizes must not change the canonical 8x3 footprint.

## Verification
- `cmake --preset mac-test -DYAZE_FORCE_BUNDLED_ABSL=ON -DCMAKE_CXX_COMPILER_LAUNCHER=`
- `cmake --build build/presets/mac-test --target yaze_test_unit --parallel 8`
- focused 5-test parity filter (5 passed)
- `YAZE_PREPUSH_SMOKE_FILTER='WorkspaceWindowManagerPolicyTest.*' scripts/pre-push.sh --build-dir build/presets/mac-test`
- `git diff --check`
- `git clang-format --diff origin/master -- ...`

## Review notes
Independent strict review found no blocking findings. A real-ROM rendered golden remains a useful non-blocking visual follow-up.
