### PR TITLE
fix(dungeon): match Fortune Teller room drawing

### DIFF
--- a/src/zelda3/dungeon/draw_routines/draw_routine_registry.cc
+++ b/src/zelda3/dungeon/draw_routines/draw_routine_registry.cc
@@ -466,7 +466,7 @@ void DrawRoutineRegistry::BuildObjectMapping() {
   for (int id = 0xFCF; id <= 0xFD3; id++) {
     object_to_routine_map_[id] = 110;
   }
-  object_to_routine_map_[0xFD4] = 16;
+  object_to_routine_map_[0xFD4] = DrawRoutineIds::kFortuneTellerRoom;
   object_to_routine_map_[0xFD5] = 101;
   for (int id = 0xFD6; id <= 0xFD9; id++) {
     object_to_routine_map_[id] = 110;

--- a/src/zelda3/dungeon/draw_routines/draw_routine_registry.h
+++ b/src/zelda3/dungeon/draw_routines/draw_routine_registry.h
@@ -89,6 +89,7 @@ constexpr int kTableBowl = 126;
 constexpr int kSmithyFurnace = 127;
 constexpr int kBigGrayRock = 128;
 constexpr int kAgahnimsAltar = 129;
+constexpr int kFortuneTellerRoom = 131;
 
 // Corner routines (19, 35-37, 75-78)
 constexpr int kCorner4x4 = 19;
@@ -177,7 +178,7 @@ constexpr int kSingle4x3 = 114;
 constexpr int kRupeeFloor = 115;
 constexpr int kActual4x4 = 116;
 
-// Custom object routines (130+)
+// Custom object routine.
 constexpr int kCustomObject = 130;
 
 }  // namespace DrawRoutineIds

--- a/src/zelda3/dungeon/draw_routines/special_routines.cc
+++ b/src/zelda3/dungeon/draw_routines/special_routines.cc
@@ -498,6 +498,88 @@ void DrawAgahnimsAltar(const DrawContext& ctx) {
   }
 }
 
+void DrawFortuneTellerRoom(const DrawContext& ctx) {
+  // ASM: RoomDraw_FortuneTellerRoom ($01A095) reads all 26 words from
+  // obj202E and writes 116 tiles into a sparse, fixed 14x14 BG1 footprint.
+  if (ctx.tiles.size() < 26)
+    return;
+
+  auto write = [&](int dx, int dy, size_t tile_index,
+                   bool force_horizontal_mirror = false,
+                   bool toggle_horizontal_mirror = false) {
+    gfx::TileInfo tile = ctx.tiles[tile_index];
+    if (force_horizontal_mirror) {
+      tile.horizontal_mirror_ = true;
+    } else if (toggle_horizontal_mirror) {
+      tile.horizontal_mirror_ = !tile.horizontal_mirror_;
+    }
+    DrawRoutineUtils::WriteTile8(ctx.target_bg, ctx.object.x_ + dx,
+                                 ctx.object.y_ + dy, tile);
+  };
+
+  // Six repeated two-column roof sections across rows 0..2.
+  for (int section = 0; section < 6; ++section) {
+    const int x = section * 2;
+    write(x + 1, 0, 0);
+    write(x + 2, 0, 0);
+    write(x + 1, 1, 0);
+    write(x + 2, 1, 0);
+    write(x + 1, 2, 1);
+    write(x + 2, 2, 1, /*force_horizontal_mirror=*/true);
+  }
+
+  // Three complete mirrored rows. The left/right wall tile advances through
+  // words 2..4 while the center tile advances through words 5..7.
+  for (int row = 0; row < 3; ++row) {
+    const size_t wall_tile = static_cast<size_t>(2 + row);
+    const size_t center_tile = static_cast<size_t>(5 + row);
+    const int y = 3 + row;
+
+    for (int x : {0, 2, 10, 12}) {
+      write(x, y, wall_tile);
+    }
+    for (int x : {1, 3, 11, 13}) {
+      write(x, y, wall_tile, /*force_horizontal_mirror=*/true);
+    }
+    for (int x : {4, 6, 8}) {
+      write(x, y, center_tile);
+    }
+    for (int x : {5, 7, 9}) {
+      write(x, y, center_tile, /*force_horizontal_mirror=*/true);
+    }
+  }
+
+  // Outer caps around the roof.
+  write(0, 0, 8);
+  write(0, 1, 8);
+  write(13, 0, 8, /*force_horizontal_mirror=*/true);
+  write(13, 1, 8, /*force_horizontal_mirror=*/true);
+  write(0, 2, 9);
+  write(13, 2, 9, /*force_horizontal_mirror=*/true);
+
+  // Four sparse rows at the bottom. Each source word is mirrored with EOR
+  // #$4000, so an existing H-flip must be toggled rather than forced on.
+  for (int row = 0; row < 4; ++row) {
+    const int y = 10 + row;
+    write(3, y, static_cast<size_t>(10 + row));
+    write(10, y, static_cast<size_t>(10 + row),
+          /*force_horizontal_mirror=*/false,
+          /*toggle_horizontal_mirror=*/true);
+    write(4, y, static_cast<size_t>(14 + row));
+    write(9, y, static_cast<size_t>(14 + row),
+          /*force_horizontal_mirror=*/false,
+          /*toggle_horizontal_mirror=*/true);
+    write(5, y, static_cast<size_t>(18 + row));
+    write(8, y, static_cast<size_t>(18 + row),
+          /*force_horizontal_mirror=*/false,
+          /*toggle_horizontal_mirror=*/true);
+    write(6, y, static_cast<size_t>(22 + row));
+    write(7, y, static_cast<size_t>(22 + row),
+          /*force_horizontal_mirror=*/false,
+          /*toggle_horizontal_mirror=*/true);
+  }
+}
+
 void DrawUtility3x5(const DrawContext& ctx) {
   // ASM: RoomDraw_Utility3x5 ($01A194) uses:
   // - top row: tiles 0..2
@@ -2029,6 +2111,17 @@ void RegisterSpecialRoutines(std::vector<DrawRoutineInfo>& registry) {
       .base_width = 14,
       .base_height = 14,
       .min_tiles = 84,
+      .category = DrawRoutineInfo::Category::Special,
+  });
+
+  registry.push_back(DrawRoutineInfo{
+      .id = DrawRoutineIds::kFortuneTellerRoom,  // 131
+      .name = "FortuneTellerRoom",
+      .function = DrawFortuneTellerRoom,
+      .draws_to_both_bgs = false,
+      .base_width = 14,
+      .base_height = 14,
+      .min_tiles = 26,
       .category = DrawRoutineInfo::Category::Special,
   });
 

