### PR TITLE
feat(cli): add manifest-safe dungeon door edits

### DIFF
--- a/docs/internal/agents/rom-safety-guardrails.md
+++ b/docs/internal/agents/rom-safety-guardrails.md
@@ -23,9 +23,18 @@ This repo is used to edit ROM hacks (including Oracle of Secrets). Treat ROM wri
   has no previous bytes to back up. A completed required backup is retained if
   the later target write fails, so recovery bytes remain available.
 - `dungeon-place-sprite`, `dungeon-remove-sprite`, `dungeon-place-object`,
-  `dungeon-set-collision-tile`, and `dungeon-set-room-property` wrap their
-  serializer, required backup, and disk commit in `ScopedRomTransaction`. Any
-  failure restores the caller's ROM bytes, filename, size, and dirty state.
+  `dungeon-set-door-type`, `dungeon-set-collision-tile`, and
+  `dungeon-set-room-property` wrap their serializer or fixed-width write,
+  required backup, and disk commit in `ScopedRomTransaction`. Any failure
+  before a successful disk commit restores the caller's ROM bytes, filename,
+  size, and dirty state.
+- `dungeon-set-door-type` is dry-run by default and requires exact coordinates,
+  an expected old type, and a `copy_on_write` object-stream manifest. It rejects
+  incomplete pointer inventories, invalid/aliased/overlapping selected streams,
+  and any other room door pointer into that stream. It fences write mode to the
+  resolved one-byte type field and cross-checks model/raw readback before the
+  required-backup save; the focused unit test independently reopens the saved
+  ROM and validates the persisted door.
 - Dungeon `layout`, `floor1`, and `floor2` edits use a separate object-stream
   header dirty mask. They preserve unrelated header bits and object payload,
   save after any dirty object payload, and fail closed on shared streams unless

--- a/docs/public/reference/z3ed-command-reference.md
+++ b/docs/public/reference/z3ed-command-reference.md
@@ -163,6 +163,7 @@ These commands operate directly on ROM data (no GUI required).
 - `entrance-info --entrance <hex> [--spawn]`
 - `dungeon-export-room --room <hex> --output <file>`
 - `dungeon-place-object --room <hex> --id <hex> --x <int> --y <int> [--size <int>] [--layer <0|1|2>] [--manifest <path>] [--write]`
+- `dungeon-set-door-type --room <hex> --x <int> --y <int> --type <hex> --expect-type <hex> --manifest <path> [--write]`
 - `dungeon-get-room-tiles --room <hex>` *(stubbed)*
 - `dungeon-set-room-property --room <hex> --property <name> --value <value> [--manifest <path>]`
 
@@ -174,6 +175,23 @@ an explicit manifest defines `dungeon_stream_regions.objects` with the
 ownership guard: protected current-stream, allocation, object-pointer, or
 door-pointer writes are rejected before either dry-run or write can mutate ROM
 bytes.
+
+`dungeon-set-door-type` changes only the fixed-width type byte of an existing
+door selected by exact tile coordinates. It is a dry-run unless `--write` is
+supplied. The command requires the expected current type as a compare-and-swap
+guard and an object-stream manifest using `copy_on_write`. Before either mode
+succeeds it verifies the runtime and manifest pointer tables agree, inventories
+all 296 object pointers, rejects selected-stream aliases/overlaps and any other
+room door pointer into that stream, cross-checks the room model against the raw
+door-pointer entry, and checks the exact one-byte write against manifest
+ownership. Write mode uses a one-byte write fence, required backup, pre-save
+model/raw readback, and atomic ROM replacement. The focused unit test
+independently reopens the saved ROM and validates the persisted door.
+
+Use `dungeon-describe-room` first to discover each door's exact `tile_x`,
+`tile_y`, `index`, and raw `type_id`. Pass those tile coordinates and
+`type_id` to `dungeon-set-door-type`; the command reports the matched index and
+old/new symbolic names but never selects a door by display-name text.
 
 `dungeon-set-room-property` accepts `layout`/`layout_id` values `0`-`7` and
 `floor1`/`floor2` values `0`-`15`. These properties are persisted in the

