### PR TITLE
feat(cli): add manifest-safe existing pot-item edits

### DIFF
--- a/docs/internal/agents/rom-safety-guardrails.md
+++ b/docs/internal/agents/rom-safety-guardrails.md
@@ -23,8 +23,9 @@ This repo is used to edit ROM hacks (including Oracle of Secrets). Treat ROM wri
   has no previous bytes to back up. A completed required backup is retained if
   the later target write fails, so recovery bytes remain available.
 - `dungeon-place-sprite`, `dungeon-remove-sprite`, `dungeon-place-object`,
-  `dungeon-set-door-type`, `dungeon-set-collision-tile`, and
-  `dungeon-set-room-property` wrap their serializer or fixed-width write,
+  `dungeon-set-door-type`, `dungeon-set-pot-item`,
+  `dungeon-set-collision-tile`, and `dungeon-set-room-property` wrap their
+  serializer or fixed-width write,
   required backup, and disk commit in `ScopedRomTransaction`. Any failure
   before a successful disk commit restores the caller's ROM bytes, filename,
   size, and dirty state.
@@ -35,6 +36,14 @@ This repo is used to edit ROM hacks (including Oracle of Secrets). Treat ROM wri
   resolved one-byte type field and cross-checks model/raw readback before the
   required-backup save; the focused unit test independently reopens the saved
   ROM and validates the persisted door.
+- `dungeon-set-pot-item` is dry-run by default and requires an exact existing
+  entry index, expected raw position/item values, and a pot-item stream
+  manifest. It inventories all room pointers, rejects selected aliases,
+  overlaps, malformed streams, and interior pointers, cross-checks raw/model
+  entries and the terminator, blocks manifest-owned item bytes before mutation,
+  and fences write mode to one byte. It never adds, removes, repositions, or
+  repacks pot entries; required-backup save and external reopen coverage match
+  the door-edit contract.
 - Dungeon `layout`, `floor1`, and `floor2` edits use a separate object-stream
   header dirty mask. They preserve unrelated header bits and object payload,
   save after any dirty object payload, and fail closed on shared streams unless

--- a/docs/internal/agents/rom-safety-guardrails.md
+++ b/docs/internal/agents/rom-safety-guardrails.md
@@ -38,12 +38,12 @@ This repo is used to edit ROM hacks (including Oracle of Secrets). Treat ROM wri
   ROM and validates the persisted door.
 - `dungeon-set-pot-item` is dry-run by default and requires an exact existing
   entry index, expected raw position/item values, and a pot-item stream
-  manifest. It inventories all room pointers, rejects selected aliases,
-  overlaps, malformed streams, and interior pointers, cross-checks raw/model
-  entries and the terminator, blocks manifest-owned item bytes before mutation,
-  and fences write mode to one byte. It never adds, removes, repositions, or
-  repacks pot entries; required-backup save and external reopen coverage match
-  the door-edit contract.
+  manifest. It inventories all room pointers and fails closed if any room has
+  an invalid or malformed stream, then rejects selected aliases, overlaps, and
+  interior pointers, cross-checks raw/model entries and the terminator, blocks
+  manifest-owned item bytes before mutation, and fences write mode to one byte.
+  It never adds, removes, repositions, or repacks pot entries; required-backup
+  save and external reopen coverage match the door-edit contract.
 - Dungeon `layout`, `floor1`, and `floor2` edits use a separate object-stream
   header dirty mask. They preserve unrelated header bits and object payload,
   save after any dirty object payload, and fail closed on shared streams unless

--- a/docs/public/reference/z3ed-command-reference.md
+++ b/docs/public/reference/z3ed-command-reference.md
@@ -201,11 +201,12 @@ address. `dungeon-set-pot-item` changes only that fixed-width item byte. It is
 a dry-run unless `--write` is supplied and requires an exact index plus
 expected raw position/item compare-and-swap and a pot-item stream manifest.
 The setter's dry-run and write modes inventory the complete manifest pointer
-table, reject selected stream aliases, overlaps, malformed pointers/streams,
-and pointers landing inside the selected stream, then cross-check the raw
-three-byte entries, room model, and `0xFFFF` terminator. Write mode uses a
-one-byte write fence, required backup, pre-save readback, and atomic ROM
-replacement. It does not add, remove, reposition, or repack pot items.
+table and fail closed if any room has an invalid or malformed stream. They also
+reject selected stream aliases, overlaps, and pointers landing inside the
+selected stream, then cross-check the raw three-byte entries, room model, and
+`0xFFFF` terminator. Write mode uses a one-byte write fence, required backup,
+pre-save readback, and atomic ROM replacement. It does not add, remove,
+reposition, or repack pot items.
 
 `dungeon-set-room-property` accepts `layout`/`layout_id` values `0`-`7` and
 `floor1`/`floor2` values `0`-`15`. These properties are persisted in the

--- a/docs/public/reference/z3ed-command-reference.md
+++ b/docs/public/reference/z3ed-command-reference.md
@@ -164,6 +164,8 @@ These commands operate directly on ROM data (no GUI required).
 - `dungeon-export-room --room <hex> --output <file>`
 - `dungeon-place-object --room <hex> --id <hex> --x <int> --y <int> [--size <int>] [--layer <0|1|2>] [--manifest <path>] [--write]`
 - `dungeon-set-door-type --room <hex> --x <int> --y <int> --type <hex> --expect-type <hex> --manifest <path> [--write]`
+- `dungeon-list-pot-items --room <hex>`
+- `dungeon-set-pot-item --room <hex> --index <int> --expect-position <hex> --expect-item <hex> --item <hex> --manifest <path> [--write]`
 - `dungeon-get-room-tiles --room <hex>` *(stubbed)*
 - `dungeon-set-room-property --room <hex> --property <name> --value <value> [--manifest <path>]`
 
@@ -192,6 +194,18 @@ Use `dungeon-describe-room` first to discover each door's exact `tile_x`,
 `tile_y`, `index`, and raw `type_id`. Pass those tile coordinates and
 `type_id` to `dungeon-set-door-type`; the command reports the matched index and
 old/new symbolic names but never selects a door by display-name text.
+
+`dungeon-list-pot-items` reports each existing entry's zero-based stream
+`index`, raw `position`, tile coordinates, item ID, and item-byte PC/SNES
+address. `dungeon-set-pot-item` changes only that fixed-width item byte. It is
+a dry-run unless `--write` is supplied and requires an exact index plus
+expected raw position/item compare-and-swap and a pot-item stream manifest.
+The setter's dry-run and write modes inventory the complete manifest pointer
+table, reject selected stream aliases, overlaps, malformed pointers/streams,
+and pointers landing inside the selected stream, then cross-check the raw
+three-byte entries, room model, and `0xFFFF` terminator. Write mode uses a
+one-byte write fence, required backup, pre-save readback, and atomic ROM
+replacement. It does not add, remove, reposition, or repack pot items.
 
 `dungeon-set-room-property` accepts `layout`/`layout_id` values `0`-`7` and
 `floor1`/`floor2` values `0`-`15`. These properties are persisted in the

--- a/docs/public/usage/z3ed-cli.md
+++ b/docs/public/usage/z3ed-cli.md
@@ -69,6 +69,7 @@ scripts/dev/ai-provider-matrix-smoke.sh \
 | Read ROM bytes | `z3ed rom read --address=0x1000 --length=16 --rom=zelda3.sfc` |
 | List dungeon sprites | `z3ed dungeon-list-sprites --room=1 --rom=zelda3.sfc` |
 | Describe dungeon room | `z3ed dungeon-describe-room --room=1 --rom=zelda3.sfc` |
