### PR TITLE
fix(dungeon): refresh active placement ghost palette

### DIFF
--- a/src/app/editor/dungeon/dungeon_canvas_viewer.h
+++ b/src/app/editor/dungeon/dungeon_canvas_viewer.h
@@ -723,6 +723,8 @@ class DungeonCanvasViewer {
       DungeonEditorPaletteRefreshTest_CachedRoomRefreshesThroughViewerCompositePreparation_Test;
   friend class
       DungeonEditorPaletteRefreshTest_CachedCompositePreparationPreservesTargetEntranceContext_Test;
+  friend class
+      DungeonEditorPaletteRefreshTest_CachedPanelPaletteRefreshSurvivesWorkbenchModeAndPreservesRoomPalette_Test;
 
   struct ChangePingRect {
     int x = 0;

--- a/src/app/editor/dungeon/dungeon_canvas_viewer.h
+++ b/src/app/editor/dungeon/dungeon_canvas_viewer.h
@@ -304,8 +304,21 @@ class DungeonCanvasViewer {
     current_palette_group_id_ = id;
   }
   void SetCurrentPaletteId(uint64_t id) { current_palette_id_ = id; }
-  void SetCurrentPaletteGroup(const gfx::PaletteGroup& group) {
+  void SetCurrentPaletteGroup(const gfx::PaletteGroup& group,
+                              bool force_refresh = false) {
+    bool palette_changed = current_palette_group_.name() != group.name() ||
+                           current_palette_group_.size() != group.size();
+    for (int i = 0; !palette_changed && i < static_cast<int>(group.size());
+         ++i) {
+      palette_changed =
+          current_palette_group_.palette_ref(i) != group.palette_ref(i);
+    }
+    if (!palette_changed && !force_refresh) {
+      return;
+    }
+
     current_palette_group_ = group;
+    object_interaction_.SetCurrentPaletteGroup(group, force_refresh);
   }
   void SetEntranceRenderContext(int entrance_id, uint8_t entrance_blockset) {
     current_entrance_id_ = entrance_id;

--- a/src/app/editor/dungeon/dungeon_canvas_viewer.h
+++ b/src/app/editor/dungeon/dungeon_canvas_viewer.h
@@ -725,6 +725,8 @@ class DungeonCanvasViewer {
       DungeonEditorPaletteRefreshTest_CachedCompositePreparationPreservesTargetEntranceContext_Test;
   friend class
       DungeonEditorPaletteRefreshTest_CachedPanelPaletteRefreshSurvivesWorkbenchModeAndPreservesRoomPalette_Test;
+  friend class
+      DungeonEditorPaletteRefreshTest_DungeonMainNotificationSkipsUnrelatedCachedViewerWork_Test;
 
   struct ChangePingRect {
     int x = 0;

--- a/src/app/editor/dungeon/dungeon_editor_v2.cc
+++ b/src/app/editor/dungeon/dungeon_editor_v2.cc
@@ -963,12 +963,13 @@ void DungeonEditorV2::HandleDungeonPaletteChanged(
     rooms_[current_room_id_].RenderRoomGraphics();
   }
 
-  auto apply_palette = [this](DungeonCanvasViewer* viewer) {
+  auto apply_palette = [](DungeonCanvasViewer* viewer, uint64_t palette_id,
+                          const gfx::PaletteGroup& palette_group) {
     if (!viewer) {
       return;
     }
-    viewer->SetCurrentPaletteId(current_palette_id_);
-    viewer->SetCurrentPaletteGroup(current_palette_group_,
+    viewer->SetCurrentPaletteId(palette_id);
+    viewer->SetCurrentPaletteGroup(palette_group,
                                    /*force_refresh=*/true);
   };
 
@@ -983,13 +984,29 @@ void DungeonEditorV2::HandleDungeonPaletteChanged(
               gfx::CreatePaletteGroupFromLargePalette(current_palette_);
           pal_group.ok()) {
         current_palette_group_ = pal_group.value();
-        apply_palette(workbench_viewer_.get());
-        apply_palette(workbench_compare_viewer_.get());
-        if (!IsWorkbenchWorkflowEnabled()) {
-          if (auto* existing_viewer = room_viewers_.Get(current_room_id_)) {
-            apply_palette(existing_viewer->get());
-          }
-        }
+        apply_palette(workbench_viewer_.get(), current_palette_id_,
+                      current_palette_group_);
+        apply_palette(workbench_compare_viewer_.get(), current_palette_id_,
+                      current_palette_group_);
+        room_viewers_.ForEach(
+            [this, &apply_palette, &dungeon_main_pal_group](
+                int room_id, std::unique_ptr<DungeonCanvasViewer>& viewer) {
+              if (room_id < 0 || room_id >= static_cast<int>(rooms_.size())) {
+                return;
+              }
+              const int palette_id = rooms_[room_id].ResolveDungeonPaletteId();
+              if (palette_id < 0 ||
+                  palette_id >=
+                      static_cast<int>(dungeon_main_pal_group.size())) {
+                return;
+              }
+              auto room_palette_group = gfx::CreatePaletteGroupFromLargePalette(
+                  dungeon_main_pal_group.palette_ref(palette_id));
+              if (room_palette_group.ok()) {
+                apply_palette(viewer.get(), palette_id,
+                              room_palette_group.value());
+              }
+            });
         if (object_selector_panel_) {
           object_selector_panel_->SetCurrentPaletteGroup(
               current_palette_group_);

--- a/src/app/editor/dungeon/dungeon_editor_v2.cc
+++ b/src/app/editor/dungeon/dungeon_editor_v2.cc
@@ -8,6 +8,7 @@
 
 // C++ standard library headers
 #include <algorithm>
+#include <array>
 #include <iterator>
 #include <memory>
 #include <string>
@@ -949,19 +950,22 @@ void DungeonEditorV2::HandleDungeonPaletteChanged(
     gui::DungeonPaletteChange change) {
   InvalidateDungeonPaletteUsers(change);
 
-  bool rendered_current_room = false;
-  for (int i = 0; i < active_rooms_.Size; i++) {
-    int room_id = active_rooms_[i];
-    if (room_id >= 0 && room_id < static_cast<int>(rooms_.size())) {
-      rooms_[room_id].RenderRoomGraphics();
-      rendered_current_room |= room_id == current_room_id_;
+  std::array<bool, zelda3::kNumberOfRooms> rendered_rooms{};
+  auto render_once = [this, &rendered_rooms](int room_id) {
+    if (room_id < 0 || room_id >= static_cast<int>(rooms_.size()) ||
+        room_id >= static_cast<int>(rendered_rooms.size()) ||
+        rendered_rooms[room_id]) {
+      return;
     }
+    rooms_[room_id].RenderRoomGraphics();
+    rendered_rooms[room_id] = true;
+  };
+
+  for (int i = 0; i < active_rooms_.Size; i++) {
+    render_once(active_rooms_[i]);
   }
 
-  if (!rendered_current_room && current_room_id_ >= 0 &&
-      current_room_id_ < static_cast<int>(rooms_.size())) {
-    rooms_[current_room_id_].RenderRoomGraphics();
-  }
+  render_once(current_room_id_);
 
   auto apply_palette = [](DungeonCanvasViewer* viewer, uint64_t palette_id,
                           const gfx::PaletteGroup& palette_group,
@@ -995,7 +999,7 @@ void DungeonEditorV2::HandleDungeonPaletteChanged(
                       current_palette_group_, force_shared_palette_refresh);
         room_viewers_.ForEach(
             [this, change, &apply_palette, &dungeon_main_pal_group,
-             force_shared_palette_refresh](
+             &render_once, force_shared_palette_refresh](
                 int room_id, std::unique_ptr<DungeonCanvasViewer>& viewer) {
               if (room_id < 0 || room_id >= static_cast<int>(rooms_.size())) {
                 return;
@@ -1014,6 +1018,9 @@ void DungeonEditorV2::HandleDungeonPaletteChanged(
               auto room_palette_group = gfx::CreatePaletteGroupFromLargePalette(
                   dungeon_main_pal_group.palette_ref(palette_id));
               if (room_palette_group.ok()) {
+                if (viewer && viewer->object_interaction().IsObjectLoaded()) {
+                  render_once(room_id);
+                }
                 apply_palette(viewer.get(), palette_id,
                               room_palette_group.value(),
                               force_shared_palette_refresh);

--- a/src/app/editor/dungeon/dungeon_editor_v2.cc
+++ b/src/app/editor/dungeon/dungeon_editor_v2.cc
@@ -964,17 +964,22 @@ void DungeonEditorV2::HandleDungeonPaletteChanged(
   }
 
   auto apply_palette = [](DungeonCanvasViewer* viewer, uint64_t palette_id,
-                          const gfx::PaletteGroup& palette_group) {
+                          const gfx::PaletteGroup& palette_group,
+                          bool force_shared_palette_refresh) {
     if (!viewer) {
       return;
     }
     viewer->SetCurrentPaletteId(palette_id);
-    viewer->SetCurrentPaletteGroup(palette_group,
-                                   /*force_refresh=*/true);
+    viewer->SetCurrentPaletteGroup(
+        palette_group,
+        /*force_refresh=*/force_shared_palette_refresh &&
+            viewer->object_interaction().IsObjectLoaded());
   };
 
   if (current_room_id_ >= 0 &&
       current_room_id_ < static_cast<int>(rooms_.size()) && game_data()) {
+    const bool force_shared_palette_refresh =
+        change.source == gui::DungeonRenderPaletteSource::kHud;
     auto& dungeon_main_pal_group = game_data()->palette_groups.dungeon_main;
     if (current_palette_id_ <
         static_cast<uint64_t>(dungeon_main_pal_group.size())) {
@@ -985,11 +990,12 @@ void DungeonEditorV2::HandleDungeonPaletteChanged(
           pal_group.ok()) {
         current_palette_group_ = pal_group.value();
         apply_palette(workbench_viewer_.get(), current_palette_id_,
-                      current_palette_group_);
+                      current_palette_group_, force_shared_palette_refresh);
         apply_palette(workbench_compare_viewer_.get(), current_palette_id_,
-                      current_palette_group_);
+                      current_palette_group_, force_shared_palette_refresh);
         room_viewers_.ForEach(
-            [this, &apply_palette, &dungeon_main_pal_group](
+            [this, change, &apply_palette, &dungeon_main_pal_group,
+             force_shared_palette_refresh](
                 int room_id, std::unique_ptr<DungeonCanvasViewer>& viewer) {
               if (room_id < 0 || room_id >= static_cast<int>(rooms_.size())) {
                 return;
@@ -1000,11 +1006,17 @@ void DungeonEditorV2::HandleDungeonPaletteChanged(
                       static_cast<int>(dungeon_main_pal_group.size())) {
                 return;
               }
+              if (change.source ==
+                      gui::DungeonRenderPaletteSource::kDungeonMain &&
+                  change.palette_id >= 0 && palette_id != change.palette_id) {
+                return;
+              }
               auto room_palette_group = gfx::CreatePaletteGroupFromLargePalette(
                   dungeon_main_pal_group.palette_ref(palette_id));
               if (room_palette_group.ok()) {
                 apply_palette(viewer.get(), palette_id,
-                              room_palette_group.value());
+                              room_palette_group.value(),
+                              force_shared_palette_refresh);
               }
             });
         if (object_selector_panel_) {

--- a/src/app/editor/dungeon/dungeon_editor_v2.cc
+++ b/src/app/editor/dungeon/dungeon_editor_v2.cc
@@ -949,12 +949,27 @@ void DungeonEditorV2::HandleDungeonPaletteChanged(
     gui::DungeonPaletteChange change) {
   InvalidateDungeonPaletteUsers(change);
 
+  bool rendered_current_room = false;
+  for (int i = 0; i < active_rooms_.Size; i++) {
+    int room_id = active_rooms_[i];
+    if (room_id >= 0 && room_id < static_cast<int>(rooms_.size())) {
+      rooms_[room_id].RenderRoomGraphics();
+      rendered_current_room |= room_id == current_room_id_;
+    }
+  }
+
+  if (!rendered_current_room && current_room_id_ >= 0 &&
+      current_room_id_ < static_cast<int>(rooms_.size())) {
+    rooms_[current_room_id_].RenderRoomGraphics();
+  }
+
   auto apply_palette = [this](DungeonCanvasViewer* viewer) {
     if (!viewer) {
       return;
     }
     viewer->SetCurrentPaletteId(current_palette_id_);
-    viewer->SetCurrentPaletteGroup(current_palette_group_);
+    viewer->SetCurrentPaletteGroup(current_palette_group_,
+                                   /*force_refresh=*/true);
   };
 
   if (current_room_id_ >= 0 &&
@@ -988,20 +1003,6 @@ void DungeonEditorV2::HandleDungeonPaletteChanged(
         }
       }
     }
-  }
-
-  bool rendered_current_room = false;
-  for (int i = 0; i < active_rooms_.Size; i++) {
-    int room_id = active_rooms_[i];
-    if (room_id >= 0 && room_id < static_cast<int>(rooms_.size())) {
-      rooms_[room_id].RenderRoomGraphics();
-      rendered_current_room |= room_id == current_room_id_;
-    }
-  }
-
-  if (!rendered_current_room && current_room_id_ >= 0 &&
-      current_room_id_ < static_cast<int>(rooms_.size())) {
-    rooms_[current_room_id_].RenderRoomGraphics();
   }
 }
 

--- a/src/app/editor/dungeon/dungeon_object_interaction.h
+++ b/src/app/editor/dungeon/dungeon_object_interaction.h
@@ -111,10 +111,26 @@ class DungeonObjectInteraction {
   // State management
   void SetCurrentRoom(DungeonRoomStore* rooms, int room_id);
   void SetPreviewObject(const zelda3::RoomObject& object, bool loaded);
-  void SetCurrentPaletteGroup(const gfx::PaletteGroup& group) {
+  void SetCurrentPaletteGroup(const gfx::PaletteGroup& group,
+                              bool force_refresh = false) {
+    bool palette_changed = current_palette_group_.name() != group.name() ||
+                           current_palette_group_.size() != group.size();
+    for (int i = 0; !palette_changed && i < static_cast<int>(group.size());
+         ++i) {
+      palette_changed =
+          current_palette_group_.palette_ref(i) != group.palette_ref(i);
+    }
+    if (!palette_changed && !force_refresh) {
+      return;
+    }
+
     current_palette_group_ = group;
     interaction_context_.current_palette_group = group;
     entity_coordinator_.SetContext(&interaction_context_);
+    auto& tile_handler = entity_coordinator_.tile_handler();
+    if (tile_handler.IsPlacementActive()) {
+      tile_handler.SetPreviewObject(preview_object_);
+    }
   }
 
   // Mode manager access

--- a/test/unit/editor/dungeon_editor_palette_refresh_test.cc
+++ b/test/unit/editor/dungeon_editor_palette_refresh_test.cc
@@ -85,6 +85,11 @@ class DungeonEditorPaletteRefreshTestPeer {
     }
   }
 
+  static void HandlePaletteChanged(DungeonEditorV2* editor,
+                                   gui::DungeonPaletteChange change) {
+    editor->HandleDungeonPaletteChanged(change);
+  }
+
   static DungeonRoomStore* Rooms(DungeonEditorV2* editor) {
     return &editor->rooms_;
   }
@@ -501,6 +506,44 @@ TEST_F(DungeonEditorPaletteRefreshTest,
     EXPECT_EQ(cached_viewer->current_palette_group_.palette_ref(i),
               expected_palette_group->palette_ref(i));
   }
+}
+
+TEST_F(DungeonEditorPaletteRefreshTest,
+       DungeonMainNotificationSkipsUnrelatedCachedViewerWork) {
+  ScopedWorkbenchFlag standalone_workflow(/*enabled=*/false);
+  constexpr int kCachedRoomId = 0;
+  constexpr int kCurrentRoomId = 1;
+  auto& cached_room = editor_->rooms()[kCachedRoomId];
+  cached_room.SetLoaded(true);
+  cached_room.SetPalette(6);  // Resolves to dungeon palette 2.
+  cached_room.SetTileObjects({});
+  auto& current_room = editor_->rooms()[kCurrentRoomId];
+  current_room.SetLoaded(true);
+  current_room.SetPalette(5);  // Resolves to dungeon palette 3.
+  current_room.SetTileObjects({});
+
+  DungeonEditorPaletteRefreshTestPeer::SetCurrentPaletteId(editor_.get(), 3);
+  DungeonEditorPaletteRefreshTestPeer::SetCurrentRoomId(editor_.get(),
+                                                        kCurrentRoomId);
+  DungeonEditorPaletteRefreshTestPeer::SetActiveRooms(editor_.get(),
+                                                      {kCurrentRoomId});
+  DungeonCanvasViewer* cached_viewer =
+      DungeonEditorPaletteRefreshTestPeer::GetViewerForRoom(editor_.get(),
+                                                            kCachedRoomId);
+  ASSERT_NE(cached_viewer, nullptr);
+  auto cached_palette_group = gfx::CreatePaletteGroupFromLargePalette(
+      game_data_.palette_groups.dungeon_main.palette_ref(2));
+  ASSERT_TRUE(cached_palette_group.ok());
+  cached_viewer->SetCurrentPaletteGroup(*cached_palette_group);
+
+  // Use the ID as a call sentinel while keeping the viewer's palette group
+  // valid. An unrelated concrete-palette edit must skip this cached viewer.
+  constexpr uint64_t kUntouchedSentinel = 0xFFFF;
+  cached_viewer->current_palette_id_ = kUntouchedSentinel;
+  DungeonEditorPaletteRefreshTestPeer::HandlePaletteChanged(
+      editor_.get(), {3, gui::DungeonRenderPaletteSource::kDungeonMain});
+
+  EXPECT_EQ(cached_viewer->current_palette_id_, kUntouchedSentinel);
 }
 
 TEST_F(DungeonEditorPaletteRefreshTest,

--- a/test/unit/editor/dungeon_editor_palette_refresh_test.cc
+++ b/test/unit/editor/dungeon_editor_palette_refresh_test.cc
@@ -15,6 +15,7 @@
 #include "rom/snes.h"
 #include "zelda3/dungeon/dungeon_rom_addresses.h"
 #include "zelda3/dungeon/room_layer_manager.h"
+#include "zelda3/dungeon/room_object.h"
 #include "zelda3/game_data.h"
 
 namespace yaze::editor {
@@ -49,12 +50,21 @@ class DungeonEditorPaletteRefreshTestPeer {
   static const gfx::SnesPalette& CurrentPalette(const DungeonEditorV2& editor) {
     return editor.current_palette_;
   }
+
+  static DungeonCanvasViewer* GetWorkbenchViewer(DungeonEditorV2* editor) {
+    return editor->GetWorkbenchViewer();
+  }
+
+  static DungeonRoomStore* Rooms(DungeonEditorV2* editor) {
+    return &editor->rooms_;
+  }
 };
 
 class DungeonEditorPaletteRefreshTest : public ::testing::Test {
  protected:
   void SetUp() override {
     gfx::Arena::Get().ClearTextureQueue();
+    gfx::Arena::Get().Initialize(nullptr);
     gfx::PaletteManager::Get().ResetForTesting();
 
     ASSERT_TRUE(rom_.LoadFromData(std::vector<uint8_t>(0x200000, 0)).ok());
@@ -106,6 +116,7 @@ class DungeonEditorPaletteRefreshTest : public ::testing::Test {
 
   void TearDown() override {
     gfx::Arena::Get().ClearTextureQueue();
+    gfx::Arena::Get().Initialize(nullptr);
     gfx::PaletteManager::Get().ResetForTesting();
   }
 
@@ -308,6 +319,90 @@ TEST_F(DungeonEditorPaletteRefreshTest,
       ReadSurfacePaletteColor(current_room, kHudDisplayIndex);
   EXPECT_NE(before.g, after.g);
   ExpectSurfaceColor(after, edited_color);
+}
+
+TEST_F(DungeonEditorPaletteRefreshTest,
+       SharedHudNotificationRefreshesActivePlacementGhostAndTexture) {
+  constexpr int kCurrentRoomId = 0;
+  constexpr int kHudDisplayIndex = 17;
+  auto& room = editor_->rooms()[kCurrentRoomId];
+  room.SetLoaded(true);
+  room.SetPalette(5);  // Resolves to dungeon palette 3.
+  room.SetTileObjects({});
+
+  ::testing::NiceMock<yaze::test::MockRenderer> renderer;
+  RenderToCleanState(room);
+  while (gfx::Arena::Get().texture_command_queue_size() > 0) {
+    gfx::Arena::Get().ProcessTextureQueue(&renderer);
+  }
+  ASSERT_TRUE(::testing::Mock::VerifyAndClearExpectations(&renderer));
+
+  DungeonEditorPaletteRefreshTestPeer::SetCurrentPaletteId(editor_.get(), 3);
+  DungeonEditorPaletteRefreshTestPeer::RegisterPaletteListener(editor_.get());
+  DungeonCanvasViewer* viewer =
+      DungeonEditorPaletteRefreshTestPeer::GetWorkbenchViewer(editor_.get());
+  ASSERT_NE(viewer, nullptr);
+  viewer->object_interaction().SetCurrentRoom(
+      DungeonEditorPaletteRefreshTestPeer::Rooms(editor_.get()),
+      kCurrentRoomId);
+  auto palette_group = gfx::CreatePaletteGroupFromLargePalette(
+      game_data_.palette_groups.dungeon_main.palette_ref(3));
+  ASSERT_TRUE(palette_group.ok());
+  viewer->SetCurrentPaletteGroup(*palette_group);
+
+  zelda3::RoomObject preview(/*id=*/0x33, /*x=*/0, /*y=*/0, /*size=*/0x02,
+                             /*layer=*/0);
+  preview.mutable_tiles().assign(
+      64, gfx::TileInfo(/*id=*/0, /*palette=*/0, /*v=*/false, /*h=*/false,
+                        /*o=*/false));
+  preview.tiles_loaded_ = true;
+  gfx::Arena::Get().ClearTextureQueue();
+  viewer->SetPreviewObject(preview);
+
+  auto& tile_handler =
+      viewer->object_interaction().entity_coordinator().tile_handler();
+  const auto* ghost_buffer = tile_handler.ghost_preview_buffer_for_testing();
+  ASSERT_NE(ghost_buffer, nullptr);
+  const auto& ghost_bitmap = ghost_buffer->bitmap();
+  SDL_Palette* ghost_palette =
+      platform::GetSurfacePalette(ghost_bitmap.surface());
+  ASSERT_NE(ghost_palette, nullptr);
+  const SDL_Color before = ghost_palette->colors[kHudDisplayIndex];
+
+  EXPECT_CALL(renderer,
+              UpdateTexture(::testing::_, ::testing::Ref(ghost_bitmap)))
+      .Times(1);
+  gfx::Arena::Get().ProcessTextureQueue(&renderer);
+  ASSERT_NE(ghost_bitmap.texture(), nullptr);
+  const auto ghost_texture = ghost_bitmap.texture();
+  ASSERT_TRUE(::testing::Mock::VerifyAndClearExpectations(&renderer));
+
+  const gfx::SnesColor edited_color(0x03E0);
+  auto& palette_manager = gfx::PaletteManager::Get();
+  ASSERT_TRUE(
+      palette_manager.SetColor("hud", 0, kHudDisplayIndex, edited_color).ok());
+  ASSERT_TRUE(palette_manager.ApplyPreviewChanges().ok());
+
+  SDL_Palette* refreshed_palette =
+      platform::GetSurfacePalette(ghost_bitmap.surface());
+  ASSERT_NE(refreshed_palette, nullptr);
+  const SDL_Color after = refreshed_palette->colors[kHudDisplayIndex];
+  EXPECT_NE(before.g, after.g);
+  ExpectSurfaceColor(after, edited_color);
+
+  EXPECT_CALL(renderer, CreateTexture).Times(0);
+  EXPECT_CALL(renderer,
+              UpdateTexture(ghost_texture, ::testing::Ref(ghost_bitmap)))
+      .Times(1);
+  for (int attempts = 0;
+       attempts < 64 && gfx::Arena::Get().texture_command_queue_size() > 0;
+       ++attempts) {
+    gfx::Arena::Get().ProcessTextureQueue(&renderer);
+  }
+  EXPECT_EQ(gfx::Arena::Get().texture_command_queue_size(), 0);
+  EXPECT_EQ(tile_handler.ghost_preview_buffer_for_testing(), ghost_buffer);
+  EXPECT_EQ(ghost_bitmap.texture(), ghost_texture);
+  EXPECT_TRUE(::testing::Mock::VerifyAndClearExpectations(&renderer));
 }
 
 TEST_F(DungeonEditorPaletteRefreshTest,

--- a/test/unit/editor/dungeon_editor_palette_refresh_test.cc
+++ b/test/unit/editor/dungeon_editor_palette_refresh_test.cc
@@ -1,6 +1,7 @@
 #include "app/editor/dungeon/dungeon_editor_v2.h"
 
 #include <cstdint>
+#include <initializer_list>
 #include <memory>
 #include <vector>
 
@@ -8,6 +9,7 @@
 #include "app/gfx/resource/arena.h"
 #include "app/gfx/util/palette_manager.h"
 #include "app/platform/sdl_compat.h"
+#include "core/features.h"
 #include "framework/mock_renderer.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
@@ -35,6 +37,21 @@ void SeedPaletteGroup(gfx::PaletteGroup* group, int palette_count,
   }
 }
 
+class ScopedWorkbenchFlag {
+ public:
+  explicit ScopedWorkbenchFlag(bool enabled)
+      : previous_(core::FeatureFlags::get().dungeon.kUseWorkbench) {
+    core::FeatureFlags::get().dungeon.kUseWorkbench = enabled;
+  }
+
+  ~ScopedWorkbenchFlag() {
+    core::FeatureFlags::get().dungeon.kUseWorkbench = previous_;
+  }
+
+ private:
+  bool previous_;
+};
+
 }  // namespace
 
 class DungeonEditorPaletteRefreshTestPeer {
@@ -51,8 +68,21 @@ class DungeonEditorPaletteRefreshTestPeer {
     return editor.current_palette_;
   }
 
-  static DungeonCanvasViewer* GetWorkbenchViewer(DungeonEditorV2* editor) {
-    return editor->GetWorkbenchViewer();
+  static DungeonCanvasViewer* GetViewerForRoom(DungeonEditorV2* editor,
+                                               int room_id) {
+    return editor->GetViewerForRoom(room_id);
+  }
+
+  static void SetCurrentRoomId(DungeonEditorV2* editor, int room_id) {
+    editor->current_room_id_ = room_id;
+  }
+
+  static void SetActiveRooms(DungeonEditorV2* editor,
+                             std::initializer_list<int> room_ids) {
+    editor->active_rooms_.clear();
+    for (int room_id : room_ids) {
+      editor->active_rooms_.push_back(room_id);
+    }
   }
 
   static DungeonRoomStore* Rooms(DungeonEditorV2* editor) {
@@ -322,27 +352,45 @@ TEST_F(DungeonEditorPaletteRefreshTest,
 }
 
 TEST_F(DungeonEditorPaletteRefreshTest,
-       SharedHudNotificationRefreshesActivePlacementGhostAndTexture) {
-  constexpr int kCurrentRoomId = 0;
+       SharedHudNotificationRefreshesBackgroundPanelGhostAndTexture) {
+  ScopedWorkbenchFlag standalone_workflow(/*enabled=*/false);
+  constexpr int kGhostRoomId = 0;
+  constexpr int kCurrentRoomId = 1;
   constexpr int kHudDisplayIndex = 17;
-  auto& room = editor_->rooms()[kCurrentRoomId];
-  room.SetLoaded(true);
-  room.SetPalette(5);  // Resolves to dungeon palette 3.
-  room.SetTileObjects({});
+  auto& ghost_room = editor_->rooms()[kGhostRoomId];
+  ghost_room.SetLoaded(true);
+  ghost_room.SetPalette(5);  // Resolves to dungeon palette 3.
+  ghost_room.SetTileObjects({});
+  auto& current_room = editor_->rooms()[kCurrentRoomId];
+  current_room.SetLoaded(true);
+  current_room.SetPalette(7);  // Also resolves to dungeon palette 3.
+  current_room.SetTileObjects({});
 
   ::testing::NiceMock<yaze::test::MockRenderer> renderer;
-  RenderToCleanState(room);
+  RenderToCleanState(ghost_room);
+  RenderToCleanState(current_room);
   while (gfx::Arena::Get().texture_command_queue_size() > 0) {
     gfx::Arena::Get().ProcessTextureQueue(&renderer);
   }
   ASSERT_TRUE(::testing::Mock::VerifyAndClearExpectations(&renderer));
 
   DungeonEditorPaletteRefreshTestPeer::SetCurrentPaletteId(editor_.get(), 3);
+  DungeonEditorPaletteRefreshTestPeer::SetCurrentRoomId(editor_.get(),
+                                                        kCurrentRoomId);
+  DungeonEditorPaletteRefreshTestPeer::SetActiveRooms(
+      editor_.get(), {kGhostRoomId, kCurrentRoomId});
   DungeonEditorPaletteRefreshTestPeer::RegisterPaletteListener(editor_.get());
   DungeonCanvasViewer* viewer =
-      DungeonEditorPaletteRefreshTestPeer::GetWorkbenchViewer(editor_.get());
+      DungeonEditorPaletteRefreshTestPeer::GetViewerForRoom(editor_.get(),
+                                                            kGhostRoomId);
   ASSERT_NE(viewer, nullptr);
   viewer->object_interaction().SetCurrentRoom(
+      DungeonEditorPaletteRefreshTestPeer::Rooms(editor_.get()), kGhostRoomId);
+  DungeonCanvasViewer* current_viewer =
+      DungeonEditorPaletteRefreshTestPeer::GetViewerForRoom(editor_.get(),
+                                                            kCurrentRoomId);
+  ASSERT_NE(current_viewer, nullptr);
+  current_viewer->object_interaction().SetCurrentRoom(
       DungeonEditorPaletteRefreshTestPeer::Rooms(editor_.get()),
       kCurrentRoomId);
   auto palette_group = gfx::CreatePaletteGroupFromLargePalette(
@@ -403,6 +451,56 @@ TEST_F(DungeonEditorPaletteRefreshTest,
   EXPECT_EQ(tile_handler.ghost_preview_buffer_for_testing(), ghost_buffer);
   EXPECT_EQ(ghost_bitmap.texture(), ghost_texture);
   EXPECT_TRUE(::testing::Mock::VerifyAndClearExpectations(&renderer));
+}
+
+TEST_F(DungeonEditorPaletteRefreshTest,
+       CachedPanelPaletteRefreshSurvivesWorkbenchModeAndPreservesRoomPalette) {
+  ScopedWorkbenchFlag workflow_mode(/*enabled=*/false);
+  constexpr int kCachedRoomId = 0;
+  constexpr int kCurrentRoomId = 1;
+  auto& cached_room = editor_->rooms()[kCachedRoomId];
+  cached_room.SetLoaded(true);
+  cached_room.SetPalette(6);  // Resolves to dungeon palette 2.
+  cached_room.SetTileObjects({});
+  auto& current_room = editor_->rooms()[kCurrentRoomId];
+  current_room.SetLoaded(true);
+  current_room.SetPalette(5);  // Resolves to dungeon palette 3.
+  current_room.SetTileObjects({});
+
+  DungeonEditorPaletteRefreshTestPeer::SetCurrentPaletteId(editor_.get(), 3);
+  DungeonEditorPaletteRefreshTestPeer::SetCurrentRoomId(editor_.get(),
+                                                        kCurrentRoomId);
+  DungeonEditorPaletteRefreshTestPeer::SetActiveRooms(
+      editor_.get(), {kCachedRoomId, kCurrentRoomId});
+  DungeonCanvasViewer* cached_viewer =
+      DungeonEditorPaletteRefreshTestPeer::GetViewerForRoom(editor_.get(),
+                                                            kCachedRoomId);
+  ASSERT_NE(cached_viewer, nullptr);
+  cached_viewer->object_interaction().SetCurrentRoom(
+      DungeonEditorPaletteRefreshTestPeer::Rooms(editor_.get()), kCachedRoomId);
+  auto stale_palette_group = gfx::CreatePaletteGroupFromLargePalette(
+      game_data_.palette_groups.dungeon_main.palette_ref(3));
+  ASSERT_TRUE(stale_palette_group.ok());
+  cached_viewer->SetCurrentPaletteId(3);
+  cached_viewer->SetCurrentPaletteGroup(*stale_palette_group);
+
+  core::FeatureFlags::get().dungeon.kUseWorkbench = true;
+  DungeonEditorPaletteRefreshTestPeer::RegisterPaletteListener(editor_.get());
+  auto& palette_manager = gfx::PaletteManager::Get();
+  ASSERT_TRUE(
+      palette_manager.SetColor("hud", 0, 17, gfx::SnesColor(0x03E0)).ok());
+  ASSERT_TRUE(palette_manager.ApplyPreviewChanges().ok());
+
+  auto expected_palette_group = gfx::CreatePaletteGroupFromLargePalette(
+      game_data_.palette_groups.dungeon_main.palette_ref(2));
+  ASSERT_TRUE(expected_palette_group.ok());
+  EXPECT_EQ(cached_viewer->current_palette_id_, 2);
+  ASSERT_EQ(cached_viewer->current_palette_group_.size(),
+            expected_palette_group->size());
+  for (int i = 0; i < static_cast<int>(expected_palette_group->size()); ++i) {
+    EXPECT_EQ(cached_viewer->current_palette_group_.palette_ref(i),
+              expected_palette_group->palette_ref(i));
+  }
 }
 
 TEST_F(DungeonEditorPaletteRefreshTest,

--- a/test/unit/editor/dungeon_editor_palette_refresh_test.cc
+++ b/test/unit/editor/dungeon_editor_palette_refresh_test.cc
@@ -357,7 +357,7 @@ TEST_F(DungeonEditorPaletteRefreshTest,
 }
 
 TEST_F(DungeonEditorPaletteRefreshTest,
-       SharedHudNotificationRefreshesBackgroundPanelGhostAndTexture) {
+       SharedHudNotificationRefreshesInactiveCachedPanelGhostAndReusesTexture) {
   ScopedWorkbenchFlag standalone_workflow(/*enabled=*/false);
   constexpr int kGhostRoomId = 0;
   constexpr int kCurrentRoomId = 1;
@@ -382,8 +382,8 @@ TEST_F(DungeonEditorPaletteRefreshTest,
   DungeonEditorPaletteRefreshTestPeer::SetCurrentPaletteId(editor_.get(), 3);
   DungeonEditorPaletteRefreshTestPeer::SetCurrentRoomId(editor_.get(),
                                                         kCurrentRoomId);
-  DungeonEditorPaletteRefreshTestPeer::SetActiveRooms(
-      editor_.get(), {kGhostRoomId, kCurrentRoomId});
+  DungeonEditorPaletteRefreshTestPeer::SetActiveRooms(editor_.get(),
+                                                      {kCurrentRoomId});
   DungeonEditorPaletteRefreshTestPeer::RegisterPaletteListener(editor_.get());
   DungeonCanvasViewer* viewer =
       DungeonEditorPaletteRefreshTestPeer::GetViewerForRoom(editor_.get(),

--- a/test/unit/editor/tile_object_handler_test.cc
+++ b/test/unit/editor/tile_object_handler_test.cc
@@ -1,5 +1,6 @@
 #include "app/editor/dungeon/interaction/tile_object_handler.h"
 #include "app/editor/dungeon/dungeon_canvas_transform.h"
+#include "app/editor/dungeon/dungeon_canvas_viewer.h"
 #include "app/editor/dungeon/object_selection.h"
 #include "app/gfx/resource/arena.h"
 #include "app/gui/canvas/canvas.h"
@@ -579,6 +580,84 @@ TEST_F(TileObjectHandlerTest,
   handler_.CancelPlacement();
   handler_.BeginPlacement();
   EXPECT_EQ(gfx::Arena::Get().texture_command_queue_size(), 1);
+}
+
+TEST_F(TileObjectHandlerTest,
+       ViewerPaletteChangeRefreshesActiveObjectPlacementGhost) {
+  ASSERT_TRUE(rom_.LoadFromData(std::vector<uint8_t>(0x200000, 0)).ok());
+  rooms_.SetRom(&rom_);
+  rooms_[0].SetLoaded(true);
+  auto& room_gfx =
+      const_cast<std::array<uint8_t, 0x10000>&>(rooms_[0].get_gfx_buffer());
+  room_gfx.fill(1);
+  rooms_[0].bg1_buffer().EnsureBitmapInitialized();
+
+  std::vector<SDL_Color> room_palette(256, {0, 0, 0, 255});
+  constexpr int kObservedColorIndex = 33;
+  room_palette[kObservedColorIndex] = {0x11, 0x22, 0x33, 255};
+  room_palette[255] = {0, 0, 0, 0};
+  rooms_[0].bg1_buffer().bitmap().SetPalette(room_palette);
+
+  DungeonCanvasViewer viewer(&rom_);
+  viewer.SetRooms(&rooms_);
+  viewer.object_interaction().SetCurrentRoom(&rooms_, 0);
+  gfx::PaletteGroup initial_group("dungeon_main");
+  gfx::SnesPalette initial_palette;
+  initial_palette.AddColor(gfx::SnesColor(0x001F));
+  initial_group.AddPalette(initial_palette);
+  viewer.SetCurrentPaletteGroup(initial_group);
+
+  auto object = CreateTestObject(/*x=*/0, /*y=*/0, /*size=*/0x02,
+                                 /*id=*/0x33);
+  object.mutable_tiles().assign(
+      64, gfx::TileInfo(/*id=*/0, /*palette=*/0, /*v=*/false, /*h=*/false,
+                        /*o=*/false));
+  object.tiles_loaded_ = true;
+  viewer.SetPreviewObject(object);
+
+  auto& tile_handler =
+      viewer.object_interaction().entity_coordinator().tile_handler();
+  const auto* ghost_buffer = tile_handler.ghost_preview_buffer_for_testing();
+  ASSERT_NE(ghost_buffer, nullptr);
+  SDL_Palette* ghost_palette =
+      platform::GetSurfacePalette(ghost_buffer->bitmap().surface());
+  ASSERT_NE(ghost_palette, nullptr);
+  EXPECT_EQ(ghost_palette->colors[kObservedColorIndex].r, 0x11);
+  EXPECT_EQ(ghost_palette->colors[kObservedColorIndex].g, 0x22);
+  EXPECT_EQ(ghost_palette->colors[kObservedColorIndex].b, 0x33);
+
+  room_palette[kObservedColorIndex] = {0xAA, 0xBB, 0xCC, 255};
+  rooms_[0].bg1_buffer().bitmap().SetPalette(room_palette);
+  gfx::PaletteGroup updated_group("dungeon_main");
+  gfx::SnesPalette updated_palette;
+  updated_palette.AddColor(gfx::SnesColor(0x03E0));
+  updated_group.AddPalette(updated_palette);
+  viewer.SetCurrentPaletteGroup(updated_group);
+
+  ghost_palette = platform::GetSurfacePalette(ghost_buffer->bitmap().surface());
+  ASSERT_NE(ghost_palette, nullptr);
+  EXPECT_EQ(ghost_palette->colors[kObservedColorIndex].r, 0xAA);
+  EXPECT_EQ(ghost_palette->colors[kObservedColorIndex].g, 0xBB);
+  EXPECT_EQ(ghost_palette->colors[kObservedColorIndex].b, 0xCC);
+
+  // HUD edits do not change dungeon_main contents, so the Arena notification
+  // explicitly forces a refresh even when the palette group compares equal.
+  room_palette[kObservedColorIndex] = {0xDD, 0xEE, 0xFF, 255};
+  rooms_[0].bg1_buffer().bitmap().SetPalette(room_palette);
+  viewer.SetCurrentPaletteGroup(updated_group);
+  ghost_palette = platform::GetSurfacePalette(ghost_buffer->bitmap().surface());
+  ASSERT_NE(ghost_palette, nullptr);
+  EXPECT_EQ(ghost_palette->colors[kObservedColorIndex].r, 0xAA);
+  EXPECT_EQ(ghost_palette->colors[kObservedColorIndex].g, 0xBB);
+  EXPECT_EQ(ghost_palette->colors[kObservedColorIndex].b, 0xCC);
+
+  viewer.SetCurrentPaletteGroup(updated_group, /*force_refresh=*/true);
+
+  ghost_palette = platform::GetSurfacePalette(ghost_buffer->bitmap().surface());
+  ASSERT_NE(ghost_palette, nullptr);
+  EXPECT_EQ(ghost_palette->colors[kObservedColorIndex].r, 0xDD);
+  EXPECT_EQ(ghost_palette->colors[kObservedColorIndex].g, 0xEE);
+  EXPECT_EQ(ghost_palette->colors[kObservedColorIndex].b, 0xFF);
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary

- refresh an active dungeon object placement ghost when its palette group changes
- force ghost refreshes for shared HUD palette edits even when `dungeon_main` compares equal
- refresh retained standalone/pinned room viewers even while Workbench is active
- resolve each cached viewer's own dungeon palette instead of applying the current room's palette globally
- skip unrelated cached viewers on concrete dungeon-main edits and limit forced HUD work to active object placement
- render active, current, and inactive cached ghost rooms at most once before rebuilding their ghosts so they copy fresh SDL colors
- avoid repeated palette copies/renders from high-frequency viewer context and palette-drag updates

## Verification

- `DungeonEditorPaletteRefreshTest.*:TileObjectHandlerTest.GhostPreview*:TileObjectHandlerTest.ViewerPaletteChange*`: **17/17 passed**
- inactive cached HUD ghost fresh-color/texture-reuse regression: **1/1 passed**
- final pre-push build: passed
- `WorkspaceWindowManagerPolicyTest.*`: **13/13 passed**
- change-aware UI regression: **27/27 passed**
- `clang-format --dry-run --Werror` and `git diff --check`: passed
- independent strict follow-up reviews: no blockers

## Stack

- #161 is merged; this PR targets `master`
- hosted exact-head CI remains the merge gate
