### PR TITLE
fix(dungeon): match Agahnim altar object parity

### DIFF
--- a/src/zelda3/dungeon/draw_routines/draw_routine_registry.cc
+++ b/src/zelda3/dungeon/draw_routines/draw_routine_registry.cc
@@ -438,7 +438,7 @@ void DrawRoutineRegistry::BuildObjectMapping() {
   object_to_routine_map_[0xFAA] = 16;
   object_to_routine_map_[0xFAB] = 110;
   object_to_routine_map_[0xFAC] = DrawRoutineIds::kBigGrayRock;
-  object_to_routine_map_[0xFAD] = 16;
+  object_to_routine_map_[0xFAD] = DrawRoutineIds::kAgahnimsAltar;
   object_to_routine_map_[0xFAE] = 16;
   object_to_routine_map_[0xFAF] = 110;
   object_to_routine_map_[0xFB0] = 110;

--- a/src/zelda3/dungeon/draw_routines/draw_routine_registry.h
+++ b/src/zelda3/dungeon/draw_routines/draw_routine_registry.h
@@ -88,6 +88,7 @@ constexpr int kBigWallDecor = 125;
 constexpr int kTableBowl = 126;
 constexpr int kSmithyFurnace = 127;
 constexpr int kBigGrayRock = 128;
+constexpr int kAgahnimsAltar = 129;
 
 // Corner routines (19, 35-37, 75-78)
 constexpr int kCorner4x4 = 19;

--- a/src/zelda3/dungeon/draw_routines/special_routines.cc
+++ b/src/zelda3/dungeon/draw_routines/special_routines.cc
@@ -473,6 +473,31 @@ void DrawBigGrayRock(const DrawContext& ctx) {
                   ctx.tiles, /*start_index=*/8);
 }
 
+void DrawAgahnimsAltar(const DrawContext& ctx) {
+  // ASM: RoomDraw_AgahnimsAltar ($019E30) reads six 14-tile columns from
+  // obj1B4A, duplicates the second column, then mirrors the source columns
+  // across a 14x14 destination. Columns 7..12 toggle the source H-flip with
+  // EOR #$4000; column 13 forces it with ORA #$4000.
+  if (ctx.tiles.size() < 84)
+    return;
+
+  constexpr std::array<int, 14> kSourceColumns = {
+      0, 1, 1, 2, 3, 4, 5, 5, 4, 3, 2, 1, 1, 0,
+  };
+  for (int y = 0; y < 14; ++y) {
+    for (int x = 0; x < 14; ++x) {
+      gfx::TileInfo tile = ctx.tiles[kSourceColumns[x] * 14 + y];
+      if (x >= 7 && x <= 12) {
+        tile.horizontal_mirror_ = !tile.horizontal_mirror_;
+      } else if (x == 13) {
+        tile.horizontal_mirror_ = true;
+      }
+      DrawRoutineUtils::WriteTile8(ctx.target_bg, ctx.object.x_ + x,
+                                   ctx.object.y_ + y, tile);
+    }
+  }
+}
+
 void DrawUtility3x5(const DrawContext& ctx) {
   // ASM: RoomDraw_Utility3x5 ($01A194) uses:
   // - top row: tiles 0..2
@@ -1993,6 +2018,17 @@ void RegisterSpecialRoutines(std::vector<DrawRoutineInfo>& registry) {
       .base_width = 4,
       .base_height = 4,
       .min_tiles = 16,
+      .category = DrawRoutineInfo::Category::Special,
+  });
+
+  registry.push_back(DrawRoutineInfo{
+      .id = DrawRoutineIds::kAgahnimsAltar,  // 129
+      .name = "AgahnimsAltar",
+      .function = DrawAgahnimsAltar,
+      .draws_to_both_bgs = false,
+      .base_width = 14,
+      .base_height = 14,
+      .min_tiles = 84,
       .category = DrawRoutineInfo::Category::Special,
   });
 