+| List dungeon pot items | `z3ed dungeon-list-pot-items --room=0xA8 --rom=zelda3.sfc` |
 | Show minecart collision (Oracle) | `z3ed dungeon-list-custom-collision --room=0x77 --tiles=0xB7,0xB8,0xB9,0xBA --rom=roms/oos168.sfc` |
 | Minecart audit (Oracle) | `z3ed dungeon-minecart-audit --rooms=0x77,0xA8,0xB8 --only-issues --rom=roms/oos168.sfc` |
 | ASCII room map (Oracle overlay) | `z3ed dungeon-map --room=0x77 --rom=roms/oos168.sfc` |

--- a/src/cli/handlers/command_handlers.cc
+++ b/src/cli/handlers/command_handlers.cc
@@ -154,6 +154,8 @@ CreateCliCommandHandlers() {
   handlers.push_back(std::make_unique<DungeonRemoveSpriteCommandHandler>());
   handlers.push_back(std::make_unique<DungeonPlaceObjectCommandHandler>());
   handlers.push_back(std::make_unique<DungeonSetDoorTypeCommandHandler>());
+  handlers.push_back(std::make_unique<DungeonListPotItemsCommandHandler>());
+  handlers.push_back(std::make_unique<DungeonSetPotItemCommandHandler>());
   handlers.push_back(std::make_unique<DungeonSetCollisionTileCommandHandler>());
 
   // Overworld inspection

--- a/src/cli/handlers/game/dungeon_edit_commands.cc
+++ b/src/cli/handlers/game/dungeon_edit_commands.cc
@@ -526,6 +526,218 @@ absl::StatusOr<DoorTypeTarget> ResolveDoorTypeTarget(
   return target;
 }
 
+struct PotItemManifestContext {
+  core::HackManifest manifest;
+  zelda3::DungeonStreamLayout layout;
+};
+
+absl::StatusOr<PotItemManifestContext> LoadPotItemManifestContext(
+    const resources::ArgumentParser& parser) {
+  std::string manifest_path;
+  ASSIGN_OR_RETURN(manifest_path, GetRequiredString(parser, "manifest"));
+
+  PotItemManifestContext context;
+  RETURN_IF_ERROR(context.manifest.LoadFromFile(manifest_path));
+  const core::DungeonStreamLayout* manifest_layout =
+      context.manifest.GetDungeonStreamLayout(
+          core::DungeonStreamType::kPotItems);
+  if (manifest_layout == nullptr) {
+    return absl::FailedPreconditionError(
+        "Manifest does not define dungeon_stream_regions.pot_items");
+  }
+  ASSIGN_OR_RETURN(context.layout,
+                   core::ToDungeonStreamAllocatorLayout(
+                       core::DungeonStreamType::kPotItems, *manifest_layout));
+  return context;
+}
+
+struct PotItemEntryView {
+  int index = -1;
+  zelda3::PotItem item;
+  uint32_t entry_pc = 0;
+  uint32_t item_pc = 0;
+};
+
+struct PotItemStreamView {
+  uint32_t pointer_slot_pc = 0;
+  uint32_t stream_pc = 0;
+  uint32_t stream_end_pc = 0;
+  std::vector<PotItemEntryView> entries;
+};
+
+absl::StatusOr<PotItemStreamView> ResolveRuntimePotItemStream(Rom* rom,
+                                                              int room_id) {
+  if (rom == nullptr || !rom->is_loaded()) {
+    return absl::InvalidArgumentError("ROM not loaded");
+  }
+
+  const uint64_t pointer_table_end =
+      static_cast<uint64_t>(zelda3::kRoomItemsPointers) +
+      static_cast<uint64_t>(zelda3::kNumberOfRooms) * 2u;
+  if (pointer_table_end > rom->size()) {
+    return absl::OutOfRangeError(
+        "Complete pot-item pointer table is outside ROM");
+  }
+  const uint32_t pointer_slot_pc =
+      zelda3::kRoomItemsPointers + static_cast<uint32_t>(room_id) * 2u;
+  uint16_t pointer_word = 0;
+  ASSIGN_OR_RETURN(pointer_word,
+                   rom->ReadWord(static_cast<int>(pointer_slot_pc)));
+  const uint32_t pointer_snes = 0x010000u | pointer_word;
+  if (!IsLoRomDataPointer(pointer_snes)) {
+    return absl::FailedPreconditionError(
+        "Selected pot-item pointer is not a valid bank-01 LoROM pointer");
+  }
+  const uint32_t stream_pc = SnesToPc(pointer_snes);
+  const uint64_t bank_end =
+      (static_cast<uint64_t>(stream_pc) / 0x8000u + 1u) * 0x8000u;
+  const uint32_t parse_end =
+      static_cast<uint32_t>(std::min<uint64_t>(rom->size(), bank_end));
+  if (stream_pc >= parse_end) {
+    return absl::OutOfRangeError("Selected pot-item stream is outside ROM");
+  }
+
+  PotItemStreamView view;
+  view.pointer_slot_pc = pointer_slot_pc;
+  view.stream_pc = stream_pc;
+
+  uint32_t cursor = stream_pc;
+  while (true) {
+    if (static_cast<uint64_t>(cursor) + 2u > parse_end) {
+      return absl::DataLossError("Pot-item stream has no 0xFFFF terminator");
+    }
+    uint16_t position = 0;
+    ASSIGN_OR_RETURN(position, rom->ReadWord(static_cast<int>(cursor)));
+    if (position == 0xFFFFu) {
+      view.stream_end_pc = cursor + 2u;
+      break;
+    }
+    if (static_cast<uint64_t>(cursor) + 3u > parse_end) {
+      return absl::DataLossError("Pot-item stream has a truncated record");
+    }
+    uint8_t item = 0;
+    ASSIGN_OR_RETURN(item, rom->ReadByte(static_cast<int>(cursor + 2u)));
+    view.entries.push_back({.index = static_cast<int>(view.entries.size()),
+                            .item = {.position = position, .item = item},
+                            .entry_pc = cursor,
+                            .item_pc = cursor + 2u});
+    cursor += 3u;
+  }
+
+  zelda3::Room room(room_id, rom);
+  room.LoadPotItems();
+  if (!room.ArePotItemsLoaded() ||
+      room.GetPotItems().size() != view.entries.size()) {
+    return absl::DataLossError(
+        "Pot-item room model count does not match the raw stream");
+  }
+  for (size_t index = 0; index < view.entries.size(); ++index) {
+    const zelda3::PotItem& model = room.GetPotItems()[index];
+    if (model.position != view.entries[index].item.position ||
+        model.item != view.entries[index].item.item) {
+      return absl::DataLossError(
+          "Pot-item room model does not match the raw stream");
+    }
+  }
+  return view;
+}
+
+struct PotItemTarget {
+  PotItemEntryView entry;
+  uint32_t pointer_slot_pc = 0;
+  uint32_t stream_pc = 0;
+  uint32_t stream_end_pc = 0;
+};
+
+absl::StatusOr<PotItemTarget> ResolvePotItemTarget(
+    Rom* rom, int room_id, int index,
+    const PotItemManifestContext& manifest_context) {
+  if (manifest_context.layout.pointer_count != zelda3::kNumberOfRooms) {
+    return absl::FailedPreconditionError(absl::StrFormat(
+        "Dungeon pot-item manifest pointer_count must equal %d rooms",
+        zelda3::kNumberOfRooms));
+  }
+
+  zelda3::DungeonStreamInventory inventory;
+  ASSIGN_OR_RETURN(inventory, zelda3::InventoryDungeonStreams(
+                                  *rom, manifest_context.layout));
+  if (static_cast<size_t>(room_id) >= inventory.streams.size()) {
+    return absl::FailedPreconditionError(
+        "Selected room is absent from the pot-item stream inventory");
+  }
+  if (!inventory.issues.empty()) {
+    const auto& issue = inventory.issues.front();
+    return absl::FailedPreconditionError(absl::StrFormat(
+        "Pot-item stream inventory is invalid at room 0x%03X: %s",
+        issue.room_id, issue.message));
+  }
+
+  const auto& stream = inventory.streams[room_id];
+  if (!stream.valid) {
+    return absl::FailedPreconditionError("Selected pot-item stream is invalid");
+  }
+  for (const auto& alias : inventory.aliases) {
+    if (ContainsRoomId(alias.room_ids, room_id)) {
+      return absl::FailedPreconditionError(absl::StrFormat(
+          "Selected pot-item stream at PC 0x%06X is shared by %d rooms",
+          alias.data_pc, static_cast<int>(alias.room_ids.size())));
+    }
+  }
+  for (const auto& overlap : inventory.overlaps) {
+    if (ContainsRoomId(overlap.first_room_ids, room_id) ||
+        ContainsRoomId(overlap.second_room_ids, room_id)) {
+      return absl::FailedPreconditionError(absl::StrFormat(
+          "Selected pot-item stream overlaps PC range [0x%06X, 0x%06X)",
+          overlap.intersection.begin, overlap.intersection.end));
+    }
+  }
+  for (const auto& other_stream : inventory.streams) {
+    if (other_stream.room_id == static_cast<uint32_t>(room_id)) {
+      continue;
+    }
+    if (other_stream.data_pc >= stream.data_pc &&
+        other_stream.data_pc < stream.logical_end_pc) {
+      return absl::FailedPreconditionError(absl::StrFormat(
+          "Room 0x%03X pot-item pointer PC 0x%06X starts inside selected "
+          "pot-item stream [0x%06X, 0x%06X)",
+          other_stream.room_id, other_stream.data_pc, stream.data_pc,
+          stream.logical_end_pc));
+    }
+  }
+
+  PotItemStreamView runtime;
+  ASSIGN_OR_RETURN(runtime, ResolveRuntimePotItemStream(rom, room_id));
+  if (runtime.pointer_slot_pc != stream.pointer_slot_pc ||
+      runtime.stream_pc != stream.data_pc ||
+      runtime.stream_end_pc != stream.logical_end_pc ||
+      runtime.entries.size() * 3u + 2u != stream.encoded_stream.size()) {
+    return absl::DataLossError(
+        "Runtime pot-item stream does not match the manifest inventory");
+  }
+  if (index < 0 || index >= static_cast<int>(runtime.entries.size())) {
+    return absl::OutOfRangeError(
+        absl::StrFormat("Pot-item index %d out of range (room has %d entries)",
+                        index, static_cast<int>(runtime.entries.size())));
+  }
+
+  const PotItemEntryView& entry = runtime.entries[index];
+  const auto conflicts = manifest_context.manifest.AnalyzePcWriteRanges(
+      {{entry.item_pc, entry.item_pc + 1u}});
+  if (!conflicts.empty()) {
+    return absl::PermissionDeniedError(absl::StrFormat(
+        "Pot-item byte at PC 0x%06X conflicts with Hack Manifest (%s)",
+        entry.item_pc,
+        core::AddressOwnershipToString(conflicts.front().ownership)));
+  }
+
+  return PotItemTarget{
+      .entry = entry,
+      .pointer_slot_pc = runtime.pointer_slot_pc,
+      .stream_pc = runtime.stream_pc,
+      .stream_end_pc = runtime.stream_end_pc,
+  };
+}
+
 }  // namespace
 
 // ---------------------------------------------------------------------------
