### PR TITLE
fix(dungeon): match BigGrayRock object parity

### DIFF
--- a/src/zelda3/dungeon/draw_routines/draw_routine_registry.cc
+++ b/src/zelda3/dungeon/draw_routines/draw_routine_registry.cc
@@ -437,7 +437,7 @@ void DrawRoutineRegistry::BuildObjectMapping() {
   }
   object_to_routine_map_[0xFAA] = 16;
   object_to_routine_map_[0xFAB] = 110;
-  object_to_routine_map_[0xFAC] = 110;
+  object_to_routine_map_[0xFAC] = DrawRoutineIds::kBigGrayRock;
   object_to_routine_map_[0xFAD] = 16;
   object_to_routine_map_[0xFAE] = 16;
   object_to_routine_map_[0xFAF] = 110;

--- a/src/zelda3/dungeon/draw_routines/draw_routine_registry.h
+++ b/src/zelda3/dungeon/draw_routines/draw_routine_registry.h
@@ -87,6 +87,7 @@ constexpr int kFloorLight = 123;
 constexpr int kBigWallDecor = 125;
 constexpr int kTableBowl = 126;
 constexpr int kSmithyFurnace = 127;
+constexpr int kBigGrayRock = 128;
 
 // Corner routines (19, 35-37, 75-78)
 constexpr int kCorner4x4 = 19;

--- a/src/zelda3/dungeon/draw_routines/special_routines.cc
+++ b/src/zelda3/dungeon/draw_routines/special_routines.cc
@@ -455,6 +455,24 @@ void DrawSmithyFurnace(const DrawContext& ctx) {
   DrawRowMajor(ctx.target_bg, ctx.object.x_, ctx.object.y_, 6, 8, ctx.tiles);
 }
 
+void DrawBigGrayRock(const DrawContext& ctx) {
+  // ASM: RoomDraw_BigGrayRock ($01B310) draws four 2x2 quadrants through
+  // RoomDraw_Rightwards2x2. Visually that is two 4x2 column-major bands:
+  //   0  2  4  6
+  //   1  3  5  7
+  //   8 10 12 14
+  //   9 11 13 15
+  // The liftable-rock bookkeeping in DrawBigGraySegment is runtime-only and
+  // intentionally not modeled by this visual draw routine.
+  if (ctx.tiles.size() < 16)
+    return;
+
+  DrawColumnMajor(ctx.target_bg, ctx.object.x_, ctx.object.y_, 4, 2, ctx.tiles,
+                  /*start_index=*/0);
+  DrawColumnMajor(ctx.target_bg, ctx.object.x_, ctx.object.y_ + 2, 4, 2,
+                  ctx.tiles, /*start_index=*/8);
+}
+
 void DrawUtility3x5(const DrawContext& ctx) {
   // ASM: RoomDraw_Utility3x5 ($01A194) uses:
   // - top row: tiles 0..2
@@ -1964,6 +1982,17 @@ void RegisterSpecialRoutines(std::vector<DrawRoutineInfo>& registry) {
       .base_width = 6,
       .base_height = 8,
       .min_tiles = 48,
+      .category = DrawRoutineInfo::Category::Special,
+  });
+
+  registry.push_back(DrawRoutineInfo{
+      .id = DrawRoutineIds::kBigGrayRock,  // 128
+      .name = "BigGrayRock",
+      .function = DrawBigGrayRock,
+      .draws_to_both_bgs = false,
+      .base_width = 4,
+      .base_height = 4,
+      .min_tiles = 16,
       .category = DrawRoutineInfo::Category::Special,
   });
 

