### PR TITLE
fix(cli): persist dungeon palette colors safely

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ High-level release summary. For detailed notes, see
 ## 0.8.0 (in development)
 - Development line for the Dungeon Editor completion milestone. See
   `docs/internal/plans/release-ladder-0x-2026.md` for scope.
+- Added room-aware US/OOS dungeon palette inspection and guarded persistent
+  color editing with shared-room fanout, CAS, manifest, clean-file baseline,
+  exact write fence, required backup, atomic save, and external readback.
+  Legacy `palette-set-color --write` now fails closed while preview remains
+  available.
 
 ## 0.7.2 (July 17, 2026)
 - **Dungeon RC Stabilization**:

--- a/assets/agent/function_schemas.json
+++ b/assets/agent/function_schemas.json
@@ -415,51 +415,91 @@
     },
     {
       "name": "palette-get-colors",
-      "description": "Get all colors from a specific palette",
+      "description": "Preview colors from a named generic palette group; this command is read-only",
       "parameters": {
         "type": "object",
         "properties": {
           "group": {
-            "type": "integer",
-            "description": "Palette group index (0-based)"
+            "type": "string",
+            "description": "Palette group name such as ow_main or dungeon_main"
           },
-          "palette": {
+          "index": {
             "type": "integer",
-            "description": "Palette index within group (0-7)"
+            "description": "Optional palette index within the named group"
           },
           "format": {
             "type": "string",
-            "enum": ["snes", "rgb", "hex"],
-            "description": "Color format (default: hex)"
+            "enum": ["json", "text"],
+            "description": "Output format"
           }
         },
-        "required": ["group", "palette"]
+        "required": ["group"]
       }
     },
     {
-      "name": "palette-set-color",
-      "description": "Set a specific color in a palette (creates a proposal)",
+      "name": "dungeon-get-palette",
+      "description": "Resolve a US/OOS room's full 8-bit palette-set ID to its shared global dungeon palette and list every affected room; unsupported regional layouts fail closed",
       "parameters": {
         "type": "object",
         "properties": {
-          "group": {
-            "type": "integer",
-            "description": "Palette group index"
+          "room": {
+            "type": "string",
+            "description": "Dungeon room ID in hex"
           },
-          "palette": {
+          "index": {
             "type": "integer",
-            "description": "Palette index within group"
+            "minimum": 0,
+            "maximum": 89,
+            "description": "Optional color index; omit to return all 90 colors"
+          }
+        },
+        "required": ["room"]
+      }
+    },
+    {
+      "name": "dungeon-set-palette-color",
+      "description": "Dry-run or persist one US/OOS shared dungeon palette color with full palette-set, resolved-index, old-color, manifest, clean-file baseline, backup, atomic-save, and external-readback guards",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "room": {
+            "type": "string",
+            "description": "Dungeon room ID in hex"
           },
-          "color_index": {
+          "index": {
             "type": "integer",
-            "description": "Color index in palette (0-15)"
+            "minimum": 0,
+            "maximum": 89,
+            "description": "Color index in the 90-color dungeon palette"
+          },
+          "expect-palette-set": {
+            "type": "string",
+            "description": "Expected full 8-bit room-header palette-set ID"
+          },
+          "expect-palette-index": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 19,
+            "description": "Expected resolved global dungeon palette index"
+          },
+          "expect-color": {
+            "type": "string",
+            "description": "Expected current 15-bit SNES color, 0x0000-0x7FFF"
           },
           "color": {
             "type": "string",
-            "description": "Color value in hex format (e.g., '#FF0000' or 'FF0000')"
+            "description": "Replacement 15-bit SNES color, 0x0000-0x7FFF"
+          },
+          "manifest": {
+            "type": "string",
+            "description": "Hack Manifest path used to block protected ranges"
+          },
+          "write": {
+            "type": "boolean",
+            "description": "Persist only after reviewing the default dry-run"
           }
         },
-        "required": ["group", "palette", "color_index", "color"]
+        "required": ["room", "index", "expect-palette-set", "expect-palette-index", "expect-color", "color", "manifest"]
       }
     },
     {

--- a/assets/agent/prompt_catalogue.yaml
+++ b/assets/agent/prompt_catalogue.yaml
@@ -9,11 +9,6 @@ commands:
       --group <group>  Palette group (overworld, dungeon, sprite)
       --id <id>        Palette ID (0-based index)
       --from <file>    Input JSON file path
-  palette set-color: |-
-    Modify a color in palette JSON file
-      --file <file>    Palette JSON file to modify
-      --index <index>  Color index (0-15 per palette)
-      --color <hex>    New color in hex (0xRRGGBB format)
   overworld set-tile: |-
     Place a tile in the overworld
       --map <id>       Map ID (0-based)
@@ -90,6 +85,54 @@ tools:
         description: "Response format (json or text). Defaults to JSON if omitted."
         required: false
         example: json
+  - name: dungeon-get-palette
+    description: "Read-only resolution of a US/OOS room's full 8-bit palette-set ID to its shared global dungeon palette."
+    usage_notes: "Use before any dungeon palette edit. Returns the resolved palette index, raw 15-bit colors, addresses, and every affected room; it never mutates the ROM and fails closed on unsupported regional layouts."
+    arguments:
+      - name: room
+        description: "Dungeon room ID in hex."
+        required: true
+        example: 0xA8
+      - name: index
+        description: "Optional color index from 0 through 89; omit to return all 90 colors."
+        required: false
+        example: 7
+  - name: dungeon-set-palette-color
+    description: "Guarded mutating tool for dry-running or persisting one US/OOS shared dungeon palette color."
+    usage_notes: "Dry-run by default. Copy every expected value from a fresh dungeon-get-palette result, review the complete affected-room fanout, and request write only for a clean disposable file-backed ROM with a Hack Manifest."
+    arguments:
+      - name: room
+        description: "Dungeon room ID in hex."
+        required: true
+        example: 0xA8
+      - name: index
+        description: "Color index from 0 through 89."
+        required: true
+        example: 7
+      - name: expect-palette-set
+        description: "Expected full 8-bit room-header palette-set ID."
+        required: true
+        example: 0x07
+      - name: expect-palette-index
+        description: "Expected resolved global dungeon palette index from 0 through 19."
+        required: true
+        example: 7
+      - name: expect-color
+        description: "Expected current raw 15-bit SNES color word."
+        required: true
+        example: 0x7FFF
+      - name: color
+        description: "Replacement raw 15-bit SNES color word."
+        required: true
+        example: 0x7FFE
+      - name: manifest
+        description: "Hack Manifest path used to block protected write ranges."
+        required: true
+        example: Roms/hack_manifest.json
+      - name: write
+        description: "Optional boolean. True requests the guarded persistent write after dry-run review; false or omitted previews only."
+        required: false
+        example: "false"
   - name: overworld-find-tile
     description: "Search all overworld maps for occurrences of a specific tile16 ID."
     usage_notes: "Ideal for tile lookup questions. Includes coordinates for each match."

--- a/assets/agent/prompt_catalogue_v2.yaml
+++ b/assets/agent/prompt_catalogue_v2.yaml
@@ -28,6 +28,54 @@ tools:
         description: "Response format (json or table)"
         required: false
         example: json
+  - name: dungeon-get-palette
+    description: "Read-only resolution of a US/OOS room's full 8-bit palette-set ID to its shared global dungeon palette."
+    usage_notes: "Returns the resolved palette index, raw 15-bit colors, addresses, and every affected room without mutating the ROM; unsupported regional layouts fail closed."
+    arguments:
+      - name: room
+        description: "Dungeon room ID in hex."
+        required: true
+        example: 0xA8
+      - name: index
+        description: "Optional color index from 0 through 89."
+        required: false
+        example: 7
+  - name: dungeon-set-palette-color
+    description: "Guarded mutating tool for dry-running or persisting one US/OOS shared dungeon palette color."
+    usage_notes: "Dry-run by default. Copy expected values from a fresh getter, review affected rooms, and request write only for a clean disposable file-backed ROM with a Hack Manifest."
+    arguments:
+      - name: room
+        description: "Dungeon room ID in hex."
+        required: true
+        example: 0xA8
+      - name: index
+        description: "Color index from 0 through 89."
+        required: true
+        example: 7
+      - name: expect-palette-set
+        description: "Expected full 8-bit room-header palette-set ID."
+        required: true
+        example: 0x07
+      - name: expect-palette-index
+        description: "Expected resolved global dungeon palette index from 0 through 19."
+        required: true
+        example: 7
+      - name: expect-color
+        description: "Expected current raw 15-bit SNES color word."
+        required: true
+        example: 0x7FFF
+      - name: color
+        description: "Replacement raw 15-bit SNES color word."
+        required: true
+        example: 0x7FFE
+      - name: manifest
+        description: "Hack Manifest path used to block protected write ranges."
+        required: true
+        example: Roms/hack_manifest.json
+      - name: write
+        description: "Optional boolean. True requests the guarded persistent write; false or omitted previews only."
+        required: false
+        example: "false"
 
 tile16_reference:
   grass: 0x020

--- a/assets/agent/system_prompt.txt
+++ b/assets/agent/system_prompt.txt
@@ -87,10 +87,20 @@ You: {"text_response": "This ROM contains 297 rooms including Ganon, Hyrule Cast
 
 # When to Use Tools vs Commands
 
-- **Tools** are read-only and return information about the ROM state
-- **Commands** modify the ROM and should only be used when explicitly requested
+- **Tools** are read-only unless their declaration explicitly labels them
+  mutating; mutating tools still require authorization
+- **Commands** may modify the ROM and should only be used when explicitly
+  requested
 - You can call multiple tools in one response
 - Always provide text_response after receiving tool results
+
+For dungeon palette work on US/OOS ROMs:
+- Call `dungeon-get-palette` first and review its complete shared-room fanout.
+- `dungeon-set-palette-color` is a guarded mutating tool but defaults to
+  dry-run. Supply fresh full palette-set, resolved-index, and raw-color CAS
+  values plus a Hack Manifest.
+- Request `write=true` only after dry-run review and only for a clean,
+  disposable file-backed ROM. Never call legacy `palette-set-color --write`.
 
 # Command Syntax Rules
 
@@ -100,12 +110,13 @@ You: {"text_response": "This ROM contains 297 rooms including Ganon, Hyrule Cast
 
 # Common Patterns
 
-- Palette modifications: export → set-color → import
+- Dungeon palette modification: getter → guarded setter dry-run → authorized
+  write on a disposable copy
 - Multiple tile placement: multiple overworld set-tile commands
 - Validation: single rom validate command
 
 # Error Prevention
 
-- Always export before modifying palettes
+- Always inspect shared dungeon palette scope before modifying a color
 - Use temporary file names (temp_*.json) for intermediate files
 - Validate coordinates are within bounds

--- a/assets/agent/system_prompt_v2.txt
+++ b/assets/agent/system_prompt_v2.txt
@@ -358,6 +358,15 @@ commands:
   rom validate: "Validate ROM integrity and structure"
 ```
 
+## Safe Dungeon Palette Tool Rule
+
+For US/OOS dungeon palettes, call the read-only `dungeon-get-palette` tool
+first and review every affected room. Use the guarded mutating
+`dungeon-set-palette-color` tool with fresh palette-set, resolved-index, and
+raw-color CAS values plus a Hack Manifest. It defaults to dry-run; request
+`write=true` only for a clean disposable file-backed ROM after reviewing the
+dry-run. Legacy `palette-set-color --write` is disabled.
+
 ## Tile16 Reference
 ```yaml
 tile16_reference:

--- a/assets/agent/system_prompt_v3.txt
+++ b/assets/agent/system_prompt_v3.txt
@@ -223,19 +223,27 @@ Direct ROM memory access for advanced ROM hacking:
   - Usage: `hex-search --pattern="FF 00 ?? 12" --start=0x00000`
   - Use ?? for wildcard bytes
 
-## Palette Manipulation Tools
-Color editing and analysis for graphics work:
+## Palette Inspection and Safe Dungeon Editing Tools
+Palette previews are read-only. Dungeon writes must use the room-aware command
+so shared fanout and manifest ownership are explicit:
 
-- **palette-get-colors**: Get all 16 colors from a palette
-  - Usage: `palette-get-colors --group=0 --palette=0 --format=hex`
-  - Formats: snes, rgb, hex
-  
-- **palette-set-color**: Modify a specific color (creates proposal)
-  - Usage: `palette-set-color --group=0 --palette=0 --index=5 --color=FF0000`
-  - Color in hex format (with or without #)
-  
+- **palette-get-colors**: Preview a named generic palette group
+  - Usage: `palette-get-colors --group=ow_main --index=0 --format=json`
+
+- **dungeon-get-palette**: Resolve a room's full palette-set ID, global
+  dungeon palette index, raw SNES colors, and every affected room
+  - Usage: `dungeon-get-palette --room=0xA8 --index=7`
+
+- **dungeon-set-palette-color**: Dry-run or persist one shared dungeon color
+  with exact palette-set/index/color CAS and a Hack Manifest
+  - First dry-run without `--write`; review `affected_rooms`
+  - Native write usage for a disposable current-OOS copy: `dungeon-set-palette-color --room=0xA8 --index=7 --expect-palette-set=0x07 --expect-palette-index=7 --expect-color=0x7FFF --color=0x7FFE --manifest=Roms/hack_manifest.json --write`
+  - Never use legacy `palette-set-color --write`; it is rejected
+  - Browser-terminal writes are unavailable because durable sync is not
+    guaranteed; use native z3ed on a disposable ROM copy
+
 - **palette-analyze**: Analyze palette statistics
-  - Usage: `palette-analyze --type=palette --id=0/0`
+  - Usage: `palette-analyze --group=ow_main`
   - Shows unique colors, duplicates, brightness analysis
 
 ## TODO Management

--- a/docs/internal/agents/rom-safety-guardrails.md
+++ b/docs/internal/agents/rom-safety-guardrails.md
@@ -23,12 +23,30 @@ This repo is used to edit ROM hacks (including Oracle of Secrets). Treat ROM wri
   has no previous bytes to back up. A completed required backup is retained if
   the later target write fails, so recovery bytes remain available.
 - `dungeon-place-sprite`, `dungeon-remove-sprite`, `dungeon-place-object`,
-  `dungeon-set-door-type`, `dungeon-set-pot-item`,
+  `dungeon-set-palette-color`, `dungeon-set-door-type`,
+  `dungeon-set-pot-item`,
   `dungeon-set-collision-tile`, and `dungeon-set-room-property` wrap their
   serializer or fixed-width write,
   required backup, and disk commit in `ScopedRomTransaction`. Any failure
   before a successful disk commit restores the caller's ROM bytes, filename,
   size, and dirty state.
+- `dungeon-get-palette` follows the room header's full 8-bit palette-set ID
+  through `0x75460` and `0xDEC4B`, rejects malformed referenced mappings, and
+  reports every room resolving to the same shared global palette. It proves
+  the US/OOS destination code first and fails closed on JP/EU or unproven
+  regional table layouts.
+  `dungeon-set-palette-color` is dry-run-first and requires full palette-set,
+  resolved palette-index, and raw 15-bit color CAS plus a Hack Manifest. It
+  checks the exact two-byte range even during dry-run, fences only that color,
+  rejects dirty callers or any mismatch between the in-memory baseline and
+  current file, verifies the whole-ROM diff, requires a backup and atomic save,
+  commits the caller transaction after disk replacement, then externally
+  reopens and verifies the persisted word. A post-save readback failure is
+  reported as data loss without rolling memory back from the already-persisted
+  state.
+  Legacy `palette-set-color --write` fails before ROM loading or mutation;
+  preview remains read-only. The browser registers only the getter because
+  Emscripten does not guarantee durable filesystem synchronization.
 - `dungeon-set-door-type` is dry-run by default and requires exact coordinates,
   an expected old type, and a `copy_on_write` object-stream manifest. It rejects
   incomplete pointer inventories, invalid/aliased/overlapping selected streams,

--- a/docs/public/cli/README.md
+++ b/docs/public/cli/README.md
@@ -27,6 +27,7 @@ Machine-readable test discovery and execution.
 | `hex-read` | Read raw bytes from ROM |
 | `hex-search` | Search for byte patterns |
 | `palette-get-colors` | Extract palette data |
+| `dungeon-get-palette` | Resolve a room's shared dungeon palette and fanout |
 | `sprite-list` | List sprites |
 | `music-list` | List music tracks |
 | `dialogue-list` | List dialogue entries |
@@ -67,6 +68,8 @@ Prefer `z3ed debug ...` as the front door (Mesen2 is the default backend).
 | `dungeon-list-sprites` | List dungeon sprites |
 | `dungeon-describe-room` | Describe room properties |
 | `dungeon-list-objects` | List room objects |
+| `dungeon-get-palette` | Inspect full palette-set mapping and affected rooms |
+| `dungeon-set-palette-color` | Guarded dry-run/write of one shared color |
 
 ---
 

--- a/docs/public/developer/palette-system-overview.md
+++ b/docs/public/developer/palette-system-overview.md
@@ -100,6 +100,24 @@ Room palette property = 16
 | ...    | ...    | ...        |
 | 38     | 0x0D5C | 19         |
 
+#### Safe CLI Inspection and Editing
+
+Use `dungeon-get-palette --room <hex> [--index <0..89>]` rather than treating
+the room-header byte as a direct palette index. Its output preserves the full
+8-bit palette-set ID, validates the referenced table entry and pointer word,
+and lists every room resolving to the same global palette. That fanout matters:
+two different palette-set IDs can alias the same palette. This bounded command
+currently supports only the US/OOS table layout and fails closed for Japanese,
+European, or otherwise unproven regional layouts.
+
+`dungeon-set-palette-color` accepts raw 15-bit SNES words and is dry-run-first.
+It requires expected palette-set, resolved palette index, old color, and a Hack
+Manifest before it will even preview the exact shared write. Native `--write`
+uses an exact two-byte write fence, required backup, atomic save, whole-ROM
+diff, and external reopen/readback. Legacy `palette-set-color --write` is
+disabled; browser-terminal writes are not offered because durable Emscripten
+filesystem synchronization cannot be guaranteed.
+
 #### Common Pitfall: Direct Palette ID Usage
 
 **WRONG** (causes purple/wrong colors for palette sets 16+):

--- a/docs/public/examples/web-terminal-integration.md
+++ b/docs/public/examples/web-terminal-integration.md
@@ -216,8 +216,14 @@ The WASM build includes a subset of z3ed commands that don't require native depe
 - `hex-read --address <hex> --length <bytes> [--data-format <hex|ascii|both>]` - Read ROM bytes
 - `hex-write --address <hex> --data <hex>` - Write ROM bytes
 - `hex-search --pattern <hex>` - Search for a byte pattern
-- `palette-get-colors --palette <id>` - Read palette colors
-- `palette-set-color --palette <id> --index <idx> --color <hex>` - Update a palette entry
+- `palette-get-colors --group <name> [--index <palette>]` - Preview generic palette colors
+- `dungeon-get-palette --room <hex> [--index <0..89>]` - Resolve a room's shared dungeon palette and affected rooms
+
+The browser terminal intentionally does not expose
+`dungeon-set-palette-color`: an in-session Emscripten save cannot guarantee a
+durable filesystem sync. Legacy `palette-set-color` remains preview-only and
+rejects `--write`. Use native z3ed on a disposable ROM copy for manifest-safe
+dungeon palette writes.
 
 ## Build Configuration
 

--- a/docs/public/reference/changelog.md
+++ b/docs/public/reference/changelog.md
@@ -6,6 +6,15 @@
 - Opened the post-v0.7.2 development line for dungeon correctness, object
   parity, persistence stability, and Oracle daily-driver readiness.
 
+### CLI and ROM safety
+- Added `dungeon-get-palette` to resolve the full room palette-set mapping,
+  raw colors, and every room sharing the selected global US/OOS palette.
+- Added dry-run-first `dungeon-set-palette-color` with exact mapping/color CAS,
+  Hack Manifest ownership checks, clean disk baseline, two-byte write fence,
+  required backup, atomic save, whole-ROM diff, and external reopen/readback.
+- Disabled legacy `palette-set-color --write` because it could report an
+  in-memory mutation as persisted; its read-only preview remains available.
+
 ## 0.7.2 (July 17, 2026)
 
 ### Dungeon Editor Follow-through
@@ -126,7 +135,8 @@
 
 ### CLI
 - Added `palette-get-colors` for palette dump/report output.
-- Added `palette-set-color` for direct palette writes.
+- Added `palette-set-color` for direct palette writes (legacy write mode is
+  disabled on the 0.8 development line; preview remains available).
 - Added `palette-analyze` for palette usage analysis.
 
 ### Themed Widget System

--- a/docs/public/usage/z3ed-cli.md
+++ b/docs/public/usage/z3ed-cli.md
@@ -70,6 +70,7 @@ scripts/dev/ai-provider-matrix-smoke.sh \
 | List dungeon sprites | `z3ed dungeon-list-sprites --room=1 --rom=zelda3.sfc` |
 | Describe dungeon room | `z3ed dungeon-describe-room --room=1 --rom=zelda3.sfc` |
 | List dungeon pot items | `z3ed dungeon-list-pot-items --room=0xA8 --rom=zelda3.sfc` |
+| Resolve shared dungeon palette | `z3ed dungeon-get-palette --room=0xA8 --rom=zelda3.sfc` |
 | Show minecart collision (Oracle) | `z3ed dungeon-list-custom-collision --room=0x77 --tiles=0xB7,0xB8,0xB9,0xBA --rom=roms/oos168.sfc` |
 | Minecart audit (Oracle) | `z3ed dungeon-minecart-audit --rooms=0x77,0xA8,0xB8 --only-issues --rom=roms/oos168.sfc` |
 | ASCII room map (Oracle overlay) | `z3ed dungeon-map --room=0x77 --rom=roms/oos168.sfc` |
@@ -84,6 +85,45 @@ z3ed --help
 z3ed help dungeon
 z3ed help dungeon-list-sprites
 ```
+
+### Safe Dungeon Palette Color Edits
+
+Dungeon palettes are global, shared resources: a room header stores a full
+8-bit palette-set ID, which resolves through two tables to one of 20 global
+90-color palettes. These bounded commands currently support the US/OOS table
+layout and fail closed on other regional layouts. Always inspect the mapping
+and fanout first:
+
+```bash
+z3ed dungeon-get-palette \
+  --room=0xA8 --index=7 --rom=Roms/oos168.sfc --format=json
+```
+
+The setter is dry-run-first and requires exact compare-and-swap values plus a
+Hack Manifest. Copy the current values from the getter output each time; the
+example below matches the documented canonical OOS snapshot but is not a
+substitute for a fresh getter. Run it against a disposable ROM copy:
+
+```bash
+# Preview only. Review palette_set_id, resolved_palette_index,
+# old_color, color_pc, and every affected_rooms entry.
+z3ed dungeon-set-palette-color \
+  --room=0xA8 --index=7 \
+  --expect-palette-set=0x07 --expect-palette-index=7 \
+  --expect-color=0x7FFF --color=0x7FFE \
+  --manifest=Roms/hack_manifest.json \
+  --rom=/tmp/oos-work.sfc --format=json
+
+# Repeat the identical command with --write only after reviewing the preview.
+```
+
+Native write mode fences exactly the resolved two-byte color, blocks manifest
+conflicts, rejects a dirty caller or a mismatch with the current file, requires
+a backup, atomically replaces the ROM, compares the whole-ROM diff, and
+externally reopens the file before reporting verified success.
+`palette-set-color --write` is intentionally rejected; its legacy mode is
+preview-only. Browser-terminal palette writes are unavailable because
+Emscripten cannot guarantee durable filesystem synchronization.
 
 ---
 

--- a/src/cli/handlers/command_handlers.cc
+++ b/src/cli/handlers/command_handlers.cc
@@ -153,6 +153,8 @@ CreateCliCommandHandlers() {
   handlers.push_back(std::make_unique<DungeonPlaceSpriteCommandHandler>());
   handlers.push_back(std::make_unique<DungeonRemoveSpriteCommandHandler>());
   handlers.push_back(std::make_unique<DungeonPlaceObjectCommandHandler>());
+  handlers.push_back(std::make_unique<DungeonGetPaletteCommandHandler>());
+  handlers.push_back(std::make_unique<DungeonSetPaletteColorCommandHandler>());
   handlers.push_back(std::make_unique<DungeonSetDoorTypeCommandHandler>());
   handlers.push_back(std::make_unique<DungeonListPotItemsCommandHandler>());
   handlers.push_back(std::make_unique<DungeonSetPotItemCommandHandler>());

--- a/src/cli/handlers/command_handlers.h
+++ b/src/cli/handlers/command_handlers.h
@@ -57,6 +57,8 @@ class DungeonMinecartMapCommandHandler;
 class DungeonPlaceSpriteCommandHandler;
 class DungeonRemoveSpriteCommandHandler;
 class DungeonPlaceObjectCommandHandler;
+class DungeonGetPaletteCommandHandler;
+class DungeonSetPaletteColorCommandHandler;
 class DungeonSetCollisionTileCommandHandler;
 class OracleMenuIndexCommandHandler;
 class OracleMenuSetOffsetCommandHandler;

--- a/src/cli/handlers/command_handlers_browser.cc
+++ b/src/cli/handlers/command_handlers_browser.cc
@@ -5,6 +5,7 @@
 
 #include "cli/handlers/game/dungeon_collision_commands.h"
 #include "cli/handlers/game/dungeon_commands.h"
+#include "cli/handlers/game/dungeon_edit_commands.h"
 #include "cli/handlers/game/minecart_commands.h"
 #include "cli/handlers/game/overworld_commands.h"
 #include "cli/handlers/game/overworld_graph_commands.h"
@@ -50,6 +51,10 @@ CreateCliCommandHandlers() {
       std::make_unique<DungeonImportWaterFillJsonCommandHandler>());
   handlers.push_back(std::make_unique<DungeonGetRoomTilesCommandHandler>());
   handlers.push_back(std::make_unique<DungeonSetRoomPropertyCommandHandler>());
+  // Read-only palette resolution is safe in the browser terminal. The
+  // mutating setter is intentionally omitted because Emscripten cannot
+  // guarantee durable IDBFS synchronization after an in-session save.
+  handlers.push_back(std::make_unique<DungeonGetPaletteCommandHandler>());
   handlers.push_back(std::make_unique<DungeonMinecartAuditCommandHandler>());
   handlers.push_back(std::make_unique<DungeonMinecartMapCommandHandler>());
 

--- a/src/cli/handlers/game/dungeon_commands.cc
+++ b/src/cli/handlers/game/dungeon_commands.cc
@@ -1012,7 +1012,9 @@ absl::Status DungeonRoomHeaderCommandHandler::Execute(
     formatter.AddField("bg2", (byte0 >> 5) & 0x07);
     formatter.AddField("collision", (byte0 >> 2) & 0x07);
     formatter.AddField("is_light", (byte0 & 0x01) == 1);
-    formatter.AddField("palette", byte1 & 0x3F);
+    // This is the full 8-bit palette-set ID. Values 0x40-0x47 are valid;
+    // masking to six bits silently aliases them to the wrong palette set.
+    formatter.AddField("palette", byte1);
     formatter.AddField("blockset", byte2);
     formatter.AddField("spriteset", byte3);
     formatter.AddField("effect", rom->data()[room_header_pc + 4]);

--- a/src/cli/handlers/game/dungeon_edit_commands.cc
+++ b/src/cli/handlers/game/dungeon_edit_commands.cc
@@ -11,6 +11,7 @@
 #include "absl/strings/numbers.h"
 #include "absl/strings/str_format.h"
 #include "absl/strings/str_split.h"
+#include "app/gfx/types/snes_palette.h"
 #include "cli/util/hex_util.h"
 #include "core/dungeon_stream_layout_adapter.h"
 #include "core/hack_manifest.h"
@@ -24,6 +25,7 @@
 #include "zelda3/dungeon/room.h"
 #include "zelda3/dungeon/room_object.h"
 #include "zelda3/dungeon/track_collision_generator.h"
+#include "zelda3/game_data.h"
 #include "zelda3/resource_labels.h"
 #include "zelda3/sprite/sprite.h"
 
@@ -281,6 +283,367 @@ bool IsLoRomDataPointer(uint32_t snes_address) {
   }
   const uint32_t pc_address = SnesToPc(snes_address);
   return (PcToSnes(pc_address) & 0x7FFFFFu) == (snes_address & 0x7FFFFFu);
+}
+
+constexpr int kDungeonPaletteColorCount = 90;
+constexpr int kDungeonPaletteCount = gfx::DungeonsMainPalettesMax;
+constexpr uint32_t kDungeonPaletteDataStart = gfx::kDungeonMainPalettes;
+constexpr uint32_t kSnesDestinationCodePc = 0x7FD9;
+constexpr uint32_t kDungeonPaletteDataEnd =
+    kDungeonPaletteDataStart +
+    kDungeonPaletteCount * zelda3::kDungeonPaletteBytes;
+
+bool IsValidRomRange(const Rom& rom, uint64_t start, uint64_t length) {
+  return start <= rom.size() && length <= rom.size() - start;
+}
+
+absl::Status ValidateSupportedDungeonPaletteRom(const Rom& rom) {
+  if (!IsValidRomRange(rom, kSnesDestinationCodePc, 1)) {
+    return absl::FailedPreconditionError(
+        "ROM is too small to prove US/OOS dungeon palette table layout");
+  }
+  uint8_t destination_code = 0;
+  ASSIGN_OR_RETURN(destination_code,
+                   rom.ReadByte(static_cast<int>(kSnesDestinationCodePc)));
+  if (destination_code != 0x01) {
+    return absl::FailedPreconditionError(absl::StrFormat(
+        "Dungeon palette commands currently support only the US/OOS table "
+        "layout (SNES destination code 0x01); got unsupported code 0x%02X",
+        destination_code));
+  }
+  return absl::OkStatus();
+}
+
+struct DungeonPaletteRoomMapping {
+  int room_id = -1;
+  uint8_t palette_set_id = 0;
+  uint8_t palette_pointer_offset = 0;
+  uint16_t palette_pointer_word = 0;
+  int palette_index = -1;
+  uint32_t room_header_pc = 0;
+  uint32_t palette_set_pc = 0;
+  uint32_t palette_pointer_pc = 0;
+  uint32_t palette_pc = 0;
+};
+
+absl::StatusOr<uint32_t> ResolveRoomHeaderPcStrict(const Rom& rom,
+                                                   int room_id) {
+  RETURN_IF_ERROR(ValidateRoomId(room_id));
+  if (!IsValidRomRange(rom, zelda3::kRoomHeaderPointer, 3) ||
+      !IsValidRomRange(rom, zelda3::kRoomHeaderPointerBank, 1)) {
+    return absl::FailedPreconditionError(
+        "Dungeon room-header pointer metadata is outside the ROM");
+  }
+
+  uint32_t table_snes = 0;
+  ASSIGN_OR_RETURN(table_snes, rom.ReadLong(zelda3::kRoomHeaderPointer));
+  if (!IsLoRomDataPointer(table_snes)) {
+    return absl::FailedPreconditionError(absl::StrFormat(
+        "Dungeon room-header pointer table is not a valid LoROM pointer: "
+        "0x%06X",
+        table_snes));
+  }
+  const uint32_t table_pc = SnesToPc(table_snes);
+  const uint64_t slot_pc =
+      static_cast<uint64_t>(table_pc) + static_cast<uint64_t>(room_id) * 2u;
+  if (!IsValidRomRange(rom, slot_pc, 2)) {
+    return absl::FailedPreconditionError(absl::StrFormat(
+        "Dungeon room 0x%03X header pointer slot is outside the ROM", room_id));
+  }
+
+  uint16_t header_offset = 0;
+  uint8_t header_bank = 0;
+  ASSIGN_OR_RETURN(header_offset, rom.ReadWord(static_cast<int>(slot_pc)));
+  ASSIGN_OR_RETURN(header_bank, rom.ReadByte(zelda3::kRoomHeaderPointerBank));
+  const uint32_t header_snes =
+      (static_cast<uint32_t>(header_bank) << 16) | header_offset;
+  if (!IsLoRomDataPointer(header_snes)) {
+    return absl::FailedPreconditionError(absl::StrFormat(
+        "Dungeon room 0x%03X header is not a valid LoROM pointer: 0x%06X",
+        room_id, header_snes));
+  }
+
+  const uint32_t header_pc = SnesToPc(header_snes);
+  if (!IsValidRomRange(rom, header_pc, 14)) {
+    return absl::FailedPreconditionError(absl::StrFormat(
+        "Dungeon room 0x%03X header is outside the ROM", room_id));
+  }
+  return header_pc;
+}
+
+absl::StatusOr<DungeonPaletteRoomMapping> ResolveDungeonPaletteRoomMapping(
+    const Rom& rom, int room_id) {
+  DungeonPaletteRoomMapping mapping;
+  mapping.room_id = room_id;
+  ASSIGN_OR_RETURN(mapping.room_header_pc,
+                   ResolveRoomHeaderPcStrict(rom, room_id));
+  ASSIGN_OR_RETURN(mapping.palette_set_id,
+                   rom.ReadByte(static_cast<int>(mapping.room_header_pc + 1u)));
+  if (mapping.palette_set_id >= zelda3::kNumPalettesets) {
+    return absl::FailedPreconditionError(absl::StrFormat(
+        "Dungeon room 0x%03X has out-of-range 8-bit palette-set ID 0x%02X "
+        "(expected 0x00-0x%02X)",
+        room_id, mapping.palette_set_id, zelda3::kNumPalettesets - 1));
+  }
+
+  mapping.palette_set_pc = zelda3::kPalettesetIdsAddress +
+                           static_cast<uint32_t>(mapping.palette_set_id) * 4u;
+  if (!IsValidRomRange(rom, mapping.palette_set_pc, 4)) {
+    return absl::FailedPreconditionError(absl::StrFormat(
+        "Palette-set entry 0x%02X is outside the ROM", mapping.palette_set_id));
+  }
+  ASSIGN_OR_RETURN(mapping.palette_pointer_offset,
+                   rom.ReadByte(static_cast<int>(mapping.palette_set_pc)));
+  if ((mapping.palette_pointer_offset & 1u) != 0u ||
+      mapping.palette_pointer_offset >= kDungeonPaletteCount * 2) {
+    return absl::FailedPreconditionError(absl::StrFormat(
+        "Palette-set 0x%02X has malformed dungeon palette pointer offset "
+        "0x%02X (expected an even byte offset 0x00-0x%02X)",
+        mapping.palette_set_id, mapping.palette_pointer_offset,
+        kDungeonPaletteCount * 2 - 2));
+  }
+
+  mapping.palette_pointer_pc =
+      zelda3::kDungeonPalettePointerTable + mapping.palette_pointer_offset;
+  if (!IsValidRomRange(rom, mapping.palette_pointer_pc, 2)) {
+    return absl::FailedPreconditionError(
+        "Resolved dungeon palette pointer is outside the ROM");
+  }
+  ASSIGN_OR_RETURN(mapping.palette_pointer_word,
+                   rom.ReadWord(static_cast<int>(mapping.palette_pointer_pc)));
+  if (mapping.palette_pointer_word % zelda3::kDungeonPaletteBytes != 0) {
+    return absl::FailedPreconditionError(absl::StrFormat(
+        "Palette-set 0x%02X resolves to malformed palette word 0x%04X "
+        "(not divisible by %d)",
+        mapping.palette_set_id, mapping.palette_pointer_word,
+        zelda3::kDungeonPaletteBytes));
+  }
+
+  mapping.palette_index =
+      mapping.palette_pointer_word / zelda3::kDungeonPaletteBytes;
+  if (mapping.palette_index < 0 ||
+      mapping.palette_index >= kDungeonPaletteCount) {
+    return absl::FailedPreconditionError(absl::StrFormat(
+        "Palette-set 0x%02X resolves to out-of-range dungeon palette %d",
+        mapping.palette_set_id, mapping.palette_index));
+  }
+
+  mapping.palette_pc = kDungeonPaletteDataStart + mapping.palette_pointer_word;
+  if (mapping.palette_pc < kDungeonPaletteDataStart ||
+      static_cast<uint64_t>(mapping.palette_pc) + zelda3::kDungeonPaletteBytes >
+          kDungeonPaletteDataEnd ||
+      !IsValidRomRange(rom, mapping.palette_pc, zelda3::kDungeonPaletteBytes)) {
+    return absl::FailedPreconditionError(absl::StrFormat(
+        "Palette-set 0x%02X resolves outside the fixed dungeon palette "
+        "region [0x%06X,0x%06X)",
+        mapping.palette_set_id, kDungeonPaletteDataStart,
+        kDungeonPaletteDataEnd));
+  }
+  return mapping;
+}
+
+struct DungeonPaletteSelection {
+  DungeonPaletteRoomMapping selected;
+  std::vector<uint32_t> affected_rooms;
+};
+
+absl::StatusOr<DungeonPaletteSelection> ResolveDungeonPaletteSelection(
+    const Rom& rom, int room_id) {
+  RETURN_IF_ERROR(ValidateSupportedDungeonPaletteRom(rom));
+  DungeonPaletteSelection selection;
+  ASSIGN_OR_RETURN(selection.selected,
+                   ResolveDungeonPaletteRoomMapping(rom, room_id));
+  selection.affected_rooms.reserve(zelda3::kNumberOfRooms);
+  for (int candidate = 0; candidate < zelda3::kNumberOfRooms; ++candidate) {
+    auto mapping_or = ResolveDungeonPaletteRoomMapping(rom, candidate);
+    if (!mapping_or.ok()) {
+      return absl::Status(
+          mapping_or.status().code(),
+          absl::StrFormat(
+              "Cannot prove complete shared palette fanout because room "
+              "0x%03X mapping is invalid: %s",
+              candidate, mapping_or.status().message()));
+    }
+    if (mapping_or->palette_index == selection.selected.palette_index) {
+      selection.affected_rooms.push_back(static_cast<uint32_t>(candidate));
+    }
+  }
+  return selection;
+}
+
+absl::Status ValidateDungeonPaletteColorIndex(int color_index) {
+  if (color_index < 0 || color_index >= kDungeonPaletteColorCount) {
+    return absl::InvalidArgumentError(absl::StrFormat(
+        "--index must be in range 0-%d", kDungeonPaletteColorCount - 1));
+  }
+  return absl::OkStatus();
+}
+
+absl::Status ValidateSnes15BitColor(int color, const char* argument_name) {
+  if (color < 0 || color > 0x7FFF) {
+    return absl::InvalidArgumentError(absl::StrFormat(
+        "--%s must be a 15-bit SNES color in range 0x0000-0x7FFF",
+        argument_name));
+  }
+  return absl::OkStatus();
+}
+
+uint32_t DungeonPaletteColorPc(const DungeonPaletteRoomMapping& mapping,
+                               int color_index) {
+  return mapping.palette_pc + static_cast<uint32_t>(color_index) * 2u;
+}
+
+absl::StatusOr<uint16_t> ReadDungeonPaletteColor(
+    const Rom& rom, const DungeonPaletteRoomMapping& mapping, int color_index) {
+  RETURN_IF_ERROR(ValidateDungeonPaletteColorIndex(color_index));
+  const uint32_t color_pc = DungeonPaletteColorPc(mapping, color_index);
+  if (!IsValidRomRange(rom, color_pc, 2) ||
+      color_pc < kDungeonPaletteDataStart ||
+      static_cast<uint64_t>(color_pc) + 2u > kDungeonPaletteDataEnd) {
+    return absl::FailedPreconditionError(
+        "Resolved dungeon palette color is outside the fixed palette region");
+  }
+  uint16_t color = 0;
+  ASSIGN_OR_RETURN(color, rom.ReadWord(static_cast<int>(color_pc)));
+  if (color > 0x7FFF) {
+    return absl::FailedPreconditionError(absl::StrFormat(
+        "Resolved dungeon palette color at PC 0x%06X is not a 15-bit SNES "
+        "color: 0x%04X",
+        color_pc, color));
+  }
+  return color;
+}
+
+void AddDungeonPaletteScope(resources::OutputFormatter& formatter,
+                            const DungeonPaletteSelection& selection) {
+  const auto& mapping = selection.selected;
+  formatter.AddHexField("room_id", mapping.room_id, 3);
+  formatter.AddHexField("palette_set_id", mapping.palette_set_id, 2);
+  formatter.AddField("resolved_palette_index", mapping.palette_index);
+  formatter.AddHexField("room_header_pc", mapping.room_header_pc, 6);
+  formatter.AddHexField("palette_set_pc", mapping.palette_set_pc, 6);
+  formatter.AddHexField("palette_pointer_offset",
+                        mapping.palette_pointer_offset, 2);
+  formatter.AddHexField("palette_pointer_pc", mapping.palette_pointer_pc, 6);
+  formatter.AddHexField("palette_pointer_word", mapping.palette_pointer_word,
+                        4);
+  formatter.AddHexField("palette_pc", mapping.palette_pc, 6);
+  formatter.AddHexField("palette_snes", PcToSnes(mapping.palette_pc), 6);
+  formatter.AddField("scope", "shared_global_dungeon_palette");
+  formatter.AddField("affected_room_count",
+                     static_cast<int>(selection.affected_rooms.size()));
+  formatter.BeginArray("affected_rooms");
+  for (uint32_t affected_room : selection.affected_rooms) {
+    formatter.AddArrayItem(absl::StrFormat("0x%03X", affected_room));
+  }
+  formatter.EndArray();
+}
+
+absl::Status ValidateDungeonPaletteManifestRange(
+    const core::HackManifest& manifest, uint32_t color_pc) {
+  const auto conflicts =
+      manifest.AnalyzePcWriteRanges({{color_pc, color_pc + 2u}});
+  if (conflicts.empty()) {
+    return absl::OkStatus();
+  }
+  const core::WriteConflict& conflict = conflicts.front();
+  return absl::PermissionDeniedError(absl::StrFormat(
+      "Dungeon palette color range [0x%06X,0x%06X) conflicts with Hack "
+      "Manifest ownership at SNES 0x%06X (%s%s%s)",
+      color_pc, color_pc + 2u, conflict.address,
+      core::AddressOwnershipToString(conflict.ownership),
+      conflict.module.empty() ? "" : ", module=",
+      conflict.module.empty() ? "" : conflict.module));
+}
+
+absl::StatusOr<std::vector<uint32_t>> ValidateDungeonPaletteWholeRomDiff(
+    const std::vector<uint8_t>& before, const Rom& after, uint32_t color_pc) {
+  if (after.size() != before.size()) {
+    return absl::DataLossError(
+        "Dungeon palette write unexpectedly resized the ROM");
+  }
+
+  std::vector<uint32_t> changed;
+  for (uint32_t pc = 0; pc < before.size(); ++pc) {
+    if (before[pc] == after.data()[pc]) {
+      continue;
+    }
+    if (pc < color_pc || pc >= color_pc + 2u) {
+      return absl::DataLossError(absl::StrFormat(
+          "Dungeon palette write changed unexpected ROM byte 0x%06X", pc));
+    }
+    changed.push_back(pc);
+  }
+  if (changed.empty() || changed.size() > 2u) {
+    return absl::DataLossError(absl::StrFormat(
+        "Dungeon palette write changed %zu bytes; expected one or two bytes "
+        "inside the fenced color word",
+        changed.size()));
+  }
+  return changed;
+}
+
+absl::Status ValidateDungeonPaletteWriteBaseline(const Rom& rom) {
+  if (rom.dirty()) {
+    return absl::FailedPreconditionError(
+        "Dungeon palette write requires a clean file-backed ROM; save or "
+        "discard unrelated in-memory edits first");
+  }
+  if (rom.filename().empty()) {
+    return absl::FailedPreconditionError(
+        "Dungeon palette write requires a ROM filename");
+  }
+
+  Rom disk_rom;
+  Rom::LoadOptions options;
+  options.strip_header = false;
+  options.load_resource_labels = false;
+  RETURN_IF_ERROR(disk_rom.LoadFromFile(rom.filename(), options));
+  if (disk_rom.vector() != rom.vector()) {
+    return absl::FailedPreconditionError(
+        "Dungeon palette write requires in-memory ROM bytes to exactly match "
+        "the current file; refusing to persist unrelated or stale bytes");
+  }
+  return absl::OkStatus();
+}
+
+absl::Status VerifyDungeonPaletteExternalReadback(
+    const Rom& saved_rom, int room_id, int expected_palette_set,
+    int expected_palette_index, int color_index, uint16_t expected_color) {
+  if (saved_rom.filename().empty()) {
+    return absl::FailedPreconditionError(
+        "Write mode requires a ROM filename for external readback");
+  }
+
+  Rom reopened;
+  Rom::LoadOptions options;
+  options.strip_header = false;
+  options.load_resource_labels = false;
+  RETURN_IF_ERROR(reopened.LoadFromFile(saved_rom.filename(), options));
+  if (reopened.vector() != saved_rom.vector()) {
+    return absl::DataLossError(
+        "External reopen bytes do not match the saved in-memory ROM");
+  }
+
+  RETURN_IF_ERROR(ValidateSupportedDungeonPaletteRom(reopened));
+  DungeonPaletteRoomMapping reopened_mapping;
+  ASSIGN_OR_RETURN(reopened_mapping,
+                   ResolveDungeonPaletteRoomMapping(reopened, room_id));
+  if (reopened_mapping.palette_set_id != expected_palette_set ||
+      reopened_mapping.palette_index != expected_palette_index) {
+    return absl::DataLossError(
+        "External reopen changed the selected dungeon palette mapping");
+  }
+  uint16_t reopened_color = 0;
+  ASSIGN_OR_RETURN(
+      reopened_color,
+      ReadDungeonPaletteColor(reopened, reopened_mapping, color_index));
+  if (reopened_color != expected_color) {
+    return absl::DataLossError(absl::StrFormat(
+        "External reopen color mismatch: expected 0x%04X, got 0x%04X",
+        expected_color, reopened_color));
+  }
+  return absl::OkStatus();
 }
 
 struct DoorTypeTarget {
@@ -1117,6 +1480,237 @@ absl::Status DungeonPlaceObjectCommandHandler::Execute(
     }
   }
 
+  formatter.EndObject();
+  return absl::OkStatus();
+}
+
+// ---------------------------------------------------------------------------
+// dungeon-get-palette
+// ---------------------------------------------------------------------------
+
+absl::Status DungeonGetPaletteCommandHandler::Execute(
+    Rom* rom, const resources::ArgumentParser& parser,
+    resources::OutputFormatter& formatter) {
+  int room_id = 0;
+  ASSIGN_OR_RETURN(room_id, GetRequiredHex(parser, "room"));
+  RETURN_IF_ERROR(ValidateRoomId(room_id));
+
+  std::optional<int> requested_index;
+  if (parser.GetString("index").has_value()) {
+    int color_index = 0;
+    ASSIGN_OR_RETURN(color_index, GetRequiredInt(parser, "index"));
+    RETURN_IF_ERROR(ValidateDungeonPaletteColorIndex(color_index));
+    requested_index = color_index;
+  }
+
+  DungeonPaletteSelection selection;
+  ASSIGN_OR_RETURN(selection, ResolveDungeonPaletteSelection(*rom, room_id));
+
+  formatter.BeginObject("Dungeon Palette");
+  AddDungeonPaletteScope(formatter, selection);
+  formatter.AddField("color_count", kDungeonPaletteColorCount);
+
+  if (requested_index.has_value()) {
+    const uint32_t color_pc =
+        DungeonPaletteColorPc(selection.selected, *requested_index);
+    uint16_t color = 0;
+    ASSIGN_OR_RETURN(color, ReadDungeonPaletteColor(*rom, selection.selected,
+                                                    *requested_index));
+    formatter.AddField("color_index", *requested_index);
+    formatter.AddHexField("color_pc", color_pc, 6);
+    formatter.AddHexField("color_snes_address", PcToSnes(color_pc), 6);
+    formatter.AddHexField("color_snes", color, 4);
+  } else {
+    formatter.BeginArray("colors");
+    for (int color_index = 0; color_index < kDungeonPaletteColorCount;
+         ++color_index) {
+      const uint32_t color_pc =
+          DungeonPaletteColorPc(selection.selected, color_index);
+      uint16_t color = 0;
+      ASSIGN_OR_RETURN(color, ReadDungeonPaletteColor(*rom, selection.selected,
+                                                      color_index));
+      formatter.BeginObject();
+      formatter.AddField("index", color_index);
+      formatter.AddHexField("pc", color_pc, 6);
+      formatter.AddHexField("snes_address", PcToSnes(color_pc), 6);
+      formatter.AddHexField("snes_color", color, 4);
+      formatter.EndObject();
+    }
+    formatter.EndArray();
+  }
+
+  formatter.AddField("status", "success");
+  formatter.EndObject();
+  return absl::OkStatus();
+}
+
+// ---------------------------------------------------------------------------
+// dungeon-set-palette-color
+// ---------------------------------------------------------------------------
+
+absl::Status DungeonSetPaletteColorCommandHandler::Execute(
+    Rom* rom, const resources::ArgumentParser& parser,
+    resources::OutputFormatter& formatter) {
+  const bool do_write = parser.HasFlag("write");
+#if defined(__EMSCRIPTEN__)
+  if (do_write) {
+    return absl::FailedPreconditionError(
+        "dungeon-set-palette-color --write is unavailable in the browser "
+        "terminal because durable filesystem sync cannot be guaranteed; use "
+        "native z3ed on a disposable ROM copy");
+  }
+#endif
+  if (do_write && rom->filename().empty()) {
+    return absl::FailedPreconditionError(
+        "dungeon-set-palette-color --write requires a ROM loaded from a "
+        "filesystem path");
+  }
+
+  int room_id = 0;
+  int color_index = 0;
+  int expected_palette_set = 0;
+  int expected_palette_index = 0;
+  int expected_color = 0;
+  int replacement_color = 0;
+  ASSIGN_OR_RETURN(room_id, GetRequiredHex(parser, "room"));
+  ASSIGN_OR_RETURN(color_index, GetRequiredInt(parser, "index"));
+  ASSIGN_OR_RETURN(expected_palette_set,
+                   GetRequiredHex(parser, "expect-palette-set"));
+  ASSIGN_OR_RETURN(expected_palette_index,
+                   GetRequiredInt(parser, "expect-palette-index"));
+  ASSIGN_OR_RETURN(expected_color, GetRequiredHex(parser, "expect-color"));
+  ASSIGN_OR_RETURN(replacement_color, GetRequiredHex(parser, "color"));
+
+  RETURN_IF_ERROR(ValidateRoomId(room_id));
+  RETURN_IF_ERROR(ValidateDungeonPaletteColorIndex(color_index));
+  if (expected_palette_set < 0 || expected_palette_set > 0xFF) {
+    return absl::InvalidArgumentError(
+        "--expect-palette-set must be an 8-bit value in range 0x00-0xFF");
+  }
+  if (expected_palette_index < 0 ||
+      expected_palette_index >= kDungeonPaletteCount) {
+    return absl::InvalidArgumentError(
+        absl::StrFormat("--expect-palette-index must be in range 0-%d",
+                        kDungeonPaletteCount - 1));
+  }
+  RETURN_IF_ERROR(ValidateSnes15BitColor(expected_color, "expect-color"));
+  RETURN_IF_ERROR(ValidateSnes15BitColor(replacement_color, "color"));
+
+  const std::string manifest_path = parser.GetString("manifest").value();
+  core::HackManifest manifest;
+  RETURN_IF_ERROR(manifest.LoadFromFile(manifest_path));
+
+  DungeonPaletteSelection selection;
+  ASSIGN_OR_RETURN(selection, ResolveDungeonPaletteSelection(*rom, room_id));
+  if (selection.selected.palette_set_id != expected_palette_set) {
+    return absl::FailedPreconditionError(absl::StrFormat(
+        "Palette-set CAS failed for room 0x%03X: expected full 8-bit ID "
+        "0x%02X, got 0x%02X",
+        room_id, expected_palette_set, selection.selected.palette_set_id));
+  }
+  if (selection.selected.palette_index != expected_palette_index) {
+    return absl::FailedPreconditionError(absl::StrFormat(
+        "Resolved palette CAS failed for room 0x%03X: expected %d, got %d",
+        room_id, expected_palette_index, selection.selected.palette_index));
+  }
+
+  uint16_t actual_color = 0;
+  ASSIGN_OR_RETURN(actual_color, ReadDungeonPaletteColor(
+                                     *rom, selection.selected, color_index));
+  if (actual_color != expected_color) {
+    return absl::FailedPreconditionError(absl::StrFormat(
+        "Color CAS failed at palette %d index %d: expected 0x%04X, got "
+        "0x%04X",
+        selection.selected.palette_index, color_index, expected_color,
+        actual_color));
+  }
+  if (replacement_color == actual_color) {
+    return absl::InvalidArgumentError(absl::StrFormat(
+        "Refusing no-op dungeon palette write: color is already 0x%04X",
+        actual_color));
+  }
+
+  const uint32_t color_pc =
+      DungeonPaletteColorPc(selection.selected, color_index);
+  RETURN_IF_ERROR(ValidateDungeonPaletteManifestRange(manifest, color_pc));
+  if (do_write) {
+    RETURN_IF_ERROR(ValidateDungeonPaletteWriteBaseline(*rom));
+  }
+
+  formatter.BeginObject("Set Dungeon Palette Color");
+  AddDungeonPaletteScope(formatter, selection);
+  formatter.AddField("manifest", manifest_path);
+  formatter.AddField("manifest_write_policy", "block");
+  formatter.AddField("mode", do_write ? "write" : "dry-run");
+  formatter.AddField("color_index", color_index);
+  formatter.AddHexField("color_pc", color_pc, 6);
+  formatter.AddHexField("color_snes_address", PcToSnes(color_pc), 6);
+  formatter.AddHexField("old_color", actual_color, 4);
+  formatter.AddHexField("new_color", replacement_color, 4);
+  formatter.AddField("preflight_status", "success");
+
+  if (!do_write) {
+    formatter.AddField("status", "dry-run");
+    formatter.EndObject();
+    return absl::OkStatus();
+  }
+
+  rom::WriteFence write_fence;
+  RETURN_IF_ERROR(
+      write_fence.Allow(color_pc, color_pc + 2u, "DungeonPaletteColor"));
+  const std::vector<uint8_t> before = rom->vector();
+  ScopedRomTransaction transaction(*rom);
+  {
+    rom::ScopedWriteFence scoped_fence(rom, &write_fence);
+    RETURN_IF_ERROR(
+        rom->WriteShort(color_pc, static_cast<uint16_t>(replacement_color)));
+  }
+
+  std::vector<uint32_t> changed_bytes;
+  ASSIGN_OR_RETURN(changed_bytes,
+                   ValidateDungeonPaletteWholeRomDiff(before, *rom, color_pc));
+  uint16_t memory_color = 0;
+  ASSIGN_OR_RETURN(memory_color, ReadDungeonPaletteColor(
+                                     *rom, selection.selected, color_index));
+  if (memory_color != replacement_color) {
+    return absl::DataLossError(
+        "In-memory dungeon palette readback did not match the replacement");
+  }
+  formatter.AddField("write_status", "success");
+  formatter.AddField("whole_rom_diff_status", "verified");
+  formatter.AddField("changed_byte_count",
+                     static_cast<int>(changed_bytes.size()));
+  formatter.BeginArray("changed_byte_pcs");
+  for (uint32_t changed_pc : changed_bytes) {
+    formatter.AddArrayItem(absl::StrFormat("0x%06X", changed_pc));
+  }
+  formatter.EndArray();
+  formatter.AddField("memory_readback_status", "verified");
+
+  const absl::Status save_status = SaveRomWithBackup(rom, formatter);
+  if (!save_status.ok()) {
+    formatter.AddField("status", "error");
+    formatter.EndObject();
+    return save_status;
+  }
+
+  // The atomic disk replacement has succeeded. Commit the caller's in-memory
+  // transaction before external verification so a later reopen/readback
+  // failure cannot roll memory back while leaving the persisted file changed.
+  transaction.Commit();
+  const absl::Status reopen_status = VerifyDungeonPaletteExternalReadback(
+      *rom, room_id, expected_palette_set, expected_palette_index, color_index,
+      static_cast<uint16_t>(replacement_color));
+  if (!reopen_status.ok()) {
+    formatter.AddField("readback_status", "external_reopen_failed");
+    formatter.AddField("readback_error", std::string(reopen_status.message()));
+    formatter.AddField("status", "error");
+    formatter.EndObject();
+    return reopen_status;
+  }
+
+  formatter.AddField("readback_status", "external_reopen_verified");
+  formatter.AddField("status", "success");
   formatter.EndObject();
   return absl::OkStatus();
 }

--- a/src/cli/handlers/game/dungeon_edit_commands.h
+++ b/src/cli/handlers/game/dungeon_edit_commands.h
@@ -84,6 +84,61 @@ class DungeonPlaceObjectCommandHandler : public resources::CommandHandler {
 };
 
 /**
+ * @brief Resolve and inspect the shared dungeon palette used by one room.
+ *
+ * Room headers contain an 8-bit palette-set ID. This command follows the
+ * palette-set and pointer tables to the global dungeon palette and reports
+ * every room affected by edits to that shared palette.
+ */
+class DungeonGetPaletteCommandHandler : public resources::CommandHandler {
+ public:
+  std::string GetName() const override { return "dungeon-get-palette"; }
+  std::string GetDescription() const {
+    return "Inspect a room's resolved shared dungeon palette in a US/OOS ROM";
+  }
+  std::string GetUsage() const override {
+    return "dungeon-get-palette --room <hex> [--index <0..89>] "
+           "[--format <json|text>]";
+  }
+
+  absl::Status ValidateArgs(const resources::ArgumentParser& parser) override {
+    return parser.RequireArgs({"room"});
+  }
+
+  absl::Status Execute(Rom* rom, const resources::ArgumentParser& parser,
+                       resources::OutputFormatter& formatter) override;
+};
+
+/**
+ * @brief Change one color in a room's resolved shared dungeon palette.
+ *
+ * Dry-run is the default. The full palette-set ID, resolved palette index, and
+ * old color are compare-and-swap guards. A Hack Manifest is always required.
+ */
+class DungeonSetPaletteColorCommandHandler : public resources::CommandHandler {
+ public:
+  std::string GetName() const override { return "dungeon-set-palette-color"; }
+  std::string GetDescription() const {
+    return "Change one US/OOS shared dungeon palette color with safety guards";
+  }
+  std::string GetUsage() const override {
+    return "dungeon-set-palette-color --room <hex> --index <0..89> "
+           "--expect-palette-set <hex> --expect-palette-index <0..19> "
+           "--expect-color <hex> --color <hex> --manifest <path> "
+           "[--write] [--format <json|text>]";
+  }
+
+  absl::Status ValidateArgs(const resources::ArgumentParser& parser) override {
+    return parser.RequireArgs({"room", "index", "expect-palette-set",
+                               "expect-palette-index", "expect-color", "color",
+                               "manifest"});
+  }
+
+  absl::Status Execute(Rom* rom, const resources::ArgumentParser& parser,
+                       resources::OutputFormatter& formatter) override;
+};
+
+/**
  * @brief Change one existing dungeon door's fixed-width type byte.
  *
  * The target is selected by exact tile coordinates and guarded by a required

--- a/src/cli/handlers/graphics/palette_commands.cc
+++ b/src/cli/handlers/graphics/palette_commands.cc
@@ -204,6 +204,12 @@ absl::Status PaletteSetColorCommandHandler::Execute(
   auto index_str = parser.GetString("index").value();
   auto color_str = parser.GetString("color").value();
   bool write = parser.HasFlag("write");
+  if (write) {
+    return absl::FailedPreconditionError(
+        "palette-set-color --write is disabled because it cannot guarantee "
+        "durable, manifest-safe persistence; use "
+        "dungeon-set-palette-color for dungeon palette writes");
+  }
 
   int palette_idx;
   if (!absl::SimpleAtoi(palette_str, &palette_idx)) {
@@ -277,18 +283,11 @@ absl::Status PaletteSetColorCommandHandler::Execute(
   formatter.AddHexField("old_snes", old_color.snes(), 4);
   formatter.AddHexField("new_snes", new_color.snes(), 4);
 
-  if (write) {
-    // Compute the ROM address for this color entry and write 2 bytes.
-    uint32_t addr = gfx::GetPaletteAddress(group_name, palette_idx, color_idx);
-    uint16_t snes_val = new_color.snes();
-    RETURN_IF_ERROR(rom->WriteShort(addr, snes_val));
-
-    formatter.AddField("status", "written");
-    formatter.AddHexField("rom_address", addr, 6);
-  } else {
-    formatter.AddField("status", "dry_run");
-    formatter.AddField("message", "Use --write to apply the change to the ROM");
-  }
+  formatter.AddField("status", "dry_run");
+  formatter.AddField(
+      "message",
+      "Legacy preview only; use a domain-specific manifest-safe command for "
+      "persistent writes");
 
   formatter.EndObject();
   return absl::OkStatus();

--- a/src/cli/handlers/graphics/palette_commands.h
+++ b/src/cli/handlers/graphics/palette_commands.h
@@ -41,30 +41,36 @@ class PaletteGetColorsCommandHandler : public resources::CommandHandler {
 };
 
 /**
- * @brief Command handler for setting a palette color in the ROM.
+ * @brief Legacy read-only preview for changing one palette color.
  *
- * Modifies a specific color entry within a palette group and writes it back
- * to the ROM. The color can be specified as an RGB hex string (e.g., FF0000
- * for red) or as a 15-bit SNES color value.
+ * Computes the requested color replacement without mutating the ROM. The
+ * legacy --write flag is retained only so it can fail closed and direct users
+ * to a domain-specific manifest-safe writer.
  *
  * Usage:
  *   palette-set-color --group <group_name> --palette <palette_index>
  *                     --index <color_index> --color <RRGGBB|snes_hex>
- *                     [--write] [--format <json|text>]
+ *                     [--format <json|text>]
  */
 class PaletteSetColorCommandHandler : public resources::CommandHandler {
  public:
   std::string GetName() const override { return "palette-set-color"; }
   std::string GetDescription() const {
-    return "Set a color in a ROM palette entry";
+    return "Preview a color replacement; persistent writes are disabled";
   }
   std::string GetUsage() const override {
     return "palette-set-color --group <group_name> --palette <palette_index> "
-           "--index <color_index> --color <RRGGBB> [--write] "
+           "--index <color_index> --color <RRGGBB> "
            "[--format <json|text>]";
   }
 
   absl::Status ValidateArgs(const resources::ArgumentParser& parser) override {
+    if (parser.HasFlag("write")) {
+      return absl::FailedPreconditionError(
+          "palette-set-color --write is disabled because it cannot guarantee "
+          "durable, manifest-safe persistence; use "
+          "dungeon-set-palette-color for dungeon palette writes");
+    }
     return parser.RequireArgs({"group", "palette", "index", "color"});
   }
 

--- a/src/cli/service/agent/advanced_routing.cc
+++ b/src/cli/service/agent/advanced_routing.cc
@@ -57,7 +57,9 @@ AdvancedRouter::RoutedResponse AdvancedRouter::RouteHexAnalysis(
     response.next_steps =
         "Use overworld-find-tile to see where this tile appears";
   } else if (data_type.find("palette") != std::string::npos) {
-    response.next_steps = "Use palette-get-colors to see full palette";
+    response.next_steps =
+        "Use palette-get-colors for a generic preview, or "
+        "dungeon-get-palette with a room ID to resolve shared dungeon scope";
   } else {
     response.next_steps = "Use hex-search to find similar patterns in ROM";
   }
@@ -122,7 +124,10 @@ AdvancedRouter::RoutedResponse AdvancedRouter::RoutePaletteAnalysis(
   }
 
   response.detailed_data = detailed.str();
-  response.next_steps = "Use palette-set-color to modify colors";
+  response.next_steps =
+      "Legacy palette-set-color is preview-only. For a dungeon palette, use "
+      "dungeon-get-palette, then dry-run dungeon-set-palette-color with exact "
+      "CAS values and a Hack Manifest before requesting --write";
 
   return response;
 }

--- a/src/cli/service/agent/agent_pretraining.cc
+++ b/src/cli/service/agent/agent_pretraining.cc
@@ -150,9 +150,9 @@ Result: "Hyrule Castle (dungeon 0) has 3 guards (sprite 0x41), 2 knights..."
 ## Example 2: Palette Investigation
 User: "What colors are used for grass?"
 Tool chain:
-1. overworld-find-tile --tile_id=0x20 (grass tile)
-2. palette-get-colors --group=0 --palette=0
-3. palette-analyze --type=palette --id=0/0
+1. overworld-find-tile --tile=0x020 (grass tile)
+2. palette-get-colors --group=ow_main --index=0
+3. palette-analyze --group=ow_main
 Result: "Grass uses palette 0/0 with colors: light green #98FB98..."
 
 ## Example 3: Hex Pattern Search

--- a/src/cli/service/agent/tool_registration.cc
+++ b/src/cli/service/agent/tool_registration.cc
@@ -4,6 +4,7 @@
 #include "cli/handlers/game/dialogue_commands.h"
 #include "cli/handlers/game/dungeon_collision_commands.h"
 #include "cli/handlers/game/dungeon_commands.h"
+#include "cli/handlers/game/dungeon_edit_commands.h"
 #include "cli/handlers/game/message_commands.h"
 #include "cli/handlers/game/minecart_commands.h"
 #include "cli/handlers/game/music_commands.h"
@@ -219,6 +220,27 @@ void RegisterBuiltinAgentTools(ToolRegistry& registry) {
                               "Debug room header bytes",
                               "dungeon-room-header --room=<id>", {}, true,
                               false, DungeonRoomHeaderCommandHandler)
+  REGISTER_BUILTIN_AGENT_TOOL(
+      "dungeon-get-palette", "dungeon",
+      "Resolve a US/OOS room's shared dungeon palette and affected rooms",
+      "dungeon-get-palette --room=<hex> [--index=<0..89>]", {}, true, false,
+      DungeonGetPaletteCommandHandler)
+  RegisterBuiltinTool<DungeonSetPaletteColorCommandHandler>(
+      registry,
+      {"dungeon-set-palette-color",
+       "dungeon",
+       "Dry-run or persist one US/OOS shared dungeon palette color with CAS, "
+       "manifest, clean-file baseline, backup, atomic-save, and "
+       "external-readback guards",
+       "dungeon-set-palette-color --room=<hex> --index=<0..89> "
+       "--expect-palette-set=<hex> --expect-palette-index=<0..19> "
+       "--expect-color=<hex> --color=<hex> --manifest=<path> [--write]",
+       {},
+       true,
+       false,
+       ToolAccess::kMutating,
+       {},
+       {"write"}});
 
   // Overworld commands
   REGISTER_BUILTIN_AGENT_TOOL("overworld-get-tile", "overworld",

--- a/src/cli/service/agent/tool_registry.cc
+++ b/src/cli/service/agent/tool_registry.cc
@@ -116,6 +116,7 @@ ToolAccess InferToolAccess(const std::string& tool_name) {
       "build-test",
       "dungeon-import-custom-collision-json",
       "dungeon-import-water-fill-json",
+      "dungeon-set-palette-color",
       "dungeon-set-room-property",
       "emulator-clear-breakpoint",
       "emulator-pause",

--- a/src/cli/service/ai/anthropic_ai_service.cc
+++ b/src/cli/service/ai/anthropic_ai_service.cc
@@ -16,6 +16,7 @@
 #include "absl/time/time.h"
 #include "cli/service/agent/conversational_agent_service.h"
 #include "cli/service/ai/provider_ids.h"
+#include "cli/service/ai/tool_call_argument_codec.h"
 #include "cli/service/ai/tool_schema_builder.h"
 #include "util/platform_paths.h"
 
@@ -441,15 +442,7 @@ absl::StatusOr<AgentResponse> AnthropicAIService::ParseAnthropicResponse(
       tool_call.tool_name = block.value("name", "");
 
       if (block.contains("input") && block["input"].is_object()) {
-        for (auto& [key, value] : block["input"].items()) {
-          if (value.is_string()) {
-            tool_call.args[key] = value.get<std::string>();
-          } else if (value.is_number()) {
-            tool_call.args[key] = std::to_string(value.get<double>());
-          } else if (value.is_boolean()) {
-            tool_call.args[key] = value.get<bool>() ? "true" : "false";
-          }
-        }
+        tool_call.args = ai::DecodeToolCallArguments(block["input"]);
       }
       agent_response.tool_calls.push_back(tool_call);
     }

--- a/src/cli/service/ai/gemini_ai_service.cc
+++ b/src/cli/service/ai/gemini_ai_service.cc
@@ -16,6 +16,7 @@
 #include "absl/time/time.h"
 #include "cli/service/agent/conversational_agent_service.h"
 #include "cli/service/ai/provider_ids.h"
+#include "cli/service/ai/tool_call_argument_codec.h"
 #include "cli/service/ai/tool_schema_builder.h"
 #include "util/platform_paths.h"
 
@@ -700,16 +701,7 @@ absl::StatusOr<AgentResponse> GeminiAIService::ParseGeminiResponse(
                 tool_call.tool_name = call["tool_name"].get<std::string>();
 
                 if (call.contains("args") && call["args"].is_object()) {
-                  for (auto& [key, value] : call["args"].items()) {
-                    if (value.is_string()) {
-                      tool_call.args[key] = value.get<std::string>();
-                    } else if (value.is_number()) {
-                      tool_call.args[key] = std::to_string(value.get<double>());
-                    } else if (value.is_boolean()) {
-                      tool_call.args[key] =
-                          value.get<bool>() ? "true" : "false";
-                    }
-                  }
+                  tool_call.args = ai::DecodeToolCallArguments(call["args"]);
                 }
                 agent_response.tool_calls.push_back(tool_call);
               }
@@ -739,13 +731,7 @@ absl::StatusOr<AgentResponse> GeminiAIService::ParseGeminiResponse(
           ToolCall tool_call;
           tool_call.tool_name = call["name"].get<std::string>();
           if (call.contains("args") && call["args"].is_object()) {
-            for (auto& [key, value] : call["args"].items()) {
-              if (value.is_string()) {
-                tool_call.args[key] = value.get<std::string>();
-              } else if (value.is_number()) {
-                tool_call.args[key] = std::to_string(value.get<double>());
-              }
-            }
+            tool_call.args = ai::DecodeToolCallArguments(call["args"]);
           }
           agent_response.tool_calls.push_back(tool_call);
         }

--- a/src/cli/service/ai/openai_ai_service.cc
+++ b/src/cli/service/ai/openai_ai_service.cc
@@ -17,6 +17,7 @@
 #include "absl/time/time.h"
 #include "cli/service/agent/conversational_agent_service.h"
 #include "cli/service/ai/provider_ids.h"
+#include "cli/service/ai/tool_call_argument_codec.h"
 #include "cli/service/ai/tool_schema_builder.h"
 #include "util/platform_paths.h"
 
@@ -699,15 +700,7 @@ absl::StatusOr<AgentResponse> OpenAIAIService::ParseOpenAIResponse(
             ToolCall tool_call;
             tool_call.tool_name = call["tool_name"].get<std::string>();
             if (call.contains("args") && call["args"].is_object()) {
-              for (auto& [key, value] : call["args"].items()) {
-                if (value.is_string()) {
-                  tool_call.args[key] = value.get<std::string>();
-                } else if (value.is_number()) {
-                  tool_call.args[key] = std::to_string(value.get<double>());
-                } else if (value.is_boolean()) {
-                  tool_call.args[key] = value.get<bool>() ? "true" : "false";
-                }
-              }
+              tool_call.args = ai::DecodeToolCallArguments(call["args"]);
             }
             agent_response.tool_calls.push_back(tool_call);
           }
@@ -731,13 +724,7 @@ absl::StatusOr<AgentResponse> OpenAIAIService::ParseOpenAIResponse(
           auto args_json = nlohmann::json::parse(
               func["arguments"].get<std::string>(), nullptr, false);
           if (!args_json.is_discarded() && args_json.is_object()) {
-            for (auto& [key, value] : args_json.items()) {
-              if (value.is_string()) {
-                tool_call.args[key] = value.get<std::string>();
-              } else if (value.is_number()) {
-                tool_call.args[key] = std::to_string(value.get<double>());
-              }
-            }
+            tool_call.args = ai::DecodeToolCallArguments(args_json);
           }
         }
         agent_response.tool_calls.push_back(tool_call);

--- a/src/cli/service/ai/tool_call_argument_codec.h
+++ b/src/cli/service/ai/tool_call_argument_codec.h
@@ -1,0 +1,40 @@
+#ifndef YAZE_CLI_SERVICE_AI_TOOL_CALL_ARGUMENT_CODEC_H_
+#define YAZE_CLI_SERVICE_AI_TOOL_CALL_ARGUMENT_CODEC_H_
+
+#include <cstdint>
+#include <map>
+#include <string>
+
+#include "nlohmann/json.hpp"
+
+namespace yaze::cli::ai {
+
+// Convert provider-native JSON tool arguments into the string map consumed by
+// ToolDispatcher. Preserve integer spelling so CLI integer parsers receive
+// "7", not "7.000000", and preserve booleans for flag arguments.
+inline std::map<std::string, std::string> DecodeToolCallArguments(
+    const nlohmann::json& arguments) {
+  std::map<std::string, std::string> decoded;
+  if (!arguments.is_object()) {
+    return decoded;
+  }
+
+  for (const auto& [key, value] : arguments.items()) {
+    if (value.is_string()) {
+      decoded[key] = value.get<std::string>();
+    } else if (value.is_boolean()) {
+      decoded[key] = value.get<bool>() ? "true" : "false";
+    } else if (value.is_number_unsigned()) {
+      decoded[key] = std::to_string(value.get<uint64_t>());
+    } else if (value.is_number_integer()) {
+      decoded[key] = std::to_string(value.get<int64_t>());
+    } else if (value.is_number_float()) {
+      decoded[key] = value.dump();
+    }
+  }
+  return decoded;
+}
+
+}  // namespace yaze::cli::ai
+
+#endif  // YAZE_CLI_SERVICE_AI_TOOL_CALL_ARGUMENT_CODEC_H_

--- a/src/cli/service/command_registry.cc
+++ b/src/cli/service/command_registry.cc
@@ -146,6 +146,33 @@ void CommandRegistry::RegisterHandlers(
             "z3ed dungeon-place-object --room=0x98 --id=0x0031 --x=20 --y=20 "
             "--size=4 --manifest=hack_manifest.json --write "
             "--rom=/tmp/oos-work.sfc --format=json"};
+      } else if (name == "dungeon-get-palette") {
+        metadata.description =
+            "Resolve a US/OOS room's full 8-bit palette-set ID to its shared "
+            "global dungeon palette and report every affected room; other "
+            "regional layouts fail closed";
+        metadata.examples = {
+            "z3ed dungeon-get-palette --room=0xA8 "
+            "--rom=Roms/oos168.sfc --format=json",
+            "z3ed dungeon-get-palette --room=0xA8 --index=0x07 "
+            "--rom=Roms/oos168.sfc --format=json"};
+      } else if (name == "dungeon-set-palette-color") {
+        metadata.description =
+            "Dry-run or persist one US/OOS shared dungeon palette color with "
+            "palette-set/index/color CAS, manifest ownership, exact fence, "
+            "clean-file baseline, required backup, atomic save, and external "
+            "reopen guards";
+        metadata.examples = {
+            "z3ed dungeon-set-palette-color --room=0xA8 --index=7 "
+            "--expect-palette-set=0x07 --expect-palette-index=7 "
+            "--expect-color=0x7FFF --color=0x7FFE "
+            "--manifest=Roms/hack_manifest.json "
+            "--rom=Roms/oos168.sfc --format=json",
+            "z3ed dungeon-set-palette-color --room=0xA8 --index=7 "
+            "--expect-palette-set=0x07 --expect-palette-index=7 "
+            "--expect-color=0x7FFF --color=0x7FFE "
+            "--manifest=Roms/hack_manifest.json --write "
+            "--rom=/tmp/oos-work.sfc --format=json"};
       } else if (name == "dungeon-set-door-type") {
         metadata.description =
             "Change one existing door type with coordinate/CAS and manifest "

--- a/test/unit/cli/dungeon_edit_commands_test.cc
+++ b/test/unit/cli/dungeon_edit_commands_test.cc
@@ -18,6 +18,8 @@
 
 #include "absl/status/status.h"
 #include "absl/strings/str_format.h"
+#include "app/gfx/types/snes_palette.h"
+#include "cli/service/command_registry.h"
 #include "rom/rom.h"
 #include "rom/snes.h"
 #include "zelda3/dungeon/dungeon_rom_addresses.h"
@@ -25,6 +27,7 @@
 #include "zelda3/dungeon/oracle_rom_safety_preflight.h"
 #include "zelda3/dungeon/room.h"
 #include "zelda3/dungeon/room_object.h"
+#include "zelda3/game_data.h"
 
 #if !defined(_WIN32)
 #include <unistd.h>
@@ -55,6 +58,17 @@ constexpr int kPotDataPc = 0x00E000;
 constexpr int kOtherPotDataPc = 0x00E040;
 constexpr int kPotDataEndPc = 0x00E100;
 constexpr int kPotItemBytePc = kPotDataPc + 2;
+constexpr int kDungeonPaletteSetId = 0x40;
+constexpr int kDungeonPaletteAliasSetId = 0x20;
+constexpr int kDungeonPaletteIndex = 4;
+constexpr int kDungeonPaletteColorIndex = 7;
+constexpr uint16_t kDungeonPaletteOldColor = 0x1234;
+constexpr uint16_t kDungeonPaletteNewColor = 0x4321;
+constexpr int kUnrelatedPaletteBaselinePc = 0x000100;
+constexpr int kDungeonPaletteColorPc =
+    gfx::kDungeonMainPalettes +
+    kDungeonPaletteIndex * zelda3::kDungeonPaletteBytes +
+    kDungeonPaletteColorIndex * 2;
 
 void ExpectInvalidArgument(const absl::Status& status,
                            const std::string& message_fragment) {
@@ -193,6 +207,75 @@ void InitializeRoomHeaderRom(Rom* rom) {
   }
   rom->mutable_data()[kSyntheticPotTerminatorPc] = 0xFF;
   rom->mutable_data()[kSyntheticPotTerminatorPc + 1] = 0xFF;
+  rom->set_dirty(false);
+}
+
+void InitializeDungeonPaletteRom(Rom* rom) {
+  InitializeRoomHeaderRom(rom);
+  rom->mutable_data()[0x7FD9] = 0x01;
+
+  // Give every room a distinct header while keeping all headers in the same
+  // LoROM bank used by kRoomHeaderPointerBank.
+  const uint32_t header_bank_snes = PcToSnes(kRoomHeaderDataPc);
+  rom->mutable_data()[zelda3::kRoomHeaderPointerBank] =
+      (header_bank_snes >> 16) & 0xFF;
+  for (int room_id = 0; room_id < zelda3::kNumberOfRooms; ++room_id) {
+    const int header_pc =
+        kRoomHeaderDataPc + room_id * kRoomHeaderSentinel.size();
+    const uint32_t header_snes = PcToSnes(header_pc);
+    ASSERT_EQ((header_snes >> 16) & 0xFF, (header_bank_snes >> 16) & 0xFF);
+    const int pointer = kRoomHeaderPointerTablePc + room_id * 2;
+    rom->mutable_data()[pointer] = header_snes & 0xFF;
+    rom->mutable_data()[pointer + 1] = (header_snes >> 8) & 0xFF;
+    for (size_t index = 0; index < kRoomHeaderSentinel.size(); ++index) {
+      rom->mutable_data()[header_pc + index] = kRoomHeaderSentinel[index];
+    }
+    rom->mutable_data()[header_pc + 1] = 0x01;
+  }
+
+  // Two different palette-set IDs intentionally alias global palette 4.
+  rom->mutable_data()[kRoomHeaderDataPc + 1] = kDungeonPaletteSetId;
+  rom->mutable_data()[kRoomHeaderDataPc + kRoomHeaderSentinel.size() + 1] =
+      kDungeonPaletteAliasSetId;
+
+  for (int palette_set = 0;
+       palette_set < static_cast<int>(zelda3::kNumPalettesets); ++palette_set) {
+    const int entry = zelda3::kPalettesetIdsAddress + palette_set * 4;
+    rom->mutable_data()[entry] = (palette_set % 20) * 2;
+    rom->mutable_data()[entry + 1] = 0;
+    rom->mutable_data()[entry + 2] = 0;
+    rom->mutable_data()[entry + 3] = 0;
+  }
+  rom->mutable_data()[zelda3::kPalettesetIdsAddress +
+                      kDungeonPaletteSetId * 4] = kDungeonPaletteIndex * 2;
+  rom->mutable_data()[zelda3::kPalettesetIdsAddress +
+                      kDungeonPaletteAliasSetId * 4] = kDungeonPaletteIndex * 2;
+
+  // Match known Oracle behavior: unused table rows may be malformed. A strict
+  // resolver must validate referenced rows, not reject unreachable rows.
+  rom->mutable_data()[zelda3::kPalettesetIdsAddress + 0x30 * 4] = 0x01;
+  rom->mutable_data()[zelda3::kPalettesetIdsAddress + 0x37 * 4] = 0xFF;
+
+  for (int palette = 0; palette < gfx::DungeonsMainPalettesMax; ++palette) {
+    const uint16_t offset =
+        static_cast<uint16_t>(palette * zelda3::kDungeonPaletteBytes);
+    const int pointer = zelda3::kDungeonPalettePointerTable + palette * 2;
+    rom->mutable_data()[pointer] = offset & 0xFF;
+    rom->mutable_data()[pointer + 1] = (offset >> 8) & 0xFF;
+  }
+  for (int palette = 0; palette < gfx::DungeonsMainPalettesMax; ++palette) {
+    for (int color = 0; color < 90; ++color) {
+      const uint16_t value =
+          static_cast<uint16_t>((palette * 90 + color) & 0x7FFF);
+      const int pc = gfx::kDungeonMainPalettes +
+                     palette * zelda3::kDungeonPaletteBytes + color * 2;
+      rom->mutable_data()[pc] = value & 0xFF;
+      rom->mutable_data()[pc + 1] = (value >> 8) & 0xFF;
+    }
+  }
+  rom->mutable_data()[kDungeonPaletteColorPc] = kDungeonPaletteOldColor & 0xFF;
+  rom->mutable_data()[kDungeonPaletteColorPc + 1] =
+      (kDungeonPaletteOldColor >> 8) & 0xFF;
   rom->set_dirty(false);
 }
 
@@ -435,6 +518,21 @@ void WriteOwnershipOnlyManifest(const std::filesystem::path& path,
   ASSERT_TRUE(output.is_open());
   output << json;
   ASSERT_TRUE(output.good());
+}
+
+std::vector<std::string> DungeonPaletteSetArgs(
+    const std::filesystem::path& manifest_path,
+    std::string replacement = "0x4321") {
+  return {
+      "--room=0x00",
+      "--index=7",
+      "--expect-palette-set=0x40",
+      "--expect-palette-index=4",
+      "--expect-color=0x1234",
+      absl::StrFormat("--color=%s", replacement),
+      absl::StrFormat("--manifest=%s", manifest_path.string()),
+      "--format=json",
+  };
 }
 
 void WritePotItemManifest(const std::filesystem::path& path,
@@ -2466,6 +2564,527 @@ TEST(DungeonEditCommandsTest, SetDoorTypeDiskSaveFailureRollsBackCallerRom) {
   EXPECT_EQ(rom.filename(), filename_before);
   EXPECT_EQ(ReadFile(cleanup.rom_path), disk_before);
   EXPECT_EQ(CountBackupArtifacts(cleanup.rom_path), 1);
+}
+
+TEST(DungeonEditCommandsTest,
+     DungeonPaletteCommandsAreRegisteredWithSafetyHelp) {
+  auto& registry = CommandRegistry::Instance();
+  EXPECT_TRUE(registry.HasCommand("dungeon-get-palette"));
+  EXPECT_TRUE(registry.HasCommand("dungeon-set-palette-color"));
+
+  const std::string get_help = registry.GenerateHelp("dungeon-get-palette");
+  EXPECT_THAT(get_help, HasSubstr("--room"));
+  EXPECT_THAT(get_help, HasSubstr("--index"));
+
+  const std::string set_help =
+      registry.GenerateHelp("dungeon-set-palette-color");
+  EXPECT_THAT(set_help, HasSubstr("--expect-palette-set"));
+  EXPECT_THAT(set_help, HasSubstr("--expect-palette-index"));
+  EXPECT_THAT(set_help, HasSubstr("--expect-color"));
+  EXPECT_THAT(set_help, HasSubstr("--manifest"));
+  EXPECT_THAT(set_help, HasSubstr("--write"));
+}
+
+TEST(DungeonEditCommandsTest,
+     DungeonRoomHeaderReportsFullEightBitPaletteSetId) {
+  Rom rom;
+  InitializeRoomHeaderRom(&rom);
+  rom.mutable_data()[kRoomHeaderDataPc + 1] = 0xC1;
+  rom.set_dirty(false);
+
+  handlers::DungeonRoomHeaderCommandHandler handler;
+  std::string output;
+  const absl::Status status =
+      handler.Run({"--room=0x00", "--format=json"}, &rom, &output);
+
+  ASSERT_TRUE(status.ok()) << status;
+  const auto report = nlohmann::json::parse(output);
+  EXPECT_EQ(report.at("Room Header Debug").at("decoded").at("palette"), 0xC1);
+}
+
+TEST(DungeonEditCommandsTest,
+     GetDungeonPaletteResolvesFullSetAndSharedAliasFanout) {
+  Rom rom;
+  InitializeDungeonPaletteRom(&rom);
+  const std::vector<uint8_t> before = rom.vector();
+
+  handlers::DungeonGetPaletteCommandHandler handler;
+  std::string output;
+  const absl::Status status =
+      handler.Run({"--room=0x00", "--format=json"}, &rom, &output);
+
+  ASSERT_TRUE(status.ok()) << status;
+  const auto report = nlohmann::json::parse(output);
+  const auto& result = report.at("Dungeon Palette");
+  EXPECT_EQ(result.at("room_id"), "0x000");
+  EXPECT_EQ(result.at("palette_set_id"), "0x40");
+  EXPECT_EQ(result.at("resolved_palette_index"), kDungeonPaletteIndex);
+  EXPECT_EQ(result.at("palette_pointer_offset"), "0x08");
+  EXPECT_EQ(result.at("palette_pointer_word"), "0x02D0");
+  EXPECT_EQ(result.at("scope"), "shared_global_dungeon_palette");
+  EXPECT_EQ(result.at("affected_room_count"), 2);
+  ASSERT_EQ(result.at("affected_rooms").size(), 2u);
+  EXPECT_EQ(result.at("affected_rooms")[0], "0x000");
+  EXPECT_EQ(result.at("affected_rooms")[1], "0x001");
+  ASSERT_EQ(result.at("colors").size(), 90u);
+  EXPECT_EQ(result.at("colors")[kDungeonPaletteColorIndex].at("index"),
+            kDungeonPaletteColorIndex);
+  EXPECT_EQ(result.at("colors")[kDungeonPaletteColorIndex].at("snes_color"),
+            "0x1234");
+  EXPECT_EQ(rom.vector(), before);
+  EXPECT_FALSE(rom.dirty());
+
+  // The decimal-or-0x parser must accept the last legal color index.
+  std::string indexed_output;
+  const absl::Status indexed_status = handler.Run(
+      {"--room=0x00", "--index=0x59", "--format=json"}, &rom, &indexed_output);
+  ASSERT_TRUE(indexed_status.ok()) << indexed_status;
+  const auto indexed_report = nlohmann::json::parse(indexed_output);
+  EXPECT_EQ(indexed_report.at("Dungeon Palette").at("color_index"), 89);
+  EXPECT_EQ(rom.vector(), before);
+}
+
+TEST(DungeonEditCommandsTest,
+     DungeonPaletteCommandsRejectUnsupportedJapaneseAndEuropeanLayouts) {
+  handlers::DungeonGetPaletteCommandHandler handler;
+  for (const uint8_t destination_code : {uint8_t{0x00}, uint8_t{0x02}}) {
+    SCOPED_TRACE(static_cast<int>(destination_code));
+    Rom rom;
+    InitializeDungeonPaletteRom(&rom);
+    rom.mutable_data()[0x7FD9] = destination_code;
+    rom.set_dirty(false);
+    const std::vector<uint8_t> before = rom.vector();
+
+    std::string output;
+    const absl::Status status =
+        handler.Run({"--room=0x00", "--format=json"}, &rom, &output);
+
+    EXPECT_TRUE(absl::IsFailedPrecondition(status)) << status;
+    EXPECT_THAT(std::string(status.message()),
+                HasSubstr("support only the US/OOS table layout"));
+    EXPECT_EQ(rom.vector(), before);
+    EXPECT_FALSE(rom.dirty());
+  }
+}
+
+TEST(DungeonEditCommandsTest,
+     SetDungeonPaletteDryRunIsManifestCheckedAndImmutable) {
+  Rom rom;
+  InitializeDungeonPaletteRom(&rom);
+  ScopedRomArtifactsCleanup cleanup(MakeUniqueTempRomPath());
+  ScopedFileCleanup manifest_cleanup(cleanup.rom_path.string() +
+                                     ".manifest.json");
+  WriteRomFile(rom, cleanup.rom_path);
+  WriteOwnershipOnlyManifest(manifest_cleanup.file_path);
+  rom.set_filename(cleanup.rom_path.string());
+  rom.set_dirty(false);
+
+  const std::vector<uint8_t> before = rom.vector();
+  const std::vector<uint8_t> disk_before = ReadFile(cleanup.rom_path);
+  handlers::DungeonSetPaletteColorCommandHandler handler;
+  std::string output;
+  const absl::Status status = handler.Run(
+      DungeonPaletteSetArgs(manifest_cleanup.file_path), &rom, &output);
+
+  ASSERT_TRUE(status.ok()) << status;
+  const auto report = nlohmann::json::parse(output);
+  const auto& result = report.at("Set Dungeon Palette Color");
+  EXPECT_EQ(result.at("mode"), "dry-run");
+  EXPECT_EQ(result.at("status"), "dry-run");
+  EXPECT_EQ(result.at("preflight_status"), "success");
+  EXPECT_EQ(result.at("palette_set_id"), "0x40");
+  EXPECT_EQ(result.at("resolved_palette_index"), kDungeonPaletteIndex);
+  EXPECT_EQ(result.at("affected_rooms"),
+            nlohmann::json::array({"0x000", "0x001"}));
+  EXPECT_EQ(result.at("color_pc"),
+            absl::StrFormat("0x%06X", kDungeonPaletteColorPc));
+  EXPECT_EQ(result.at("old_color"), "0x1234");
+  EXPECT_EQ(result.at("new_color"), "0x4321");
+  EXPECT_EQ(rom.vector(), before);
+  EXPECT_FALSE(rom.dirty());
+  EXPECT_EQ(ReadFile(cleanup.rom_path), disk_before);
+  EXPECT_EQ(CountBackupArtifacts(cleanup.rom_path), 0);
+  EXPECT_FALSE(std::filesystem::exists(cleanup.rom_path.string() + ".tmp"));
+}
+
+TEST(DungeonEditCommandsTest, SetDungeonPaletteRequiresManifestAndExactCas) {
+  handlers::DungeonSetPaletteColorCommandHandler handler;
+
+  {
+    Rom rom;
+    InitializeDungeonPaletteRom(&rom);
+    std::string output;
+    const absl::Status status =
+        handler.Run({"--room=0x00", "--index=7", "--expect-palette-set=0x40",
+                     "--expect-palette-index=4", "--expect-color=0x1234",
+                     "--color=0x4321", "--format=json"},
+                    &rom, &output);
+    ExpectInvalidArgument(status, "manifest");
+  }
+
+  Rom rom;
+  InitializeDungeonPaletteRom(&rom);
+  ScopedFileCleanup manifest_cleanup(MakeUniqueTempRomPath().string() +
+                                     ".manifest.json");
+  WriteOwnershipOnlyManifest(manifest_cleanup.file_path);
+  const std::vector<uint8_t> before = rom.vector();
+
+  struct CasCase {
+    size_t argument_index;
+    const char* replacement;
+    const char* message;
+  };
+  const std::array<CasCase, 3> cases = {{
+      {2, "--expect-palette-set=0x00", "Palette-set CAS failed"},
+      {3, "--expect-palette-index=5", "Resolved palette CAS failed"},
+      {4, "--expect-color=0x1235", "Color CAS failed"},
+  }};
+  for (const CasCase& test_case : cases) {
+    auto args = DungeonPaletteSetArgs(manifest_cleanup.file_path);
+    args[test_case.argument_index] = test_case.replacement;
+    std::string output;
+    const absl::Status status = handler.Run(args, &rom, &output);
+    EXPECT_TRUE(absl::IsFailedPrecondition(status)) << status;
+    EXPECT_THAT(std::string(status.message()), HasSubstr(test_case.message));
+    EXPECT_EQ(rom.vector(), before);
+    EXPECT_FALSE(rom.dirty());
+  }
+}
+
+TEST(DungeonEditCommandsTest,
+     DungeonPaletteRejectsMalformedReferencedMappingButIgnoresUnusedRows) {
+  Rom rom;
+  InitializeDungeonPaletteRom(&rom);
+  const std::vector<uint8_t> valid_before = rom.vector();
+
+  handlers::DungeonGetPaletteCommandHandler get_handler;
+  std::string valid_output;
+  ASSERT_TRUE(
+      get_handler.Run({"--room=0x00", "--format=json"}, &rom, &valid_output)
+          .ok());
+  EXPECT_EQ(rom.vector(), valid_before);
+
+  rom.mutable_data()[zelda3::kPalettesetIdsAddress + kDungeonPaletteSetId * 4] =
+      0x01;
+  rom.set_dirty(false);
+  const std::vector<uint8_t> malformed_before = rom.vector();
+  std::string output;
+  const absl::Status status =
+      get_handler.Run({"--room=0x00", "--format=json"}, &rom, &output);
+  EXPECT_TRUE(absl::IsFailedPrecondition(status)) << status;
+  EXPECT_THAT(std::string(status.message()),
+              HasSubstr("malformed dungeon palette pointer offset"));
+  EXPECT_EQ(rom.vector(), malformed_before);
+  EXPECT_FALSE(rom.dirty());
+}
+
+TEST(DungeonEditCommandsTest, SetDungeonPaletteRejectsRangeBit15AndNoOp) {
+  Rom rom;
+  InitializeDungeonPaletteRom(&rom);
+  ScopedFileCleanup manifest_cleanup(MakeUniqueTempRomPath().string() +
+                                     ".manifest.json");
+  WriteOwnershipOnlyManifest(manifest_cleanup.file_path);
+  handlers::DungeonSetPaletteColorCommandHandler handler;
+  const std::vector<uint8_t> before = rom.vector();
+
+  {
+    auto args = DungeonPaletteSetArgs(manifest_cleanup.file_path);
+    args[1] = "--index=90";
+    std::string output;
+    const absl::Status status = handler.Run(args, &rom, &output);
+    ExpectInvalidArgument(status, "--index");
+  }
+  {
+    auto args = DungeonPaletteSetArgs(manifest_cleanup.file_path);
+    args[5] = "--color=0x8000";
+    std::string output;
+    const absl::Status status = handler.Run(args, &rom, &output);
+    ExpectInvalidArgument(status, "15-bit");
+  }
+  {
+    auto args = DungeonPaletteSetArgs(manifest_cleanup.file_path, "0x1234");
+    std::string output;
+    const absl::Status status = handler.Run(args, &rom, &output);
+    ExpectInvalidArgument(status, "no-op");
+  }
+  EXPECT_EQ(rom.vector(), before);
+  EXPECT_FALSE(rom.dirty());
+
+  rom.mutable_data()[kDungeonPaletteColorPc] = 0x34;
+  rom.mutable_data()[kDungeonPaletteColorPc + 1] = 0x92;
+  rom.set_dirty(false);
+  const std::vector<uint8_t> bit15_before = rom.vector();
+  std::string output;
+  const absl::Status status = handler.Run(
+      DungeonPaletteSetArgs(manifest_cleanup.file_path), &rom, &output);
+  EXPECT_TRUE(absl::IsFailedPrecondition(status)) << status;
+  EXPECT_THAT(std::string(status.message()), HasSubstr("not a 15-bit"));
+  EXPECT_EQ(rom.vector(), bit15_before);
+  EXPECT_FALSE(rom.dirty());
+}
+
+TEST(DungeonEditCommandsTest,
+     SetDungeonPaletteRejectsManifestProtectedSecondByte) {
+  Rom rom;
+  InitializeDungeonPaletteRom(&rom);
+  ScopedRomArtifactsCleanup cleanup(MakeUniqueTempRomPath());
+  ScopedFileCleanup manifest_cleanup(cleanup.rom_path.string() +
+                                     ".manifest.json");
+  WriteRomFile(rom, cleanup.rom_path);
+  WriteOwnershipOnlyManifest(manifest_cleanup.file_path,
+                             kDungeonPaletteColorPc + 1);
+  rom.set_filename(cleanup.rom_path.string());
+  rom.set_dirty(false);
+  const std::vector<uint8_t> before = rom.vector();
+  const std::vector<uint8_t> disk_before = ReadFile(cleanup.rom_path);
+
+  handlers::DungeonSetPaletteColorCommandHandler handler;
+  std::string output;
+  const absl::Status status = handler.Run(
+      DungeonPaletteSetArgs(manifest_cleanup.file_path), &rom, &output);
+
+  EXPECT_TRUE(absl::IsPermissionDenied(status)) << status;
+  EXPECT_THAT(std::string(status.message()),
+              HasSubstr("conflicts with Hack Manifest"));
+  EXPECT_EQ(rom.vector(), before);
+  EXPECT_FALSE(rom.dirty());
+  EXPECT_EQ(ReadFile(cleanup.rom_path), disk_before);
+  EXPECT_EQ(CountBackupArtifacts(cleanup.rom_path), 0);
+  EXPECT_FALSE(std::filesystem::exists(cleanup.rom_path.string() + ".tmp"));
+}
+
+TEST(DungeonEditCommandsTest,
+     SetDungeonPaletteWriteRejectsPreexistingDirtyCallerRom) {
+  Rom rom;
+  InitializeDungeonPaletteRom(&rom);
+  ScopedRomArtifactsCleanup cleanup(MakeUniqueTempRomPath());
+  ScopedFileCleanup manifest_cleanup(cleanup.rom_path.string() +
+                                     ".manifest.json");
+  WriteRomFile(rom, cleanup.rom_path);
+  WriteOwnershipOnlyManifest(manifest_cleanup.file_path);
+  rom.set_filename(cleanup.rom_path.string());
+  rom.set_dirty(false);
+  const std::vector<uint8_t> disk_before = ReadFile(cleanup.rom_path);
+  ASSERT_TRUE(rom.WriteByte(kUnrelatedPaletteBaselinePc, 0x5A).ok());
+  ASSERT_TRUE(rom.dirty());
+  const std::vector<uint8_t> caller_before = rom.vector();
+
+  auto args = DungeonPaletteSetArgs(manifest_cleanup.file_path);
+  args.push_back("--write");
+  handlers::DungeonSetPaletteColorCommandHandler handler;
+  std::string output;
+  const absl::Status status = handler.Run(args, &rom, &output);
+
+  EXPECT_TRUE(absl::IsFailedPrecondition(status)) << status;
+  EXPECT_THAT(std::string(status.message()),
+              HasSubstr("requires a clean file-backed ROM"));
+  EXPECT_EQ(rom.vector(), caller_before);
+  EXPECT_TRUE(rom.dirty());
+  EXPECT_EQ(ReadFile(cleanup.rom_path), disk_before);
+  EXPECT_EQ(CountBackupArtifacts(cleanup.rom_path), 0);
+  EXPECT_FALSE(std::filesystem::exists(cleanup.rom_path.string() + ".tmp"));
+}
+
+TEST(DungeonEditCommandsTest,
+     SetDungeonPaletteWriteRejectsCleanFlagWithDiskByteMismatch) {
+  Rom rom;
+  InitializeDungeonPaletteRom(&rom);
+  ScopedRomArtifactsCleanup cleanup(MakeUniqueTempRomPath());
+  ScopedFileCleanup manifest_cleanup(cleanup.rom_path.string() +
+                                     ".manifest.json");
+  WriteRomFile(rom, cleanup.rom_path);
+  WriteOwnershipOnlyManifest(manifest_cleanup.file_path);
+  rom.set_filename(cleanup.rom_path.string());
+  rom.mutable_data()[kUnrelatedPaletteBaselinePc] = 0x5A;
+  rom.set_dirty(false);
+  const std::vector<uint8_t> caller_before = rom.vector();
+  const std::vector<uint8_t> disk_before = ReadFile(cleanup.rom_path);
+
+  auto args = DungeonPaletteSetArgs(manifest_cleanup.file_path);
+  args.push_back("--write");
+  handlers::DungeonSetPaletteColorCommandHandler handler;
+  std::string output;
+  const absl::Status status = handler.Run(args, &rom, &output);
+
+  EXPECT_TRUE(absl::IsFailedPrecondition(status)) << status;
+  EXPECT_THAT(std::string(status.message()),
+              HasSubstr("exactly match the current file"));
+  EXPECT_EQ(rom.vector(), caller_before);
+  EXPECT_FALSE(rom.dirty());
+  EXPECT_EQ(ReadFile(cleanup.rom_path), disk_before);
+  EXPECT_EQ(CountBackupArtifacts(cleanup.rom_path), 0);
+  EXPECT_FALSE(std::filesystem::exists(cleanup.rom_path.string() + ".tmp"));
+}
+
+TEST(DungeonEditCommandsTest,
+     SetDungeonPaletteWriteBacksUpAtomicallyDiffsAndExternallyReopens) {
+  Rom rom;
+  InitializeDungeonPaletteRom(&rom);
+  ScopedRomArtifactsCleanup cleanup(MakeUniqueTempRomPath());
+  ScopedFileCleanup manifest_cleanup(cleanup.rom_path.string() +
+                                     ".manifest.json");
+  WriteRomFile(rom, cleanup.rom_path);
+  WriteOwnershipOnlyManifest(manifest_cleanup.file_path);
+  rom.set_filename(cleanup.rom_path.string());
+  rom.set_dirty(false);
+  const std::vector<uint8_t> before = rom.vector();
+  const std::vector<uint8_t> disk_before = ReadFile(cleanup.rom_path);
+
+  auto args = DungeonPaletteSetArgs(manifest_cleanup.file_path);
+  args.push_back("--write");
+  handlers::DungeonSetPaletteColorCommandHandler handler;
+  std::string output;
+  const absl::Status status = handler.Run(args, &rom, &output);
+
+  ASSERT_TRUE(status.ok()) << status;
+  const auto report = nlohmann::json::parse(output);
+  const auto& result = report.at("Set Dungeon Palette Color");
+  EXPECT_EQ(result.at("mode"), "write");
+  EXPECT_EQ(result.at("write_status"), "success");
+  EXPECT_EQ(result.at("whole_rom_diff_status"), "verified");
+  EXPECT_EQ(result.at("changed_byte_count"), 2);
+  EXPECT_EQ(result.at("changed_byte_pcs"),
+            nlohmann::json::array(
+                {absl::StrFormat("0x%06X", kDungeonPaletteColorPc),
+                 absl::StrFormat("0x%06X", kDungeonPaletteColorPc + 1)}));
+  EXPECT_EQ(result.at("save_status"), "saved");
+  EXPECT_EQ(result.at("readback_status"), "external_reopen_verified");
+  EXPECT_EQ(result.at("status"), "success");
+
+  std::vector<uint8_t> expected = before;
+  expected[kDungeonPaletteColorPc] = kDungeonPaletteNewColor & 0xFF;
+  expected[kDungeonPaletteColorPc + 1] = (kDungeonPaletteNewColor >> 8) & 0xFF;
+  EXPECT_EQ(rom.vector(), expected);
+  EXPECT_EQ(ReadFile(cleanup.rom_path), expected);
+  EXPECT_FALSE(rom.dirty());
+  EXPECT_FALSE(std::filesystem::exists(cleanup.rom_path.string() + ".tmp"));
+
+  const auto backups = FindBackupArtifacts(cleanup.rom_path);
+  ASSERT_EQ(backups.size(), 1u);
+  EXPECT_EQ(ReadFile(backups.front()), disk_before);
+
+  Rom reopened;
+  ASSERT_TRUE(reopened.LoadFromFile(cleanup.rom_path.string()).ok());
+  ASSERT_EQ(reopened.vector(), expected);
+  auto reopened_color = reopened.ReadWord(kDungeonPaletteColorPc);
+  ASSERT_TRUE(reopened_color.ok()) << reopened_color.status();
+  EXPECT_EQ(*reopened_color, kDungeonPaletteNewColor);
+}
+
+TEST(DungeonEditCommandsTest,
+     SetDungeonPaletteWholeRomDiffAllowsOneChangedByte) {
+  Rom rom;
+  InitializeDungeonPaletteRom(&rom);
+  ScopedRomArtifactsCleanup cleanup(MakeUniqueTempRomPath());
+  ScopedFileCleanup manifest_cleanup(cleanup.rom_path.string() +
+                                     ".manifest.json");
+  WriteRomFile(rom, cleanup.rom_path);
+  WriteOwnershipOnlyManifest(manifest_cleanup.file_path);
+  rom.set_filename(cleanup.rom_path.string());
+  rom.set_dirty(false);
+
+  auto args = DungeonPaletteSetArgs(manifest_cleanup.file_path, "0x5634");
+  args.push_back("--write");
+  handlers::DungeonSetPaletteColorCommandHandler handler;
+  std::string output;
+  const absl::Status status = handler.Run(args, &rom, &output);
+
+  ASSERT_TRUE(status.ok()) << status;
+  const auto result =
+      nlohmann::json::parse(output).at("Set Dungeon Palette Color");
+  EXPECT_EQ(result.at("changed_byte_count"), 1);
+  EXPECT_EQ(result.at("changed_byte_pcs"),
+            nlohmann::json::array(
+                {absl::StrFormat("0x%06X", kDungeonPaletteColorPc + 1)}));
+  EXPECT_EQ(result.at("readback_status"), "external_reopen_verified");
+}
+
+TEST(DungeonEditCommandsTest,
+     SetDungeonPaletteDiskSaveFailureRollsBackAndRetainsBackup) {
+  Rom rom;
+  InitializeDungeonPaletteRom(&rom);
+  ScopedRomArtifactsCleanup cleanup(MakeUniqueTempRomPath());
+  ScopedFileCleanup manifest_cleanup(cleanup.rom_path.string() +
+                                     ".manifest.json");
+  WriteRomFile(rom, cleanup.rom_path);
+  WriteOwnershipOnlyManifest(manifest_cleanup.file_path);
+  rom.set_filename(cleanup.rom_path.string());
+  rom.set_dirty(false);
+  ASSERT_TRUE(
+      std::filesystem::create_directory(cleanup.rom_path.string() + ".tmp"));
+  const std::vector<uint8_t> before = rom.vector();
+  const std::vector<uint8_t> disk_before = ReadFile(cleanup.rom_path);
+  const bool dirty_before = rom.dirty();
+  const std::string filename_before = rom.filename();
+
+  auto args = DungeonPaletteSetArgs(manifest_cleanup.file_path);
+  args.push_back("--write");
+  handlers::DungeonSetPaletteColorCommandHandler handler;
+  std::string output;
+  const absl::Status status = handler.Run(args, &rom, &output);
+
+  EXPECT_TRUE(absl::IsInternal(status)) << status;
+  EXPECT_THAT(std::string(status.message()),
+              HasSubstr("Could not open temp ROM file for writing"));
+  EXPECT_THAT(output, HasSubstr("\"whole_rom_diff_status\": \"verified\""));
+  EXPECT_THAT(output, HasSubstr("\"save_error\""));
+  EXPECT_EQ(rom.vector(), before);
+  EXPECT_EQ(rom.dirty(), dirty_before);
+  EXPECT_EQ(rom.filename(), filename_before);
+  EXPECT_EQ(ReadFile(cleanup.rom_path), disk_before);
+  const auto backups = FindBackupArtifacts(cleanup.rom_path);
+  ASSERT_EQ(backups.size(), 1u);
+  EXPECT_EQ(ReadFile(backups.front()), disk_before);
+}
+
+TEST(DungeonEditCommandsTest,
+     SetDungeonPaletteRequiredBackupFailureRollsBackWithoutArtifacts) {
+#if defined(_WIN32)
+  GTEST_SKIP() << "NAME_MAX backup failure fixture is POSIX-only";
+#else
+  Rom rom;
+  InitializeDungeonPaletteRom(&rom);
+
+  const auto parent = std::filesystem::temp_directory_path();
+  const long name_max = pathconf(parent.c_str(), _PC_NAME_MAX);
+  if (name_max < 128) {
+    GTEST_SKIP() << "Filesystem does not expose a usable NAME_MAX";
+  }
+  const auto nonce =
+      std::chrono::steady_clock::now().time_since_epoch().count();
+  std::string filename = "yaze_dungeon_palette_backup_" + std::to_string(nonce);
+  const size_t target_length = static_cast<size_t>(name_max) - 4;
+  ASSERT_LT(filename.size(), target_length);
+  filename.append(target_length - filename.size(), 'r');
+
+  ScopedRomArtifactsCleanup cleanup(parent / filename);
+  ScopedFileCleanup manifest_cleanup(MakeUniqueTempRomPath().string() +
+                                     ".manifest.json");
+  WriteRomFile(rom, cleanup.rom_path);
+  WriteOwnershipOnlyManifest(manifest_cleanup.file_path);
+  rom.set_filename(cleanup.rom_path.string());
+  rom.set_dirty(false);
+  const std::vector<uint8_t> before = rom.vector();
+  const std::vector<uint8_t> disk_before = ReadFile(cleanup.rom_path);
+  const bool dirty_before = rom.dirty();
+  const std::string filename_before = rom.filename();
+
+  auto args = DungeonPaletteSetArgs(manifest_cleanup.file_path);
+  args.push_back("--write");
+  handlers::DungeonSetPaletteColorCommandHandler handler;
+  std::string output;
+  const absl::Status status = handler.Run(args, &rom, &output);
+
+  EXPECT_FALSE(status.ok());
+  EXPECT_THAT(std::string(status.message()), HasSubstr("required ROM backup"));
+  EXPECT_THAT(output, HasSubstr("\"save_error\""));
+  EXPECT_EQ(rom.vector(), before);
+  EXPECT_EQ(rom.dirty(), dirty_before);
+  EXPECT_EQ(rom.filename(), filename_before);
+  EXPECT_EQ(ReadFile(cleanup.rom_path), disk_before);
+  EXPECT_EQ(CountBackupArtifacts(cleanup.rom_path), 0);
+  EXPECT_FALSE(std::filesystem::exists(cleanup.rom_path.string() + ".tmp"));
+#endif
 }
 
 }  // namespace

--- a/test/unit/cli/palette_commands_test.cc
+++ b/test/unit/cli/palette_commands_test.cc
@@ -62,6 +62,19 @@ TEST(PaletteCommandsTest, SetColorRequiresAllArgs) {
   EXPECT_FALSE(status.ok());
 }
 
+TEST(PaletteCommandsTest,
+     LegacySetColorWriteFailsClosedBeforeArgsOrRomLoading) {
+  handlers::PaletteSetColorCommandHandler handler;
+  std::string output;
+  const absl::Status status = handler.Run({"--write"}, nullptr, &output);
+
+  EXPECT_TRUE(absl::IsFailedPrecondition(status)) << status;
+  EXPECT_THAT(std::string(status.message()),
+              HasSubstr("palette-set-color --write is disabled"));
+  EXPECT_THAT(std::string(status.message()),
+              HasSubstr("dungeon-set-palette-color"));
+}
+
 TEST(PaletteCommandsTest, AnalyzeHasNoRequiredArgs) {
   // palette-analyze ValidateArgs returns OkStatus, but it still needs a ROM
   // to actually execute. We verify that validation itself passes.
@@ -88,6 +101,7 @@ TEST(PaletteCommandsTest, SetColorHelpShowsUsage) {
   auto& registry = CommandRegistry::Instance();
   std::string help = registry.GenerateHelp("palette-set-color");
   EXPECT_THAT(help, HasSubstr("palette-set-color"));
+  EXPECT_THAT(help, ::testing::Not(HasSubstr("[--write]")));
 }
 
 TEST(PaletteCommandsTest, AnalyzeHelpShowsUsage) {
@@ -174,6 +188,29 @@ TEST(PaletteCommandsTest, GetColorsWithoutIndexStillSucceeds) {
   absl::Status status = handler.Run({"--group", "ow_main"}, &rom, &output);
   EXPECT_TRUE(status.ok()) << status.message();
   EXPECT_THAT(output, HasSubstr("ow_main"));
+}
+
+TEST(PaletteCommandsTest, LegacySetColorPreviewRemainsReadOnly) {
+  handlers::PaletteSetColorCommandHandler handler;
+  Rom rom;
+  std::vector<uint8_t> rom_data(0x200000, 0x00);
+  ASSERT_TRUE(rom.LoadFromData(rom_data).ok());
+  rom.set_dirty(false);
+  const std::vector<uint8_t> before = rom.vector();
+
+  std::string output;
+  const absl::Status status =
+      handler.Run({"--group=dungeon_main", "--palette=0", "--index=0",
+                   "--color=FF0000", "--format=json"},
+                  &rom, &output);
+
+  ASSERT_TRUE(status.ok()) << status;
+  EXPECT_THAT(output, HasSubstr("\"status\": \"dry_run\""));
+  EXPECT_THAT(output, HasSubstr("Legacy preview only"));
+  EXPECT_THAT(output, ::testing::Not(HasSubstr("Use --write")));
+  EXPECT_THAT(output, ::testing::Not(HasSubstr("\"status\": \"written\"")));
+  EXPECT_EQ(rom.vector(), before);
+  EXPECT_FALSE(rom.dirty());
 }
 
 }  // namespace

--- a/test/unit/cli/tool_dispatcher_test.cc
+++ b/test/unit/cli/tool_dispatcher_test.cc
@@ -116,6 +116,26 @@ TEST(ToolDispatcherUnitTest,
   EXPECT_THAT(water->flag_args, Contains("strict-masks"));
 }
 
+TEST(ToolDispatcherUnitTest,
+     DungeonPaletteToolsExposeReadOnlyGetterAndMutatingGuardedSetter) {
+  const auto getter =
+      ToolRegistry::Get().GetToolDefinition("dungeon-get-palette");
+  ASSERT_TRUE(getter.has_value());
+  EXPECT_EQ(getter->access, ToolAccess::kReadOnly);
+  EXPECT_THAT(getter->required_args, Contains("room"));
+
+  const auto setter =
+      ToolRegistry::Get().GetToolDefinition("dungeon-set-palette-color");
+  ASSERT_TRUE(setter.has_value());
+  EXPECT_EQ(setter->access, ToolAccess::kMutating);
+  EXPECT_THAT(setter->required_args, Contains("room"));
+  EXPECT_THAT(setter->required_args, Contains("expect-palette-set"));
+  EXPECT_THAT(setter->required_args, Contains("expect-palette-index"));
+  EXPECT_THAT(setter->required_args, Contains("expect-color"));
+  EXPECT_THAT(setter->required_args, Contains("manifest"));
+  EXPECT_THAT(setter->flag_args, Contains("write"));
+}
+
 TEST(ToolDispatcherUnitTest, SharedValidationRejectsMissingRequiredArgs) {
   ToolRegistry::Get().RegisterTool(
       {"test-required-arg",

--- a/test/unit/cli/tool_schema_builder_test.cc
+++ b/test/unit/cli/tool_schema_builder_test.cc
@@ -1,9 +1,11 @@
 #include "cli/service/ai/tool_schema_builder.h"
 
+#include <set>
 #include <string>
 
 #include <gtest/gtest.h>
 
+#include "cli/service/ai/tool_call_argument_codec.h"
 #include "nlohmann/json.hpp"
 
 namespace yaze::cli {
@@ -120,6 +122,68 @@ TEST(ToolSchemaBuilderTest,
   EXPECT_TRUE(anthropic_tools[0].contains("description"));
   EXPECT_TRUE(anthropic_tools[0].contains("input_schema"));
   EXPECT_FALSE(anthropic_tools[0].contains("parameters"));
+}
+
+TEST(ToolSchemaBuilderTest,
+     ActiveCataloguesExposeGuardedDungeonPaletteToolsToProviders) {
+  for (const std::string catalogue : {"", "agent/prompt_catalogue_v2.yaml"}) {
+    SCOPED_TRACE(catalogue.empty() ? "default" : catalogue);
+    PromptBuilder prompt_builder;
+    ASSERT_TRUE(prompt_builder.LoadResourceCatalogue(catalogue).ok());
+
+    auto declarations_or =
+        ToolSchemaBuilder::ResolveFunctionDeclarations(prompt_builder);
+    ASSERT_TRUE(declarations_or.ok()) << declarations_or.status();
+
+    const nlohmann::json* getter = nullptr;
+    const nlohmann::json* setter = nullptr;
+    for (const auto& declaration : *declarations_or) {
+      const std::string name = declaration.value("name", "");
+      if (name == "dungeon-get-palette") {
+        getter = &declaration;
+      } else if (name == "dungeon-set-palette-color") {
+        setter = &declaration;
+      }
+    }
+    ASSERT_NE(getter, nullptr);
+    ASSERT_NE(setter, nullptr);
+    EXPECT_NE(getter->at("description").get<std::string>().find("Read-only"),
+              std::string::npos);
+    EXPECT_NE(setter->at("description").get<std::string>().find("mutating"),
+              std::string::npos);
+
+    std::set<std::string> required;
+    for (const auto& name : setter->at("parameters").at("required")) {
+      required.insert(name.get<std::string>());
+    }
+    EXPECT_EQ(required,
+              (std::set<std::string>{"room", "index", "expect-palette-set",
+                                     "expect-palette-index", "expect-color",
+                                     "color", "manifest"}));
+    EXPECT_TRUE(setter->at("parameters").at("properties").contains("write"));
+    EXPECT_FALSE(required.contains("write"));
+  }
+}
+
+TEST(ToolSchemaBuilderTest,
+     ProviderToolArgumentCodecPreservesDungeonPaletteIntegersAndWriteFlag) {
+  const nlohmann::json provider_arguments = {
+      {"room", "0xA8"},
+      {"index", 7},
+      {"expect-palette-set", "0x07"},
+      {"expect-palette-index", 7},
+      {"expect-color", "0x7FFF"},
+      {"color", "0x7FFE"},
+      {"manifest", "Roms/hack_manifest.json"},
+      {"write", true},
+  };
+
+  const auto decoded = ai::DecodeToolCallArguments(provider_arguments);
+
+  EXPECT_EQ(decoded.at("room"), "0xA8");
+  EXPECT_EQ(decoded.at("index"), "7");
+  EXPECT_EQ(decoded.at("expect-palette-index"), "7");
+  EXPECT_EQ(decoded.at("write"), "true");
 }
 
 TEST(ToolSchemaBuilderTest,


### PR DESCRIPTION
## Summary
- add `dungeon-get-palette` with strict full-8-bit room palette-set resolution, raw SNES color/address reporting, and complete shared-room fanout
- add dry-run-first `dungeon-set-palette-color` with exact set/index/color CAS, manifest ownership preflight, two-byte write fencing, whole-ROM diff validation, transaction rollback, required backup, atomic save, and external reopen/readback
- fail closed on legacy `palette-set-color --write` before ROM loading or mutation while retaining its read-only preview
- fix `dungeon-room-header` to report the full 8-bit palette-set ID
- expose the safe getter/setter through native CLI and agent tooling; browser exposes the getter only because durable IDBFS persistence is not guaranteed
- update active schemas, prompts, routing, help, public safety docs, and the breaking-change migration note

## Why
The legacy palette setter reported `status=written` after changing only the in-memory ROM. A disposable OOS proof showed the command claimed a change while the file SHA-256 remained unchanged. Dungeon palettes are also shared global resources: D6 room `0xA8` resolves palette set `0x07` to palette 7, which affects 26 rooms through set IDs `0x07` and `0x20`.

## Safety contract
- US/OOS palette layout only; unsupported ROM versions fail closed
- resolve only room-referenced set IDs, while rejecting malformed mappings for any referenced room
- raw 15-bit ROM words are authoritative for CAS and readback
- required manifest analyzes exactly `[color_pc,color_pc+2)` in dry-run and write modes
- write mode requires a clean file-backed ROM matching disk
- exactly one fenced color word may change; one- or two-byte physical deltas are accepted
- successful disk replacement commits caller state before external verification, preventing disk/memory divergence
- add/remove/repack, palette-set table edits, pointer edits, bulk import/export, and GUI changes are excluded

## Validation
- focused `z3ed` and `yaze_test_unit` build passed
- independent review reports 23 focused dungeon palette/header, legacy fail-close, registry, schema, provider-codec, and help/fallback checks passing
- clang-format, `git diff --check`, JSON, both YAML catalogues, pre-commit formatting, and release checks passed
- canonical OOS getter: room `0xA8` -> set `0x07` -> palette 7; index 7 at PC `0x0DDC2E` = `0x7FFF`; 26 affected rooms
- canonical guarded setter dry-run passed manifest preflight
- canonical OOS SHA-256 remained `d289b2408c3ccc312abeadf274f04f475106034fcab8ebff3f307fd229db4799`
- independent strict review found no P0/P1/P2 blockers

## Residual
No dedicated WASM registration unit test yet; code inspection confirms the browser registers the getter and omits the persistent setter.

Closes #174
