### PR TITLE
fix(cli): enforce room property manifest ownership

### DIFF
--- a/docs/internal/agents/rom-safety-guardrails.md
+++ b/docs/internal/agents/rom-safety-guardrails.md
@@ -39,6 +39,11 @@ This repo is used to edit ROM hacks (including Oracle of Secrets). Treat ROM wri
   header dirty mask. They preserve unrelated header bits and object payload,
   save after any dirty object payload, and fail closed on shared streams unless
   a `copy_on_write` object-stream manifest supplies allocator-owned space.
+- `dungeon-set-room-property` keeps `--manifest` optional for compatibility,
+  but honors it for every supported property when supplied. Fixed room-header
+  fields preflight the serializer's full 14-byte header and two-byte room
+  message-ID ranges before caller bytes, backup artifacts, or disk state can
+  change.
 - Non-dry-run `dungeon-import-custom-collision-json` and
   `dungeon-import-water-fill-json` use the same transaction and required-backup
   contract, then immediately save the active ROM. With `--sandbox`, the active

--- a/docs/public/reference/z3ed-command-reference.md
+++ b/docs/public/reference/z3ed-command-reference.md
@@ -197,8 +197,12 @@ old/new symbolic names but never selects a door by display-name text.
 `floor1`/`floor2` values `0`-`15`. These properties are persisted in the
 two-byte object-stream header with per-field read/modify/write; unrelated bits
 and the object payload remain unchanged. A shared stream requires the same
-manifest-backed `copy_on_write` capability described above. Successful
-non-mock writes require a completed destination backup before replacement.
+manifest-backed `copy_on_write` capability described above. The manifest is
+optional for compatibility, but when supplied it is enforced for every
+supported property before mutation. Palette, blockset, spriteset, effect, tag,
+and hole-warp changes validate the complete serializer footprint: the selected
+room's 14-byte header and its two-byte message ID. Successful non-mock writes
+require a completed destination backup before replacement.
 
 The collision and water-fill JSON import commands validate without mutation
 when `--dry-run` is present. Without it, they immediately save the active ROM