--- a/src/zelda3/dungeon/draw_routines/special_routines.h
+++ b/src/zelda3/dungeon/draw_routines/special_routines.h
@@ -130,6 +130,13 @@ void DrawTableBowl(const DrawContext& ctx);
 void DrawSmithyFurnace(const DrawContext& ctx);
 
 /**
+ * @brief Draw the fixed 4x4 big gray rock as two column-major 4x2 bands
+ *
+ * ASM: RoomDraw_BigGrayRock ($01B310 -> DrawBigGraySegment)
+ */
+void DrawBigGrayRock(const DrawContext& ctx);
+
+/**
  * @brief Draw utility 3x5 pattern (special row pattern)
  *
  * ASM: RoomDraw_Utility3x5 ($01A194)

--- a/src/zelda3/dungeon/object_dimensions.cc
+++ b/src/zelda3/dungeon/object_dimensions.cc
@@ -927,6 +927,8 @@ void ObjectDimensionTable::InitializeDefaults() {
     dimensions_[id] = {4, 4, Dir::None, 0, false};
   }
   dimensions_[0xFB3] = {4, 4, Dir::None, 0, false};
+  // Big gray rock is a fixed 4x4 stamp; its encoded size is ignored.
+  dimensions_[0xFAC] = {4, 4, Dir::None, 0, false};
   // Repeatable 4x4 patterns
   for (int id = 0xFB4; id <= 0xFB9; id++) {
     dimensions_[id] = {4, 4, Dir::Horizontal, 4, false};

--- a/src/zelda3/dungeon/object_drawer.cc
+++ b/src/zelda3/dungeon/object_drawer.cc
@@ -1440,6 +1440,14 @@ void ObjectDrawer::InitializeDrawRoutines() {
                                        tiles, state);
       };
 
+  ensure_index(DrawRoutineIds::kBigGrayRock);
+  draw_routines_[DrawRoutineIds::kBigGrayRock] =
+      [](ObjectDrawer* self, const RoomObject& obj, gfx::BackgroundBuffer& bg,
+         std::span<const gfx::TileInfo> tiles, const DungeonState* state) {
+        self->DrawUsingRegistryRoutine(DrawRoutineIds::kBigGrayRock, obj, bg,
+                                       tiles, state);
+      };
+
   // Routine 130 - Custom Object (Oracle of Secrets 0x31, 0x32)
   // Uses external binary files instead of ROM tile data.
   // Requires CustomObjectManager initialization and enable_custom_objects flag.
@@ -3231,6 +3239,11 @@ std::pair<int, int> yaze::zelda3::ObjectDrawer::CalculateObjectDimensions(
     case DrawRoutineIds::kSmithyFurnace:
       width = 48;
       height = 64;
+      break;
+
+    case DrawRoutineIds::kBigGrayRock:
+      width = 32;
+      height = 32;
       break;
 
     default:

--- a/src/zelda3/dungeon/object_parser.cc
+++ b/src/zelda3/dungeon/object_parser.cc
@@ -339,6 +339,8 @@ absl::StatusOr<std::vector<gfx::TileInfo>> ObjectParser::ParseSubtype3(
   constexpr int kClosedBigChestTileOffset = 0x14AC;
   constexpr int kOpenBigChestTileOffset = 0x14C4;
   constexpr int kBigChestStateTileCount = 12;
+  constexpr int kBigGrayRockTileOffset = 0x0E62;
+  constexpr int kBigGrayRockTileCount = 16;
   constexpr int kSmithyFurnaceTileOffset = 0x1F92;
   constexpr int kSmithyFurnaceTileCount = 48;
 
@@ -432,6 +434,14 @@ absl::StatusOr<std::vector<gfx::TileInfo>> ObjectParser::ParseSubtype3(
     closed_tiles->insert(closed_tiles->end(), open_tiles->begin(),
                          open_tiles->end());
     return closed_tiles;
+  }
+
+  // BigGrayRock replaces the table-derived data pointer with literal obj0E62,
+  // then draws its four contiguous 2x2 quadrants. Follow the runtime literal
+  // so a relocated FAC table entry cannot change only the editor rendering.
+  if (object_id == 0xFAC) {
+    return ReadTileData(kRoomObjectTileAddress + kBigGrayRockTileOffset,
+                        kBigGrayRockTileCount);
   }
 
   // SmithyFurnace replaces the table-derived data pointer with literal
@@ -643,6 +653,11 @@ int ObjectParser::GetSubtype3TileCount(int16_t object_id) const {
   // Straight inter-room stairs (4x4)
   if ((object_id >= 0xF9E && object_id <= 0xFA1) ||
       (object_id >= 0xFA6 && object_id <= 0xFA9)) {
+    return 16;
+  }
+  // BigGrayRock (0xFAC = ASM 0x22C) loads obj0E62 and draws four fixed
+  // 2x2 quadrants, consuming 16 contiguous tile words.
+  if (object_id == 0xFAC) {
     return 16;
   }
   // SmithyFurnace (0xFCC = ASM 0x24C) loads obj1F92 and draws a fixed

--- a/test/unit/zelda3/dungeon/draw_routine_mapping_test.cc
+++ b/test/unit/zelda3/dungeon/draw_routine_mapping_test.cc
@@ -693,6 +693,9 @@ TEST_F(DrawRoutineMappingTest, VerifiesSubtype3Mappings) {
   EXPECT_EQ(drawer.GetDrawRoutineId(0xF90), DrawRoutineIds::kSingle2x2);
   EXPECT_EQ(drawer.GetDrawRoutineId(0xF92), DrawRoutineIds::kRupeeFloor);
   EXPECT_EQ(drawer.GetDrawRoutineId(0xF96), DrawRoutineIds::kSingle2x2);
+  EXPECT_EQ(drawer.GetDrawRoutineId(0xFAB), DrawRoutineIds::kSingle2x2);
+  EXPECT_EQ(drawer.GetDrawRoutineId(0xFAC), DrawRoutineIds::kBigGrayRock);
+  EXPECT_EQ(drawer.GetDrawRoutineId(0xFAD), 16);
   EXPECT_EQ(drawer.GetDrawRoutineId(0xFB1), DrawRoutineIds::kSingle4x3);
   EXPECT_EQ(drawer.GetDrawRoutineId(0xFD5), DrawRoutineIds::kUtility3x5);
   for (int object_id : {0xFD6, 0xFD7, 0xFD8, 0xFD9}) {
@@ -759,6 +762,17 @@ TEST_F(DrawRoutineMappingTest, VerifiesSubtype3Mappings) {
   EXPECT_FALSE(smithy_furnace->draws_to_both_bgs);
   EXPECT_EQ(smithy_furnace->category, DrawRoutineInfo::Category::Special);
 
+  const DrawRoutineInfo* big_gray_rock =
+      DrawRoutineRegistry::Get().GetRoutineInfo(DrawRoutineIds::kBigGrayRock);
+  ASSERT_NE(big_gray_rock, nullptr);
+  EXPECT_EQ(big_gray_rock->name, "BigGrayRock");
+  EXPECT_TRUE(static_cast<bool>(big_gray_rock->function));
+  EXPECT_EQ(big_gray_rock->base_width, 4);
+  EXPECT_EQ(big_gray_rock->base_height, 4);
+  EXPECT_EQ(big_gray_rock->min_tiles, 16);
+  EXPECT_FALSE(big_gray_rock->draws_to_both_bgs);
+  EXPECT_EQ(big_gray_rock->category, DrawRoutineInfo::Category::Special);
+
   const auto& routines = DrawRoutineRegistry::Get().GetAllRoutines();
   EXPECT_EQ(std::count_if(routines.begin(), routines.end(),
                           [](const DrawRoutineInfo& info) {
@@ -768,6 +782,11 @@ TEST_F(DrawRoutineMappingTest, VerifiesSubtype3Mappings) {
   EXPECT_EQ(std::count_if(routines.begin(), routines.end(),
                           [](const DrawRoutineInfo& info) {
                             return info.id == DrawRoutineIds::kSmithyFurnace;
+                          }),
+            1);
+  EXPECT_EQ(std::count_if(routines.begin(), routines.end(),
+                          [](const DrawRoutineInfo& info) {
+                            return info.id == DrawRoutineIds::kBigGrayRock;
                           }),
             1);
 }

--- a/test/unit/zelda3/dungeon/object_dimensions_test.cc
+++ b/test/unit/zelda3/dungeon/object_dimensions_test.cc
@@ -72,9 +72,9 @@ TEST(DrawRoutineRegistryTest, Subtype3SpecialMappingsHaveRegisteredRoutines) {
   auto& reg = DrawRoutineRegistry::Get();
 
   for (int16_t object_id :
-       {0x0122, 0x012C, 0x013E, 0x0F90, 0x0F92, 0x0FB1, 0x0FD5, 0x0FBA, 0x0FBC,
-        0x0FE0, 0x0FE6, 0x0FE9, 0x0FEB, 0x0FF0, 0x0FF1, 0x0FF2, 0x0FF8, 0x0047,
-        0x0048}) {
+       {0x0122, 0x012C, 0x013E, 0x0F90, 0x0F92, 0x0FB1, 0x0FD5,
+        0x0FBA, 0x0FBC, 0x0FAC, 0x0FE0, 0x0FE6, 0x0FE9, 0x0FEB,
+        0x0FF0, 0x0FF1, 0x0FF2, 0x0FF8, 0x0047, 0x0048}) {
     int routine_id = reg.GetRoutineIdForObject(object_id);
     ASSERT_GE(routine_id, 0) << "Object 0x" << std::hex << object_id;
     EXPECT_NE(reg.GetRoutineInfo(routine_id), nullptr)
@@ -389,6 +389,40 @@ TEST_F(ObjectDimensionTableTest, SmithyFurnaceUsesFixedSixByEightBounds) {
         ObjectDrawer(rom_.get(), 0).CalculateObjectDimensions(object);
     EXPECT_EQ(legacy_width, 48);
     EXPECT_EQ(legacy_height, 64);
+  }
+}
+
+TEST_F(ObjectDimensionTableTest, BigGrayRockUsesFixedFourByFourBounds) {
+  auto& table = ObjectDimensionTable::Get();
+  ASSERT_TRUE(table.LoadFromRom(rom_.get()).ok());
+  EXPECT_EQ(table.GetBaseDimensions(0xFAC), std::make_pair(4, 4));
+
+  for (uint8_t size : {uint8_t{0x00}, uint8_t{0x03}, uint8_t{0x0F},
+                       uint8_t{0xF0}, uint8_t{0xFF}}) {
+    SCOPED_TRACE(::testing::Message() << "size=" << static_cast<int>(size));
+
+    const auto [width, height] = table.GetDimensions(0xFAC, size);
+    EXPECT_EQ(width, 4);
+    EXPECT_EQ(height, 4);
+
+    const auto selection = table.GetSelectionBounds(0xFAC, size);
+    EXPECT_EQ(selection.offset_x, 0);
+    EXPECT_EQ(selection.offset_y, 0);
+    EXPECT_EQ(selection.width, 4);
+    EXPECT_EQ(selection.height, 4);
+
+    const RoomObject object(0xFAC, 0, 0, size, 0);
+    const auto geometry = ObjectGeometry::Get().MeasureByObjectId(object);
+    ASSERT_TRUE(geometry.ok());
+    EXPECT_EQ(geometry->min_x_tiles, 0);
+    EXPECT_EQ(geometry->min_y_tiles, 0);
+    EXPECT_EQ(geometry->width_tiles, 4);
+    EXPECT_EQ(geometry->height_tiles, 4);
+
+    const auto [legacy_width, legacy_height] =
+        ObjectDrawer(rom_.get(), 0).CalculateObjectDimensions(object);
+    EXPECT_EQ(legacy_width, 32);
+    EXPECT_EQ(legacy_height, 32);
   }
 }
 

--- a/test/unit/zelda3/dungeon/object_drawer_registry_replay_test.cc
+++ b/test/unit/zelda3/dungeon/object_drawer_registry_replay_test.cc
@@ -176,6 +176,41 @@ std::vector<SnapshotTileWrite> MakeRowMajorSnapshot(int x, int y, int width,
   return out;
 }
 
+std::vector<SnapshotTileWrite> MakeBigGrayRockSnapshot(int x, int y,
+                                                       uint16_t start_tile_id) {
+  // USDASM draws four 2x2 quadrants, producing this coordinate layout:
+  //   0  2  4  6
+  //   1  3  5  7
+  //   8 10 12 14
+  //   9 11 13 15
+  constexpr std::array<std::pair<int, int>, 16> kOffsets = {{
+      {0, 0},
+      {0, 1},
+      {1, 0},
+      {1, 1},
+      {2, 0},
+      {2, 1},
+      {3, 0},
+      {3, 1},
+      {0, 2},
+      {0, 3},
+      {1, 2},
+      {1, 3},
+      {2, 2},
+      {2, 3},
+      {3, 2},
+      {3, 3},
+  }};
+
+  std::vector<SnapshotTileWrite> out;
+  out.reserve(kOffsets.size());
+  for (size_t i = 0; i < kOffsets.size(); ++i) {
+    out.push_back({x + kOffsets[i].first, y + kOffsets[i].second,
+                   static_cast<uint16_t>(start_tile_id + i)});
+  }
+  return out;
+}
+
 void ExpectTraceMatchesSnapshot(
     const std::vector<ObjectDrawer::TileTrace>& trace,
     const std::vector<SnapshotTileWrite>& expected) {
@@ -2549,6 +2584,36 @@ TEST(ObjectDrawerRegistryReplayTest,
       ExpectTraceMatchesSnapshot(
           selected, MakeRowMajorSnapshot(kX, kY, /*width=*/6, /*height=*/8,
                                          /*start_tile_id=*/kFirstTile));