--- a/src/zelda3/dungeon/draw_routines/special_routines.h
+++ b/src/zelda3/dungeon/draw_routines/special_routines.h
@@ -144,6 +144,13 @@ void DrawBigGrayRock(const DrawContext& ctx);
 void DrawAgahnimsAltar(const DrawContext& ctx);
 
 /**
+ * @brief Draw the fixed 14x14 fortune teller room on BG1
+ *
+ * ASM: RoomDraw_FortuneTellerRoom ($01A095)
+ */
+void DrawFortuneTellerRoom(const DrawContext& ctx);
+
+/**
  * @brief Draw utility 3x5 pattern (special row pattern)
  *
  * ASM: RoomDraw_Utility3x5 ($01A194)

--- a/src/zelda3/dungeon/object_dimensions.cc
+++ b/src/zelda3/dungeon/object_dimensions.cc
@@ -931,13 +931,14 @@ void ObjectDimensionTable::InitializeDefaults() {
   dimensions_[0xFAC] = {4, 4, Dir::None, 0, false};
   // Agahnim's altar is a fixed 14x14 mirrored stamp.
   dimensions_[0xFAD] = {14, 14, Dir::None, 0, false};
+  // Fortune teller facade is a sparse fixed 14x14 BG1 stamp.
+  dimensions_[0xFD4] = {14, 14, Dir::None, 0, false};
   // Repeatable 4x4 patterns
   for (int id = 0xFB4; id <= 0xFB9; id++) {
     dimensions_[id] = {4, 4, Dir::Horizontal, 4, false};
   }
   dimensions_[0xFAA] = {4, 4, Dir::Horizontal, 4, false};
   dimensions_[0xFAE] = {4, 4, Dir::Horizontal, 4, false};
-  dimensions_[0xFD4] = {4, 4, Dir::Horizontal, 4, false};
   dimensions_[0xFE2] = {4, 4, Dir::Horizontal, 4, false};
   // Big wall decor aliases are fixed 8x3 objects; their size nibble is ignored.
   dimensions_[0xFCB] = {8, 3, Dir::None, 0, false};

--- a/src/zelda3/dungeon/object_drawer.cc
+++ b/src/zelda3/dungeon/object_drawer.cc
@@ -350,8 +350,10 @@ absl::Status ObjectDrawer::DrawObject(
 
   // Special routines may need a second buffer for mixed-layer draws or fixed
   // BG1/BG2 routing regardless of the parsed object-layer flag.
-  if (!is_both_bg && routine_id == DrawRoutineIds::kAgahnimsAltar) {
-    // USDASM writes the altar directly to the upper tilemap at $7E2000.
+  if (!is_both_bg && (routine_id == DrawRoutineIds::kAgahnimsAltar ||
+                      routine_id == DrawRoutineIds::kFortuneTellerRoom)) {
+    // USDASM writes these fixed room facades directly to the upper tilemap at
+    // $7E2000.
     dispatch_bg = &bg1;
     registry_primary_layer_ = RoomObject::LayerType::BG1;
   } else if (!is_both_bg && routine_id == DrawRoutineIds::kAutoStairs) {
@@ -1458,6 +1460,14 @@ void ObjectDrawer::InitializeDrawRoutines() {
          std::span<const gfx::TileInfo> tiles, const DungeonState* state) {
         self->DrawUsingRegistryRoutine(DrawRoutineIds::kAgahnimsAltar, obj, bg,
                                        tiles, state);
+      };
+
+  ensure_index(DrawRoutineIds::kFortuneTellerRoom);
+  draw_routines_[DrawRoutineIds::kFortuneTellerRoom] =
+      [](ObjectDrawer* self, const RoomObject& obj, gfx::BackgroundBuffer& bg,
+         std::span<const gfx::TileInfo> tiles, const DungeonState* state) {
+        self->DrawUsingRegistryRoutine(DrawRoutineIds::kFortuneTellerRoom, obj,
+                                       bg, tiles, state);
       };
 
   // Routine 130 - Custom Object (Oracle of Secrets 0x31, 0x32)
@@ -3259,6 +3269,11 @@ std::pair<int, int> yaze::zelda3::ObjectDrawer::CalculateObjectDimensions(
       break;
 
     case DrawRoutineIds::kAgahnimsAltar:
+      width = 112;
+      height = 112;
+      break;
+
+    case DrawRoutineIds::kFortuneTellerRoom:
       width = 112;
       height = 112;
       break;

--- a/src/zelda3/dungeon/object_layer_semantics.h
+++ b/src/zelda3/dungeon/object_layer_semantics.h
@@ -45,7 +45,8 @@ inline ObjectLayerSemantics GetObjectLayerSemantics(const RoomObject& object) {
     return out;
   }
 
-  if (out.routine_id == DrawRoutineIds::kAgahnimsAltar) {
+  if (out.routine_id == DrawRoutineIds::kAgahnimsAltar ||
+      out.routine_id == DrawRoutineIds::kFortuneTellerRoom) {
     out.effective_bg_layer = EffectiveBgLayer::kBg1;
     return out;
   }

--- a/src/zelda3/dungeon/object_parser.cc
+++ b/src/zelda3/dungeon/object_parser.cc
@@ -343,6 +343,8 @@ absl::StatusOr<std::vector<gfx::TileInfo>> ObjectParser::ParseSubtype3(
   constexpr int kBigGrayRockTileCount = 16;
   constexpr int kAgahnimsAltarTileOffset = 0x1B4A;
   constexpr int kAgahnimsAltarTileCount = 84;
+  constexpr int kFortuneTellerRoomTileOffset = 0x202E;
+  constexpr int kFortuneTellerRoomTileCount = 26;
   constexpr int kSmithyFurnaceTileOffset = 0x1F92;
   constexpr int kSmithyFurnaceTileCount = 48;
 
@@ -451,6 +453,13 @@ absl::StatusOr<std::vector<gfx::TileInfo>> ObjectParser::ParseSubtype3(
   if (object_id == 0xFAD) {
     return ReadTileData(kRoomObjectTileAddress + kAgahnimsAltarTileOffset,
                         kAgahnimsAltarTileCount);
+  }
+
+  // FortuneTellerRoom ignores its table-derived pointer and loads literal
+  // obj202E before writing a sparse, fixed 14x14 room facade.
+  if (object_id == 0xFD4) {
+    return ReadTileData(kRoomObjectTileAddress + kFortuneTellerRoomTileOffset,
+                        kFortuneTellerRoomTileCount);
   }
 
   // SmithyFurnace replaces the table-derived data pointer with literal
@@ -674,6 +683,11 @@ int ObjectParser::GetSubtype3TileCount(int16_t object_id) const {
   if (object_id == 0xFAD) {
     return 84;
   }
+  // FortuneTellerRoom (0xFD4 = ASM 0x254) consumes all 26 words from obj202E
+  // while writing a sparse, fixed 14x14 BG1 footprint.
+  if (object_id == 0xFD4) {
+    return 26;
+  }
   // SmithyFurnace (0xFCC = ASM 0x24C) loads obj1F92 and draws a fixed
   // 6-column x 8-row block through RoomDraw_SomeBigDecors.
   if (object_id == 0xFCC) {
@@ -681,8 +695,7 @@ int ObjectParser::GetSubtype3TileCount(int16_t object_id) const {
   }
   // 4x4 single-pattern objects
   if (object_id == 0xFAA || object_id == 0xFAE ||
-      (object_id >= 0xFB4 && object_id <= 0xFB9) || object_id == 0xFD4 ||
-      object_id == 0xFE2) {
+      (object_id >= 0xFB4 && object_id <= 0xFB9) || object_id == 0xFE2) {
     return 16;
   }
   // Big wall decor aliases: RoomDraw_BigWallDecor calls

--- a/test/unit/zelda3/dungeon/draw_routine_mapping_test.cc
+++ b/test/unit/zelda3/dungeon/draw_routine_mapping_test.cc
@@ -696,6 +696,7 @@ TEST_F(DrawRoutineMappingTest, VerifiesSubtype3Mappings) {
   EXPECT_EQ(drawer.GetDrawRoutineId(0xFAB), DrawRoutineIds::kSingle2x2);
   EXPECT_EQ(drawer.GetDrawRoutineId(0xFAC), DrawRoutineIds::kBigGrayRock);
   EXPECT_EQ(drawer.GetDrawRoutineId(0xFAD), DrawRoutineIds::kAgahnimsAltar);
+  EXPECT_EQ(drawer.GetDrawRoutineId(0xFD4), DrawRoutineIds::kFortuneTellerRoom);
   EXPECT_EQ(drawer.GetDrawRoutineId(0xFB1), DrawRoutineIds::kSingle4x3);
   EXPECT_EQ(drawer.GetDrawRoutineId(0xFD5), DrawRoutineIds::kUtility3x5);
   for (int object_id : {0xFD6, 0xFD7, 0xFD8, 0xFD9}) {
@@ -784,6 +785,18 @@ TEST_F(DrawRoutineMappingTest, VerifiesSubtype3Mappings) {
   EXPECT_FALSE(agahnims_altar->draws_to_both_bgs);
   EXPECT_EQ(agahnims_altar->category, DrawRoutineInfo::Category::Special);
 
+  const DrawRoutineInfo* fortune_teller_room =
+      DrawRoutineRegistry::Get().GetRoutineInfo(
+          DrawRoutineIds::kFortuneTellerRoom);
+  ASSERT_NE(fortune_teller_room, nullptr);
+  EXPECT_EQ(fortune_teller_room->name, "FortuneTellerRoom");
+  EXPECT_TRUE(static_cast<bool>(fortune_teller_room->function));
+  EXPECT_EQ(fortune_teller_room->base_width, 14);
+  EXPECT_EQ(fortune_teller_room->base_height, 14);
+  EXPECT_EQ(fortune_teller_room->min_tiles, 26);
+  EXPECT_FALSE(fortune_teller_room->draws_to_both_bgs);
+  EXPECT_EQ(fortune_teller_room->category, DrawRoutineInfo::Category::Special);
+
   const auto& routines = DrawRoutineRegistry::Get().GetAllRoutines();
   EXPECT_EQ(std::count_if(routines.begin(), routines.end(),
                           [](const DrawRoutineInfo& info) {
@@ -803,6 +816,12 @@ TEST_F(DrawRoutineMappingTest, VerifiesSubtype3Mappings) {
   EXPECT_EQ(std::count_if(routines.begin(), routines.end(),
                           [](const DrawRoutineInfo& info) {
                             return info.id == DrawRoutineIds::kAgahnimsAltar;
+                          }),
+            1);
+  EXPECT_EQ(std::count_if(routines.begin(), routines.end(),
+                          [](const DrawRoutineInfo& info) {
+                            return info.id ==
+                                   DrawRoutineIds::kFortuneTellerRoom;
                           }),
             1);
 }

--- a/test/unit/zelda3/dungeon/object_dimensions_test.cc
+++ b/test/unit/zelda3/dungeon/object_dimensions_test.cc
@@ -462,6 +462,41 @@ TEST_F(ObjectDimensionTableTest,
 }
 
 TEST_F(ObjectDimensionTableTest,
+       FortuneTellerRoomUsesFixedFourteenByFourteenBounds) {
+  auto& table = ObjectDimensionTable::Get();
+  ASSERT_TRUE(table.LoadFromRom(rom_.get()).ok());
+  EXPECT_EQ(table.GetBaseDimensions(0xFD4), std::make_pair(14, 14));
+
+  for (uint8_t size : {uint8_t{0x00}, uint8_t{0x03}, uint8_t{0x0F},
+                       uint8_t{0xF0}, uint8_t{0xFF}}) {
+    SCOPED_TRACE(::testing::Message() << "size=" << static_cast<int>(size));
+
+    const auto [width, height] = table.GetDimensions(0xFD4, size);
+    EXPECT_EQ(width, 14);
+    EXPECT_EQ(height, 14);
+
+    const auto selection = table.GetSelectionBounds(0xFD4, size);
+    EXPECT_EQ(selection.offset_x, 0);
+    EXPECT_EQ(selection.offset_y, 0);
+    EXPECT_EQ(selection.width, 14);
+    EXPECT_EQ(selection.height, 14);
+
+    const RoomObject object(0xFD4, 0, 0, size, 0);
+    const auto geometry = ObjectGeometry::Get().MeasureByObjectId(object);
+    ASSERT_TRUE(geometry.ok());
+    EXPECT_EQ(geometry->min_x_tiles, 0);
+    EXPECT_EQ(geometry->min_y_tiles, 0);
+    EXPECT_EQ(geometry->width_tiles, 14);
+    EXPECT_EQ(geometry->height_tiles, 14);
+
+    const auto [legacy_width, legacy_height] =
+        ObjectDrawer(rom_.get(), 0).CalculateObjectDimensions(object);
+    EXPECT_EQ(legacy_width, 112);
+    EXPECT_EQ(legacy_height, 112);
+  }
+}
+
+TEST_F(ObjectDimensionTableTest,
        BigWallDecorAliasesUseFixedEightByThreeBounds) {
   auto& table = ObjectDimensionTable::Get();
   ASSERT_TRUE(table.LoadFromRom(rom_.get()).ok());

--- a/test/unit/zelda3/dungeon/object_drawer_registry_replay_test.cc
+++ b/test/unit/zelda3/dungeon/object_drawer_registry_replay_test.cc
@@ -2673,6 +2673,116 @@ TEST(ObjectDrawerRegistryReplayTest,
 }
 
 TEST(ObjectDrawerRegistryReplayTest,
+     FortuneTellerRoomDrawsSparseFourteenByFourteenOnFixedBg1) {
+  ScopedCustomObjectsFlag disable_custom(false);
+
+  constexpr int kX = 10;
+  constexpr int kY = 12;
+  constexpr uint16_t kFirstTile = 0x0100;
+
+  auto tiles = MakeSequentialTiles(/*count=*/26, /*start_tile_id=*/kFirstTile);
+  for (size_t i = 0; i < tiles.size(); ++i) {
+    tiles[i].horizontal_mirror_ = (i % 3) == 0;
+  }
+
+  for (uint8_t size : {uint8_t{0}, uint8_t{3}}) {
+    for (const auto layer :
+         {RoomObject::LayerType::BG1, RoomObject::LayerType::BG2}) {
+      SCOPED_TRACE(::testing::Message()
+                   << "size=" << static_cast<int>(size)
+                   << " layer=" << static_cast<int>(layer));
+
+      const auto trace =
+          ReplayObjectTrace(/*object_id=*/0x0FD4, kX, kY, size, layer, tiles);
+      const auto bg1 = FilterTraceByLayer(trace, RoomObject::LayerType::BG1);
+      const auto bg2 = FilterTraceByLayer(trace, RoomObject::LayerType::BG2);
+      ASSERT_EQ(bg1.size(), 116u);
+      EXPECT_TRUE(bg2.empty());
+      ExpectTraceBounds(bg1, kX, kY, kX + 13, kY + 13);
+
+      size_t write_index = 0;
+      auto expect_write = [&](int dx, int dy, size_t source_index,
+                              bool force_horizontal_mirror = false,
+                              bool toggle_horizontal_mirror = false) {
+        ASSERT_LT(write_index, bg1.size());
+        const auto& actual = bg1[write_index++];
+        EXPECT_EQ(actual.x_tile, kX + dx);
+        EXPECT_EQ(actual.y_tile, kY + dy);
+        EXPECT_EQ(actual.tile_id,
+                  static_cast<uint16_t>(kFirstTile + source_index));
+
+        bool expected_h_flip = tiles[source_index].horizontal_mirror_;
+        if (force_horizontal_mirror) {
+          expected_h_flip = true;
+        } else if (toggle_horizontal_mirror) {
+          expected_h_flip = !expected_h_flip;
+        }
+        EXPECT_EQ((actual.flags & 0x1) != 0, expected_h_flip)
+            << "source_index=" << source_index << " dx=" << dx << " dy=" << dy;
+      };
+
+      for (int section = 0; section < 6; ++section) {
+        const int x = section * 2;
+        expect_write(x + 1, 0, 0);
+        expect_write(x + 2, 0, 0);
+        expect_write(x + 1, 1, 0);
+        expect_write(x + 2, 1, 0);
+        expect_write(x + 1, 2, 1);
+        expect_write(x + 2, 2, 1, /*force_horizontal_mirror=*/true);
+      }
+
+      for (int row = 0; row < 3; ++row) {
+        const size_t wall_tile = static_cast<size_t>(2 + row);
+        const size_t center_tile = static_cast<size_t>(5 + row);
+        const int y = 3 + row;
+        for (int x : {0, 2, 10, 12}) {
+          expect_write(x, y, wall_tile);
+        }
+        for (int x : {1, 3, 11, 13}) {
+          expect_write(x, y, wall_tile,
+                       /*force_horizontal_mirror=*/true);
+        }
+        for (int x : {4, 6, 8}) {
+          expect_write(x, y, center_tile);
+        }
+        for (int x : {5, 7, 9}) {
+          expect_write(x, y, center_tile,
+                       /*force_horizontal_mirror=*/true);
+        }
+      }
+
+      expect_write(0, 0, 8);
+      expect_write(0, 1, 8);
+      expect_write(13, 0, 8, /*force_horizontal_mirror=*/true);
+      expect_write(13, 1, 8, /*force_horizontal_mirror=*/true);
+      expect_write(0, 2, 9);
+      expect_write(13, 2, 9, /*force_horizontal_mirror=*/true);
+
+      for (int row = 0; row < 4; ++row) {
+        const int y = 10 + row;
+        expect_write(3, y, static_cast<size_t>(10 + row));
+        expect_write(10, y, static_cast<size_t>(10 + row),
+                     /*force_horizontal_mirror=*/false,
+                     /*toggle_horizontal_mirror=*/true);
+        expect_write(4, y, static_cast<size_t>(14 + row));
+        expect_write(9, y, static_cast<size_t>(14 + row),
+                     /*force_horizontal_mirror=*/false,
+                     /*toggle_horizontal_mirror=*/true);
+        expect_write(5, y, static_cast<size_t>(18 + row));
+        expect_write(8, y, static_cast<size_t>(18 + row),
+                     /*force_horizontal_mirror=*/false,
+                     /*toggle_horizontal_mirror=*/true);
+        expect_write(6, y, static_cast<size_t>(22 + row));
+        expect_write(7, y, static_cast<size_t>(22 + row),
+                     /*force_horizontal_mirror=*/false,
+                     /*toggle_horizontal_mirror=*/true);
+      }
+      EXPECT_EQ(write_index, bg1.size());
+    }
+  }
+}
+
+TEST(ObjectDrawerRegistryReplayTest,
      BigWallDecorAliasesDrawFixedEightByThreeOnSelectedLayer) {
   ScopedCustomObjectsFlag disable_custom(false);
 

--- a/test/unit/zelda3/dungeon/object_drawing_comprehensive_test.cc
+++ b/test/unit/zelda3/dungeon/object_drawing_comprehensive_test.cc
@@ -147,12 +147,16 @@ int ExpectedSubtype3TileCount(int id) {
   if (id == 0xFAD) {
     return 84;
   }
+  // Fortune teller room consumes all 26 words from obj202E.
+  if (id == 0xFD4) {
+    return 26;
+  }
   // Smithy furnace is a fixed 6x8 row-major payload.
   if (id == 0xFCC) {
     return 48;
   }
   if (id == 0xFAA || id == 0xFAE || (id >= 0xFB4 && id <= 0xFB9) ||
-      id == 0xFD4 || id == 0xFE2) {
+      id == 0xFE2) {
     return 16;
   }
   // Big wall decor aliases consume one 8x3 column-major payload.

--- a/test/unit/zelda3/dungeon/object_layer_semantics_test.cc
+++ b/test/unit/zelda3/dungeon/object_layer_semantics_test.cc
@@ -58,6 +58,17 @@ TEST(ObjectLayerSemanticsTest, AgahnimsAltarAlwaysReportsFixedBg1) {
   }
 }
 
+TEST(ObjectLayerSemanticsTest, FortuneTellerRoomAlwaysReportsFixedBg1) {
+  for (uint8_t layer : {uint8_t{0}, uint8_t{1}}) {
+    RoomObject obj(/*id=*/0xFD4, /*x=*/0, /*y=*/0, /*size=*/7, layer);
+
+    const auto sem = GetObjectLayerSemantics(obj);
+    EXPECT_EQ(sem.routine_id, DrawRoutineIds::kFortuneTellerRoom);
+    EXPECT_FALSE(sem.draws_to_both_bgs);
+    EXPECT_EQ(sem.effective_bg_layer, EffectiveBgLayer::kBg1);
+  }
+}
+
 TEST(DungeonObjectLayerGuardrailsTest,
      SingleAndBatchStreamChangesIncludeBothBgObjects) {
   Rom rom;

--- a/test/unit/zelda3/object_parser_test.cc
+++ b/test/unit/zelda3/object_parser_test.cc
@@ -173,10 +173,10 @@ TEST_F(ObjectParserTest, RuntimeLiteralObjectsIgnoreRelocatedTablePointers) {
     }
   };
 
-  // Move all eight pointer-table entries. F98/F99/FB1/FAC/FAD/FCC must ignore
-  // their moved entries because their routines load literal data blocks;
-  // F9A/FB2 are direct-open routines and must continue following their moved
-  // pointers.
+  // Move all nine pointer-table entries. F98/F99/FB1/FAC/FAD/FCC/FD4 must
+  // ignore their moved entries because their routines load literal data
+  // blocks; F9A/FB2 are direct-open routines and must continue following
+  // their moved pointers.
   constexpr uint16_t kMovedBigKeyLockOffset = 0x0100;
   constexpr uint16_t kMovedChestOffset = 0x0180;
   constexpr uint16_t kMovedOpenChestOffset = 0x0200;
@@ -185,6 +185,7 @@ TEST_F(ObjectParserTest, RuntimeLiteralObjectsIgnoreRelocatedTablePointers) {
   constexpr uint16_t kMovedSmithyFurnaceOffset = 0x0400;
   constexpr uint16_t kMovedBigGrayRockOffset = 0x0480;
   constexpr uint16_t kMovedAgahnimsAltarOffset = 0x0580;
+  constexpr uint16_t kMovedFortuneTellerRoomOffset = 0x0680;
   write_pointer(0xF98, kMovedBigKeyLockOffset);
   write_pointer(0xF99, kMovedChestOffset);
   write_pointer(0xF9A, kMovedOpenChestOffset);
@@ -193,6 +194,7 @@ TEST_F(ObjectParserTest, RuntimeLiteralObjectsIgnoreRelocatedTablePointers) {
   write_pointer(0xFCC, kMovedSmithyFurnaceOffset);
   write_pointer(0xFAC, kMovedBigGrayRockOffset);
   write_pointer(0xFAD, kMovedAgahnimsAltarOffset);
+  write_pointer(0xFD4, kMovedFortuneTellerRoomOffset);
 
   write_words(0x1494, 4, 0x0040);   // BigKeyLock literal
   write_words(0x149C, 4, 0x0080);   // Chest closed literal
@@ -202,6 +204,7 @@ TEST_F(ObjectParserTest, RuntimeLiteralObjectsIgnoreRelocatedTablePointers) {
   write_words(0x1F92, 48, 0x0280);  // SmithyFurnace literal
   write_words(0x0E62, 16, 0x0440);  // BigGrayRock literal
   write_words(0x1B4A, 84, 0x0080);  // AgahnimsAltar literal
+  write_words(0x202E, 26, 0x0120);  // FortuneTellerRoom literal
 
   write_words(kMovedBigKeyLockOffset, 4, 0x03C0);
   write_words(kMovedChestOffset, 4, 0x03A0);
@@ -211,6 +214,7 @@ TEST_F(ObjectParserTest, RuntimeLiteralObjectsIgnoreRelocatedTablePointers) {
   write_words(kMovedSmithyFurnaceOffset, 48, 0x0340);
   write_words(kMovedBigGrayRockOffset, 16, 0x0640);
   write_words(kMovedAgahnimsAltarOffset, 84, 0x0200);
+  write_words(kMovedFortuneTellerRoomOffset, 26, 0x0320);
 
   auto lock = parser_->ParseObject(0xF98);
   auto chest = parser_->ParseObject(0xF99);
@@ -220,6 +224,7 @@ TEST_F(ObjectParserTest, RuntimeLiteralObjectsIgnoreRelocatedTablePointers) {
   auto smithy_furnace = parser_->ParseObject(0xFCC);
   auto big_gray_rock = parser_->ParseObject(0xFAC);
   auto agahnims_altar = parser_->ParseObject(0xFAD);
+  auto fortune_teller_room = parser_->ParseObject(0xFD4);
   ASSERT_TRUE(lock.ok());
   ASSERT_TRUE(chest.ok());
   ASSERT_TRUE(open_chest.ok());
@@ -228,6 +233,7 @@ TEST_F(ObjectParserTest, RuntimeLiteralObjectsIgnoreRelocatedTablePointers) {
   ASSERT_TRUE(smithy_furnace.ok());
   ASSERT_TRUE(big_gray_rock.ok());
   ASSERT_TRUE(agahnims_altar.ok());
+  ASSERT_TRUE(fortune_teller_room.ok());
 
   for (int i = 0; i < 4; ++i) {
     EXPECT_TRUE((*lock)[i] ==
@@ -267,6 +273,13 @@ TEST_F(ObjectParserTest, RuntimeLiteralObjectsIgnoreRelocatedTablePointers) {
                 gfx::WordToTileInfo(static_cast<uint16_t>(0x0080 + i)));
     EXPECT_FALSE((*agahnims_altar)[i] ==
                  gfx::WordToTileInfo(static_cast<uint16_t>(0x0200 + i)));
+  }
+  ASSERT_EQ(fortune_teller_room->size(), 26u);
+  for (int i = 0; i < 26; ++i) {
+    EXPECT_TRUE((*fortune_teller_room)[i] ==
+                gfx::WordToTileInfo(static_cast<uint16_t>(0x0120 + i)));
+    EXPECT_FALSE((*fortune_teller_room)[i] ==
+                 gfx::WordToTileInfo(static_cast<uint16_t>(0x0320 + i)));
   }
 }
 
@@ -626,6 +639,25 @@ TEST_F(ObjectParserTest, AgahnimsAltarUsesEightyFourTilesAndDedicatedRoutine) {
   const auto info = parser_->GetObjectDrawInfo(0xFAD);
   EXPECT_EQ(info.tile_count, 84);
   EXPECT_EQ(info.draw_routine_id, zelda3::DrawRoutineIds::kAgahnimsAltar);
+}
+
+TEST_F(ObjectParserTest,
+       FortuneTellerRoomUsesTwentySixTilesAndDedicatedRoutine) {
+  auto& registry = zelda3::DrawRoutineRegistry::Get();
+  EXPECT_EQ(registry.GetRoutineIdForObject(0xFD4),
+            zelda3::DrawRoutineIds::kFortuneTellerRoom);
+
+  const auto subtype = parser_->GetObjectSubtype(0xFD4);
+  ASSERT_TRUE(subtype.ok());
+  EXPECT_EQ(subtype->max_tile_count, 26);
+
+  const auto parsed = parser_->ParseObject(0xFD4);
+  ASSERT_TRUE(parsed.ok());
+  EXPECT_EQ(parsed->size(), 26u);
+
+  const auto info = parser_->GetObjectDrawInfo(0xFD4);
+  EXPECT_EQ(info.tile_count, 26);
+  EXPECT_EQ(info.draw_routine_id, zelda3::DrawRoutineIds::kFortuneTellerRoom);
 }
 
 TEST_F(ObjectParserTest, HammerPegUsesUsdasmSingle2x2RoutineAndFourTiles) {


### PR DESCRIPTION
## Summary
- add a dedicated draw routine for editor object `0xFD4` / ASM object `0x254`
- load the runtime literal `obj202E` payload and reproduce its sparse 116-write, 14x14 BG1 footprint
- match USDASM horizontal flip behavior and expose fixed dimensions/layer semantics throughout the editor
- add focused parser, registry, geometry, layer, and draw-replay coverage

## Why
The Fortune Teller room object was routed through a generic 4x4 routine, so its editor preview, selection bounds, source data, and layer semantics did not match the game. This brings the backend rendering path to USDASM parity without changing ROM data.

## Validation
- `yaze_test_unit` focused Fortune Teller/parity filter: 8/8 passed
- `clang-format --dry-run --Werror` on all 14 changed C++ files
- `git diff --check`
- independent strict review against USDASM: no findings
- canonical Oracle of Secrets read-only validation: 116 BG1 writes, 14x14 bounds, zero mismatches; room `0x122` 34/34 placements validated; exhaustive scan found exactly two placements

## Remaining gap
No GUI or emulator visual confirmation is claimed; hosted CI is the merge gate.