--- a/src/cli/handlers/command_handlers.cc
+++ b/src/cli/handlers/command_handlers.cc
@@ -153,6 +153,7 @@ CreateCliCommandHandlers() {
   handlers.push_back(std::make_unique<DungeonPlaceSpriteCommandHandler>());
   handlers.push_back(std::make_unique<DungeonRemoveSpriteCommandHandler>());
   handlers.push_back(std::make_unique<DungeonPlaceObjectCommandHandler>());
+  handlers.push_back(std::make_unique<DungeonSetDoorTypeCommandHandler>());
   handlers.push_back(std::make_unique<DungeonSetCollisionTileCommandHandler>());
 
   // Overworld inspection

--- a/src/cli/handlers/game/dungeon_commands.cc
+++ b/src/cli/handlers/game/dungeon_commands.cc
@@ -373,11 +373,15 @@ absl::Status DungeonDescribeRoomCommandHandler::Execute(
 
   // Export Doors
   formatter.BeginArray("doors");
-  for (const auto& door : room.GetDoors()) {
+  const auto& doors = room.GetDoors();
+  for (size_t index = 0; index < doors.size(); ++index) {
+    const auto& door = doors[index];
     formatter.BeginObject();
+    formatter.AddField("index", static_cast<int>(index));
     formatter.AddField("position", door.position);
     formatter.AddField("direction", std::string(door.GetDirectionName()));
     formatter.AddField("type", std::string(door.GetTypeName()));
+    formatter.AddHexField("type_id", static_cast<uint8_t>(door.type), 2);
     auto [tx, ty] = door.GetTileCoords();
     formatter.AddField("tile_x", tx);
     formatter.AddField("tile_y", ty);

--- a/src/cli/handlers/game/dungeon_edit_commands.cc
+++ b/src/cli/handlers/game/dungeon_edit_commands.cc
@@ -1,8 +1,10 @@
 #include "cli/handlers/game/dungeon_edit_commands.h"
 
+#include <algorithm>
 #include <cstdint>
 #include <limits>
 #include <optional>
+#include <string>
 #include <utility>
 #include <vector>
 
@@ -16,6 +18,7 @@
 #include "rom/rom.h"
 #include "rom/snes.h"
 #include "rom/transaction.h"
+#include "rom/write_fence.h"
 #include "util/macro.h"
 #include "zelda3/dungeon/dungeon_stream_allocator.h"
 #include "zelda3/dungeon/room.h"
@@ -237,6 +240,290 @@ absl::Status PreflightObjectSave(
   return scratch_room.SaveObjects(manifest_context != nullptr
                                       ? &manifest_context->allocator_layout
                                       : nullptr);
+}
+
+absl::StatusOr<int> GetRequiredHex(const resources::ArgumentParser& parser,
+                                   const char* name) {
+  auto value_or = GetRequiredString(parser, name);
+  if (!value_or.ok()) {
+    return value_or.status();
+  }
+
+  int value = 0;
+  if (!ParseHexString(*value_or, &value)) {
+    return absl::InvalidArgumentError(absl::StrFormat(
+        "Invalid --%s value '%s' (expected integer/hex)", name, *value_or));
+  }
+  return value;
+}
+
+absl::Status ValidateDoorType(int type, const char* argument_name) {
+  if (type < 0 || type > 0x66 || (type & 1) != 0) {
+    return absl::InvalidArgumentError(absl::StrFormat(
+        "--%s must be an even door type in range 0x00-0x66", argument_name));
+  }
+  return absl::OkStatus();
+}
+
+bool ContainsRoomId(const std::vector<uint32_t>& room_ids, int room_id) {
+  return std::find(room_ids.begin(), room_ids.end(),
+                   static_cast<uint32_t>(room_id)) != room_ids.end();
+}
+
+bool IsLoRomDataPointer(uint32_t snes_address) {
+  if ((snes_address & 0xFFFFu) < 0x8000u) {
+    return false;
+  }
+  const uint8_t normalized_bank =
+      static_cast<uint8_t>((snes_address >> 16) & 0x7Fu);
+  if (normalized_bank >= 0x7Eu) {
+    return false;
+  }
+  const uint32_t pc_address = SnesToPc(snes_address);
+  return (PcToSnes(pc_address) & 0x7FFFFFu) == (snes_address & 0x7FFFFFu);
+}
+
+struct DoorTypeTarget {
+  int door_index = -1;
+  zelda3::Room::Door door;
+  uint32_t object_stream_pc = 0;
+  uint32_t object_stream_end_pc = 0;
+  uint32_t door_pointer_pc = 0;
+  uint32_t door_entry_pc = 0;
+  uint32_t type_pc = 0;
+};
+
+absl::StatusOr<DoorTypeTarget> ResolveDoorTypeTarget(
+    Rom* rom, int room_id, int x, int y,
+    const ObjectSaveManifestContext& manifest_context) {
+  if (manifest_context.allocator_layout.pointer_encoding !=
+      zelda3::DungeonPointerEncoding::kLong24) {
+    return absl::FailedPreconditionError(
+        "Dungeon object manifest pointer encoding must be long24");
+  }
+  if (manifest_context.allocator_layout.pointer_count !=
+      zelda3::kNumberOfRooms) {
+    return absl::FailedPreconditionError(absl::StrFormat(
+        "Dungeon object manifest pointer_count must equal %d rooms",
+        zelda3::kNumberOfRooms));
+  }
+
+  uint32_t runtime_pointer_table_snes = 0;
+  ASSIGN_OR_RETURN(runtime_pointer_table_snes,
+                   rom->ReadLong(zelda3::kRoomObjectPointer));
+  if (!IsLoRomDataPointer(runtime_pointer_table_snes)) {
+    return absl::FailedPreconditionError(
+        "Runtime object pointer table is not a valid LoROM data pointer");
+  }
+  const uint32_t runtime_pointer_table_pc =
+      SnesToPc(runtime_pointer_table_snes);
+  if (runtime_pointer_table_pc !=
+      manifest_context.allocator_layout.pointer_table_pc) {
+    return absl::FailedPreconditionError(absl::StrFormat(
+        "Manifest object pointer table PC 0x%06X does not match runtime "
+        "table PC 0x%06X",
+        manifest_context.allocator_layout.pointer_table_pc,
+        runtime_pointer_table_pc));
+  }
+
+  zelda3::DungeonStreamInventory inventory;
+  ASSIGN_OR_RETURN(inventory, zelda3::InventoryDungeonStreams(
+                                  *rom, manifest_context.allocator_layout));
+  if (static_cast<size_t>(room_id) >= inventory.streams.size()) {
+    return absl::FailedPreconditionError(
+        "Selected room is absent from the object stream inventory");
+  }
+  for (const auto& issue : inventory.issues) {
+    if (issue.room_id == static_cast<uint32_t>(room_id)) {
+      return absl::FailedPreconditionError(absl::StrFormat(
+          "Selected object stream is invalid: %s", issue.message));
+    }
+  }
+
+  const auto& stream = inventory.streams[room_id];
+  if (!stream.valid) {
+    return absl::FailedPreconditionError("Selected object stream is invalid");
+  }
+  for (const auto& alias : inventory.aliases) {
+    if (ContainsRoomId(alias.room_ids, room_id)) {
+      return absl::FailedPreconditionError(absl::StrFormat(
+          "Selected object stream at PC 0x%06X is shared by %d rooms",
+          alias.data_pc, static_cast<int>(alias.room_ids.size())));
+    }
+  }
+  for (const auto& overlap : inventory.overlaps) {
+    if (ContainsRoomId(overlap.first_room_ids, room_id) ||
+        ContainsRoomId(overlap.second_room_ids, room_id)) {
+      return absl::FailedPreconditionError(absl::StrFormat(
+          "Selected object stream overlaps PC range [0x%06X, 0x%06X)",
+          overlap.intersection.begin, overlap.intersection.end));
+    }
+  }
+  for (const auto& other_stream : inventory.streams) {
+    if (other_stream.room_id == static_cast<uint32_t>(room_id)) {
+      continue;
+    }
+    if (other_stream.data_pc >= stream.data_pc &&
+        other_stream.data_pc < stream.logical_end_pc) {
+      return absl::FailedPreconditionError(absl::StrFormat(
+          "Room 0x%03X object pointer PC 0x%06X starts inside selected "
+          "object stream [0x%06X, 0x%06X)",
+          other_stream.room_id, other_stream.data_pc, stream.data_pc,
+          stream.logical_end_pc));
+    }
+  }
+  for (int other_room_id = 0; other_room_id < zelda3::kNumberOfRooms;
+       ++other_room_id) {
+    if (other_room_id == room_id) {
+      continue;
+    }
+    const uint32_t other_door_pointer_slot =
+        zelda3::kDoorPointers + static_cast<uint32_t>(other_room_id) * 3u;
+    uint32_t other_door_pointer_snes = 0;
+    ASSIGN_OR_RETURN(other_door_pointer_snes,
+                     rom->ReadLong(static_cast<int>(other_door_pointer_slot)));
+    if (!IsLoRomDataPointer(other_door_pointer_snes)) {
+      continue;
+    }
+    const uint32_t other_door_pointer_pc = SnesToPc(other_door_pointer_snes);
+    if (other_door_pointer_pc >= stream.data_pc &&
+        other_door_pointer_pc < stream.logical_end_pc) {
+      return absl::FailedPreconditionError(absl::StrFormat(
+          "Room 0x%03X door pointer PC 0x%06X points inside selected "
+          "object stream [0x%06X, 0x%06X)",
+          other_room_id, other_door_pointer_pc, stream.data_pc,
+          stream.logical_end_pc));
+    }
+  }
+
+  const uint64_t runtime_pointer_slot =
+      static_cast<uint64_t>(runtime_pointer_table_pc) +
+      static_cast<uint64_t>(room_id) * 3u;
+  if (runtime_pointer_slot + 3u > rom->size() ||
+      runtime_pointer_slot != stream.pointer_slot_pc) {
+    return absl::FailedPreconditionError(
+        "Selected runtime object pointer slot does not match the manifest");
+  }
+  uint32_t runtime_stream_snes = 0;
+  ASSIGN_OR_RETURN(runtime_stream_snes,
+                   rom->ReadLong(static_cast<int>(runtime_pointer_slot)));
+  if (!IsLoRomDataPointer(runtime_stream_snes)) {
+    return absl::FailedPreconditionError(
+        "Selected runtime object stream is not a valid LoROM data pointer");
+  }
+  const uint32_t runtime_stream_pc = SnesToPc(runtime_stream_snes);
+  if (runtime_stream_pc != stream.data_pc) {
+    return absl::FailedPreconditionError(absl::StrFormat(
+        "Selected runtime object stream PC 0x%06X does not match inventory "
+        "PC 0x%06X",
+        runtime_stream_pc, stream.data_pc));
+  }
+
+  zelda3::Room room = zelda3::LoadRoomFromRom(rom, room_id);
+  const auto& doors = room.GetDoors();
+  int selected_index = -1;
+  for (int index = 0; index < static_cast<int>(doors.size()); ++index) {
+    const auto [door_x, door_y] = doors[index].GetTileCoords();
+    if (door_x != x || door_y != y) {
+      continue;
+    }
+    if (selected_index >= 0) {
+      return absl::FailedPreconditionError(absl::StrFormat(
+          "Multiple doors match tile coordinates (%d, %d)", x, y));
+    }
+    selected_index = index;
+  }
+  if (selected_index < 0) {
+    return absl::NotFoundError(absl::StrFormat(
+        "No door matches tile coordinates (%d, %d) in room 0x%03X", x, y,
+        room_id));
+  }
+
+  const uint64_t door_pointer_slot =
+      static_cast<uint64_t>(zelda3::kDoorPointers) +
+      static_cast<uint64_t>(room_id) * 3u;
+  if (door_pointer_slot + 3u > rom->size()) {
+    return absl::OutOfRangeError("Selected door pointer slot is outside ROM");
+  }
+  uint32_t door_pointer_snes = 0;
+  ASSIGN_OR_RETURN(door_pointer_snes,
+                   rom->ReadLong(static_cast<int>(door_pointer_slot)));
+  if (!IsLoRomDataPointer(door_pointer_snes)) {
+    return absl::FailedPreconditionError(
+        "Selected door pointer is not a valid LoROM data pointer");
+  }
+  const uint32_t door_pointer_pc = SnesToPc(door_pointer_snes);
+  const uint64_t door_entry_pc = static_cast<uint64_t>(door_pointer_pc) +
+                                 static_cast<uint64_t>(selected_index) * 2u;
+  const uint64_t expected_stream_end =
+      static_cast<uint64_t>(door_pointer_pc) +
+      static_cast<uint64_t>(doors.size()) * 2u + 2u;
+  if (door_pointer_pc < stream.data_pc ||
+      door_entry_pc + 2u > stream.logical_end_pc ||
+      expected_stream_end != stream.logical_end_pc) {
+    return absl::FailedPreconditionError(
+        "Door pointer/count does not match the inventoried object stream end");
+  }
+
+  uint8_t raw_byte1 = 0;
+  uint8_t raw_byte2 = 0;
+  for (int index = 0; index < static_cast<int>(doors.size()); ++index) {
+    const uint32_t entry_pc =
+        door_pointer_pc + static_cast<uint32_t>(index) * 2u;
+    uint8_t entry_byte1 = 0;
+    uint8_t entry_byte2 = 0;
+    ASSIGN_OR_RETURN(entry_byte1, rom->ReadByte(static_cast<int>(entry_pc)));
+    ASSIGN_OR_RETURN(entry_byte2,
+                     rom->ReadByte(static_cast<int>(entry_pc + 1u)));
+    const auto [model_byte1, model_byte2] = doors[index].EncodeBytes();
+    if (model_byte1 != entry_byte1 || model_byte2 != entry_byte2 ||
+        doors[index].byte1 != entry_byte1 ||
+        doors[index].byte2 != entry_byte2) {
+      return absl::DataLossError(
+          "Door model does not match the raw door-pointer entries");
+    }
+    if (index == selected_index) {
+      raw_byte1 = entry_byte1;
+      raw_byte2 = entry_byte2;
+    }
+  }
+  uint16_t door_terminator = 0;
+  ASSIGN_OR_RETURN(door_terminator,
+                   rom->ReadWord(static_cast<int>(expected_stream_end - 2u)));
+  if (door_terminator != 0xFFFFu) {
+    return absl::DataLossError(
+        "Door list does not end with the expected 0xFFFF terminator");
+  }
+
+  const zelda3::Room::Door raw_door =
+      zelda3::Room::Door::FromRomBytes(raw_byte1, raw_byte2);
+  const zelda3::Room::Door& model_door = doors[selected_index];
+  const auto [raw_x, raw_y] = raw_door.GetTileCoords();
+  if (model_door.position != raw_door.position ||
+      model_door.direction != raw_door.direction ||
+      model_door.type != raw_door.type || raw_x != x || raw_y != y) {
+    return absl::DataLossError(
+        "Door model does not match the raw door-pointer entry");
+  }
+
+  const uint32_t type_pc = static_cast<uint32_t>(door_entry_pc + 1u);
+  const auto conflicts =
+      manifest_context.manifest.AnalyzePcWriteRanges({{type_pc, type_pc + 1u}});
+  if (!conflicts.empty()) {
+    return absl::PermissionDeniedError(absl::StrFormat(
+        "Door type byte at PC 0x%06X conflicts with Hack Manifest (%s)",
+        type_pc, core::AddressOwnershipToString(conflicts.front().ownership)));
+  }
+
+  DoorTypeTarget target;
+  target.door_index = selected_index;
+  target.door = model_door;
+  target.object_stream_pc = stream.data_pc;
+  target.object_stream_end_pc = stream.logical_end_pc;
+  target.door_pointer_pc = door_pointer_pc;
+  target.door_entry_pc = static_cast<uint32_t>(door_entry_pc);
+  target.type_pc = type_pc;
+  return target;
 }
 
 }  // namespace
@@ -618,6 +905,179 @@ absl::Status DungeonPlaceObjectCommandHandler::Execute(
     }
   }
 
+  formatter.EndObject();
+  return absl::OkStatus();
+}
+
+// ---------------------------------------------------------------------------
+// dungeon-set-door-type
+// ---------------------------------------------------------------------------
+
+absl::Status DungeonSetDoorTypeCommandHandler::Execute(
+    Rom* rom, const resources::ArgumentParser& parser,
+    resources::OutputFormatter& formatter) {
+  int room_id = 0;
+  ASSIGN_OR_RETURN(room_id, GetRequiredHex(parser, "room"));
+  RETURN_IF_ERROR(ValidateRoomId(room_id));
+
+  int x = 0;
+  int y = 0;
+  ASSIGN_OR_RETURN(x, GetRequiredInt(parser, "x"));
+  ASSIGN_OR_RETURN(y, GetRequiredInt(parser, "y"));
+  if (x < 0 || x > 63 || y < 0 || y > 63) {
+    return absl::InvalidArgumentError(
+        "Door tile coordinates must be in range 0-63");
+  }
+
+  int new_type = 0;
+  int expected_type = 0;
+  ASSIGN_OR_RETURN(new_type, GetRequiredHex(parser, "type"));
+  ASSIGN_OR_RETURN(expected_type, GetRequiredHex(parser, "expect-type"));
+  RETURN_IF_ERROR(ValidateDoorType(new_type, "type"));
+  RETURN_IF_ERROR(ValidateDoorType(expected_type, "expect-type"));
+
+  std::optional<ObjectSaveManifestContext> manifest_context;
+  ASSIGN_OR_RETURN(manifest_context, LoadObjectSaveManifestContext(parser));
+  if (!manifest_context.has_value()) {
+    return absl::FailedPreconditionError(
+        "--manifest is required for dungeon-set-door-type");
+  }
+
+  DoorTypeTarget target;
+  ASSIGN_OR_RETURN(
+      target, ResolveDoorTypeTarget(rom, room_id, x, y, *manifest_context));
+  const int old_type = static_cast<int>(target.door.type);
+  if (old_type != expected_type) {
+    return absl::FailedPreconditionError(absl::StrFormat(
+        "Door type compare-and-swap failed at (%d, %d): expected 0x%02X, "
+        "found 0x%02X",
+        x, y, expected_type, old_type));
+  }
+  if (new_type == old_type) {
+    return absl::InvalidArgumentError(
+        "--type must differ from the current door type");
+  }
+
+  const bool do_write = parser.HasFlag("write");
+  if (do_write && rom->filename().empty()) {
+    return absl::FailedPreconditionError("Write mode requires a ROM filename");
+  }
+
+  formatter.BeginObject("Set Door Type");
+  formatter.AddHexField("room_id", room_id, 3);
+  formatter.AddField("door_index", target.door_index);
+  formatter.AddField("x", x);
+  formatter.AddField("y", y);
+  formatter.AddField("position", target.door.position);
+  formatter.AddField("direction", std::string(target.door.GetDirectionName()));
+  formatter.AddHexField("old_type", old_type, 2);
+  formatter.AddField("old_type_name", std::string(target.door.GetTypeName()));
+  formatter.AddHexField("new_type", new_type, 2);
+  formatter.AddField(
+      "new_type_name",
+      std::string(zelda3::GetDoorTypeName(
+          zelda3::DoorTypeFromRaw(static_cast<uint8_t>(new_type)))));
+  formatter.AddHexField("object_stream_pc", target.object_stream_pc, 6);
+  formatter.AddHexField("object_stream_end_pc", target.object_stream_end_pc, 6);
+  formatter.AddHexField("door_pointer_pc", target.door_pointer_pc, 6);
+  formatter.AddHexField("door_entry_pc", target.door_entry_pc, 6);
+  formatter.AddHexField("type_pc", target.type_pc, 6);
+  formatter.AddHexField("type_snes", PcToSnes(target.type_pc), 6);
+  formatter.AddField("manifest", *parser.GetString("manifest"));
+  formatter.AddField("manifest_write_policy", "block");
+  formatter.AddField("stream_alias_status", "unique");
+  formatter.AddField("mode", do_write ? "write" : "dry-run");
+  formatter.AddField("preflight_status", "success");
+
+  if (!do_write) {
+    formatter.AddField("write_status", "not_requested");
+    formatter.AddField("save_status", "not_requested");
+    formatter.AddField("readback_status", "not_requested");
+    formatter.AddField("status", "success");
+    formatter.EndObject();
+    return absl::OkStatus();
+  }
+
+  const auto finish_error = [&formatter](const absl::Status& status,
+                                         const char* field) -> absl::Status {
+    formatter.AddField("status", "error");
+    formatter.AddField(field, std::string(status.message()));
+    formatter.EndObject();
+    return status;
+  };
+  const auto verify_readback =
+      [&target, new_type](const DoorTypeTarget& readback) -> absl::Status {
+    if (readback.door_index != target.door_index ||
+        readback.type_pc != target.type_pc ||
+        readback.door.position != target.door.position ||
+        readback.door.direction != target.door.direction ||
+        static_cast<int>(readback.door.type) != new_type) {
+      return absl::DataLossError(
+          "Door type readback does not match the requested change");
+    }
+    return absl::OkStatus();
+  };
+
+  rom::WriteFence write_fence;
+  const absl::Status allow_status = write_fence.Allow(
+      target.type_pc, target.type_pc + 1u, "dungeon door type");
+  if (!allow_status.ok()) {
+    return finish_error(allow_status, "write_error");
+  }
+
+  const std::vector<uint8_t> before = rom->vector();
+  ScopedRomTransaction transaction(*rom);
+  {
+    rom::ScopedWriteFence write_scope(rom, &write_fence);
+    const absl::Status write_status = rom->WriteByte(
+        static_cast<int>(target.type_pc), static_cast<uint8_t>(new_type));
+    if (!write_status.ok()) {
+      return finish_error(write_status, "write_error");
+    }
+  }
+
+  if (rom->size() != before.size()) {
+    return finish_error(
+        absl::DataLossError("Door type edit unexpectedly resized the ROM"),
+        "write_error");
+  }
+  int changed_bytes = 0;
+  uint32_t changed_pc = 0;
+  for (uint32_t pc = 0; pc < before.size(); ++pc) {
+    if (before[pc] != rom->data()[pc]) {
+      ++changed_bytes;
+      changed_pc = pc;
+    }
+  }
+  if (changed_bytes != 1 || changed_pc != target.type_pc) {
+    return finish_error(
+        absl::DataLossError(absl::StrFormat(
+            "Door type edit changed %d bytes; expected only PC 0x%06X",
+            changed_bytes, target.type_pc)),
+        "write_error");
+  }
+
+  auto memory_readback =
+      ResolveDoorTypeTarget(rom, room_id, x, y, *manifest_context);
+  if (!memory_readback.ok()) {
+    return finish_error(memory_readback.status(), "readback_error");
+  }
+  const absl::Status memory_verify = verify_readback(*memory_readback);
+  if (!memory_verify.ok()) {
+    return finish_error(memory_verify, "readback_error");
+  }
+  formatter.AddField("readback_status", "pre_save_verified");
+  formatter.AddField("write_status", "success");
+
+  const absl::Status save_status = SaveRomWithBackup(rom, formatter);
+  if (!save_status.ok()) {
+    formatter.AddField("status", "error");
+    formatter.EndObject();
+    return save_status;
+  }
+
+  transaction.Commit();
+  formatter.AddField("status", "success");
   formatter.EndObject();
   return absl::OkStatus();
 }

--- a/src/cli/handlers/game/dungeon_edit_commands.h
+++ b/src/cli/handlers/game/dungeon_edit_commands.h
@@ -84,6 +84,33 @@ class DungeonPlaceObjectCommandHandler : public resources::CommandHandler {
 };
 
 /**
+ * @brief Change one existing dungeon door's fixed-width type byte.
+ *
+ * The target is selected by exact tile coordinates and guarded by a required
+ * expected old type. Dry-run is the default; use --write to commit + save ROM.
+ */
+class DungeonSetDoorTypeCommandHandler : public resources::CommandHandler {
+ public:
+  std::string GetName() const override { return "dungeon-set-door-type"; }
+  std::string GetDescription() const {
+    return "Change an existing dungeon door type";
+  }
+  std::string GetUsage() const override {
+    return "dungeon-set-door-type --room <hex> --x <int> --y <int> "
+           "--type <hex> --expect-type <hex> --manifest <path> "
+           "[--write] [--format <json|text>]";
+  }
+
+  absl::Status ValidateArgs(const resources::ArgumentParser& parser) override {
+    return parser.RequireArgs(
+        {"room", "x", "y", "type", "expect-type", "manifest"});
+  }
+
+  absl::Status Execute(Rom* rom, const resources::ArgumentParser& parser,
+                       resources::OutputFormatter& formatter) override;
+};
+
+/**
  * @brief Set individual custom collision tiles in a dungeon room.
  *
  * Supports setting one or more tiles. Dry-run by default.

--- a/src/cli/service/command_registry.cc
+++ b/src/cli/service/command_registry.cc
@@ -146,6 +146,19 @@ void CommandRegistry::RegisterHandlers(
             "z3ed dungeon-place-object --room=0x98 --id=0x0031 --x=20 --y=20 "
             "--size=4 --manifest=hack_manifest.json --write "
             "--rom=/tmp/oos-work.sfc --format=json"};
+      } else if (name == "dungeon-set-door-type") {
+        metadata.description =
+            "Change one existing door type with coordinate/CAS and manifest "
+            "guards (dry-run by default)";
+        metadata.examples = {
+            "z3ed dungeon-set-door-type --room=0xA8 --x=46 --y=58 "
+            "--type=0x00 --expect-type=0x18 "
+            "--manifest=hack_manifest.json --rom=Roms/oos168.sfc "
+            "--format=json",
+            "z3ed dungeon-set-door-type --room=0xA8 --x=46 --y=58 "
+            "--type=0x00 --expect-type=0x18 "
+            "--manifest=hack_manifest.json --write "
+            "--rom=/tmp/oos-work.sfc --format=json"};
       } else if (name == "dungeon-oracle-preflight") {
         metadata.description =
             "Oracle ROM safety preflight: water-fill region/table, collision "

--- a/test/unit/cli/dungeon_edit_commands_test.cc
+++ b/test/unit/cli/dungeon_edit_commands_test.cc
@@ -49,6 +49,8 @@ constexpr std::array<uint8_t, 14> kRoomHeaderSentinel = {
 constexpr uint16_t kRoomMessageSentinel = 0xDDCC;
 constexpr uint8_t kObjectHeaderByte0 = 0xA5;
 constexpr uint8_t kObjectHeaderByte1 = 0xE3;
+constexpr int kDoorEntryPc = kObjectDataPc + 8;
+constexpr int kDoorTypePc = kDoorEntryPc + 1;
 
 void ExpectInvalidArgument(const absl::Status& status,
                            const std::string& message_fragment) {
@@ -190,6 +192,47 @@ void InitializeRoomHeaderRom(Rom* rom) {
   rom->set_dirty(false);
 }
 
+void SetRoomObjectPointer(Rom* rom, int room_id, int pc_addr);
+
+void InitializeDoorTypeRom(Rom* rom, bool duplicate_coordinate = false) {
+  InitializeRoomHeaderRom(rom);
+
+  constexpr int kOtherObjectDataPc = kObjectDataPc + 0x20;
+  SetRoomObjectPointer(rom, 0, kObjectDataPc);
+  for (int room_id = 1; room_id < zelda3::kNumberOfRooms; ++room_id) {
+    SetRoomObjectPointer(rom, room_id, kOtherObjectDataPc);
+  }
+
+  std::vector<uint8_t> selected_stream = {
+      kObjectHeaderByte0,
+      kObjectHeaderByte1,
+      0xFF,
+      0xFF,
+      0xFF,
+      0xFF,
+      0xF0,
+      0xFF,
+      0x81,
+      0x18,
+  };
+  if (duplicate_coordinate) {
+    selected_stream.insert(selected_stream.end(), {0x81, 0x00});
+  }
+  selected_stream.insert(selected_stream.end(), {0xFF, 0xFF});
+  ASSERT_TRUE(rom->WriteVector(kObjectDataPc, std::move(selected_stream)).ok());
+  ASSERT_TRUE(
+      rom->WriteVector(kOtherObjectDataPc, {0x00, 0x00, 0xFF, 0xFF, 0xFF, 0xFF,
+                                            0xF0, 0xFF, 0xFF, 0xFF})
+          .ok());
+
+  WriteLong(rom, zelda3::kDoorPointers, PcToSnes(kDoorEntryPc));
+  for (int room_id = 1; room_id < zelda3::kNumberOfRooms; ++room_id) {
+    WriteLong(rom, zelda3::kDoorPointers + room_id * 3,
+              PcToSnes(kOtherObjectDataPc + 8));
+  }
+  rom->set_dirty(false);
+}
+
 void SetRoomObjectPointer(Rom* rom, int room_id, int pc_addr) {
   WriteLong(rom, kObjectPointerTablePc + room_id * 3, PcToSnes(pc_addr));
 }
@@ -273,7 +316,9 @@ void InitializeDescribeRoomObjectsRom(Rom* rom) {
 }
 
 void WriteObjectCowManifest(const std::filesystem::path& path,
-                            bool protect_allocation = false) {
+                            bool protect_allocation = false,
+                            int protected_pc = -1,
+                            int pointer_count = zelda3::kNumberOfRooms) {
   std::string protected_section;
   if (protect_allocation) {
     protected_section = absl::StrFormat(
@@ -292,6 +337,22 @@ void WriteObjectCowManifest(const std::filesystem::path& path,
   })json",
         PcToSnes(kObjectAllocationPc), PcToSnes(kObjectDataEndPc),
         kObjectDataEndPc - kObjectAllocationPc);
+  } else if (protected_pc >= 0) {
+    protected_section = absl::StrFormat(
+        R"json(,
+  "protected_regions": {
+    "total_hooks": 1,
+    "regions": [
+      {
+        "start": "0x%06X",
+        "end": "0x%06X",
+        "size": 1,
+        "hook_count": 1,
+        "module": "DoorTypeGuard"
+      }
+    ]
+  })json",
+        PcToSnes(protected_pc), PcToSnes(protected_pc + 1));
   }
   const std::string json = absl::StrFormat(
       R"json({
@@ -299,7 +360,7 @@ void WriteObjectCowManifest(const std::filesystem::path& path,
   "dungeon_stream_regions": {
     "objects": {
       "pointer_table": "0x%06X",
-      "pointer_count": 296,
+      "pointer_count": %d,
       "pointer_encoding": "long24",
       "strategy": "copy_on_write",
       "data_regions": [
@@ -311,7 +372,7 @@ void WriteObjectCowManifest(const std::filesystem::path& path,
     }
   }%s
 })json",
-      PcToSnes(kObjectPointerTablePc), PcToSnes(kObjectDataPc),
+      PcToSnes(kObjectPointerTablePc), pointer_count, PcToSnes(kObjectDataPc),
       PcToSnes(kObjectDataEndPc), PcToSnes(kObjectAllocationPc),
       PcToSnes(kObjectDataEndPc), protected_section);
   std::ofstream output(path, std::ios::trunc);
@@ -522,6 +583,8 @@ TEST(DungeonEditCommandsTest,
   // The legacy count includes the synthesized lightable-torch table object.
   EXPECT_EQ(result.at("properties").at("object_count"), 4);
   ASSERT_EQ(result.at("doors").size(), 1u);
+  EXPECT_EQ(result.at("doors").at(0).at("index"), 0);
+  EXPECT_EQ(result.at("doors").at(0).at("type_id"), "0x04");
   EXPECT_EQ(rom.vector(), before);
   EXPECT_FALSE(rom.dirty());
 }
@@ -1417,6 +1480,415 @@ TEST(DungeonEditCommandsTest,
   EXPECT_EQ(*disk_hash_after_write, *disk_hash_before);
   EXPECT_EQ(ReadRoomObjectPointerPc(rom, 0), pointer_before);
   EXPECT_EQ(CountBackupArtifacts(cleanup.rom_path), 0);
+}
+
+TEST(DungeonEditCommandsTest,
+     SetDoorTypeDryRunLeavesRomDiskAndBackupsUnchanged) {
+  Rom rom;
+  InitializeDoorTypeRom(&rom);
+  ScopedRomArtifactsCleanup cleanup(MakeUniqueTempRomPath());
+  ScopedFileCleanup manifest_cleanup(cleanup.rom_path.string() +
+                                     ".manifest.json");
+  WriteRomFile(rom, cleanup.rom_path);
+  WriteObjectCowManifest(manifest_cleanup.file_path);
+  rom.set_filename(cleanup.rom_path.string());
+  rom.set_dirty(false);
+
+  const std::vector<uint8_t> before = rom.vector();
+  const std::vector<uint8_t> disk_before = ReadFile(cleanup.rom_path);
+  handlers::DungeonSetDoorTypeCommandHandler handler;
+  std::string output;
+  const absl::Status status = handler.Run(
+      {"--room=0x00", "--x=46", "--y=58", "--type=0x00", "--expect-type=0x18",
+       absl::StrFormat("--manifest=%s", manifest_cleanup.file_path.string()),
+       "--format=json"},
+      &rom, &output);
+
+  ASSERT_TRUE(status.ok()) << status;
+  EXPECT_THAT(output, HasSubstr("\"mode\": \"dry-run\""));
+  EXPECT_THAT(output, HasSubstr("\"preflight_status\": \"success\""));
+  EXPECT_THAT(output, HasSubstr("\"door_index\": 0"));
+  EXPECT_THAT(output, HasSubstr("\"direction\": \"South\""));
+  EXPECT_THAT(output, HasSubstr("\"old_type\": \"0x18\""));
+  EXPECT_THAT(output, HasSubstr("\"new_type\": \"0x00\""));
+  EXPECT_THAT(output, HasSubstr("\"type_pc\": \"0x060009\""));
+  EXPECT_EQ(rom.vector(), before);
+  EXPECT_FALSE(rom.dirty());
+  EXPECT_EQ(ReadFile(cleanup.rom_path), disk_before);
+  EXPECT_EQ(CountBackupArtifacts(cleanup.rom_path), 0);
+}
+
+TEST(DungeonEditCommandsTest,
+     SetDoorTypeRejectsStaleExpectedTypeWithoutMutation) {
+  Rom rom;
+  InitializeDoorTypeRom(&rom);
+  ScopedFileCleanup manifest_cleanup(MakeUniqueTempRomPath().string() +
+                                     ".manifest.json");
+  WriteObjectCowManifest(manifest_cleanup.file_path);
+  const std::vector<uint8_t> before = rom.vector();
+
+  handlers::DungeonSetDoorTypeCommandHandler handler;
+  std::string output;
+  const absl::Status status = handler.Run(
+      {"--room=0x00", "--x=46", "--y=58", "--type=0x00", "--expect-type=0x1A",
+       absl::StrFormat("--manifest=%s", manifest_cleanup.file_path.string()),
+       "--format=json"},
+      &rom, &output);
+
+  EXPECT_TRUE(absl::IsFailedPrecondition(status)) << status;
+  EXPECT_THAT(std::string(status.message()),
+              HasSubstr("compare-and-swap failed"));
+  EXPECT_EQ(rom.vector(), before);
+  EXPECT_FALSE(rom.dirty());
+}
+
+TEST(DungeonEditCommandsTest, SetDoorTypeRejectsInvalidDoorTypeValues) {
+  Rom rom;
+  InitializeDoorTypeRom(&rom);
+  ScopedFileCleanup manifest_cleanup(MakeUniqueTempRomPath().string() +
+                                     ".manifest.json");
+  WriteObjectCowManifest(manifest_cleanup.file_path);
+  const std::vector<uint8_t> before = rom.vector();
+  handlers::DungeonSetDoorTypeCommandHandler handler;
+
+  for (const std::string& type : {"0x19", "0x68"}) {
+    SCOPED_TRACE(type);
+    std::string output;
+    const absl::Status status = handler.Run(
+        {"--room=0x00", "--x=46", "--y=58", "--type=" + type,
+         "--expect-type=0x18",
+         absl::StrFormat("--manifest=%s", manifest_cleanup.file_path.string()),
+         "--format=json"},
+        &rom, &output);
+    ExpectInvalidArgument(status, "even door type");
+    EXPECT_EQ(rom.vector(), before);
+    EXPECT_FALSE(rom.dirty());
+  }
+}
+
+TEST(DungeonEditCommandsTest,
+     SetDoorTypeRejectsMissingAndAmbiguousCoordinates) {
+  ScopedFileCleanup manifest_cleanup(MakeUniqueTempRomPath().string() +
+                                     ".manifest.json");
+  WriteObjectCowManifest(manifest_cleanup.file_path);
+  handlers::DungeonSetDoorTypeCommandHandler handler;
+
+  {
+    Rom rom;
+    InitializeDoorTypeRom(&rom);
+    const std::vector<uint8_t> before = rom.vector();
+    std::string output;
+    const absl::Status status = handler.Run(
+        {"--room=0x00", "--x=45", "--y=58", "--type=0x00", "--expect-type=0x18",
+         absl::StrFormat("--manifest=%s", manifest_cleanup.file_path.string()),
+         "--format=json"},
+        &rom, &output);
+    EXPECT_TRUE(absl::IsNotFound(status)) << status;
+    EXPECT_THAT(std::string(status.message()), HasSubstr("No door matches"));
+    EXPECT_EQ(rom.vector(), before);
+  }
+
+  {
+    Rom rom;
+    InitializeDoorTypeRom(&rom, /*duplicate_coordinate=*/true);
+    const std::vector<uint8_t> before = rom.vector();
+    std::string output;
+    const absl::Status status = handler.Run(
+        {"--room=0x00", "--x=46", "--y=58", "--type=0x00", "--expect-type=0x18",
+         absl::StrFormat("--manifest=%s", manifest_cleanup.file_path.string()),
+         "--format=json"},
+        &rom, &output);
+    EXPECT_TRUE(absl::IsFailedPrecondition(status)) << status;
+    EXPECT_THAT(std::string(status.message()),
+                HasSubstr("Multiple doors match"));
+    EXPECT_EQ(rom.vector(), before);
+  }
+}
+
+TEST(DungeonEditCommandsTest,
+     SetDoorTypeRejectsAliasedSelectedStreamWithoutMutation) {
+  Rom rom;
+  InitializeDoorTypeRom(&rom);
+  SetRoomObjectPointer(&rom, 1, kObjectDataPc);
+  rom.set_dirty(false);
+  ScopedFileCleanup manifest_cleanup(MakeUniqueTempRomPath().string() +
+                                     ".manifest.json");
+  WriteObjectCowManifest(manifest_cleanup.file_path);
+  const std::vector<uint8_t> before = rom.vector();
+
+  handlers::DungeonSetDoorTypeCommandHandler handler;
+  std::string output;
+  const absl::Status status = handler.Run(
+      {"--room=0x00", "--x=46", "--y=58", "--type=0x00", "--expect-type=0x18",
+       absl::StrFormat("--manifest=%s", manifest_cleanup.file_path.string()),
+       "--format=json"},
+      &rom, &output);
+
+  EXPECT_TRUE(absl::IsFailedPrecondition(status)) << status;
+  EXPECT_THAT(std::string(status.message()), HasSubstr("shared by 2 rooms"));
+  EXPECT_EQ(rom.vector(), before);
+  EXPECT_FALSE(rom.dirty());
+}
+
+TEST(DungeonEditCommandsTest,
+     SetDoorTypeRejectsOverlappingSelectedStreamWithoutMutation) {
+  Rom rom;
+  InitializeDoorTypeRom(&rom);
+  ASSERT_TRUE(
+      rom.WriteVector(kObjectDataPc, {0x00, 0x00, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+                                      0xFF, 0xF0, 0xFF, 0x81, 0x18, 0xFF, 0xFF})
+          .ok());
+  SetRoomObjectPointer(&rom, 0, kObjectDataPc + 2);
+  SetRoomObjectPointer(&rom, 1, kObjectDataPc);
+  WriteLong(&rom, zelda3::kDoorPointers, PcToSnes(kObjectDataPc + 10));
+  rom.set_dirty(false);
+  ScopedFileCleanup manifest_cleanup(MakeUniqueTempRomPath().string() +
+                                     ".manifest.json");
+  WriteObjectCowManifest(manifest_cleanup.file_path);
+  const std::vector<uint8_t> before = rom.vector();
+
+  handlers::DungeonSetDoorTypeCommandHandler handler;
+  std::string output;
+  const absl::Status status = handler.Run(
+      {"--room=0x00", "--x=46", "--y=58", "--type=0x00", "--expect-type=0x18",
+       absl::StrFormat("--manifest=%s", manifest_cleanup.file_path.string()),
+       "--format=json"},
+      &rom, &output);
+
+  EXPECT_TRUE(absl::IsFailedPrecondition(status)) << status;
+  EXPECT_THAT(std::string(status.message()), HasSubstr("overlaps PC range"));
+  EXPECT_EQ(rom.vector(), before);
+  EXPECT_FALSE(rom.dirty());
+}
+
+TEST(DungeonEditCommandsTest, SetDoorTypeAllowsUnrelatedMalformedObjectStream) {
+  Rom rom;
+  InitializeDoorTypeRom(&rom);
+  SetRoomObjectPointer(&rom, 1, kObjectDataPc + 0x80);
+  rom.set_dirty(false);
+  ScopedFileCleanup manifest_cleanup(MakeUniqueTempRomPath().string() +
+                                     ".manifest.json");
+  WriteObjectCowManifest(manifest_cleanup.file_path);
+  const std::vector<uint8_t> before = rom.vector();
+
+  handlers::DungeonSetDoorTypeCommandHandler handler;
+  std::string output;
+  const absl::Status status = handler.Run(
+      {"--room=0x00", "--x=46", "--y=58", "--type=0x00", "--expect-type=0x18",
+       absl::StrFormat("--manifest=%s", manifest_cleanup.file_path.string()),
+       "--format=json"},
+      &rom, &output);
+
+  ASSERT_TRUE(status.ok()) << status;
+  EXPECT_THAT(output, HasSubstr("\"preflight_status\": \"success\""));
+  EXPECT_EQ(rom.vector(), before);
+  EXPECT_FALSE(rom.dirty());
+}
+
+TEST(DungeonEditCommandsTest,
+     SetDoorTypeRejectsMalformedPointerInsideSelectedStream) {
+  Rom rom;
+  InitializeDoorTypeRom(&rom);
+  constexpr int kSelectedStreamPc = kObjectDataEndPc - 12;
+  constexpr int kSelectedDoorPc = kSelectedStreamPc + 8;
+  constexpr int kSelectedTypePc = kSelectedDoorPc + 1;
+  ASSERT_TRUE(
+      rom.WriteVector(kSelectedStreamPc,
+                      {kObjectHeaderByte0, kObjectHeaderByte1, 0xFF, 0xFF, 0xFF,
+                       0xFF, 0xF0, 0xFF, 0x81, 0x18, 0xFF, 0xFF})
+          .ok());
+  SetRoomObjectPointer(&rom, 0, kSelectedStreamPc);
+  SetRoomObjectPointer(&rom, 1, kSelectedTypePc);
+  WriteLong(&rom, zelda3::kDoorPointers, PcToSnes(kSelectedDoorPc));
+  rom.set_dirty(false);
+  ScopedFileCleanup manifest_cleanup(MakeUniqueTempRomPath().string() +
+                                     ".manifest.json");
+  WriteObjectCowManifest(manifest_cleanup.file_path);
+  const std::vector<uint8_t> before = rom.vector();
+
+  handlers::DungeonSetDoorTypeCommandHandler handler;
+  std::string output;
+  const absl::Status status = handler.Run(
+      {"--room=0x00", "--x=46", "--y=58", "--type=0x00", "--expect-type=0x18",
+       absl::StrFormat("--manifest=%s", manifest_cleanup.file_path.string()),
+       "--format=json"},
+      &rom, &output);
+
+  EXPECT_TRUE(absl::IsFailedPrecondition(status)) << status;
+  EXPECT_THAT(std::string(status.message()),
+              HasSubstr("starts inside selected object stream"));
+  EXPECT_EQ(rom.vector(), before);
+  EXPECT_FALSE(rom.dirty());
+}
+
+TEST(DungeonEditCommandsTest,
+     SetDoorTypeRejectsPartialManifestPointerInventory) {
+  Rom rom;
+  InitializeDoorTypeRom(&rom);
+  ScopedFileCleanup manifest_cleanup(MakeUniqueTempRomPath().string() +
+                                     ".manifest.json");
+  WriteObjectCowManifest(manifest_cleanup.file_path,
+                         /*protect_allocation=*/false,
+                         /*protected_pc=*/-1,
+                         /*pointer_count=*/zelda3::kNumberOfRooms - 1);
+  const std::vector<uint8_t> before = rom.vector();
+
+  handlers::DungeonSetDoorTypeCommandHandler handler;
+  std::string output;
+  const absl::Status status = handler.Run(
+      {"--room=0x00", "--x=46", "--y=58", "--type=0x00", "--expect-type=0x18",
+       absl::StrFormat("--manifest=%s", manifest_cleanup.file_path.string()),
+       "--format=json"},
+      &rom, &output);
+
+  EXPECT_TRUE(absl::IsFailedPrecondition(status)) << status;
+  EXPECT_THAT(std::string(status.message()),
+              HasSubstr("pointer_count must equal 296 rooms"));
+  EXPECT_EQ(rom.vector(), before);
+  EXPECT_FALSE(rom.dirty());
+}
+
+TEST(DungeonEditCommandsTest,
+     SetDoorTypeRejectsOtherRoomDoorPointerInsideSelectedStream) {
+  Rom rom;
+  InitializeDoorTypeRom(&rom);
+  WriteLong(&rom, zelda3::kDoorPointers + 3, PcToSnes(kDoorTypePc));
+  rom.set_dirty(false);
+  ScopedFileCleanup manifest_cleanup(MakeUniqueTempRomPath().string() +
+                                     ".manifest.json");
+  WriteObjectCowManifest(manifest_cleanup.file_path);
+  const std::vector<uint8_t> before = rom.vector();
+
+  handlers::DungeonSetDoorTypeCommandHandler handler;
+  std::string output;
+  const absl::Status status = handler.Run(
+      {"--room=0x00", "--x=46", "--y=58", "--type=0x00", "--expect-type=0x18",
+       absl::StrFormat("--manifest=%s", manifest_cleanup.file_path.string()),
+       "--format=json"},
+      &rom, &output);
+
+  EXPECT_TRUE(absl::IsFailedPrecondition(status)) << status;
+  EXPECT_THAT(std::string(status.message()),
+              HasSubstr("door pointer PC 0x060009 points inside selected"));
+  EXPECT_EQ(rom.vector(), before);
+  EXPECT_FALSE(rom.dirty());
+}
+
+TEST(DungeonEditCommandsTest,
+     SetDoorTypeRejectsProtectedByteWithoutMutationOrArtifacts) {
+  Rom rom;
+  InitializeDoorTypeRom(&rom);
+  ScopedRomArtifactsCleanup cleanup(MakeUniqueTempRomPath());
+  ScopedFileCleanup manifest_cleanup(cleanup.rom_path.string() +
+                                     ".manifest.json");
+  WriteRomFile(rom, cleanup.rom_path);
+  WriteObjectCowManifest(manifest_cleanup.file_path,
+                         /*protect_allocation=*/false, kDoorTypePc);
+  rom.set_filename(cleanup.rom_path.string());
+  rom.set_dirty(false);
+  const std::vector<uint8_t> before = rom.vector();
+  const std::vector<uint8_t> disk_before = ReadFile(cleanup.rom_path);
+
+  handlers::DungeonSetDoorTypeCommandHandler handler;
+  std::string output;
+  const absl::Status status = handler.Run(
+      {"--room=0x00", "--x=46", "--y=58", "--type=0x00", "--expect-type=0x18",
+       absl::StrFormat("--manifest=%s", manifest_cleanup.file_path.string()),
+       "--write", "--format=json"},
+      &rom, &output);
+
+  EXPECT_TRUE(absl::IsPermissionDenied(status)) << status;
+  EXPECT_THAT(std::string(status.message()),
+              HasSubstr("conflicts with Hack Manifest"));
+  EXPECT_EQ(rom.vector(), before);
+  EXPECT_FALSE(rom.dirty());
+  EXPECT_EQ(ReadFile(cleanup.rom_path), disk_before);
+  EXPECT_EQ(CountBackupArtifacts(cleanup.rom_path), 0);
+}
+
+TEST(DungeonEditCommandsTest, SetDoorTypeWriteChangesOneByteBacksUpAndReopens) {
+  Rom rom;
+  InitializeDoorTypeRom(&rom);
+  ScopedRomArtifactsCleanup cleanup(MakeUniqueTempRomPath());
+  ScopedFileCleanup manifest_cleanup(cleanup.rom_path.string() +
+                                     ".manifest.json");
+  WriteRomFile(rom, cleanup.rom_path);
+  WriteObjectCowManifest(manifest_cleanup.file_path);
+  rom.set_filename(cleanup.rom_path.string());
+  rom.set_dirty(false);
+  const std::vector<uint8_t> before = rom.vector();
+  const std::vector<uint8_t> disk_before = ReadFile(cleanup.rom_path);
+
+  handlers::DungeonSetDoorTypeCommandHandler handler;
+  std::string output;
+  const absl::Status status = handler.Run(
+      {"--room=0x00", "--x=46", "--y=58", "--type=0x00", "--expect-type=0x18",
+       absl::StrFormat("--manifest=%s", manifest_cleanup.file_path.string()),
+       "--write", "--format=json"},
+      &rom, &output);
+
+  ASSERT_TRUE(status.ok()) << status;
+  EXPECT_THAT(output, HasSubstr("\"mode\": \"write\""));
+  EXPECT_THAT(output, HasSubstr("\"write_status\": \"success\""));
+  EXPECT_THAT(output, HasSubstr("\"save_status\": \"saved\""));
+  EXPECT_THAT(output, HasSubstr("\"readback_status\": \"pre_save_verified\""));
+  std::vector<uint8_t> expected = before;
+  expected[kDoorTypePc] = 0x00;
+  EXPECT_EQ(rom.vector(), expected);
+  EXPECT_EQ(ReadFile(cleanup.rom_path), expected);
+  EXPECT_FALSE(rom.dirty());
+
+  const auto backups = FindBackupArtifacts(cleanup.rom_path);
+  ASSERT_EQ(backups.size(), 1u);
+  EXPECT_EQ(ReadFile(backups.front()), disk_before);
+
+  Rom reopened;
+  ASSERT_TRUE(reopened.LoadFromFile(cleanup.rom_path.string()).ok());
+  const zelda3::Room room = zelda3::LoadRoomFromRom(&reopened, 0);
+  ASSERT_EQ(room.GetDoors().size(), 1u);
+  const auto& door = room.GetDoors().front();
+  EXPECT_EQ(door.GetTileCoords(), std::make_pair(46, 58));
+  EXPECT_EQ(door.direction, zelda3::DoorDirection::South);
+  EXPECT_EQ(door.position, 8);
+  EXPECT_EQ(door.type, zelda3::DoorType::NormalDoor);
+}
+
+TEST(DungeonEditCommandsTest, SetDoorTypeDiskSaveFailureRollsBackCallerRom) {
+  Rom rom;
+  InitializeDoorTypeRom(&rom);
+  ScopedRomArtifactsCleanup cleanup(MakeUniqueTempRomPath());
+  ScopedFileCleanup manifest_cleanup(cleanup.rom_path.string() +
+                                     ".manifest.json");
+  WriteRomFile(rom, cleanup.rom_path);
+  WriteObjectCowManifest(manifest_cleanup.file_path);
+  rom.set_filename(cleanup.rom_path.string());
+  rom.set_dirty(false);
+  ASSERT_TRUE(
+      std::filesystem::create_directory(cleanup.rom_path.string() + ".tmp"));
+  const std::vector<uint8_t> before = rom.vector();
+  const std::vector<uint8_t> disk_before = ReadFile(cleanup.rom_path);
+  const bool dirty_before = rom.dirty();
+  const std::string filename_before = rom.filename();
+
+  handlers::DungeonSetDoorTypeCommandHandler handler;
+  std::string output;
+  const absl::Status status = handler.Run(
+      {"--room=0x00", "--x=46", "--y=58", "--type=0x00", "--expect-type=0x18",
+       absl::StrFormat("--manifest=%s", manifest_cleanup.file_path.string()),
+       "--write", "--format=json"},
+      &rom, &output);
+
+  EXPECT_TRUE(absl::IsInternal(status)) << status;
+  EXPECT_THAT(std::string(status.message()),
+              HasSubstr("Could not open temp ROM file for writing"));
+  EXPECT_THAT(output, HasSubstr("\"readback_status\": \"pre_save_verified\""));
+  EXPECT_THAT(output, HasSubstr("\"write_status\": \"success\""));
+  EXPECT_THAT(output, HasSubstr("\"save_error\""));
+  EXPECT_EQ(rom.vector(), before);
+  EXPECT_EQ(rom.dirty(), dirty_before);
+  EXPECT_EQ(rom.filename(), filename_before);
+  EXPECT_EQ(ReadFile(cleanup.rom_path), disk_before);
+  EXPECT_EQ(CountBackupArtifacts(cleanup.rom_path), 1);
 }
 
 }  // namespace