--- a/src/zelda3/dungeon/draw_routines/special_routines.h
+++ b/src/zelda3/dungeon/draw_routines/special_routines.h
@@ -137,6 +137,13 @@ void DrawSmithyFurnace(const DrawContext& ctx);
 void DrawBigGrayRock(const DrawContext& ctx);
 
 /**
+ * @brief Draw the fixed 14x14 Agahnim altar with mirrored right half
+ *
+ * ASM: RoomDraw_AgahnimsAltar ($019E30)
+ */
+void DrawAgahnimsAltar(const DrawContext& ctx);
+
+/**
  * @brief Draw utility 3x5 pattern (special row pattern)
  *
  * ASM: RoomDraw_Utility3x5 ($01A194)

--- a/src/zelda3/dungeon/object_dimensions.cc
+++ b/src/zelda3/dungeon/object_dimensions.cc
@@ -929,12 +929,13 @@ void ObjectDimensionTable::InitializeDefaults() {
   dimensions_[0xFB3] = {4, 4, Dir::None, 0, false};
   // Big gray rock is a fixed 4x4 stamp; its encoded size is ignored.
   dimensions_[0xFAC] = {4, 4, Dir::None, 0, false};
+  // Agahnim's altar is a fixed 14x14 mirrored stamp.
+  dimensions_[0xFAD] = {14, 14, Dir::None, 0, false};
   // Repeatable 4x4 patterns
   for (int id = 0xFB4; id <= 0xFB9; id++) {
     dimensions_[id] = {4, 4, Dir::Horizontal, 4, false};
   }
   dimensions_[0xFAA] = {4, 4, Dir::Horizontal, 4, false};
-  dimensions_[0xFAD] = {4, 4, Dir::Horizontal, 4, false};
   dimensions_[0xFAE] = {4, 4, Dir::Horizontal, 4, false};
   dimensions_[0xFD4] = {4, 4, Dir::Horizontal, 4, false};
   dimensions_[0xFE2] = {4, 4, Dir::Horizontal, 4, false};

--- a/src/zelda3/dungeon/object_drawer.cc
+++ b/src/zelda3/dungeon/object_drawer.cc
@@ -348,9 +348,13 @@ absl::Status ObjectDrawer::DrawObject(
       use_bg2 ? RoomObject::LayerType::BG1 : RoomObject::LayerType::BG2;
   gfx::BackgroundBuffer* dispatch_bg = &target_bg;
 
-  // Special stair families need either a second buffer for mixed-layer draws
-  // or fixed BG1/BG2 routing regardless of the parsed object-layer flag.
-  if (!is_both_bg && routine_id == DrawRoutineIds::kAutoStairs) {
+  // Special routines may need a second buffer for mixed-layer draws or fixed
+  // BG1/BG2 routing regardless of the parsed object-layer flag.
+  if (!is_both_bg && routine_id == DrawRoutineIds::kAgahnimsAltar) {
+    // USDASM writes the altar directly to the upper tilemap at $7E2000.
+    dispatch_bg = &bg1;
+    registry_primary_layer_ = RoomObject::LayerType::BG1;
+  } else if (!is_both_bg && routine_id == DrawRoutineIds::kAutoStairs) {
     registry_secondary_bg_ = &other_bg;
   } else if (!is_both_bg &&
              (routine_id == DrawRoutineIds::kStraightInterRoomStairs ||
@@ -1445,6 +1449,14 @@ void ObjectDrawer::InitializeDrawRoutines() {
       [](ObjectDrawer* self, const RoomObject& obj, gfx::BackgroundBuffer& bg,
          std::span<const gfx::TileInfo> tiles, const DungeonState* state) {
         self->DrawUsingRegistryRoutine(DrawRoutineIds::kBigGrayRock, obj, bg,
+                                       tiles, state);
+      };
+
+  ensure_index(DrawRoutineIds::kAgahnimsAltar);
+  draw_routines_[DrawRoutineIds::kAgahnimsAltar] =
+      [](ObjectDrawer* self, const RoomObject& obj, gfx::BackgroundBuffer& bg,
+         std::span<const gfx::TileInfo> tiles, const DungeonState* state) {
+        self->DrawUsingRegistryRoutine(DrawRoutineIds::kAgahnimsAltar, obj, bg,
                                        tiles, state);
       };
 
@@ -3244,6 +3256,11 @@ std::pair<int, int> yaze::zelda3::ObjectDrawer::CalculateObjectDimensions(
     case DrawRoutineIds::kBigGrayRock:
       width = 32;
       height = 32;
+      break;
+
+    case DrawRoutineIds::kAgahnimsAltar:
+      width = 112;
+      height = 112;
       break;
 
     default:

--- a/src/zelda3/dungeon/object_layer_semantics.h
+++ b/src/zelda3/dungeon/object_layer_semantics.h
@@ -45,6 +45,11 @@ inline ObjectLayerSemantics GetObjectLayerSemantics(const RoomObject& object) {
     return out;
   }
 
+  if (out.routine_id == DrawRoutineIds::kAgahnimsAltar) {
+    out.effective_bg_layer = EffectiveBgLayer::kBg1;
+    return out;
+  }
+
   out.effective_bg_layer = (object.layer_ == RoomObject::LayerType::BG2)
                                ? EffectiveBgLayer::kBg2
                                : EffectiveBgLayer::kBg1;

--- a/src/zelda3/dungeon/object_parser.cc
+++ b/src/zelda3/dungeon/object_parser.cc
@@ -341,6 +341,8 @@ absl::StatusOr<std::vector<gfx::TileInfo>> ObjectParser::ParseSubtype3(
   constexpr int kBigChestStateTileCount = 12;
   constexpr int kBigGrayRockTileOffset = 0x0E62;
   constexpr int kBigGrayRockTileCount = 16;
+  constexpr int kAgahnimsAltarTileOffset = 0x1B4A;
+  constexpr int kAgahnimsAltarTileCount = 84;
   constexpr int kSmithyFurnaceTileOffset = 0x1F92;
   constexpr int kSmithyFurnaceTileCount = 48;
 
@@ -442,6 +444,13 @@ absl::StatusOr<std::vector<gfx::TileInfo>> ObjectParser::ParseSubtype3(
   if (object_id == 0xFAC) {
     return ReadTileData(kRoomObjectTileAddress + kBigGrayRockTileOffset,
                         kBigGrayRockTileCount);
+  }
+
+  // AgahnimsAltar replaces the table-derived pointer with literal obj1B4A,
+  // then mirrors its six source columns into a fixed 14x14 destination.
+  if (object_id == 0xFAD) {
+    return ReadTileData(kRoomObjectTileAddress + kAgahnimsAltarTileOffset,
+                        kAgahnimsAltarTileCount);
   }
 
   // SmithyFurnace replaces the table-derived data pointer with literal
@@ -660,13 +669,18 @@ int ObjectParser::GetSubtype3TileCount(int16_t object_id) const {
   if (object_id == 0xFAC) {
     return 16;
   }
+  // AgahnimsAltar (0xFAD = ASM 0x22D) consumes six 14-tile source columns
+  // from obj1B4A before mirroring them into a 14x14 destination.
+  if (object_id == 0xFAD) {
+    return 84;
+  }
   // SmithyFurnace (0xFCC = ASM 0x24C) loads obj1F92 and draws a fixed
   // 6-column x 8-row block through RoomDraw_SomeBigDecors.
   if (object_id == 0xFCC) {
     return 48;
   }
   // 4x4 single-pattern objects
-  if (object_id == 0xFAA || object_id == 0xFAD || object_id == 0xFAE ||
+  if (object_id == 0xFAA || object_id == 0xFAE ||
       (object_id >= 0xFB4 && object_id <= 0xFB9) || object_id == 0xFD4 ||
       object_id == 0xFE2) {
     return 16;

--- a/test/unit/zelda3/dungeon/draw_routine_mapping_test.cc
+++ b/test/unit/zelda3/dungeon/draw_routine_mapping_test.cc
@@ -695,7 +695,7 @@ TEST_F(DrawRoutineMappingTest, VerifiesSubtype3Mappings) {
   EXPECT_EQ(drawer.GetDrawRoutineId(0xF96), DrawRoutineIds::kSingle2x2);
   EXPECT_EQ(drawer.GetDrawRoutineId(0xFAB), DrawRoutineIds::kSingle2x2);
   EXPECT_EQ(drawer.GetDrawRoutineId(0xFAC), DrawRoutineIds::kBigGrayRock);
-  EXPECT_EQ(drawer.GetDrawRoutineId(0xFAD), 16);
+  EXPECT_EQ(drawer.GetDrawRoutineId(0xFAD), DrawRoutineIds::kAgahnimsAltar);
   EXPECT_EQ(drawer.GetDrawRoutineId(0xFB1), DrawRoutineIds::kSingle4x3);
   EXPECT_EQ(drawer.GetDrawRoutineId(0xFD5), DrawRoutineIds::kUtility3x5);
   for (int object_id : {0xFD6, 0xFD7, 0xFD8, 0xFD9}) {
@@ -773,6 +773,17 @@ TEST_F(DrawRoutineMappingTest, VerifiesSubtype3Mappings) {
   EXPECT_FALSE(big_gray_rock->draws_to_both_bgs);
   EXPECT_EQ(big_gray_rock->category, DrawRoutineInfo::Category::Special);
 
+  const DrawRoutineInfo* agahnims_altar =
+      DrawRoutineRegistry::Get().GetRoutineInfo(DrawRoutineIds::kAgahnimsAltar);
+  ASSERT_NE(agahnims_altar, nullptr);
+  EXPECT_EQ(agahnims_altar->name, "AgahnimsAltar");
+  EXPECT_TRUE(static_cast<bool>(agahnims_altar->function));
+  EXPECT_EQ(agahnims_altar->base_width, 14);
+  EXPECT_EQ(agahnims_altar->base_height, 14);
+  EXPECT_EQ(agahnims_altar->min_tiles, 84);
+  EXPECT_FALSE(agahnims_altar->draws_to_both_bgs);
+  EXPECT_EQ(agahnims_altar->category, DrawRoutineInfo::Category::Special);
+
   const auto& routines = DrawRoutineRegistry::Get().GetAllRoutines();
   EXPECT_EQ(std::count_if(routines.begin(), routines.end(),
                           [](const DrawRoutineInfo& info) {
@@ -787,6 +798,11 @@ TEST_F(DrawRoutineMappingTest, VerifiesSubtype3Mappings) {
   EXPECT_EQ(std::count_if(routines.begin(), routines.end(),
                           [](const DrawRoutineInfo& info) {
                             return info.id == DrawRoutineIds::kBigGrayRock;
+                          }),
+            1);
+  EXPECT_EQ(std::count_if(routines.begin(), routines.end(),
+                          [](const DrawRoutineInfo& info) {
+                            return info.id == DrawRoutineIds::kAgahnimsAltar;
                           }),
             1);
 }

--- a/test/unit/zelda3/dungeon/object_dimensions_test.cc
+++ b/test/unit/zelda3/dungeon/object_dimensions_test.cc
@@ -73,8 +73,8 @@ TEST(DrawRoutineRegistryTest, Subtype3SpecialMappingsHaveRegisteredRoutines) {
 
   for (int16_t object_id :
        {0x0122, 0x012C, 0x013E, 0x0F90, 0x0F92, 0x0FB1, 0x0FD5,
-        0x0FBA, 0x0FBC, 0x0FAC, 0x0FE0, 0x0FE6, 0x0FE9, 0x0FEB,
-        0x0FF0, 0x0FF1, 0x0FF2, 0x0FF8, 0x0047, 0x0048}) {
+        0x0FBA, 0x0FBC, 0x0FAC, 0x0FAD, 0x0FE0, 0x0FE6, 0x0FE9,
+        0x0FEB, 0x0FF0, 0x0FF1, 0x0FF2, 0x0FF8, 0x0047, 0x0048}) {
     int routine_id = reg.GetRoutineIdForObject(object_id);
     ASSERT_GE(routine_id, 0) << "Object 0x" << std::hex << object_id;
     EXPECT_NE(reg.GetRoutineInfo(routine_id), nullptr)
@@ -423,6 +423,41 @@ TEST_F(ObjectDimensionTableTest, BigGrayRockUsesFixedFourByFourBounds) {
         ObjectDrawer(rom_.get(), 0).CalculateObjectDimensions(object);
     EXPECT_EQ(legacy_width, 32);
     EXPECT_EQ(legacy_height, 32);
+  }
+}
+
+TEST_F(ObjectDimensionTableTest,
+       AgahnimsAltarUsesFixedFourteenByFourteenBounds) {
+  auto& table = ObjectDimensionTable::Get();
+  ASSERT_TRUE(table.LoadFromRom(rom_.get()).ok());
+  EXPECT_EQ(table.GetBaseDimensions(0xFAD), std::make_pair(14, 14));
+
+  for (uint8_t size : {uint8_t{0x00}, uint8_t{0x03}, uint8_t{0x0F},
+                       uint8_t{0xF0}, uint8_t{0xFF}}) {
+    SCOPED_TRACE(::testing::Message() << "size=" << static_cast<int>(size));
+
+    const auto [width, height] = table.GetDimensions(0xFAD, size);
+    EXPECT_EQ(width, 14);
+    EXPECT_EQ(height, 14);
+
+    const auto selection = table.GetSelectionBounds(0xFAD, size);
+    EXPECT_EQ(selection.offset_x, 0);
+    EXPECT_EQ(selection.offset_y, 0);
+    EXPECT_EQ(selection.width, 14);
+    EXPECT_EQ(selection.height, 14);
+
+    const RoomObject object(0xFAD, 0, 0, size, 0);
+    const auto geometry = ObjectGeometry::Get().MeasureByObjectId(object);
+    ASSERT_TRUE(geometry.ok());
+    EXPECT_EQ(geometry->min_x_tiles, 0);
+    EXPECT_EQ(geometry->min_y_tiles, 0);
+    EXPECT_EQ(geometry->width_tiles, 14);
+    EXPECT_EQ(geometry->height_tiles, 14);
+
+    const auto [legacy_width, legacy_height] =
+        ObjectDrawer(rom_.get(), 0).CalculateObjectDimensions(object);
+    EXPECT_EQ(legacy_width, 112);
+    EXPECT_EQ(legacy_height, 112);
   }
 }
 

--- a/test/unit/zelda3/dungeon/object_drawer_registry_replay_test.cc
+++ b/test/unit/zelda3/dungeon/object_drawer_registry_replay_test.cc
@@ -2620,6 +2620,59 @@ TEST(ObjectDrawerRegistryReplayTest,
 }
 
 TEST(ObjectDrawerRegistryReplayTest,
+     AgahnimsAltarDrawsMirroredFourteenByFourteenOnFixedBg1) {
+  ScopedCustomObjectsFlag disable_custom(false);
+
+  constexpr int kX = 10;
+  constexpr int kY = 12;
+  constexpr uint16_t kFirstTile = 0x0100;
+  constexpr std::array<int, 14> kSourceColumns = {
+      0, 1, 1, 2, 3, 4, 5, 5, 4, 3, 2, 1, 1, 0,
+  };
+
+  auto tiles = MakeSequentialTiles(/*count=*/84, /*start_tile_id=*/kFirstTile);
+  for (size_t i = 0; i < tiles.size(); ++i) {
+    tiles[i].horizontal_mirror_ = (i % 3) == 0;
+  }
+
+  for (uint8_t size : {uint8_t{0}, uint8_t{3}}) {
+    for (const auto layer :
+         {RoomObject::LayerType::BG1, RoomObject::LayerType::BG2}) {
+      SCOPED_TRACE(::testing::Message()
+                   << "size=" << static_cast<int>(size)
+                   << " layer=" << static_cast<int>(layer));
+
+      const auto trace =
+          ReplayObjectTrace(/*object_id=*/0x0FAD, kX, kY, size, layer, tiles);
+      const auto bg1 = FilterTraceByLayer(trace, RoomObject::LayerType::BG1);
+      const auto bg2 = FilterTraceByLayer(trace, RoomObject::LayerType::BG2);
+      ASSERT_EQ(bg1.size(), 196u);
+      EXPECT_TRUE(bg2.empty());
+
+      size_t write_index = 0;
+      for (int y = 0; y < 14; ++y) {
+        for (int x = 0; x < 14; ++x, ++write_index) {
+          const size_t source_index = kSourceColumns[x] * 14 + y;
+          EXPECT_EQ(bg1[write_index].x_tile, kX + x);
+          EXPECT_EQ(bg1[write_index].y_tile, kY + y);
+          EXPECT_EQ(bg1[write_index].tile_id,
+                    static_cast<uint16_t>(kFirstTile + source_index));
+
+          bool expected_h_flip = tiles[source_index].horizontal_mirror_;
+          if (x >= 7 && x <= 12) {
+            expected_h_flip = !expected_h_flip;
+          } else if (x == 13) {
+            expected_h_flip = true;
+          }
+          EXPECT_EQ((bg1[write_index].flags & 0x1) != 0, expected_h_flip)
+              << "x=" << x << " y=" << y;
+        }
+      }
+    }
+  }
+}
+
+TEST(ObjectDrawerRegistryReplayTest,
      BigWallDecorAliasesDrawFixedEightByThreeOnSelectedLayer) {
   ScopedCustomObjectsFlag disable_custom(false);
 

--- a/test/unit/zelda3/dungeon/object_drawing_comprehensive_test.cc
+++ b/test/unit/zelda3/dungeon/object_drawing_comprehensive_test.cc
@@ -143,12 +143,16 @@ int ExpectedSubtype3TileCount(int id) {
   if (id == 0xFAC) {
     return 16;
   }
+  // Agahnim's altar consumes six 14-tile source columns.
+  if (id == 0xFAD) {
+    return 84;
+  }
   // Smithy furnace is a fixed 6x8 row-major payload.
   if (id == 0xFCC) {
     return 48;
   }
-  if (id == 0xFAA || id == 0xFAD || id == 0xFAE ||
-      (id >= 0xFB4 && id <= 0xFB9) || id == 0xFD4 || id == 0xFE2) {
+  if (id == 0xFAA || id == 0xFAE || (id >= 0xFB4 && id <= 0xFB9) ||
+      id == 0xFD4 || id == 0xFE2) {
     return 16;
   }
   // Big wall decor aliases consume one 8x3 column-major payload.

--- a/test/unit/zelda3/dungeon/object_layer_semantics_test.cc
+++ b/test/unit/zelda3/dungeon/object_layer_semantics_test.cc
@@ -47,6 +47,17 @@ TEST(ObjectLayerSemanticsTest, NonBothBgUsesStoredLayer) {
   EXPECT_EQ(sem.effective_bg_layer, EffectiveBgLayer::kBg2);
 }
 
+TEST(ObjectLayerSemanticsTest, AgahnimsAltarAlwaysReportsFixedBg1) {
+  for (uint8_t layer : {uint8_t{0}, uint8_t{1}}) {
+    RoomObject obj(/*id=*/0xFAD, /*x=*/0, /*y=*/0, /*size=*/7, layer);
+
+    const auto sem = GetObjectLayerSemantics(obj);
+    EXPECT_EQ(sem.routine_id, DrawRoutineIds::kAgahnimsAltar);
+    EXPECT_FALSE(sem.draws_to_both_bgs);
+    EXPECT_EQ(sem.effective_bg_layer, EffectiveBgLayer::kBg1);
+  }
+}
+
 TEST(DungeonObjectLayerGuardrailsTest,
      SingleAndBatchStreamChangesIncludeBothBgObjects) {
   Rom rom;

--- a/test/unit/zelda3/object_parser_test.cc
+++ b/test/unit/zelda3/object_parser_test.cc
@@ -173,7 +173,7 @@ TEST_F(ObjectParserTest, RuntimeLiteralObjectsIgnoreRelocatedTablePointers) {
     }
   };
 
-  // Move all seven pointer-table entries. F98/F99/FB1/FAC/FCC must ignore
+  // Move all eight pointer-table entries. F98/F99/FB1/FAC/FAD/FCC must ignore
   // their moved entries because their routines load literal data blocks;
   // F9A/FB2 are direct-open routines and must continue following their moved
   // pointers.
@@ -184,6 +184,7 @@ TEST_F(ObjectParserTest, RuntimeLiteralObjectsIgnoreRelocatedTablePointers) {
   constexpr uint16_t kMovedOpenBigChestOffset = 0x0300;
   constexpr uint16_t kMovedSmithyFurnaceOffset = 0x0400;
   constexpr uint16_t kMovedBigGrayRockOffset = 0x0480;
+  constexpr uint16_t kMovedAgahnimsAltarOffset = 0x0580;
   write_pointer(0xF98, kMovedBigKeyLockOffset);
   write_pointer(0xF99, kMovedChestOffset);
   write_pointer(0xF9A, kMovedOpenChestOffset);
@@ -191,6 +192,7 @@ TEST_F(ObjectParserTest, RuntimeLiteralObjectsIgnoreRelocatedTablePointers) {
   write_pointer(0xFB2, kMovedOpenBigChestOffset);
   write_pointer(0xFCC, kMovedSmithyFurnaceOffset);
   write_pointer(0xFAC, kMovedBigGrayRockOffset);
+  write_pointer(0xFAD, kMovedAgahnimsAltarOffset);
 
   write_words(0x1494, 4, 0x0040);   // BigKeyLock literal
   write_words(0x149C, 4, 0x0080);   // Chest closed literal
@@ -199,6 +201,7 @@ TEST_F(ObjectParserTest, RuntimeLiteralObjectsIgnoreRelocatedTablePointers) {
   write_words(0x14C4, 12, 0x0300);  // BigChest opened literal
   write_words(0x1F92, 48, 0x0280);  // SmithyFurnace literal
   write_words(0x0E62, 16, 0x0440);  // BigGrayRock literal
+  write_words(0x1B4A, 84, 0x0080);  // AgahnimsAltar literal
 
   write_words(kMovedBigKeyLockOffset, 4, 0x03C0);
   write_words(kMovedChestOffset, 4, 0x03A0);
@@ -207,6 +210,7 @@ TEST_F(ObjectParserTest, RuntimeLiteralObjectsIgnoreRelocatedTablePointers) {
   write_words(kMovedOpenBigChestOffset, 12, 0x0140);
   write_words(kMovedSmithyFurnaceOffset, 48, 0x0340);
   write_words(kMovedBigGrayRockOffset, 16, 0x0640);
+  write_words(kMovedAgahnimsAltarOffset, 84, 0x0200);
 
   auto lock = parser_->ParseObject(0xF98);
   auto chest = parser_->ParseObject(0xF99);
@@ -215,6 +219,7 @@ TEST_F(ObjectParserTest, RuntimeLiteralObjectsIgnoreRelocatedTablePointers) {
   auto open_big_chest = parser_->ParseObject(0xFB2);
   auto smithy_furnace = parser_->ParseObject(0xFCC);
   auto big_gray_rock = parser_->ParseObject(0xFAC);
+  auto agahnims_altar = parser_->ParseObject(0xFAD);
   ASSERT_TRUE(lock.ok());
   ASSERT_TRUE(chest.ok());
   ASSERT_TRUE(open_chest.ok());
@@ -222,6 +227,7 @@ TEST_F(ObjectParserTest, RuntimeLiteralObjectsIgnoreRelocatedTablePointers) {
   ASSERT_TRUE(open_big_chest.ok());
   ASSERT_TRUE(smithy_furnace.ok());
   ASSERT_TRUE(big_gray_rock.ok());
+  ASSERT_TRUE(agahnims_altar.ok());
 
   for (int i = 0; i < 4; ++i) {
     EXPECT_TRUE((*lock)[i] ==
@@ -254,6 +260,13 @@ TEST_F(ObjectParserTest, RuntimeLiteralObjectsIgnoreRelocatedTablePointers) {
                 gfx::WordToTileInfo(static_cast<uint16_t>(0x0440 + i)));
     EXPECT_FALSE((*big_gray_rock)[i] ==
                  gfx::WordToTileInfo(static_cast<uint16_t>(0x0640 + i)));
+  }
+  ASSERT_EQ(agahnims_altar->size(), 84u);
+  for (int i = 0; i < 84; ++i) {
+    EXPECT_TRUE((*agahnims_altar)[i] ==
+                gfx::WordToTileInfo(static_cast<uint16_t>(0x0080 + i)));
+    EXPECT_FALSE((*agahnims_altar)[i] ==
+                 gfx::WordToTileInfo(static_cast<uint16_t>(0x0200 + i)));
   }
 }
 
@@ -595,6 +608,24 @@ TEST_F(ObjectParserTest, BigGrayRockUsesSixteenTilesAndDedicatedRoutine) {
   const auto info = parser_->GetObjectDrawInfo(0xFAC);
   EXPECT_EQ(info.tile_count, 16);
   EXPECT_EQ(info.draw_routine_id, zelda3::DrawRoutineIds::kBigGrayRock);
+}
+
+TEST_F(ObjectParserTest, AgahnimsAltarUsesEightyFourTilesAndDedicatedRoutine) {
+  auto& registry = zelda3::DrawRoutineRegistry::Get();
+  EXPECT_EQ(registry.GetRoutineIdForObject(0xFAD),
+            zelda3::DrawRoutineIds::kAgahnimsAltar);
+
+  const auto subtype = parser_->GetObjectSubtype(0xFAD);
+  ASSERT_TRUE(subtype.ok());
+  EXPECT_EQ(subtype->max_tile_count, 84);
+
+  const auto parsed = parser_->ParseObject(0xFAD);
+  ASSERT_TRUE(parsed.ok());
+  EXPECT_EQ(parsed->size(), 84u);
+
+  const auto info = parser_->GetObjectDrawInfo(0xFAD);
+  EXPECT_EQ(info.tile_count, 84);
+  EXPECT_EQ(info.draw_routine_id, zelda3::DrawRoutineIds::kAgahnimsAltar);
 }
 
 TEST_F(ObjectParserTest, HammerPegUsesUsdasmSingle2x2RoutineAndFourTiles) {


### PR DESCRIPTION
## Summary

- map subtype-3 object `0xFAD` to a dedicated Agahnim altar routine
- mirror the runtime's literal `obj1B4A` source and consume all 84 tile words
- draw the fixed 14x14 mirrored altar on BG1 regardless of the encoded object-list layer
- preserve the runtime's asymmetric horizontal-flip behavior: columns 7-12 toggle H-flip and column 13 forces it
- align parser counts, registry metadata, selection bounds, legacy pixel dimensions, inspector layer labels, and focused replay coverage

## Why

`0xFAD` currently follows the generic repeatable 4x4 path. Its subtype pointer is intentionally zero, so the editor reads 16 unrelated words and models a size-7 Oracle placement as a 32x4 strip. The original `RoomDraw_AgahnimsAltar` routine at `$019E30` instead hard-loads `obj1B4A` and writes a fixed 14x14 altar to `$7E2000` (BG1).

The six 14-word source columns expand to:

```text
0 1 1 2 3 4 5 5 4 3 2 1 1 0
```

The right half mirrors the source flags exactly as the 65816 routine does.

## Impact

An exhaustive read-only scan of all 296 rooms in the canonical Oracle of Secrets development ROM found five `0xFAD` placements: rooms `0x01D`, `0x030`, `0x048`, `0x066`, and `0x09E`. They now render as fixed 14x14 altars instead of repeatable 4x4 strips sourced from the wrong data.

## Verification

- focused parser/mapping/registry/dimension/geometry/BG replay/layer-semantics/comprehensive tests: **8/8 passed**
- exact-ROM `dungeon-object-validate`: 196 writes, 14x14 bounds, BG1, zero mismatches, zero empty traces
- read-only scan of all 296 rooms in canonical `oos168.sfc`: five matching placements
- canonical ROM SHA-256 remained `d289b2408c3ccc312abeadf274f04f475106034fcab8ebff3f307fd229db4799` before and after validation
- `clang-format --dry-run --Werror` on all 14 changed C++ files: passed
- `git diff --check`: passed
- independent USDASM review: no blocking findings

## Integration

- #166 merged into `master` as `7bebbb4878a99e7e178c2c27f8f77fef2b3477ba`
- this branch contains the atomic implementation plus one focused review-fix commit keeping inspector/issue-report layer semantics aligned with the fixed-BG1 renderer

## Residual risk

No manual GUI or emulator-side room render was run. The editor writes the same unique destinations and final tilemap as USDASM, but its diagnostic trace order is row-major rather than the runtime routine's interleaved store order. Existing custom-object overrides retain their global precedence over the built-in routine.