+      EXPECT_TRUE(other.empty());
+    }
+  }
+}
+
+TEST(ObjectDrawerRegistryReplayTest,
+     BigGrayRockDrawsFixedFourByFourQuadrantsOnSelectedLayer) {
+  ScopedCustomObjectsFlag disable_custom(false);
+
+  constexpr int kX = 10;
+  constexpr int kY = 12;
+  constexpr uint16_t kFirstTile = 0x0200;
+
+  for (uint8_t size : {uint8_t{0}, uint8_t{3}}) {
+    for (const auto layer :
+         {RoomObject::LayerType::BG1, RoomObject::LayerType::BG2}) {
+      SCOPED_TRACE(::testing::Message()
+                   << "size=" << static_cast<int>(size)
+                   << " layer=" << static_cast<int>(layer));
+
+      const auto trace = ReplayObjectTrace(
+          /*object_id=*/0x0FAC, kX, kY, size, layer,
+          MakeSequentialTiles(/*count=*/16, /*start_tile_id=*/kFirstTile));
+      const auto bg1 = FilterTraceByLayer(trace, RoomObject::LayerType::BG1);
+      const auto bg2 = FilterTraceByLayer(trace, RoomObject::LayerType::BG2);
+      const auto& selected = layer == RoomObject::LayerType::BG1 ? bg1 : bg2;
+      const auto& other = layer == RoomObject::LayerType::BG1 ? bg2 : bg1;
+
+      ExpectTraceMatchesSnapshot(selected,
+                                 MakeBigGrayRockSnapshot(kX, kY, kFirstTile));
       EXPECT_TRUE(other.empty());
     }
   }

--- a/test/unit/zelda3/dungeon/object_drawing_comprehensive_test.cc
+++ b/test/unit/zelda3/dungeon/object_drawing_comprehensive_test.cc
@@ -139,6 +139,10 @@ int ExpectedSubtype3TileCount(int id) {
   if ((id >= 0xF9E && id <= 0xFA1) || (id >= 0xFA6 && id <= 0xFA9)) {
     return 16;
   }
+  // Big gray rock is four fixed 2x2 quadrants.
+  if (id == 0xFAC) {
+    return 16;
+  }
   // Smithy furnace is a fixed 6x8 row-major payload.
   if (id == 0xFCC) {
     return 48;

--- a/test/unit/zelda3/object_parser_test.cc
+++ b/test/unit/zelda3/object_parser_test.cc
@@ -173,21 +173,24 @@ TEST_F(ObjectParserTest, RuntimeLiteralObjectsIgnoreRelocatedTablePointers) {
     }
   };
 
-  // Move all six pointer-table entries. F98/F99/FB1/FCC must ignore their
-  // moved entries because their routines load literal data blocks; F9A/FB2
-  // are direct-open routines and must continue following their moved pointers.
+  // Move all seven pointer-table entries. F98/F99/FB1/FAC/FCC must ignore
+  // their moved entries because their routines load literal data blocks;
+  // F9A/FB2 are direct-open routines and must continue following their moved
+  // pointers.
   constexpr uint16_t kMovedBigKeyLockOffset = 0x0100;
   constexpr uint16_t kMovedChestOffset = 0x0180;
   constexpr uint16_t kMovedOpenChestOffset = 0x0200;
   constexpr uint16_t kMovedBigChestOffset = 0x0280;
   constexpr uint16_t kMovedOpenBigChestOffset = 0x0300;
   constexpr uint16_t kMovedSmithyFurnaceOffset = 0x0400;
+  constexpr uint16_t kMovedBigGrayRockOffset = 0x0480;
   write_pointer(0xF98, kMovedBigKeyLockOffset);
   write_pointer(0xF99, kMovedChestOffset);
   write_pointer(0xF9A, kMovedOpenChestOffset);
   write_pointer(0xFB1, kMovedBigChestOffset);
   write_pointer(0xFB2, kMovedOpenBigChestOffset);
   write_pointer(0xFCC, kMovedSmithyFurnaceOffset);
+  write_pointer(0xFAC, kMovedBigGrayRockOffset);
 
   write_words(0x1494, 4, 0x0040);   // BigKeyLock literal
   write_words(0x149C, 4, 0x0080);   // Chest closed literal
@@ -195,6 +198,7 @@ TEST_F(ObjectParserTest, RuntimeLiteralObjectsIgnoreRelocatedTablePointers) {
   write_words(0x14AC, 12, 0x0200);  // BigChest closed literal
   write_words(0x14C4, 12, 0x0300);  // BigChest opened literal
   write_words(0x1F92, 48, 0x0280);  // SmithyFurnace literal
+  write_words(0x0E62, 16, 0x0440);  // BigGrayRock literal
 
   write_words(kMovedBigKeyLockOffset, 4, 0x03C0);
   write_words(kMovedChestOffset, 4, 0x03A0);
@@ -202,6 +206,7 @@ TEST_F(ObjectParserTest, RuntimeLiteralObjectsIgnoreRelocatedTablePointers) {
   write_words(kMovedBigChestOffset, 12, 0x0360);
   write_words(kMovedOpenBigChestOffset, 12, 0x0140);
   write_words(kMovedSmithyFurnaceOffset, 48, 0x0340);
+  write_words(kMovedBigGrayRockOffset, 16, 0x0640);
 
   auto lock = parser_->ParseObject(0xF98);
   auto chest = parser_->ParseObject(0xF99);
@@ -209,12 +214,14 @@ TEST_F(ObjectParserTest, RuntimeLiteralObjectsIgnoreRelocatedTablePointers) {
   auto big_chest = parser_->ParseObject(0xFB1);
   auto open_big_chest = parser_->ParseObject(0xFB2);
   auto smithy_furnace = parser_->ParseObject(0xFCC);
+  auto big_gray_rock = parser_->ParseObject(0xFAC);
   ASSERT_TRUE(lock.ok());
   ASSERT_TRUE(chest.ok());
   ASSERT_TRUE(open_chest.ok());
   ASSERT_TRUE(big_chest.ok());
   ASSERT_TRUE(open_big_chest.ok());
   ASSERT_TRUE(smithy_furnace.ok());
+  ASSERT_TRUE(big_gray_rock.ok());
 
   for (int i = 0; i < 4; ++i) {
     EXPECT_TRUE((*lock)[i] ==
@@ -240,6 +247,13 @@ TEST_F(ObjectParserTest, RuntimeLiteralObjectsIgnoreRelocatedTablePointers) {
                 gfx::WordToTileInfo(static_cast<uint16_t>(0x0280 + i)));
     EXPECT_FALSE((*smithy_furnace)[i] ==
                  gfx::WordToTileInfo(static_cast<uint16_t>(0x0340 + i)));
+  }
+  ASSERT_EQ(big_gray_rock->size(), 16u);
+  for (int i = 0; i < 16; ++i) {
+    EXPECT_TRUE((*big_gray_rock)[i] ==
+                gfx::WordToTileInfo(static_cast<uint16_t>(0x0440 + i)));
+    EXPECT_FALSE((*big_gray_rock)[i] ==
+                 gfx::WordToTileInfo(static_cast<uint16_t>(0x0640 + i)));
   }
 }
 
@@ -565,6 +579,24 @@ TEST_F(ObjectParserTest, SmithyFurnaceUsesFortyEightTilesAndDedicatedRoutine) {
   EXPECT_EQ(info.draw_routine_id, zelda3::DrawRoutineIds::kSmithyFurnace);
 }
 
+TEST_F(ObjectParserTest, BigGrayRockUsesSixteenTilesAndDedicatedRoutine) {
+  auto& registry = zelda3::DrawRoutineRegistry::Get();
+  EXPECT_EQ(registry.GetRoutineIdForObject(0xFAC),
+            zelda3::DrawRoutineIds::kBigGrayRock);
+
+  const auto subtype = parser_->GetObjectSubtype(0xFAC);
+  ASSERT_TRUE(subtype.ok());
+  EXPECT_EQ(subtype->max_tile_count, 16);
+
+  const auto parsed = parser_->ParseObject(0xFAC);
+  ASSERT_TRUE(parsed.ok());
+  EXPECT_EQ(parsed->size(), 16u);
+
+  const auto info = parser_->GetObjectDrawInfo(0xFAC);
+  EXPECT_EQ(info.tile_count, 16);
+  EXPECT_EQ(info.draw_routine_id, zelda3::DrawRoutineIds::kBigGrayRock);
+}
+
 TEST_F(ObjectParserTest, HammerPegUsesUsdasmSingle2x2RoutineAndFourTiles) {
   auto& registry = zelda3::DrawRoutineRegistry::Get();
   EXPECT_EQ(registry.GetRoutineIdForObject(0xF96),
@@ -699,8 +731,8 @@ TEST_F(ObjectParserTest, OverFetchClusterIdsRouteToAuditedRoutines) {
   // Cluster scoped to IDs explicitly mapped in the registry; the
   // initial audit listed a broader set, but registry diff showed the
   // others fall through to a different default routine.
-  for (int id : {0xF90, 0xF91, 0xF93, 0xFAB, 0xFAC, 0xFAF, 0xFB0, 0xFC9, 0xFCA,
-                 0xFDE, 0xFDF, 0xFF5}) {
+  for (int id : {0xF90, 0xF91, 0xF93, 0xFAB, 0xFAF, 0xFB0, 0xFC9, 0xFCA, 0xFDE,
+                 0xFDF, 0xFF5}) {
     SCOPED_TRACE(::testing::Message()
                  << "id=0x" << std::hex << id << " expects routine 110");
     EXPECT_EQ(registry.GetRoutineIdForObject(id), 110);


### PR DESCRIPTION
## Summary

- map subtype-3 object `0xFAC` to a dedicated BigGrayRock routine
- mirror the runtime's literal `obj0E62` source and consume all 16 tile words
- draw the fixed four-quadrant 4x4 layout on the selected background layer
- align registry metadata, parser counts, canonical bounds, and legacy 32x32 pixel dimensions
- remove `0xFAC` from the generic 2x2 over-fetch cluster and add mapping, pointer, geometry, and BG replay coverage

## Why

`0xFAC` currently inherits the generic `Single2x2` path and an eight-tile parser count. The original `RoomDraw_BigGrayRock` routine instead hard-loads four contiguous 2x2 quadrants from `obj0E62`, producing this fixed layout:

```text
 0  2  4  6
 1  3  5  7
 8 10 12 14
 9 11 13 15
```

The mismatch truncates the rock to a 2x2 fragment and gives it incorrect selection bounds.

## Impact

The canonical Oracle of Secrets development ROM contains five `0xFAC` instances (`0x023`, `0x041`, `0x0A1`, `0x0F8`, and `0x117`). They now preview as complete fixed 4x4 rocks instead of truncated fragments.

## Verification

- focused BigGrayRock mapping/parser/dimension/comprehensive/BG replay tests: **8/8 passed**
- `scripts/pre-push.sh --build-dir build/presets/mac-ai` with the focused eight-test filter: passed
- `clang-format --dry-run --Werror` on all 12 changed C++ files: passed
- `git diff --check`: passed
- independent strict review against USDASM: no findings
- read-only scan of all 296 rooms in canonical `oos168.sfc` (SHA-256 `d289b2408c3ccc312abeadf274f04f475106034fcab8ebff3f307fd229db4799`): five matching placements

## Integration

- #165 merged into `master` as `cdbc18f98b631cf2eeebcb9f44d54ba527f7bc5f`
- this PR is now retargeted directly to `master`
- the PR was reopened after retargeting to trigger the complete master-targeted exact-head CI gate

## Residual risk

No manual GUI or emulator-side room render was run. This visual/editor slice intentionally does not model the SNES routine's liftable-rock bookkeeping; that belongs to a future interactive gameplay-simulation layer.


### Downstream Oracle merge gate (2026-07-27)

- built `z3ed` and `yaze_test_unit` from synthetic merge ref `3c59f60e3d68ddb66791ad78bd9407f048976001` (`master` `cdbc18f9` + exact head `01d9ac91`)
- combined palette/TableBowl/SmithyFurnace/BigGrayRock focused slice: **26/26 passed**
- read-only `dungeon-object-validate` on the canonical OoS ROM: `0xFDA` 8 tiles / 4x2, `0xFCC` 48 tiles / 6x8, `0xFAC` 16 tiles / 4x4; all three reported zero mismatches and zero empty traces
- exact-ROM placement scan: `0xFDA` 24 placements in 16 rooms, `0xFCC` 1 placement, `0xFAC` 5 placements
- ROM SHA-256 remained `d289b2408c3ccc312abeadf274f04f475106034fcab8ebff3f307fd229db4799` before and after validation