@@ -1059,6 +1271,212 @@ absl::Status DungeonSetDoorTypeCommandHandler::Execute(
 
   auto memory_readback =
       ResolveDoorTypeTarget(rom, room_id, x, y, *manifest_context);
+  if (!memory_readback.ok()) {
+    return finish_error(memory_readback.status(), "readback_error");
+  }
+  const absl::Status memory_verify = verify_readback(*memory_readback);
+  if (!memory_verify.ok()) {
+    return finish_error(memory_verify, "readback_error");
+  }
+  formatter.AddField("readback_status", "pre_save_verified");
+  formatter.AddField("write_status", "success");
+
+  const absl::Status save_status = SaveRomWithBackup(rom, formatter);
+  if (!save_status.ok()) {
+    formatter.AddField("status", "error");
+    formatter.EndObject();
+    return save_status;
+  }
+
+  transaction.Commit();
+  formatter.AddField("status", "success");
+  formatter.EndObject();
+  return absl::OkStatus();
+}
+
+// ---------------------------------------------------------------------------
+// dungeon-list-pot-items
+// ---------------------------------------------------------------------------
+
+absl::Status DungeonListPotItemsCommandHandler::Execute(
+    Rom* rom, const resources::ArgumentParser& parser,
+    resources::OutputFormatter& formatter) {
+  int room_id = 0;
+  ASSIGN_OR_RETURN(room_id, GetRequiredHex(parser, "room"));
+  RETURN_IF_ERROR(ValidateRoomId(room_id));
+
+  PotItemStreamView stream;
+  ASSIGN_OR_RETURN(stream, ResolveRuntimePotItemStream(rom, room_id));
+
+  formatter.BeginObject("Dungeon Pot Items");
+  formatter.AddHexField("room_id", room_id, 3);
+  formatter.AddHexField("pointer_slot_pc", stream.pointer_slot_pc, 6);
+  formatter.AddHexField("stream_pc", stream.stream_pc, 6);
+  formatter.AddHexField("stream_end_pc", stream.stream_end_pc, 6);
+  formatter.AddField("item_count", static_cast<int>(stream.entries.size()));
+  formatter.BeginArray("items");
+  for (const PotItemEntryView& entry : stream.entries) {
+    formatter.BeginObject();
+    formatter.AddField("index", entry.index);
+    formatter.AddHexField("position", entry.item.position, 4);
+    formatter.AddField("tile_x", entry.item.GetTileX());
+    formatter.AddField("tile_y", entry.item.GetTileY());
+    formatter.AddHexField("item_id", entry.item.item, 2);
+    formatter.AddHexField("item_pc", entry.item_pc, 6);
+    formatter.AddHexField("item_snes", PcToSnes(entry.item_pc), 6);
+    formatter.EndObject();
+  }
+  formatter.EndArray();
+  formatter.AddField("status", "success");
+  formatter.EndObject();
+  return absl::OkStatus();
+}
+
+// ---------------------------------------------------------------------------
+// dungeon-set-pot-item
+// ---------------------------------------------------------------------------
+
+absl::Status DungeonSetPotItemCommandHandler::Execute(
+    Rom* rom, const resources::ArgumentParser& parser,
+    resources::OutputFormatter& formatter) {
+  int room_id = 0;
+  int index = 0;
+  int expected_position = 0;
+  int expected_item = 0;
+  int new_item = 0;
+  ASSIGN_OR_RETURN(room_id, GetRequiredHex(parser, "room"));
+  RETURN_IF_ERROR(ValidateRoomId(room_id));
+  ASSIGN_OR_RETURN(index, GetRequiredInt(parser, "index"));
+  ASSIGN_OR_RETURN(expected_position,
+                   GetRequiredHex(parser, "expect-position"));
+  ASSIGN_OR_RETURN(expected_item, GetRequiredHex(parser, "expect-item"));
+  ASSIGN_OR_RETURN(new_item, GetRequiredHex(parser, "item"));
+  if (expected_position < 0 || expected_position > 0xFFFF) {
+    return absl::InvalidArgumentError(
+        "--expect-position must be in range 0x0000-0xFFFF");
+  }
+  if (expected_item < 0 || expected_item > 0xFF) {
+    return absl::InvalidArgumentError(
+        "--expect-item must be in range 0x00-0xFF");
+  }
+  if (new_item < 0 || new_item > 0xFF) {
+    return absl::InvalidArgumentError("--item must be in range 0x00-0xFF");
+  }
+
+  PotItemManifestContext manifest_context;
+  ASSIGN_OR_RETURN(manifest_context, LoadPotItemManifestContext(parser));
+  PotItemTarget target;
+  ASSIGN_OR_RETURN(target,
+                   ResolvePotItemTarget(rom, room_id, index, manifest_context));
+  if (target.entry.item.position != expected_position ||
+      target.entry.item.item != expected_item) {
+    return absl::FailedPreconditionError(absl::StrFormat(
+        "Pot-item compare-and-swap failed at index %d: expected "
+        "position/item 0x%04X/0x%02X, found 0x%04X/0x%02X",
+        index, expected_position, expected_item, target.entry.item.position,
+        target.entry.item.item));
+  }
+  if (new_item == expected_item) {
+    return absl::InvalidArgumentError(
+        "--item must differ from the current pot item");
+  }
+
+  const bool do_write = parser.HasFlag("write");
+  if (do_write && rom->filename().empty()) {
+    return absl::FailedPreconditionError("Write mode requires a ROM filename");
+  }
+
+  formatter.BeginObject("Set Pot Item");
+  formatter.AddHexField("room_id", room_id, 3);
+  formatter.AddField("index", index);
+  formatter.AddHexField("position", target.entry.item.position, 4);
+  formatter.AddField("tile_x", target.entry.item.GetTileX());
+  formatter.AddField("tile_y", target.entry.item.GetTileY());
+  formatter.AddHexField("old_item", expected_item, 2);
+  formatter.AddHexField("new_item", new_item, 2);
+  formatter.AddHexField("pointer_slot_pc", target.pointer_slot_pc, 6);
+  formatter.AddHexField("stream_pc", target.stream_pc, 6);
+  formatter.AddHexField("stream_end_pc", target.stream_end_pc, 6);
+  formatter.AddHexField("item_pc", target.entry.item_pc, 6);
+  formatter.AddHexField("item_snes", PcToSnes(target.entry.item_pc), 6);
+  formatter.AddField("manifest", *parser.GetString("manifest"));
+  formatter.AddField("manifest_write_policy", "block");
+  formatter.AddField("stream_alias_status", "unique");
+  formatter.AddField("mode", do_write ? "write" : "dry-run");
+  formatter.AddField("preflight_status", "success");
+
+  if (!do_write) {
+    formatter.AddField("write_status", "not_requested");
+    formatter.AddField("save_status", "not_requested");
+    formatter.AddField("readback_status", "not_requested");
+    formatter.AddField("status", "success");
+    formatter.EndObject();
+    return absl::OkStatus();
+  }
+
+  const auto finish_error = [&formatter](const absl::Status& status,
+                                         const char* field) -> absl::Status {
+    formatter.AddField("status", "error");
+    formatter.AddField(field, std::string(status.message()));
+    formatter.EndObject();
+    return status;
+  };
+  const auto verify_readback =
+      [&target, new_item](const PotItemTarget& readback) -> absl::Status {
+    if (readback.entry.index != target.entry.index ||
+        readback.entry.entry_pc != target.entry.entry_pc ||
+        readback.entry.item_pc != target.entry.item_pc ||
+        readback.entry.item.position != target.entry.item.position ||
+        readback.entry.item.item != new_item ||
+        readback.stream_pc != target.stream_pc ||
+        readback.stream_end_pc != target.stream_end_pc) {
+      return absl::DataLossError(
+          "Pot-item readback does not match the requested change");
+    }
+    return absl::OkStatus();
+  };
+
+  rom::WriteFence write_fence;
+  const absl::Status allow_status = write_fence.Allow(
+      target.entry.item_pc, target.entry.item_pc + 1u, "dungeon pot item");
+  if (!allow_status.ok()) {
+    return finish_error(allow_status, "write_error");
+  }
+
+  const std::vector<uint8_t> before = rom->vector();
+  ScopedRomTransaction transaction(*rom);
+  {
+    rom::ScopedWriteFence write_scope(rom, &write_fence);
+    const absl::Status write_status = rom->WriteByte(
+        static_cast<int>(target.entry.item_pc), static_cast<uint8_t>(new_item));
+    if (!write_status.ok()) {
+      return finish_error(write_status, "write_error");
+    }
+  }
+
+  if (rom->size() != before.size()) {
+    return finish_error(
+        absl::DataLossError("Pot-item edit unexpectedly resized the ROM"),
+        "write_error");
+  }
+  int changed_bytes = 0;
+  uint32_t changed_pc = 0;
+  for (uint32_t pc = 0; pc < before.size(); ++pc) {
+    if (before[pc] != rom->data()[pc]) {
+      ++changed_bytes;
+      changed_pc = pc;
+    }
+  }
+  if (changed_bytes != 1 || changed_pc != target.entry.item_pc) {
+    return finish_error(
+        absl::DataLossError(absl::StrFormat(
+            "Pot-item edit changed %d bytes; expected only PC 0x%06X",
+            changed_bytes, target.entry.item_pc)),
+        "write_error");
+  }
+
+  auto memory_readback =
+      ResolvePotItemTarget(rom, room_id, index, manifest_context);
   if (!memory_readback.ok()) {
     return finish_error(memory_readback.status(), "readback_error");
   }

--- a/src/cli/handlers/game/dungeon_edit_commands.h
+++ b/src/cli/handlers/game/dungeon_edit_commands.h
@@ -111,6 +111,55 @@ class DungeonSetDoorTypeCommandHandler : public resources::CommandHandler {
 };
 
 /**
+ * @brief List existing pot-item entries and their exact ROM addresses.
+ */
+class DungeonListPotItemsCommandHandler : public resources::CommandHandler {
+ public:
+  std::string GetName() const override { return "dungeon-list-pot-items"; }
+  std::string GetDescription() const {
+    return "List existing dungeon pot-item entries";
+  }
+  std::string GetUsage() const override {
+    return "dungeon-list-pot-items --room <hex> "
+           "[--format <json|text>]";
+  }
+
+  absl::Status ValidateArgs(const resources::ArgumentParser& parser) override {
+    return parser.RequireArgs({"room"});
+  }
+
+  absl::Status Execute(Rom* rom, const resources::ArgumentParser& parser,
+                       resources::OutputFormatter& formatter) override;
+};
+
+/**
+ * @brief Change one existing pot item's fixed-width item byte.
+ *
+ * The target is selected by exact stream index and guarded by expected raw
+ * position and item values. Dry-run is the default; use --write to commit.
+ */
+class DungeonSetPotItemCommandHandler : public resources::CommandHandler {
+ public:
+  std::string GetName() const override { return "dungeon-set-pot-item"; }
+  std::string GetDescription() const {
+    return "Change an existing dungeon pot item";
+  }
+  std::string GetUsage() const override {
+    return "dungeon-set-pot-item --room <hex> --index <int> "
+           "--expect-position <hex> --expect-item <hex> --item <hex> "
+           "--manifest <path> [--write] [--format <json|text>]";
+  }
+
+  absl::Status ValidateArgs(const resources::ArgumentParser& parser) override {
+    return parser.RequireArgs({"room", "index", "expect-position",
+                               "expect-item", "item", "manifest"});
+  }
+
+  absl::Status Execute(Rom* rom, const resources::ArgumentParser& parser,
+                       resources::OutputFormatter& formatter) override;
+};
+
+/**
  * @brief Set individual custom collision tiles in a dungeon room.
  *
  * Supports setting one or more tiles. Dry-run by default.

--- a/src/cli/service/command_registry.cc
+++ b/src/cli/service/command_registry.cc
@@ -159,6 +159,25 @@ void CommandRegistry::RegisterHandlers(
             "--type=0x00 --expect-type=0x18 "
             "--manifest=hack_manifest.json --write "
             "--rom=/tmp/oos-work.sfc --format=json"};
+      } else if (name == "dungeon-list-pot-items") {
+        metadata.description =
+            "List existing pot items with raw positions and ROM addresses";
+        metadata.examples = {
+            "z3ed dungeon-list-pot-items --room=0xA8 "
+            "--rom=Roms/oos168.sfc --format=json"};
+      } else if (name == "dungeon-set-pot-item") {
+        metadata.description =
+            "Change one existing pot item with index/position/item CAS and "
+            "manifest guards (dry-run by default)";
+        metadata.examples = {
+            "z3ed dungeon-set-pot-item --room=0xA8 --index=0 "
+            "--expect-position=0x198C --expect-item=0x05 --item=0x06 "
+            "--manifest=Roms/hack_manifest.json --rom=Roms/oos168.sfc "
+            "--format=json",
+            "z3ed dungeon-set-pot-item --room=0xA8 --index=0 "
+            "--expect-position=0x198C --expect-item=0x05 --item=0x06 "
+            "--manifest=Roms/hack_manifest.json --write "
+            "--rom=/tmp/oos-work.sfc --format=json"};
       } else if (name == "dungeon-oracle-preflight") {
         metadata.description =
             "Oracle ROM safety preflight: water-fill region/table, collision "

--- a/test/unit/cli/dungeon_edit_commands_test.cc
+++ b/test/unit/cli/dungeon_edit_commands_test.cc
@@ -1846,6 +1846,33 @@ TEST(DungeonEditCommandsTest,
 }
 
 TEST(DungeonEditCommandsTest,
+     SetPotItemRejectsUnrelatedMalformedRoomInCompleteInventory) {
+  Rom rom;
+  InitializePotItemRom(&rom);
+  SetRoomPotItemPointer(&rom, 1, kOtherPotDataPc + 2);
+  rom.set_dirty(false);
+  ScopedFileCleanup manifest_cleanup(MakeUniqueTempRomPath().string() +
+                                     ".manifest.json");
+  WritePotItemManifest(manifest_cleanup.file_path);
+  const std::vector<uint8_t> before = rom.vector();
+
+  handlers::DungeonSetPotItemCommandHandler handler;
+  std::string output;
+  const absl::Status status = handler.Run(
+      {"--room=0x00", "--index=0", "--expect-position=0x1234",
+       "--expect-item=0x56", "--item=0x06",
+       absl::StrFormat("--manifest=%s", manifest_cleanup.file_path.string()),
+       "--format=json"},
+      &rom, &output);
+
+  EXPECT_TRUE(absl::IsFailedPrecondition(status)) << status;
+  EXPECT_THAT(std::string(status.message()),
+              HasSubstr("Pot-item stream inventory is invalid at room 0x001"));
+  EXPECT_EQ(rom.vector(), before);
+  EXPECT_FALSE(rom.dirty());
+}
+
+TEST(DungeonEditCommandsTest,
      SetPotItemRejectsProtectedByteWithoutMutationOrArtifacts) {
   Rom rom;
   InitializePotItemRom(&rom);

--- a/test/unit/cli/dungeon_edit_commands_test.cc
+++ b/test/unit/cli/dungeon_edit_commands_test.cc
@@ -51,6 +51,10 @@ constexpr uint8_t kObjectHeaderByte0 = 0xA5;
 constexpr uint8_t kObjectHeaderByte1 = 0xE3;
 constexpr int kDoorEntryPc = kObjectDataPc + 8;
 constexpr int kDoorTypePc = kDoorEntryPc + 1;
+constexpr int kPotDataPc = 0x00E000;
+constexpr int kOtherPotDataPc = 0x00E040;
+constexpr int kPotDataEndPc = 0x00E100;
+constexpr int kPotItemBytePc = kPotDataPc + 2;
 
 void ExpectInvalidArgument(const absl::Status& status,
                            const std::string& message_fragment) {
@@ -233,6 +237,26 @@ void InitializeDoorTypeRom(Rom* rom, bool duplicate_coordinate = false) {
   rom->set_dirty(false);
 }
 
+void SetRoomPotItemPointer(Rom* rom, int room_id, int pc_addr) {
+  const uint16_t pointer = PcToSnes(pc_addr) & 0xFFFFu;
+  const int slot = zelda3::kRoomItemsPointers + room_id * 2;
+  rom->mutable_data()[slot] = pointer & 0xFF;
+  rom->mutable_data()[slot + 1] = (pointer >> 8) & 0xFF;
+}
+
+void InitializePotItemRom(Rom* rom) {
+  InitializeRoomHeaderRom(rom);
+  SetRoomPotItemPointer(rom, 0, kPotDataPc);
+  for (int room_id = 1; room_id < zelda3::kNumberOfRooms; ++room_id) {
+    SetRoomPotItemPointer(rom, room_id, kOtherPotDataPc);
+  }
+  ASSERT_TRUE(rom->WriteVector(kPotDataPc,
+                               {0x34, 0x12, 0x56, 0x78, 0x56, 0x9A, 0xFF, 0xFF})
+                  .ok());
+  ASSERT_TRUE(rom->WriteVector(kOtherPotDataPc, {0xFF, 0xFF}).ok());
+  rom->set_dirty(false);
+}
+
 void SetRoomObjectPointer(Rom* rom, int room_id, int pc_addr) {
   WriteLong(rom, kObjectPointerTablePc + room_id * 3, PcToSnes(pc_addr));
 }
@@ -375,6 +399,56 @@ void WriteObjectCowManifest(const std::filesystem::path& path,
       PcToSnes(kObjectPointerTablePc), pointer_count, PcToSnes(kObjectDataPc),
       PcToSnes(kObjectDataEndPc), PcToSnes(kObjectAllocationPc),
       PcToSnes(kObjectDataEndPc), protected_section);
+  std::ofstream output(path, std::ios::trunc);
+  ASSERT_TRUE(output.is_open());
+  output << json;
+  ASSERT_TRUE(output.good());
+}
+
+void WritePotItemManifest(const std::filesystem::path& path,
+                          int protected_pc = -1,
+                          int pointer_count = zelda3::kNumberOfRooms,
+                          int data_start_pc = kPotDataPc) {
+  std::string protected_section;
+  if (protected_pc >= 0) {
+    protected_section = absl::StrFormat(
+        R"json(,
+  "protected_regions": {
+    "total_hooks": 1,
+    "regions": [
+      {
+        "start": "0x%06X",
+        "end": "0x%06X",
+        "size": 1,
+        "hook_count": 1,
+        "module": "PotItemGuard"
+      }
+    ]
+  })json",
+        PcToSnes(protected_pc), PcToSnes(protected_pc + 1));
+  }
+  const std::string json = absl::StrFormat(
+      R"json({
+  "manifest_version": 3,
+  "dungeon_stream_regions": {
+    "pot_items": {
+      "pointer_table": "0x%06X",
+      "pointer_count": %d,
+      "pointer_encoding": "bank16",
+      "pointer_bank": "0x01",
+      "strategy": "repack_all",
+      "data_regions": [
+        {"start": "0x%06X", "end": "0x%06X"}
+      ],
+      "allocation_regions": [
+        {"start": "0x%06X", "end": "0x%06X"}
+      ]
+    }
+  }%s
+})json",
+      PcToSnes(zelda3::kRoomItemsPointers), pointer_count,
+      PcToSnes(data_start_pc), PcToSnes(kPotDataEndPc), PcToSnes(data_start_pc),
+      PcToSnes(kPotDataEndPc), protected_section);
   std::ofstream output(path, std::ios::trunc);
   ASSERT_TRUE(output.is_open());
   output << json;
@@ -1516,6 +1590,379 @@ TEST(DungeonEditCommandsTest,
   EXPECT_FALSE(rom.dirty());
   EXPECT_EQ(ReadFile(cleanup.rom_path), disk_before);
   EXPECT_EQ(CountBackupArtifacts(cleanup.rom_path), 0);
+}
+
+TEST(DungeonEditCommandsTest,
+     ListPotItemsReportsExactPositionsCoordinatesAndAddresses) {
+  Rom rom;
+  InitializePotItemRom(&rom);
+  const std::vector<uint8_t> before = rom.vector();
+
+  handlers::DungeonListPotItemsCommandHandler handler;
+  std::string output;
+  const absl::Status status =
+      handler.Run({"--room=0x00", "--format=json"}, &rom, &output);
+
+  ASSERT_TRUE(status.ok()) << status;
+  const auto report = nlohmann::json::parse(output);
+  const auto& result = report.at("Dungeon Pot Items");
+  EXPECT_EQ(result.at("room_id"), "0x000");
+  EXPECT_EQ(result.at("stream_pc"), "0x00E000");
+  EXPECT_EQ(result.at("stream_end_pc"), "0x00E008");
+  ASSERT_EQ(result.at("items").size(), 2u);
+  EXPECT_EQ(result.at("items")[0].at("index"), 0);
+  EXPECT_EQ(result.at("items")[0].at("position"), "0x1234");
+  EXPECT_EQ(result.at("items")[0].at("tile_x"), 26);
+  EXPECT_EQ(result.at("items")[0].at("tile_y"), 36);
+  EXPECT_EQ(result.at("items")[0].at("item_id"), "0x56");
+  EXPECT_EQ(result.at("items")[0].at("item_pc"), "0x00E002");
+  EXPECT_EQ(result.at("items")[0].at("item_snes"), "0x01E002");
+  EXPECT_EQ(result.at("items")[1].at("index"), 1);
+  EXPECT_EQ(result.at("items")[1].at("position"), "0x5678");
+  EXPECT_EQ(result.at("items")[1].at("item_id"), "0x9A");
+  EXPECT_EQ(result.at("items")[1].at("item_pc"), "0x00E005");
+  EXPECT_EQ(rom.vector(), before);
+  EXPECT_FALSE(rom.dirty());
+}
+
+TEST(DungeonEditCommandsTest, ListPotItemsRejectsMalformedTerminator) {
+  Rom rom;
+  InitializePotItemRom(&rom);
+  rom.mutable_data()[kPotDataPc + 6] = 0xFF;
+  rom.mutable_data()[kPotDataPc + 7] = 0x00;
+  rom.set_dirty(false);
+  const std::vector<uint8_t> before = rom.vector();
+
+  handlers::DungeonListPotItemsCommandHandler handler;
+  std::string output;
+  const absl::Status status =
+      handler.Run({"--room=0x00", "--format=json"}, &rom, &output);
+
+  EXPECT_TRUE(absl::IsDataLoss(status)) << status;
+  EXPECT_THAT(std::string(status.message()), HasSubstr("truncated record"));
+  EXPECT_EQ(rom.vector(), before);
+  EXPECT_FALSE(rom.dirty());
+}
+
+TEST(DungeonEditCommandsTest,
+     SetPotItemDryRunLeavesRomDiskAndBackupsUnchanged) {
+  Rom rom;
+  InitializePotItemRom(&rom);
+  ScopedRomArtifactsCleanup cleanup(MakeUniqueTempRomPath());
+  ScopedFileCleanup manifest_cleanup(cleanup.rom_path.string() +
+                                     ".manifest.json");
+  WriteRomFile(rom, cleanup.rom_path);
+  WritePotItemManifest(manifest_cleanup.file_path);
+  rom.set_filename(cleanup.rom_path.string());
+  rom.set_dirty(false);
+  const std::vector<uint8_t> before = rom.vector();
+  const std::vector<uint8_t> disk_before = ReadFile(cleanup.rom_path);
+
+  handlers::DungeonSetPotItemCommandHandler handler;
+  std::string output;
+  const absl::Status status = handler.Run(
+      {"--room=0x00", "--index=0", "--expect-position=0x1234",
+       "--expect-item=0x56", "--item=0x06",
+       absl::StrFormat("--manifest=%s", manifest_cleanup.file_path.string()),
+       "--format=json"},
+      &rom, &output);
+
+  ASSERT_TRUE(status.ok()) << status;
+  EXPECT_THAT(output, HasSubstr("\"mode\": \"dry-run\""));
+  EXPECT_THAT(output, HasSubstr("\"preflight_status\": \"success\""));
+  EXPECT_THAT(output, HasSubstr("\"position\": \"0x1234\""));
+  EXPECT_THAT(output, HasSubstr("\"old_item\": \"0x56\""));
+  EXPECT_THAT(output, HasSubstr("\"new_item\": \"0x06\""));
+  EXPECT_THAT(output, HasSubstr("\"item_pc\": \"0x00E002\""));
+  EXPECT_EQ(rom.vector(), before);
+  EXPECT_FALSE(rom.dirty());
+  EXPECT_EQ(ReadFile(cleanup.rom_path), disk_before);
+  EXPECT_EQ(CountBackupArtifacts(cleanup.rom_path), 0);
+}
+
+TEST(DungeonEditCommandsTest,
+     SetPotItemRequiresManifestAndExactPositionItemCas) {
+  handlers::DungeonSetPotItemCommandHandler handler;
+
+  {
+    Rom rom;
+    InitializePotItemRom(&rom);
+    const std::vector<uint8_t> before = rom.vector();
+    std::string output;
+    const absl::Status status =
+        handler.Run({"--room=0x00", "--index=0", "--expect-position=0x1234",
+                     "--expect-item=0x56", "--item=0x06", "--format=json"},
+                    &rom, &output);
+    EXPECT_TRUE(absl::IsInvalidArgument(status)) << status;
+    EXPECT_EQ(rom.vector(), before);
+    EXPECT_FALSE(rom.dirty());
+  }
+
+  ScopedFileCleanup manifest_cleanup(MakeUniqueTempRomPath().string() +
+                                     ".manifest.json");
+  WritePotItemManifest(manifest_cleanup.file_path);
+  for (const auto& [position, item] :
+       std::array<std::pair<const char*, const char*>, 2>{
+           {{"0x1235", "0x56"}, {"0x1234", "0x57"}}}) {
+    SCOPED_TRACE(absl::StrFormat("%s/%s", position, item));
+    Rom rom;
+    InitializePotItemRom(&rom);
+    const std::vector<uint8_t> before = rom.vector();
+    std::string output;
+    const absl::Status status = handler.Run(
+        {"--room=0x00", "--index=0",
+         "--expect-position=" + std::string(position),
+         "--expect-item=" + std::string(item), "--item=0x06",
+         absl::StrFormat("--manifest=%s", manifest_cleanup.file_path.string()),
+         "--format=json"},
+        &rom, &output);
+    EXPECT_TRUE(absl::IsFailedPrecondition(status)) << status;
+    EXPECT_THAT(std::string(status.message()),
+                HasSubstr("compare-and-swap failed"));
+    EXPECT_EQ(rom.vector(), before);
+    EXPECT_FALSE(rom.dirty());
+  }
+}
+
+TEST(DungeonEditCommandsTest,
+     SetPotItemRejectsSharedOverlappingAndInteriorPointers) {
+  struct Case {
+    int pointer_pc;
+    const char* message;
+  };
+  const std::array<Case, 3> cases = {{
+      {kPotDataPc, "shared by 2 rooms"},
+      {kPotDataPc + 3, "overlaps PC range"},
+      {kPotDataPc + 2, "Pot-item stream inventory is invalid at room 0x001"},
+  }};
+  ScopedFileCleanup manifest_cleanup(MakeUniqueTempRomPath().string() +
+                                     ".manifest.json");
+  WritePotItemManifest(manifest_cleanup.file_path);
+
+  for (const auto& test_case : cases) {
+    SCOPED_TRACE(test_case.message);
+    Rom rom;
+    InitializePotItemRom(&rom);
+    SetRoomPotItemPointer(&rom, 1, test_case.pointer_pc);
+    rom.set_dirty(false);
+    const std::vector<uint8_t> before = rom.vector();
+
+    handlers::DungeonSetPotItemCommandHandler handler;
+    std::string output;
+    const absl::Status status = handler.Run(
+        {"--room=0x00", "--index=0", "--expect-position=0x1234",
+         "--expect-item=0x56", "--item=0x06",
+         absl::StrFormat("--manifest=%s", manifest_cleanup.file_path.string()),
+         "--format=json"},
+        &rom, &output);
+
+    EXPECT_TRUE(absl::IsFailedPrecondition(status)) << status;
+    EXPECT_THAT(std::string(status.message()), HasSubstr(test_case.message));
+    EXPECT_EQ(rom.vector(), before);
+    EXPECT_FALSE(rom.dirty());
+  }
+}
+
+TEST(DungeonEditCommandsTest,
+     SetPotItemRejectsMalformedSelectedStreamAndPartialInventory) {
+  handlers::DungeonSetPotItemCommandHandler handler;
+
+  {
+    Rom rom;
+    InitializePotItemRom(&rom);
+    rom.mutable_data()[kPotDataPc + 6] = 0xFF;
+    rom.mutable_data()[kPotDataPc + 7] = 0x00;
+    rom.set_dirty(false);
+    ScopedFileCleanup manifest_cleanup(MakeUniqueTempRomPath().string() +
+                                       ".manifest.json");
+    WritePotItemManifest(manifest_cleanup.file_path);
+    const std::vector<uint8_t> before = rom.vector();
+    std::string output;
+    const absl::Status status = handler.Run(
+        {"--room=0x00", "--index=0", "--expect-position=0x1234",
+         "--expect-item=0x56", "--item=0x06",
+         absl::StrFormat("--manifest=%s", manifest_cleanup.file_path.string()),
+         "--format=json"},
+        &rom, &output);
+    EXPECT_TRUE(absl::IsFailedPrecondition(status)) << status;
+    EXPECT_THAT(std::string(status.message()),
+                HasSubstr("Pot-item stream inventory is invalid"));
+    EXPECT_EQ(rom.vector(), before);
+    EXPECT_FALSE(rom.dirty());
+  }
+
+  {
+    Rom rom;
+    InitializePotItemRom(&rom);
+    ScopedFileCleanup manifest_cleanup(MakeUniqueTempRomPath().string() +
+                                       ".manifest.json");
+    WritePotItemManifest(manifest_cleanup.file_path, /*protected_pc=*/-1,
+                         /*pointer_count=*/zelda3::kNumberOfRooms - 1);
+    const std::vector<uint8_t> before = rom.vector();
+    std::string output;
+    const absl::Status status = handler.Run(
+        {"--room=0x00", "--index=0", "--expect-position=0x1234",
+         "--expect-item=0x56", "--item=0x06",
+         absl::StrFormat("--manifest=%s", manifest_cleanup.file_path.string()),
+         "--format=json"},
+        &rom, &output);
+    EXPECT_TRUE(absl::IsFailedPrecondition(status)) << status;
+    EXPECT_THAT(std::string(status.message()),
+                HasSubstr("pointer_count must equal 296 rooms"));
+    EXPECT_EQ(rom.vector(), before);
+    EXPECT_FALSE(rom.dirty());
+  }
+}
+
+TEST(DungeonEditCommandsTest,
+     SetPotItemRejectsMalformedPredecessorThatConsumesSelectedBytes) {
+  Rom rom;
+  InitializePotItemRom(&rom);
+  constexpr int kMalformedPredecessorPc = kPotDataPc - 1;
+  rom.mutable_data()[kMalformedPredecessorPc] = 0x00;
+  SetRoomPotItemPointer(&rom, 1, kMalformedPredecessorPc);
+  rom.set_dirty(false);
+  ScopedFileCleanup manifest_cleanup(MakeUniqueTempRomPath().string() +
+                                     ".manifest.json");
+  WritePotItemManifest(manifest_cleanup.file_path, /*protected_pc=*/-1,
+                       /*pointer_count=*/zelda3::kNumberOfRooms,
+                       /*data_start_pc=*/kMalformedPredecessorPc);
+  const std::vector<uint8_t> before = rom.vector();
+
+  handlers::DungeonSetPotItemCommandHandler handler;
+  std::string output;
+  const absl::Status status = handler.Run(
+      {"--room=0x00", "--index=0", "--expect-position=0x1234",
+       "--expect-item=0x56", "--item=0x06",
+       absl::StrFormat("--manifest=%s", manifest_cleanup.file_path.string()),
+       "--format=json"},
+      &rom, &output);
+
+  EXPECT_TRUE(absl::IsFailedPrecondition(status)) << status;
+  EXPECT_THAT(std::string(status.message()),
+              HasSubstr("Pot-item stream inventory is invalid at room 0x001"));
+  EXPECT_EQ(rom.vector(), before);
+  EXPECT_FALSE(rom.dirty());
+}
+
+TEST(DungeonEditCommandsTest,
+     SetPotItemRejectsProtectedByteWithoutMutationOrArtifacts) {
+  Rom rom;
+  InitializePotItemRom(&rom);
+  ScopedRomArtifactsCleanup cleanup(MakeUniqueTempRomPath());
+  ScopedFileCleanup manifest_cleanup(cleanup.rom_path.string() +
+                                     ".manifest.json");
+  WriteRomFile(rom, cleanup.rom_path);
+  WritePotItemManifest(manifest_cleanup.file_path, kPotItemBytePc);
+  rom.set_filename(cleanup.rom_path.string());
+  rom.set_dirty(false);
+  const std::vector<uint8_t> before = rom.vector();
+  const std::vector<uint8_t> disk_before = ReadFile(cleanup.rom_path);
+
+  handlers::DungeonSetPotItemCommandHandler handler;
+  std::string output;
+  const absl::Status status = handler.Run(
+      {"--room=0x00", "--index=0", "--expect-position=0x1234",
+       "--expect-item=0x56", "--item=0x06",
+       absl::StrFormat("--manifest=%s", manifest_cleanup.file_path.string()),
+       "--write", "--format=json"},
+      &rom, &output);
+
+  EXPECT_TRUE(absl::IsPermissionDenied(status)) << status;
+  EXPECT_THAT(std::string(status.message()),
+              HasSubstr("conflicts with Hack Manifest"));
+  EXPECT_EQ(rom.vector(), before);
+  EXPECT_FALSE(rom.dirty());
+  EXPECT_EQ(ReadFile(cleanup.rom_path), disk_before);
+  EXPECT_EQ(CountBackupArtifacts(cleanup.rom_path), 0);
+  EXPECT_FALSE(std::filesystem::exists(cleanup.rom_path.string() + ".tmp"));
+}
+
+TEST(DungeonEditCommandsTest, SetPotItemWriteChangesOneByteBacksUpAndReopens) {
+  Rom rom;
+  InitializePotItemRom(&rom);
+  ScopedRomArtifactsCleanup cleanup(MakeUniqueTempRomPath());
+  ScopedFileCleanup manifest_cleanup(cleanup.rom_path.string() +
+                                     ".manifest.json");
+  WriteRomFile(rom, cleanup.rom_path);
+  WritePotItemManifest(manifest_cleanup.file_path);
+  rom.set_filename(cleanup.rom_path.string());
+  rom.set_dirty(false);
+  const std::vector<uint8_t> before = rom.vector();
+  const std::vector<uint8_t> disk_before = ReadFile(cleanup.rom_path);
+
+  handlers::DungeonSetPotItemCommandHandler handler;
+  std::string output;
+  const absl::Status status = handler.Run(
+      {"--room=0x00", "--index=0", "--expect-position=0x1234",
+       "--expect-item=0x56", "--item=0x06",
+       absl::StrFormat("--manifest=%s", manifest_cleanup.file_path.string()),
+       "--write", "--format=json"},
+      &rom, &output);
+
+  ASSERT_TRUE(status.ok()) << status;
+  EXPECT_THAT(output, HasSubstr("\"mode\": \"write\""));
+  EXPECT_THAT(output, HasSubstr("\"write_status\": \"success\""));
+  EXPECT_THAT(output, HasSubstr("\"save_status\": \"saved\""));
+  EXPECT_THAT(output, HasSubstr("\"readback_status\": \"pre_save_verified\""));
+  std::vector<uint8_t> expected = before;
+  expected[kPotItemBytePc] = 0x06;
+  EXPECT_EQ(rom.vector(), expected);
+  EXPECT_EQ(ReadFile(cleanup.rom_path), expected);
+  EXPECT_FALSE(rom.dirty());
+
+  const auto backups = FindBackupArtifacts(cleanup.rom_path);
+  ASSERT_EQ(backups.size(), 1u);
+  EXPECT_EQ(ReadFile(backups.front()), disk_before);
+
+  Rom reopened;
+  ASSERT_TRUE(reopened.LoadFromFile(cleanup.rom_path.string()).ok());
+  zelda3::Room reopened_room(0, &reopened);
+  reopened_room.LoadPotItems();
+  ASSERT_EQ(reopened_room.GetPotItems().size(), 2u);
+  EXPECT_EQ(reopened_room.GetPotItems()[0].position, 0x1234);
+  EXPECT_EQ(reopened_room.GetPotItems()[0].item, 0x06);
+  EXPECT_EQ(reopened_room.GetPotItems()[1].position, 0x5678);
+  EXPECT_EQ(reopened_room.GetPotItems()[1].item, 0x9A);
+}
+
+TEST(DungeonEditCommandsTest, SetPotItemDiskSaveFailureRollsBackCallerRom) {
+  Rom rom;
+  InitializePotItemRom(&rom);
+  ScopedRomArtifactsCleanup cleanup(MakeUniqueTempRomPath());
+  ScopedFileCleanup manifest_cleanup(cleanup.rom_path.string() +
+                                     ".manifest.json");
+  WriteRomFile(rom, cleanup.rom_path);
+  WritePotItemManifest(manifest_cleanup.file_path);
+  rom.set_filename(cleanup.rom_path.string());
+  rom.set_dirty(false);
+  ASSERT_TRUE(
+      std::filesystem::create_directory(cleanup.rom_path.string() + ".tmp"));
+  const std::vector<uint8_t> before = rom.vector();
+  const std::vector<uint8_t> disk_before = ReadFile(cleanup.rom_path);
+  const bool dirty_before = rom.dirty();
+  const std::string filename_before = rom.filename();
+
+  handlers::DungeonSetPotItemCommandHandler handler;
+  std::string output;
+  const absl::Status status = handler.Run(
+      {"--room=0x00", "--index=0", "--expect-position=0x1234",
+       "--expect-item=0x56", "--item=0x06",
+       absl::StrFormat("--manifest=%s", manifest_cleanup.file_path.string()),
+       "--write", "--format=json"},
+      &rom, &output);
+
+  EXPECT_TRUE(absl::IsInternal(status)) << status;
+  EXPECT_THAT(std::string(status.message()),
+              HasSubstr("Could not open temp ROM file for writing"));
+  EXPECT_THAT(output, HasSubstr("\"readback_status\": \"pre_save_verified\""));
+  EXPECT_THAT(output, HasSubstr("\"write_status\": \"success\""));
+  EXPECT_THAT(output, HasSubstr("\"save_error\""));
+  EXPECT_EQ(rom.vector(), before);
+  EXPECT_EQ(rom.dirty(), dirty_before);
+  EXPECT_EQ(rom.filename(), filename_before);
+  EXPECT_EQ(ReadFile(cleanup.rom_path), disk_before);
+  EXPECT_EQ(CountBackupArtifacts(cleanup.rom_path), 1);
 }
 
 TEST(DungeonEditCommandsTest,


### PR DESCRIPTION
## Summary
- add `dungeon-list-pot-items` with exact entry index, raw position, tile coordinates, item ID, and PC/SNES address discovery
- add dry-run-first `dungeon-set-pot-item` for a one-byte existing-entry item CAS
- require a complete pot-stream manifest and fail closed on malformed inventory, aliases, overlaps, stale CAS values, and protected item bytes
- fence write mode to one byte and use transaction + required backup + atomic save semantics
- deliberately exclude add/remove/reposition/repack operations

## Why
The Oracle daily-driver proof needs a reproducible pot-item save-domain edit, but z3ed previously required raw ROM writes or GUI interaction. This supplies the smallest safe automation surface: changing one existing item byte without touching stream size or pointers.

## Validation
- `DungeonEditCommandsTest.*PotItem*`: 11/11 passed
- post-sync `DungeonEditCommandsTest.*RoomProperty*:DungeonEditCommandsTest.*PotItem*`: 28/28 passed
- focused build of `z3ed` and `yaze_test_unit`
- `clang-format --dry-run --Werror --style=file` on all changed C++ files
- `git diff --check`
- two independent read-only reviews; malformed-predecessor blocker reproduced, fixed, and re-reviewed clean; unrelated malformed-room behavior is explicitly pinned
- canonical OOS room `0xA8` listing and dry-run succeeded at item PC `0x00E375`; SHA-256 remained `d289b2408c3ccc312abeadf274f04f475106034fcab8ebff3f307fd229db4799`

## Integration
Synced by normal merge with `master` through #170 and #171 at exact head `f75722e7511ceffc3401912b082f20f68f64a858`. The single test-helper conflict retained both independently reviewed manifest fixtures; the normalized review diff remains the intended eight-file pot-item slice. A fresh exact-head hosted matrix is running.

Closes #172

