### PR TITLE
fix(dungeon): match TableBowl object parity

### DIFF
--- a/src/zelda3/dungeon/draw_routines/draw_routine_registry.cc
+++ b/src/zelda3/dungeon/draw_routines/draw_routine_registry.cc
@@ -468,9 +468,10 @@ void DrawRoutineRegistry::BuildObjectMapping() {
   }
   object_to_routine_map_[0xFD4] = 16;
   object_to_routine_map_[0xFD5] = 101;
-  for (int id = 0xFD6; id <= 0xFDA; id++) {
+  for (int id = 0xFD6; id <= 0xFD9; id++) {
     object_to_routine_map_[id] = 110;
   }
+  object_to_routine_map_[0xFDA] = DrawRoutineIds::kTableBowl;
   object_to_routine_map_[0xFDB] = 101;
   object_to_routine_map_[0xFDC] = 103;
   object_to_routine_map_[0xFDD] = 100;

--- a/src/zelda3/dungeon/draw_routines/draw_routine_registry.h
+++ b/src/zelda3/dungeon/draw_routines/draw_routine_registry.h
@@ -85,6 +85,7 @@ constexpr int kDownwardsEdge1x1_1to16plus7 = 122;
 // Late special routines.
 constexpr int kFloorLight = 123;
 constexpr int kBigWallDecor = 125;
+constexpr int kTableBowl = 126;
 
 // Corner routines (19, 35-37, 75-78)
 constexpr int kCorner4x4 = 19;

--- a/src/zelda3/dungeon/draw_routines/special_routines.cc
+++ b/src/zelda3/dungeon/draw_routines/special_routines.cc
@@ -437,6 +437,15 @@ void DrawBigWallDecor(const DrawContext& ctx) {
   Draw1x3NRightwards(ctx, /*columns=*/8, /*start_index=*/0);
 }
 
+void DrawTableBowl(const DrawContext& ctx) {
+  // ASM: RoomDraw_TableBowl ($019D6C) loads A=2 and falls through to
+  // RoomDraw_WaterHoldingObject, which writes four tiles per row.
+  if (ctx.tiles.size() < 8)
+    return;
+
+  DrawRowMajor(ctx.target_bg, ctx.object.x_, ctx.object.y_, 4, 2, ctx.tiles);
+}
+
 void DrawUtility3x5(const DrawContext& ctx) {
   // ASM: RoomDraw_Utility3x5 ($01A194) uses:
   // - top row: tiles 0..2
@@ -1924,6 +1933,17 @@ void RegisterSpecialRoutines(std::vector<DrawRoutineInfo>& registry) {
       .base_width = 8,
       .base_height = 3,
       .min_tiles = 24,
+      .category = DrawRoutineInfo::Category::Special,
+  });
+
+  registry.push_back(DrawRoutineInfo{
+      .id = DrawRoutineIds::kTableBowl,  // 126
+      .name = "TableBowl",
+      .function = DrawTableBowl,
+      .draws_to_both_bgs = false,
+      .base_width = 4,
+      .base_height = 2,
+      .min_tiles = 8,
       .category = DrawRoutineInfo::Category::Special,
   });
 

--- a/src/zelda3/dungeon/draw_routines/special_routines.h
+++ b/src/zelda3/dungeon/draw_routines/special_routines.h
@@ -116,6 +116,13 @@ void DrawUtility6x3(const DrawContext& ctx);
 void DrawBigWallDecor(const DrawContext& ctx);
 
 /**
+ * @brief Draw a fixed 4x2 table bowl in row-major order
+ *
+ * ASM: RoomDraw_TableBowl ($019D6C -> RoomDraw_WaterHoldingObject)
+ */
+void DrawTableBowl(const DrawContext& ctx);
+
+/**
  * @brief Draw utility 3x5 pattern (special row pattern)
  *
  * ASM: RoomDraw_Utility3x5 ($01A194)

--- a/src/zelda3/dungeon/object_dimensions.cc
+++ b/src/zelda3/dungeon/object_dimensions.cc
@@ -941,11 +941,14 @@ void ObjectDimensionTable::InitializeDefaults() {
   dimensions_[0xFCB] = {8, 3, Dir::None, 0, false};
   dimensions_[0xFF6] = {8, 3, Dir::None, 0, false};
   dimensions_[0xFF7] = {8, 3, Dir::None, 0, false};
-  // Utility + archery patterns
+  // Utility patterns
   dimensions_[0xFCD] = {6, 3, Dir::None, 0, false};
   dimensions_[0xFDD] = {6, 3, Dir::None, 0, false};
   dimensions_[0xFD5] = {3, 5, Dir::None, 0, false};
   dimensions_[0xFDB] = {3, 5, Dir::None, 0, false};
+  // Table bowl is a fixed 4x2 stamp; its encoded size is ignored.
+  dimensions_[0xFDA] = {4, 2, Dir::None, 0, false};
+  // Archery patterns
   dimensions_[0xFE0] = {3, 6, Dir::None, 0, false};
   dimensions_[0xFE1] = {3, 6, Dir::None, 0, false};
   // Solid wall decor 3x4

--- a/src/zelda3/dungeon/object_drawer.cc
+++ b/src/zelda3/dungeon/object_drawer.cc
@@ -1424,6 +1424,14 @@ void ObjectDrawer::InitializeDrawRoutines() {
                                        tiles, state);
       };
 
+  ensure_index(DrawRoutineIds::kTableBowl);
+  draw_routines_[DrawRoutineIds::kTableBowl] =
+      [](ObjectDrawer* self, const RoomObject& obj, gfx::BackgroundBuffer& bg,
+         std::span<const gfx::TileInfo> tiles, const DungeonState* state) {
+        self->DrawUsingRegistryRoutine(DrawRoutineIds::kTableBowl, obj, bg,
+                                       tiles, state);
+      };
+
   // Routine 130 - Custom Object (Oracle of Secrets 0x31, 0x32)
   // Uses external binary files instead of ROM tile data.
   // Requires CustomObjectManager initialization and enable_custom_objects flag.
@@ -3205,6 +3213,11 @@ std::pair<int, int> yaze::zelda3::ObjectDrawer::CalculateObjectDimensions(
     case DrawRoutineIds::kBigWallDecor:
       width = 64;
       height = 24;
+      break;
+
+    case DrawRoutineIds::kTableBowl:
+      width = 32;
+      height = 16;
       break;
 
     default:

--- a/test/unit/zelda3/dungeon/draw_routine_mapping_test.cc
+++ b/test/unit/zelda3/dungeon/draw_routine_mapping_test.cc
@@ -695,6 +695,11 @@ TEST_F(DrawRoutineMappingTest, VerifiesSubtype3Mappings) {
   EXPECT_EQ(drawer.GetDrawRoutineId(0xF96), DrawRoutineIds::kSingle2x2);
   EXPECT_EQ(drawer.GetDrawRoutineId(0xFB1), DrawRoutineIds::kSingle4x3);
   EXPECT_EQ(drawer.GetDrawRoutineId(0xFD5), DrawRoutineIds::kUtility3x5);
+  for (int object_id : {0xFD6, 0xFD7, 0xFD8, 0xFD9}) {
+    EXPECT_EQ(drawer.GetDrawRoutineId(object_id), DrawRoutineIds::kSingle2x2);
+  }
+  EXPECT_EQ(drawer.GetDrawRoutineId(0xFDA), DrawRoutineIds::kTableBowl);
+  EXPECT_EQ(drawer.GetDrawRoutineId(0xFDB), DrawRoutineIds::kUtility3x5);
   EXPECT_EQ(drawer.GetDrawRoutineId(0xFBA),
             DrawRoutineIds::kVerticalTurtleRockPipe);
   EXPECT_EQ(drawer.GetDrawRoutineId(0xFBC),
@@ -730,6 +735,24 @@ TEST_F(DrawRoutineMappingTest, VerifiesSubtype3Mappings) {
   EXPECT_EQ(big_wall_decor->base_height, 3);
   EXPECT_EQ(big_wall_decor->min_tiles, 24);
   EXPECT_FALSE(big_wall_decor->draws_to_both_bgs);
+
+  const DrawRoutineInfo* table_bowl =
+      DrawRoutineRegistry::Get().GetRoutineInfo(DrawRoutineIds::kTableBowl);
+  ASSERT_NE(table_bowl, nullptr);
+  EXPECT_EQ(table_bowl->name, "TableBowl");
+  EXPECT_TRUE(static_cast<bool>(table_bowl->function));
+  EXPECT_EQ(table_bowl->base_width, 4);
+  EXPECT_EQ(table_bowl->base_height, 2);
+  EXPECT_EQ(table_bowl->min_tiles, 8);
+  EXPECT_FALSE(table_bowl->draws_to_both_bgs);
+  EXPECT_EQ(table_bowl->category, DrawRoutineInfo::Category::Special);
+
+  const auto& routines = DrawRoutineRegistry::Get().GetAllRoutines();
+  EXPECT_EQ(std::count_if(routines.begin(), routines.end(),
+                          [](const DrawRoutineInfo& info) {
+                            return info.id == DrawRoutineIds::kTableBowl;
+                          }),
+            1);
 }
 
 }  // namespace zelda3

--- a/test/unit/zelda3/dungeon/object_dimensions_test.cc
+++ b/test/unit/zelda3/dungeon/object_dimensions_test.cc
@@ -325,6 +325,39 @@ TEST_F(ObjectDimensionTableTest, HammerPegUsesFixedTwoByTwoBounds) {
   }
 }
 
+TEST_F(ObjectDimensionTableTest, TableBowlUsesFixedFourByTwoBounds) {
+  auto& table = ObjectDimensionTable::Get();
+  ASSERT_TRUE(table.LoadFromRom(rom_.get()).ok());
+
+  for (uint8_t size : {uint8_t{0x00}, uint8_t{0x0A}, uint8_t{0x0F},
+                       uint8_t{0xF0}, uint8_t{0xFF}}) {
+    SCOPED_TRACE(::testing::Message() << "size=" << static_cast<int>(size));
+
+    const auto [width, height] = table.GetDimensions(0xFDA, size);
+    EXPECT_EQ(width, 4);
+    EXPECT_EQ(height, 2);
+
+    const auto selection = table.GetSelectionBounds(0xFDA, size);
+    EXPECT_EQ(selection.offset_x, 0);
+    EXPECT_EQ(selection.offset_y, 0);
+    EXPECT_EQ(selection.width, 4);
+    EXPECT_EQ(selection.height, 2);
+
+    const RoomObject object(0xFDA, 0, 0, size, 0);
+    const auto geometry = ObjectGeometry::Get().MeasureByObjectId(object);
+    ASSERT_TRUE(geometry.ok());
+    EXPECT_EQ(geometry->min_x_tiles, 0);
+    EXPECT_EQ(geometry->min_y_tiles, 0);
+    EXPECT_EQ(geometry->width_tiles, 4);
+    EXPECT_EQ(geometry->height_tiles, 2);
+
+    const auto [legacy_width, legacy_height] =
+        ObjectDrawer(rom_.get(), 0).CalculateObjectDimensions(object);
+    EXPECT_EQ(legacy_width, 32);
+    EXPECT_EQ(legacy_height, 16);
+  }
+}
+
 TEST_F(ObjectDimensionTableTest,
        BigWallDecorAliasesUseFixedEightByThreeBounds) {
   auto& table = ObjectDimensionTable::Get();

--- a/test/unit/zelda3/dungeon/object_drawer_registry_replay_test.cc
+++ b/test/unit/zelda3/dungeon/object_drawer_registry_replay_test.cc
@@ -2493,6 +2493,37 @@ TEST(ObjectDrawerRegistryReplayTest, HammerPegDrawsSingleTwoByTwoAtAnchor) {
 }
 
 TEST(ObjectDrawerRegistryReplayTest,
+     TableBowlDrawsFixedFourByTwoRowMajorOnSelectedLayer) {
+  ScopedCustomObjectsFlag disable_custom(false);
+
+  constexpr int kX = 10;
+  constexpr int kY = 12;
+  constexpr uint16_t kFirstTile = 0x0240;
+
+  for (uint8_t size : {uint8_t{0}, uint8_t{10}}) {
+    for (const auto layer :
+         {RoomObject::LayerType::BG1, RoomObject::LayerType::BG2}) {
+      SCOPED_TRACE(::testing::Message()
+                   << "size=" << static_cast<int>(size)
+                   << " layer=" << static_cast<int>(layer));
+
+      const auto trace = ReplayObjectTrace(
+          /*object_id=*/0x0FDA, kX, kY, size, layer,
+          MakeSequentialTiles(/*count=*/8, /*start_tile_id=*/kFirstTile));
+      const auto bg1 = FilterTraceByLayer(trace, RoomObject::LayerType::BG1);
+      const auto bg2 = FilterTraceByLayer(trace, RoomObject::LayerType::BG2);
+      const auto& selected = layer == RoomObject::LayerType::BG1 ? bg1 : bg2;
+      const auto& other = layer == RoomObject::LayerType::BG1 ? bg2 : bg1;
+
+      ExpectTraceMatchesSnapshot(
+          selected, MakeRowMajorSnapshot(kX, kY, /*width=*/4, /*height=*/2,
+                                         /*start_tile_id=*/kFirstTile));
+      EXPECT_TRUE(other.empty());
+    }
+  }
+}
+
+TEST(ObjectDrawerRegistryReplayTest,
      BigWallDecorAliasesDrawFixedEightByThreeOnSelectedLayer) {
   ScopedCustomObjectsFlag disable_custom(false);
 

--- a/test/unit/zelda3/object_parser_test.cc
+++ b/test/unit/zelda3/object_parser_test.cc
@@ -516,6 +516,24 @@ TEST_F(ObjectParserTest, BigWallDecorAliasesProvideTwentyFourTiles) {
   }
 }
 