--- a/src/cli/handlers/game/dungeon_commands.cc
+++ b/src/cli/handlers/game/dungeon_commands.cc
@@ -55,11 +55,12 @@ bool IsEncodedRoomStreamObject(const zelda3::RoomObject& object) {
 
 struct RoomPropertyManifestContext {
   core::HackManifest manifest;
-  zelda3::DungeonStreamLayout allocator_layout;
+  std::optional<zelda3::DungeonStreamLayout> allocator_layout;
 };
 
 absl::StatusOr<std::optional<RoomPropertyManifestContext>>
-LoadRoomPropertyManifestContext(const resources::ArgumentParser& parser) {
+LoadRoomPropertyManifestContext(const resources::ArgumentParser& parser,
+                                bool require_object_allocator) {
   const auto manifest_path = parser.GetString("manifest");
   if (!manifest_path.has_value()) {
     return std::nullopt;
@@ -67,6 +68,10 @@ LoadRoomPropertyManifestContext(const resources::ArgumentParser& parser) {
 
   RoomPropertyManifestContext context;
   RETURN_IF_ERROR(context.manifest.LoadFromFile(*manifest_path));
+  if (!require_object_allocator) {
+    return std::optional<RoomPropertyManifestContext>(std::move(context));
+  }
+
   const auto* manifest_layout = context.manifest.GetDungeonStreamLayout(
       core::DungeonStreamType::kObjects);
   if (manifest_layout == nullptr) {
@@ -77,14 +82,30 @@ LoadRoomPropertyManifestContext(const resources::ArgumentParser& parser) {
     return absl::FailedPreconditionError(
         "dungeon_stream_regions.objects must use copy_on_write");
   }
-  ASSIGN_OR_RETURN(context.allocator_layout,
+  zelda3::DungeonStreamLayout allocator_layout;
+  ASSIGN_OR_RETURN(allocator_layout,
                    core::ToDungeonStreamAllocatorLayout(
                        core::DungeonStreamType::kObjects, *manifest_layout));
+  context.allocator_layout = std::move(allocator_layout);
   return std::optional<RoomPropertyManifestContext>(std::move(context));
 }
 
-absl::Status ValidateRoomPropertyManifestConflicts(
+absl::Status ValidateManifestWriteRanges(
+    const core::HackManifest& manifest,
+    const std::vector<std::pair<uint32_t, uint32_t>>& ranges) {
+  if (!manifest.AnalyzePcWriteRanges(ranges).empty()) {
+    return absl::PermissionDeniedError("Write conflict with Hack Manifest");
+  }
+  return absl::OkStatus();
+}
+
+absl::Status ValidateObjectStreamHeaderManifestConflicts(
     const Rom& rom, int room_id, const RoomPropertyManifestContext& context) {
+  if (!context.allocator_layout.has_value()) {
+    return absl::FailedPreconditionError(
+        "Object-stream header manifest is missing allocator capability");
+  }
+
   std::vector<std::pair<uint32_t, uint32_t>> ranges;
 
   uint32_t pointer_table_snes = 0;
@@ -107,11 +128,11 @@ absl::Status ValidateRoomPropertyManifestConflicts(
   }
   ranges.emplace_back(stream_pc, stream_pc + 2u);
 
-  for (const auto& range : context.allocator_layout.allocation_ranges) {
+  for (const auto& range : context.allocator_layout->allocation_ranges) {
     ranges.emplace_back(range.begin, range.end);
   }
   const uint64_t cow_pointer_slot =
-      static_cast<uint64_t>(context.allocator_layout.pointer_table_pc) +
+      static_cast<uint64_t>(context.allocator_layout->pointer_table_pc) +
       static_cast<uint64_t>(room_id) * 3u;
   if (cow_pointer_slot + 3u > std::numeric_limits<uint32_t>::max()) {
     return absl::OutOfRangeError("Selected COW pointer range overflows");
@@ -128,10 +149,50 @@ absl::Status ValidateRoomPropertyManifestConflicts(
   ranges.emplace_back(static_cast<uint32_t>(door_pointer_slot),
                       static_cast<uint32_t>(door_pointer_slot + 3u));
 
-  if (!context.manifest.AnalyzePcWriteRanges(ranges).empty()) {
-    return absl::PermissionDeniedError("Write conflict with Hack Manifest");
+  return ValidateManifestWriteRanges(context.manifest, ranges);
+}
+
+absl::StatusOr<std::vector<std::pair<uint32_t, uint32_t>>>
+CollectRoomHeaderWriteRanges(const Rom& rom, int room_id) {
+  uint32_t header_pointer_snes = 0;
+  ASSIGN_OR_RETURN(header_pointer_snes,
+                   rom.ReadLong(zelda3::kRoomHeaderPointer));
+  const uint32_t header_pointer_pc = SnesToPc(header_pointer_snes);
+  const uint64_t table_offset = static_cast<uint64_t>(header_pointer_pc) +
+                                static_cast<uint64_t>(room_id) * 2u;
+  if (table_offset + 2u > rom.size()) {
+    return absl::OutOfRangeError(
+        "Selected room header pointer slot is outside the ROM");
   }
-  return absl::OkStatus();
+
+  uint16_t header_offset = 0;
+  ASSIGN_OR_RETURN(header_offset, rom.ReadWord(static_cast<int>(table_offset)));
+  uint8_t header_bank = 0;
+  ASSIGN_OR_RETURN(header_bank, rom.ReadByte(zelda3::kRoomHeaderPointerBank));
+  const uint32_t header_pc =
+      SnesToPc((static_cast<uint32_t>(header_bank) << 16) | header_offset);
+  if (static_cast<uint64_t>(header_pc) + 14u > rom.size()) {
+    return absl::OutOfRangeError("Selected room header is outside the ROM");
+  }
+
+  const uint64_t message_pc =
+      static_cast<uint64_t>(zelda3::kMessagesIdDungeon) +
+      static_cast<uint64_t>(room_id) * 2u;
+  if (message_pc + 2u > rom.size()) {
+    return absl::OutOfRangeError("Selected room message ID is outside the ROM");
+  }
+
+  return std::vector<std::pair<uint32_t, uint32_t>>{
+      {header_pc, header_pc + 14u},
+      {static_cast<uint32_t>(message_pc),
+       static_cast<uint32_t>(message_pc + 2u)}};
+}
+
+absl::Status ValidateRoomHeaderManifestConflicts(
+    const Rom& rom, int room_id, const core::HackManifest& manifest) {
+  std::vector<std::pair<uint32_t, uint32_t>> ranges;
+  ASSIGN_OR_RETURN(ranges, CollectRoomHeaderWriteRanges(rom, room_id));
+  return ValidateManifestWriteRanges(manifest, ranges);
 }
 
 // Merge stop tiles from |existing| into |generated| without overwriting
@@ -769,6 +830,10 @@ absl::Status DungeonSetRoomPropertyCommandHandler::Execute(
   const bool is_layout = prop == "layout" || prop == "layout_id";
   const bool is_floor = prop == "floor1" || prop == "floor2";
   const bool is_object_stream_header = is_layout || is_floor;
+  const bool is_room_header = prop == "palette" || prop == "blockset" ||
+                              prop == "spriteset" || prop == "effect" ||
+                              prop == "tag1" || prop == "tag2" ||
+                              prop == "holewarp";
   const int property_max = is_layout ? 0x07 : (is_floor ? 0x0F : 0xFF);
   if (is_object_stream_header &&
       (parsed_value < 0 || parsed_value > property_max)) {
@@ -782,8 +847,9 @@ absl::Status DungeonSetRoomPropertyCommandHandler::Execute(
   }
 
   std::optional<RoomPropertyManifestContext> manifest_context;
-  if (is_object_stream_header) {
-    auto context_or = LoadRoomPropertyManifestContext(parser);
+  if (is_object_stream_header || is_room_header) {
+    auto context_or =
+        LoadRoomPropertyManifestContext(parser, is_object_stream_header);
     if (!context_or.ok()) {
       formatter.AddField("status", "error");
       formatter.AddField("error", std::string(context_or.status().message()));
@@ -793,8 +859,11 @@ absl::Status DungeonSetRoomPropertyCommandHandler::Execute(
     manifest_context = std::move(context_or).value();
     if (manifest_context.has_value()) {
       const absl::Status manifest_status =
-          ValidateRoomPropertyManifestConflicts(*rom, room_id,
-                                                *manifest_context);
+          is_object_stream_header
+              ? ValidateObjectStreamHeaderManifestConflicts(*rom, room_id,
+                                                            *manifest_context)
+              : ValidateRoomHeaderManifestConflicts(*rom, room_id,
+                                                    manifest_context->manifest);
       if (!manifest_status.ok()) {
         formatter.AddField("status", "error");
         formatter.AddField("error", std::string(manifest_status.message()));
@@ -802,7 +871,9 @@ absl::Status DungeonSetRoomPropertyCommandHandler::Execute(
         return manifest_status;
       }
       formatter.AddField("manifest", *parser.GetString("manifest"));
-      formatter.AddField("allocator_capability", "copy_on_write");
+      if (is_object_stream_header) {
+        formatter.AddField("allocator_capability", "copy_on_write");
+      }
     }
   }
 
@@ -838,11 +909,13 @@ absl::Status DungeonSetRoomPropertyCommandHandler::Execute(
   }
 
   const absl::Status write_status =
-      is_object_stream_header ? room.SaveObjectStreamHeader(
-                                    manifest_context.has_value()
-                                        ? &manifest_context->allocator_layout
-                                        : nullptr)
-                              : room.SaveRoomHeader();
+      is_object_stream_header
+          ? room.SaveObjectStreamHeader(
+                manifest_context.has_value() &&
+                        manifest_context->allocator_layout.has_value()
+                    ? &*manifest_context->allocator_layout
+                    : nullptr)
+          : room.SaveRoomHeader();
   if (!write_status.ok()) {
     formatter.AddField("status", "error");
     formatter.AddField("write_error", std::string(write_status.message()));

--- a/test/unit/cli/dungeon_edit_commands_test.cc
+++ b/test/unit/cli/dungeon_edit_commands_test.cc
@@ -381,6 +381,38 @@ void WriteObjectCowManifest(const std::filesystem::path& path,
   ASSERT_TRUE(output.good());
 }
 
+void WriteOwnershipOnlyManifest(const std::filesystem::path& path,
+                                int protected_pc = -1, int protected_size = 1) {
+  std::string protected_section;
+  if (protected_pc >= 0) {
+    protected_section = absl::StrFormat(
+        R"json(,
+  "protected_regions": {
+    "total_hooks": 1,
+    "regions": [
+      {
+        "start": "0x%06X",
+        "end": "0x%06X",
+        "size": %d,
+        "hook_count": 1,
+        "module": "RoomPropertyGuard"
+      }
+    ]
+  })json",
+        PcToSnes(protected_pc), PcToSnes(protected_pc + protected_size),
+        protected_size);
+  }
+  const std::string json = absl::StrFormat(
+      R"json({
+  "manifest_version": 3%s
+})json",
+      protected_section);
+  std::ofstream output(path, std::ios::trunc);
+  ASSERT_TRUE(output.is_open());
+  output << json;
+  ASSERT_TRUE(output.good());
+}
+
 void SetRoomSpritePointer(Rom* rom, int table_pc, int room_id, int pc_addr) {
   const uint32_t snes = PcToSnes(pc_addr);
   const int ptr_off = table_pc + room_id * 2;
@@ -746,6 +778,77 @@ TEST(DungeonEditCommandsTest, SetRoomPropertyMockRomCommitsSerializedHeader) {
   EXPECT_EQ(rom.data()[kRoomHeaderDataPc + 1], 0x02);
   EXPECT_TRUE(rom.dirty());
   EXPECT_THAT(output, HasSubstr("\"save_status\": \"mock-rom-skipped\""));
+}
+
+TEST(DungeonEditCommandsTest,
+     SetRoomPropertyHeaderManifestConflictsCreateNoSaveArtifacts) {
+  struct Case {
+    const char* name;
+    const char* property;
+    const char* value;
+    int protected_pc;
+  };
+  const std::array<Case, 3> cases = {{
+      {"palette byte", "palette", "0x02", kRoomHeaderDataPc + 1},
+      {"tag2 byte", "tag2", "0x07", kRoomHeaderDataPc + 6},
+      {"message ID footprint", "palette", "0x02", zelda3::kMessagesIdDungeon},
+  }};
+
+  for (const auto& test_case : cases) {
+    SCOPED_TRACE(test_case.name);
+    Rom rom;
+    InitializeRoomHeaderRom(&rom);
+    ScopedRomArtifactsCleanup cleanup(MakeUniqueTempRomPath());
+    WriteRomFile(rom, cleanup.rom_path);
+    rom.set_filename(cleanup.rom_path.string());
+    rom.set_dirty(false);
+    ScopedFileCleanup manifest_cleanup(cleanup.rom_path.string() +
+                                       ".manifest.json");
+    WriteOwnershipOnlyManifest(manifest_cleanup.file_path,
+                               test_case.protected_pc);
+    const std::vector<uint8_t> before = rom.vector();
+    const std::vector<uint8_t> disk_before = ReadFile(cleanup.rom_path);
+
+    handlers::DungeonSetRoomPropertyCommandHandler handler;
+    std::string output;
+    const absl::Status status = handler.Run(
+        {"--room=0x00", "--property=" + std::string(test_case.property),
+         "--value=" + std::string(test_case.value),
+         "--manifest=" + manifest_cleanup.file_path.string(), "--format=json"},
+        &rom, &output);
+
+    EXPECT_TRUE(absl::IsPermissionDenied(status)) << status;
+    EXPECT_THAT(std::string(status.message()),
+                HasSubstr("Write conflict with Hack Manifest"));
+    EXPECT_EQ(rom.vector(), before);
+    EXPECT_FALSE(rom.dirty());
+    EXPECT_EQ(ReadFile(cleanup.rom_path), disk_before);
+    EXPECT_EQ(CountBackupArtifacts(cleanup.rom_path), 0);
+    EXPECT_FALSE(std::filesystem::exists(cleanup.rom_path.string() + ".tmp"));
+  }
+}
+
+TEST(DungeonEditCommandsTest,
+     SetRoomPropertyHeaderAcceptsOwnershipOnlyManifest) {
+  Rom rom;
+  InitializeRoomHeaderRom(&rom);
+  ScopedFileCleanup manifest_cleanup(MakeUniqueTempRomPath().string() +
+                                     ".manifest.json");
+  WriteOwnershipOnlyManifest(manifest_cleanup.file_path, kObjectDataPc);
+
+  handlers::DungeonSetRoomPropertyCommandHandler handler;
+  std::string output;
+  const absl::Status status = handler.Run(
+      {"--mock-rom", "--room=0x00", "--property=palette", "--value=0x02",
+       "--manifest=" + manifest_cleanup.file_path.string(), "--format=json"},
+      &rom, &output);
+
+  ASSERT_TRUE(status.ok()) << status;
+  EXPECT_EQ(rom.data()[kRoomHeaderDataPc + 1], 0x02);
+  const auto report = nlohmann::json::parse(output);
+  const auto& result = report.at("Dungeon Room Property Set");
+  EXPECT_EQ(result.at("manifest"), manifest_cleanup.file_path.string());
+  EXPECT_FALSE(result.contains("allocator_capability"));
 }
 
 TEST(DungeonEditCommandsTest,


### PR DESCRIPTION
## Summary
- honor `--manifest` for every supported `dungeon-set-room-property` field
- preflight the exact `SaveRoomHeader()` serializer footprint: the selected 14-byte header plus its two-byte dungeon message ID
- keep object-stream copy-on-write allocator requirements isolated to layout/floor edits
- document the compatibility decision that manifests remain optional but are never ignored when supplied

## Why
Room-header properties such as palette, blockset, spriteset, effect, tags, and holewarp bypassed manifest ownership checks even when the caller supplied `--manifest`. On Oracle of Secrets this could write directly into ASM-owned bank `$22`. Conflicts now fail closed before room mutation, backup creation, or save.

## Validation
- `DungeonEditCommandsTest.SetRoomProperty*`: 17/17 passed
- `clang-format --dry-run --Werror` on changed C++ files
- `git diff --check`
- independent read-only review: no findings
- no canonical ROM write performed

## Stack
This PR is intentionally based on #169 so its review diff is one commit. After #169 merges, it will be retargeted to `master` and gated again at the exact head.

Closes #168
