### PR TITLE
fix(dungeon): match Smithy Furnace object parity

### DIFF
--- a/src/zelda3/dungeon/draw_routines/draw_routine_registry.cc
+++ b/src/zelda3/dungeon/draw_routines/draw_routine_registry.cc
@@ -460,7 +460,7 @@ void DrawRoutineRegistry::BuildObjectMapping() {
   object_to_routine_map_[0xFC9] = 110;
   object_to_routine_map_[0xFCA] = 110;
   object_to_routine_map_[0xFCB] = DrawRoutineIds::kBigWallDecor;
-  object_to_routine_map_[0xFCC] = 16;
+  object_to_routine_map_[0xFCC] = DrawRoutineIds::kSmithyFurnace;
   object_to_routine_map_[0xFCD] = 100;
   object_to_routine_map_[0xFCE] = 30;
   for (int id = 0xFCF; id <= 0xFD3; id++) {

--- a/src/zelda3/dungeon/draw_routines/draw_routine_registry.h
+++ b/src/zelda3/dungeon/draw_routines/draw_routine_registry.h
@@ -86,6 +86,7 @@ constexpr int kDownwardsEdge1x1_1to16plus7 = 122;
 constexpr int kFloorLight = 123;
 constexpr int kBigWallDecor = 125;
 constexpr int kTableBowl = 126;
+constexpr int kSmithyFurnace = 127;
 
 // Corner routines (19, 35-37, 75-78)
 constexpr int kCorner4x4 = 19;

--- a/src/zelda3/dungeon/draw_routines/special_routines.cc
+++ b/src/zelda3/dungeon/draw_routines/special_routines.cc
@@ -446,6 +446,15 @@ void DrawTableBowl(const DrawContext& ctx) {
   DrawRowMajor(ctx.target_bg, ctx.object.x_, ctx.object.y_, 4, 2, ctx.tiles);
 }
 
+void DrawSmithyFurnace(const DrawContext& ctx) {
+  // ASM: RoomDraw_SmithyFurnace ($019A66) loads A=6 before jumping to
+  // RoomDraw_SomeBigDecors, which writes six tiles per row for eight rows.
+  if (ctx.tiles.size() < 48)
+    return;
+
+  DrawRowMajor(ctx.target_bg, ctx.object.x_, ctx.object.y_, 6, 8, ctx.tiles);
+}
+
 void DrawUtility3x5(const DrawContext& ctx) {
   // ASM: RoomDraw_Utility3x5 ($01A194) uses:
   // - top row: tiles 0..2
@@ -1944,6 +1953,17 @@ void RegisterSpecialRoutines(std::vector<DrawRoutineInfo>& registry) {
       .base_width = 4,
       .base_height = 2,
       .min_tiles = 8,
+      .category = DrawRoutineInfo::Category::Special,
+  });
+
+  registry.push_back(DrawRoutineInfo{
+      .id = DrawRoutineIds::kSmithyFurnace,  // 127
+      .name = "SmithyFurnace",
+      .function = DrawSmithyFurnace,
+      .draws_to_both_bgs = false,
+      .base_width = 6,
+      .base_height = 8,
+      .min_tiles = 48,
       .category = DrawRoutineInfo::Category::Special,
   });
 

--- a/src/zelda3/dungeon/draw_routines/special_routines.h
+++ b/src/zelda3/dungeon/draw_routines/special_routines.h
@@ -123,6 +123,13 @@ void DrawBigWallDecor(const DrawContext& ctx);
 void DrawTableBowl(const DrawContext& ctx);
 
 /**
+ * @brief Draw the fixed 6x8 smithy furnace in row-major order
+ *
+ * ASM: RoomDraw_SmithyFurnace ($019A66 -> RoomDraw_SomeBigDecors)
+ */
+void DrawSmithyFurnace(const DrawContext& ctx);
+
+/**
  * @brief Draw utility 3x5 pattern (special row pattern)
  *
  * ASM: RoomDraw_Utility3x5 ($01A194)

--- a/src/zelda3/dungeon/object_dimensions.cc
+++ b/src/zelda3/dungeon/object_dimensions.cc
@@ -934,13 +934,14 @@ void ObjectDimensionTable::InitializeDefaults() {
   dimensions_[0xFAA] = {4, 4, Dir::Horizontal, 4, false};
   dimensions_[0xFAD] = {4, 4, Dir::Horizontal, 4, false};
   dimensions_[0xFAE] = {4, 4, Dir::Horizontal, 4, false};
-  dimensions_[0xFCC] = {4, 4, Dir::Horizontal, 4, false};
   dimensions_[0xFD4] = {4, 4, Dir::Horizontal, 4, false};
   dimensions_[0xFE2] = {4, 4, Dir::Horizontal, 4, false};
   // Big wall decor aliases are fixed 8x3 objects; their size nibble is ignored.
   dimensions_[0xFCB] = {8, 3, Dir::None, 0, false};
   dimensions_[0xFF6] = {8, 3, Dir::None, 0, false};
   dimensions_[0xFF7] = {8, 3, Dir::None, 0, false};
+  // Smithy furnace is a fixed 6x8 stamp; its encoded size is ignored.
+  dimensions_[0xFCC] = {6, 8, Dir::None, 0, false};
   // Utility patterns
   dimensions_[0xFCD] = {6, 3, Dir::None, 0, false};
   dimensions_[0xFDD] = {6, 3, Dir::None, 0, false};

--- a/src/zelda3/dungeon/object_drawer.cc
+++ b/src/zelda3/dungeon/object_drawer.cc
@@ -1432,6 +1432,14 @@ void ObjectDrawer::InitializeDrawRoutines() {
                                        tiles, state);
       };
 
+  ensure_index(DrawRoutineIds::kSmithyFurnace);
+  draw_routines_[DrawRoutineIds::kSmithyFurnace] =
+      [](ObjectDrawer* self, const RoomObject& obj, gfx::BackgroundBuffer& bg,
+         std::span<const gfx::TileInfo> tiles, const DungeonState* state) {
+        self->DrawUsingRegistryRoutine(DrawRoutineIds::kSmithyFurnace, obj, bg,
+                                       tiles, state);
+      };
+
   // Routine 130 - Custom Object (Oracle of Secrets 0x31, 0x32)
   // Uses external binary files instead of ROM tile data.
   // Requires CustomObjectManager initialization and enable_custom_objects flag.
@@ -3218,6 +3226,11 @@ std::pair<int, int> yaze::zelda3::ObjectDrawer::CalculateObjectDimensions(
     case DrawRoutineIds::kTableBowl:
       width = 32;
       height = 16;
+      break;
+
+    case DrawRoutineIds::kSmithyFurnace:
+      width = 48;
+      height = 64;
       break;
 
     default:

--- a/src/zelda3/dungeon/object_parser.cc
+++ b/src/zelda3/dungeon/object_parser.cc
@@ -339,6 +339,8 @@ absl::StatusOr<std::vector<gfx::TileInfo>> ObjectParser::ParseSubtype3(
   constexpr int kClosedBigChestTileOffset = 0x14AC;
   constexpr int kOpenBigChestTileOffset = 0x14C4;
   constexpr int kBigChestStateTileCount = 12;
+  constexpr int kSmithyFurnaceTileOffset = 0x1F92;
+  constexpr int kSmithyFurnaceTileCount = 48;
 
   // Type 3 object IDs are 0xF80-0xFFF (128 objects)
   // Table index should be 0-127, calculated by subtracting base offset 0xF80
@@ -430,6 +432,14 @@ absl::StatusOr<std::vector<gfx::TileInfo>> ObjectParser::ParseSubtype3(
     closed_tiles->insert(closed_tiles->end(), open_tiles->begin(),
                          open_tiles->end());
     return closed_tiles;
+  }
+
+  // SmithyFurnace replaces the table-derived data pointer with literal
+  // obj1F92 before drawing. Mirror the runtime source rather than allowing a
+  // relocated FCC table entry to change only the editor's rendering.
+  if (object_id == 0xFCC) {
+    return ReadTileData(kRoomObjectTileAddress + kSmithyFurnaceTileOffset,
+                        kSmithyFurnaceTileCount);
   }
 
   return ReadTileData(tile_data_ptr, tile_count);
@@ -635,10 +645,15 @@ int ObjectParser::GetSubtype3TileCount(int16_t object_id) const {
       (object_id >= 0xFA6 && object_id <= 0xFA9)) {
     return 16;
   }
+  // SmithyFurnace (0xFCC = ASM 0x24C) loads obj1F92 and draws a fixed
+  // 6-column x 8-row block through RoomDraw_SomeBigDecors.
+  if (object_id == 0xFCC) {
+    return 48;
+  }
   // 4x4 single-pattern objects
   if (object_id == 0xFAA || object_id == 0xFAD || object_id == 0xFAE ||
-      (object_id >= 0xFB4 && object_id <= 0xFB9) || object_id == 0xFCC ||
-      object_id == 0xFD4 || object_id == 0xFE2) {
+      (object_id >= 0xFB4 && object_id <= 0xFB9) || object_id == 0xFD4 ||
+      object_id == 0xFE2) {
     return 16;
   }
   // Big wall decor aliases: RoomDraw_BigWallDecor calls

--- a/test/unit/zelda3/dungeon/draw_routine_mapping_test.cc
+++ b/test/unit/zelda3/dungeon/draw_routine_mapping_test.cc
@@ -698,6 +698,7 @@ TEST_F(DrawRoutineMappingTest, VerifiesSubtype3Mappings) {
   for (int object_id : {0xFD6, 0xFD7, 0xFD8, 0xFD9}) {
     EXPECT_EQ(drawer.GetDrawRoutineId(object_id), DrawRoutineIds::kSingle2x2);
   }
+  EXPECT_EQ(drawer.GetDrawRoutineId(0xFCC), DrawRoutineIds::kSmithyFurnace);
   EXPECT_EQ(drawer.GetDrawRoutineId(0xFDA), DrawRoutineIds::kTableBowl);
   EXPECT_EQ(drawer.GetDrawRoutineId(0xFDB), DrawRoutineIds::kUtility3x5);
   EXPECT_EQ(drawer.GetDrawRoutineId(0xFBA),
@@ -747,10 +748,26 @@ TEST_F(DrawRoutineMappingTest, VerifiesSubtype3Mappings) {
   EXPECT_FALSE(table_bowl->draws_to_both_bgs);
   EXPECT_EQ(table_bowl->category, DrawRoutineInfo::Category::Special);
 
+  const DrawRoutineInfo* smithy_furnace =
+      DrawRoutineRegistry::Get().GetRoutineInfo(DrawRoutineIds::kSmithyFurnace);
+  ASSERT_NE(smithy_furnace, nullptr);
+  EXPECT_EQ(smithy_furnace->name, "SmithyFurnace");
+  EXPECT_TRUE(static_cast<bool>(smithy_furnace->function));
+  EXPECT_EQ(smithy_furnace->base_width, 6);
+  EXPECT_EQ(smithy_furnace->base_height, 8);
+  EXPECT_EQ(smithy_furnace->min_tiles, 48);
+  EXPECT_FALSE(smithy_furnace->draws_to_both_bgs);
+  EXPECT_EQ(smithy_furnace->category, DrawRoutineInfo::Category::Special);
+
   const auto& routines = DrawRoutineRegistry::Get().GetAllRoutines();
   EXPECT_EQ(std::count_if(routines.begin(), routines.end(),
                           [](const DrawRoutineInfo& info) {
                             return info.id == DrawRoutineIds::kTableBowl;
+                          }),
+            1);
+  EXPECT_EQ(std::count_if(routines.begin(), routines.end(),
+                          [](const DrawRoutineInfo& info) {
+                            return info.id == DrawRoutineIds::kSmithyFurnace;
                           }),
             1);
 }

--- a/test/unit/zelda3/dungeon/object_dimensions_test.cc
+++ b/test/unit/zelda3/dungeon/object_dimensions_test.cc
@@ -358,6 +358,40 @@ TEST_F(ObjectDimensionTableTest, TableBowlUsesFixedFourByTwoBounds) {
   }
 }
 
+TEST_F(ObjectDimensionTableTest, SmithyFurnaceUsesFixedSixByEightBounds) {
+  auto& table = ObjectDimensionTable::Get();
+  ASSERT_TRUE(table.LoadFromRom(rom_.get()).ok());
+  EXPECT_EQ(table.GetBaseDimensions(0xFCC), std::make_pair(6, 8));
+
+  for (uint8_t size : {uint8_t{0x00}, uint8_t{0x03}, uint8_t{0x0F},
+                       uint8_t{0xF0}, uint8_t{0xFF}}) {
+    SCOPED_TRACE(::testing::Message() << "size=" << static_cast<int>(size));
+
+    const auto [width, height] = table.GetDimensions(0xFCC, size);
+    EXPECT_EQ(width, 6);
+    EXPECT_EQ(height, 8);
+
+    const auto selection = table.GetSelectionBounds(0xFCC, size);
+    EXPECT_EQ(selection.offset_x, 0);
+    EXPECT_EQ(selection.offset_y, 0);
+    EXPECT_EQ(selection.width, 6);
+    EXPECT_EQ(selection.height, 8);
+
+    const RoomObject object(0xFCC, 0, 0, size, 0);
+    const auto geometry = ObjectGeometry::Get().MeasureByObjectId(object);
+    ASSERT_TRUE(geometry.ok());
+    EXPECT_EQ(geometry->min_x_tiles, 0);
+    EXPECT_EQ(geometry->min_y_tiles, 0);
+    EXPECT_EQ(geometry->width_tiles, 6);
+    EXPECT_EQ(geometry->height_tiles, 8);
+
+    const auto [legacy_width, legacy_height] =
+        ObjectDrawer(rom_.get(), 0).CalculateObjectDimensions(object);
+    EXPECT_EQ(legacy_width, 48);
+    EXPECT_EQ(legacy_height, 64);
+  }
+}
+
 TEST_F(ObjectDimensionTableTest,
        BigWallDecorAliasesUseFixedEightByThreeBounds) {
   auto& table = ObjectDimensionTable::Get();

--- a/test/unit/zelda3/dungeon/object_drawer_registry_replay_test.cc
+++ b/test/unit/zelda3/dungeon/object_drawer_registry_replay_test.cc
@@ -2524,6 +2524,37 @@ TEST(ObjectDrawerRegistryReplayTest,
 }
 
 TEST(ObjectDrawerRegistryReplayTest,
+     SmithyFurnaceDrawsFixedSixByEightRowMajorOnSelectedLayer) {
+  ScopedCustomObjectsFlag disable_custom(false);
+
+  constexpr int kX = 10;
+  constexpr int kY = 12;
+  constexpr uint16_t kFirstTile = 0x0200;
+
+  for (uint8_t size : {uint8_t{0}, uint8_t{3}}) {
+    for (const auto layer :
+         {RoomObject::LayerType::BG1, RoomObject::LayerType::BG2}) {
+      SCOPED_TRACE(::testing::Message()
+                   << "size=" << static_cast<int>(size)
+                   << " layer=" << static_cast<int>(layer));
+
+      const auto trace = ReplayObjectTrace(
+          /*object_id=*/0x0FCC, kX, kY, size, layer,
+          MakeSequentialTiles(/*count=*/48, /*start_tile_id=*/kFirstTile));
+      const auto bg1 = FilterTraceByLayer(trace, RoomObject::LayerType::BG1);
+      const auto bg2 = FilterTraceByLayer(trace, RoomObject::LayerType::BG2);
+      const auto& selected = layer == RoomObject::LayerType::BG1 ? bg1 : bg2;
+      const auto& other = layer == RoomObject::LayerType::BG1 ? bg2 : bg1;
+
+      ExpectTraceMatchesSnapshot(
+          selected, MakeRowMajorSnapshot(kX, kY, /*width=*/6, /*height=*/8,
+                                         /*start_tile_id=*/kFirstTile));
+      EXPECT_TRUE(other.empty());
+    }
+  }
+}
+
+TEST(ObjectDrawerRegistryReplayTest,
      BigWallDecorAliasesDrawFixedEightByThreeOnSelectedLayer) {
   ScopedCustomObjectsFlag disable_custom(false);
 

--- a/test/unit/zelda3/dungeon/object_drawing_comprehensive_test.cc
+++ b/test/unit/zelda3/dungeon/object_drawing_comprehensive_test.cc
@@ -139,9 +139,12 @@ int ExpectedSubtype3TileCount(int id) {
   if ((id >= 0xF9E && id <= 0xFA1) || (id >= 0xFA6 && id <= 0xFA9)) {
     return 16;
   }
+  // Smithy furnace is a fixed 6x8 row-major payload.
+  if (id == 0xFCC) {
+    return 48;
+  }
   if (id == 0xFAA || id == 0xFAD || id == 0xFAE ||
-      (id >= 0xFB4 && id <= 0xFB9) || id == 0xFCC || id == 0xFD4 ||
-      id == 0xFE2) {
+      (id >= 0xFB4 && id <= 0xFB9) || id == 0xFD4 || id == 0xFE2) {
     return 16;
   }
   // Big wall decor aliases consume one 8x3 column-major payload.

--- a/test/unit/zelda3/object_parser_test.cc
+++ b/test/unit/zelda3/object_parser_test.cc
@@ -173,42 +173,48 @@ TEST_F(ObjectParserTest, RuntimeLiteralObjectsIgnoreRelocatedTablePointers) {
     }
   };
 
-  // Move all five pointer-table entries. F98/F99/FB1 must ignore their moved
-  // entries because their routines load literal data blocks; F9A/FB2 are
-  // direct-open routines and must continue following their moved pointers.
+  // Move all six pointer-table entries. F98/F99/FB1/FCC must ignore their
+  // moved entries because their routines load literal data blocks; F9A/FB2
+  // are direct-open routines and must continue following their moved pointers.
   constexpr uint16_t kMovedBigKeyLockOffset = 0x0100;
   constexpr uint16_t kMovedChestOffset = 0x0180;
   constexpr uint16_t kMovedOpenChestOffset = 0x0200;
   constexpr uint16_t kMovedBigChestOffset = 0x0280;
   constexpr uint16_t kMovedOpenBigChestOffset = 0x0300;
+  constexpr uint16_t kMovedSmithyFurnaceOffset = 0x0400;
   write_pointer(0xF98, kMovedBigKeyLockOffset);
   write_pointer(0xF99, kMovedChestOffset);
   write_pointer(0xF9A, kMovedOpenChestOffset);
   write_pointer(0xFB1, kMovedBigChestOffset);
   write_pointer(0xFB2, kMovedOpenBigChestOffset);
+  write_pointer(0xFCC, kMovedSmithyFurnaceOffset);
 
   write_words(0x1494, 4, 0x0040);   // BigKeyLock literal
   write_words(0x149C, 4, 0x0080);   // Chest closed literal
   write_words(0x14A4, 4, 0x0100);   // Chest opened literal
   write_words(0x14AC, 12, 0x0200);  // BigChest closed literal
   write_words(0x14C4, 12, 0x0300);  // BigChest opened literal
+  write_words(0x1F92, 48, 0x0280);  // SmithyFurnace literal
 
   write_words(kMovedBigKeyLockOffset, 4, 0x03C0);
   write_words(kMovedChestOffset, 4, 0x03A0);
   write_words(kMovedOpenChestOffset, 4, 0x0180);
   write_words(kMovedBigChestOffset, 12, 0x0360);
   write_words(kMovedOpenBigChestOffset, 12, 0x0140);
+  write_words(kMovedSmithyFurnaceOffset, 48, 0x0340);
 
   auto lock = parser_->ParseObject(0xF98);
   auto chest = parser_->ParseObject(0xF99);
   auto open_chest = parser_->ParseObject(0xF9A);
   auto big_chest = parser_->ParseObject(0xFB1);
   auto open_big_chest = parser_->ParseObject(0xFB2);
+  auto smithy_furnace = parser_->ParseObject(0xFCC);
   ASSERT_TRUE(lock.ok());
   ASSERT_TRUE(chest.ok());
   ASSERT_TRUE(open_chest.ok());
   ASSERT_TRUE(big_chest.ok());
   ASSERT_TRUE(open_big_chest.ok());
+  ASSERT_TRUE(smithy_furnace.ok());
 
   for (int i = 0; i < 4; ++i) {
     EXPECT_TRUE((*lock)[i] ==
@@ -227,6 +233,13 @@ TEST_F(ObjectParserTest, RuntimeLiteralObjectsIgnoreRelocatedTablePointers) {
                 gfx::WordToTileInfo(static_cast<uint16_t>(0x0300 + i)));
     EXPECT_TRUE((*open_big_chest)[i] ==
                 gfx::WordToTileInfo(static_cast<uint16_t>(0x0140 + i)));
+  }
+  ASSERT_EQ(smithy_furnace->size(), 48u);
+  for (int i = 0; i < 48; ++i) {
+    EXPECT_TRUE((*smithy_furnace)[i] ==
+                gfx::WordToTileInfo(static_cast<uint16_t>(0x0280 + i)));
+    EXPECT_FALSE((*smithy_furnace)[i] ==
+                 gfx::WordToTileInfo(static_cast<uint16_t>(0x0340 + i)));
   }
 }
 
@@ -532,6 +545,24 @@ TEST_F(ObjectParserTest, TableBowlUsesEightTilesAndDedicatedRoutine) {
   const auto info = parser_->GetObjectDrawInfo(0xFDA);
   EXPECT_EQ(info.tile_count, 8);
   EXPECT_EQ(info.draw_routine_id, zelda3::DrawRoutineIds::kTableBowl);
+}
+
+TEST_F(ObjectParserTest, SmithyFurnaceUsesFortyEightTilesAndDedicatedRoutine) {
+  auto& registry = zelda3::DrawRoutineRegistry::Get();
+  EXPECT_EQ(registry.GetRoutineIdForObject(0xFCC),
+            zelda3::DrawRoutineIds::kSmithyFurnace);
+
+  const auto subtype = parser_->GetObjectSubtype(0xFCC);
+  ASSERT_TRUE(subtype.ok());
+  EXPECT_EQ(subtype->max_tile_count, 48);
+
+  const auto parsed = parser_->ParseObject(0xFCC);
+  ASSERT_TRUE(parsed.ok());
+  EXPECT_EQ(parsed->size(), 48u);
+
+  const auto info = parser_->GetObjectDrawInfo(0xFCC);
+  EXPECT_EQ(info.tile_count, 48);
+  EXPECT_EQ(info.draw_routine_id, zelda3::DrawRoutineIds::kSmithyFurnace);
 }
 
 TEST_F(ObjectParserTest, HammerPegUsesUsdasmSingle2x2RoutineAndFourTiles) {


### PR DESCRIPTION
## Summary

- map subtype-3 object `0xFCC` to a dedicated Smithy Furnace routine
- mirror the runtime's literal `obj1F92` source and consume all 48 tile words
- draw the fixed 6x8 payload row-major on the selected background layer
- align registry metadata, parser counts, canonical bounds, and legacy 48x64 pixel dimensions
- add literal-pointer, mapping, dimension, comprehensive, and BG1/BG2 replay coverage

## Why

`0xFCC` currently inherits a scalable 4x4 rightward routine and a 16-tile parser count. The original `RoomDraw_SmithyFurnace` code instead hard-loads `obj1F92`, sets six columns, and draws eight rows. The mismatch turns the Furnace into repeated 4x4 blocks with the wrong footprint and tile source.

## Impact

The editor now previews the complete fixed Smithy Furnace used by Oracle of Secrets room `0x121`, while adjacent subtype-3 mappings remain unchanged.

## Verification

- focused Furnace mapping/parser/dimension/comprehensive/BG replay tests: **6/6 passed**
- adjacent TableBowl regression tests from #164: **3/3 passed**
- `scripts/pre-push.sh --build-dir build/presets/mac-ai` with the focused six-test smoke filter: passed
- `clang-format --dry-run --Werror` on all 12 changed C++ files: passed
- `git diff --check`: passed
- independent strict review against USDASM: no findings

## Integration

- #164 merged into `master` as `3565f69c72513dc064236043d014f8617c83f394`
- this PR is now retargeted directly to `master`
- the PR was reopened after retargeting to trigger the complete master-targeted exact-head CI gate

## Residual risk

No manual GUI or emulator-side room render was run for this backend slice. The direct draw routine guards malformed payloads shorter than 48 tiles, but that guard does not have a dedicated malformed-input test.