+TEST_F(ObjectParserTest, TableBowlUsesEightTilesAndDedicatedRoutine) {
+  auto& registry = zelda3::DrawRoutineRegistry::Get();
+  EXPECT_EQ(registry.GetRoutineIdForObject(0xFDA),
+            zelda3::DrawRoutineIds::kTableBowl);
+
+  const auto subtype = parser_->GetObjectSubtype(0xFDA);
+  ASSERT_TRUE(subtype.ok());
+  EXPECT_EQ(subtype->max_tile_count, 8);
+
+  const auto parsed = parser_->ParseObject(0xFDA);
+  ASSERT_TRUE(parsed.ok());
+  EXPECT_EQ(parsed->size(), 8u);
+
+  const auto info = parser_->GetObjectDrawInfo(0xFDA);
+  EXPECT_EQ(info.tile_count, 8);
+  EXPECT_EQ(info.draw_routine_id, zelda3::DrawRoutineIds::kTableBowl);
+}
+
 TEST_F(ObjectParserTest, HammerPegUsesUsdasmSingle2x2RoutineAndFourTiles) {
   auto& registry = zelda3::DrawRoutineRegistry::Get();
   EXPECT_EQ(registry.GetRoutineIdForObject(0xF96),


### PR DESCRIPTION
## Summary

- map subtype-3 object `0xFDA` to a dedicated TableBowl draw routine
- render its eight-word payload as a fixed 4x2 row-major object on the selected background layer
- align registry metadata, parser tile count, geometry, and legacy pixel dimensions
- preserve the adjacent `0xFD6`-`0xFD9` and `0xFDB` mappings and add boundary/replay coverage

## Why

`0xFDA` inherited the generic 2x2 path, so the editor consumed and rendered only four tiles. The original USDASM `RoomDraw_TableBowl` routine consumes eight words and emits two rows of four tiles. This change gives that object an explicit, reachable routine and keeps every size/dimension surface consistent with the ROM behavior.

## Impact

Dungeon rooms using TableBowl now preview the complete 4x2 object instead of a truncated 2x2 shape. Other subtype-3 objects keep their existing mappings.

## Verification

- focused TableBowl mapping/parser/dimension/BG replay tests: **4/4 passed**
- `scripts/pre-push.sh --build-dir build/presets/mac-ai` with the focused four-test smoke filter: passed
- `clang-format --dry-run --Werror` on all 10 changed C++ files: passed
- `git diff --check`: passed
- independent strict code review against USDASM behavior: no findings

## Residual risk

No manual GUI or emulator-side room comparison was run for this backend slice; hosted CI remains the merge gate.