### PR DESCRIPTION
## Summary

- add dry-run-first `dungeon-set-door-type` for changing one existing fixed-width door type byte
- require exact tile coordinates, expected-old-type compare-and-swap, and a complete 296-room object-stream manifest
- cross-check runtime/model/raw door data, reject object-stream and door-pointer aliases, and enforce exact manifest ownership
- fence write mode to one byte, require a destination backup, save atomically, and roll caller state back on failure
- expose door `index` and raw `type_id` through `dungeon-describe-room`

## Why

The remaining Oracle daily-driver proof needs a representative D6 door edit, but the CLI could not safely inspect or change an existing door. Rewriting the complete 265-byte room `0xA8` object stream would add unnecessary relocation/capacity risk. The door type is already a fixed full byte in the runtime stream, so this command resolves it through the full room model and manifest, then permits only that exact byte.

For canonical Oracle room `0xA8`, the audited target is:

- south door at `(46,58)`, index `2`
- `Double-Sided Shutter` `0x18` -> `Normal Door` `0x00`
- object stream `[0x0FC169,0x0FC272)`
- door entry PC `0x0FC26E`; type byte PC `0x0FC26F` / SNES `$1F:C26F`

## Safety contract

- dry-run unless `--write` is supplied
- even door types only, `0x00-0x66`
- required expected old type (CAS)
- manifest must define all 296 object pointers with `copy_on_write`
- selected invalid/shared/overlapping streams fail closed
- malformed pointer starts and every other runtime door pointer are checked against the selected stream
- room model, raw door entries, pointer table, terminator, and manifest ownership must agree
- write mode uses a one-byte `WriteFence`, `ScopedRomTransaction`, required backup, atomic save, and pre-save model/raw readback

## Verification

- focused command/describe/safety tests: **14/14 passed**
- `z3ed` and `yaze_test_unit` built after syncing onto `master` merge `43db7f0625eb4a58fc0e0a1e8df6e89ba696e5d3`
- canonical OOS `0xA8` dry-run resolved the exact target above and passed every preflight
- canonical ROM SHA-256 remained `d289b2408c3ccc312abeadf274f04f475106034fcab8ebff3f307fd229db4799`
- `clang-format --dry-run --Werror`: passed
- `git diff --check`: passed
- two independent strict reviews; final re-review found no remaining blockers

## Example

```bash
z3ed dungeon-set-door-type \
  --room=0xA8 --x=46 --y=58 \
  --type=0x00 --expect-type=0x18 \
  --manifest=Roms/hack_manifest.json \
  --rom=/tmp/oos168-d6-proof.sfc --format=json
# Review the dry-run, then repeat with --write on the disposable copy.
```

## Residual scope

- This changes an existing door type only; it does not add/remove/reposition doors.
- No real OOS write, rebuild, or Mesen traversal is claimed here; the canonical run was read-only.
- Room-header palette ownership is separate: #168 tracks the current manifest-enforcement gap before an automated D6 palette proof is safe.
