### PR TITLE
fix(message): round-trip exported dictionary tokens

### DIFF
--- a/src/app/editor/message/message_data.cc
+++ b/src/app/editor/message/message_data.cc
@@ -15,7 +15,6 @@
 #include "rom/snes.h"
 #include "rom/transaction.h"
 #include "rom/write_fence.h"
-#include "util/hex.h"
 #include "util/log.h"
 #include "util/macro.h"
 
@@ -131,11 +130,15 @@ ParsedElement FindMatchingElement(const std::string& str) {
   const auto dictionary_element =
       TextElement(0x80, DICTIONARYTOKEN, true, "Dictionary");
 
-  match = dictionary_element.MatchMe(str);
+  // Keep legacy bundles with assembler-style [D:$XX] tokens importable while
+  // emitting the canonical [D:XX] form. Restrict this compatibility syntax to
+  // dictionary tokens so command argument validation remains unchanged.
+  const std::regex dictionary_pattern(
+      absl::StrFormat("^\\[%s:\\$?([0-9A-F]{1,2})\\]$", DICTIONARYTOKEN));
+  std::regex_match(str, match, dictionary_pattern);
   if (match.size() > 0) {
     try {
-      // match[1] captures ":XX" — strip the leading colon
-      std::string dict_arg = match[1].str().substr(1);
+      std::string dict_arg = match[1].str();
       const int dictionary_index = std::stoi(dict_arg, nullptr, 16);
       if (dictionary_index < 0 || dictionary_index >= kNumDictionaryEntries) {
         util::logf("Dictionary index out of range: %s", dict_arg.c_str());
@@ -671,9 +674,9 @@ std::vector<MessageData> ReadAllTextData(uint8_t* rom, int pos, int max_pos,
     // Check for dictionary.
     int8_t dictionary = FindDictionaryEntry(current_byte);
     if (dictionary >= 0) {
-      current_raw_message.append(absl::StrFormat(
-          "[%s:%s]", DICTIONARYTOKEN,
-          util::HexByte(static_cast<unsigned char>(dictionary))));
+      current_raw_message.append(
+          absl::StrFormat("[%s:%02X]", DICTIONARYTOKEN,
+                          static_cast<unsigned char>(dictionary)));
 
       // Safety: bounds-check dictionary pointer reads and dictionary expansion.
       // This parser is used by tooling (RomDoctor) that may run on dummy or

--- a/test/unit/editor/message/message_data_test.cc
+++ b/test/unit/editor/message/message_data_test.cc
@@ -222,6 +222,21 @@ TEST(MessageParseResultTest, RejectsOutOfRangeDictionaryIndex) {
   EXPECT_FALSE(wrapped_invalid.ok());
 }
 
+TEST(MessageParseResultTest,
+     LegacyDollarPrefixedDictionaryIndexMatchesCanonical) {
+  auto canonical = ParseMessageToDataWithDiagnostics("[D:2C]");
+  auto legacy = ParseMessageToDataWithDiagnostics("[D:$2C]");
+
+  ASSERT_TRUE(canonical.ok());
+  ASSERT_TRUE(legacy.ok());
+  EXPECT_EQ(legacy.bytes, canonical.bytes);
+  EXPECT_EQ(legacy.bytes,
+            std::vector<uint8_t>({static_cast<uint8_t>(DICTOFF + 0x2C)}));
+  EXPECT_FALSE(ParseMessageToDataWithDiagnostics("[D:$61]").ok());
+  EXPECT_FALSE(ParseMessageToDataWithDiagnostics("[D:$$2C]").ok());
+  EXPECT_FALSE(ParseMessageToDataWithDiagnostics("[W:$02]").ok());
+}
+
 // ===========================================================================
 // Message Bundle Tests
 // ===========================================================================
@@ -264,6 +279,32 @@ TEST(MessageBundleTest, SerializeBundleIncludesCanonicalTextField) {
   ASSERT_EQ(bundle["messages"].size(), 2);
   EXPECT_EQ(bundle["messages"][0]["text"], "Raw [K]");
   EXPECT_EQ(bundle["messages"][1]["text"], "ExpandedParsed");
+}
+
+TEST(MessageBundleTest, DictionaryTokenExportStrictlyRoundTrips) {
+  constexpr uint8_t kDictionaryIndex = 0x2C;
+  std::vector<uint8_t> source_bytes = {
+      static_cast<uint8_t>(DICTOFF + kDictionaryIndex), kMessageTerminator,
+      0xFF};
+
+  auto messages = ReadAllTextData(source_bytes.data(), 0,
+                                  static_cast<int>(source_bytes.size()), false);
+  ASSERT_EQ(messages.size(), 1);
+  EXPECT_EQ(messages[0].RawString, "[D:2C]");
+
+  const nlohmann::json bundle = SerializeMessageBundle(messages, {});
+  ASSERT_EQ(bundle["messages"].size(), 1);
+  EXPECT_EQ(bundle["messages"][0]["raw"], "[D:2C]");
+  EXPECT_EQ(bundle["messages"][0]["text"], "[D:2C]");
+
+  auto entries_or = ParseMessageBundleJson(bundle);
+  ASSERT_TRUE(entries_or.ok()) << entries_or.status();
+  ASSERT_EQ(entries_or.value().size(), 1);
+
+  auto encoded =
+      ParseMessageToDataWithDiagnostics(entries_or.value().front().text);
+  ASSERT_TRUE(encoded.ok());
+  EXPECT_EQ(encoded.bytes, messages[0].Data);
 }
 
 TEST(MessageBundleTest, ParseStructuredBundleRespectsBankAndText) {


### PR DESCRIPTION
## What changed

- emit dictionary references in the canonical `[D:XX]` form during message reads/exports
- continue accepting legacy `[D:$XX]` bundle tokens for backward compatibility
- keep the compatibility syntax scoped to dictionary tokens so command arguments remain strict
- add parser and bundle round-trip regressions

## Why

`ReadAllTextData` used `util::HexByte`, which produced `[D:$XX]`, while the strict message parser only accepted `[D:XX]`. A real Oracle of Secrets expanded-message export therefore produced 1,887 strict-import errors even though the underlying bytes were valid.

## Verification

- built `yaze_test_unit`
- 14 focused parser/bundle tests passed
- real Oracle fixture: 109 messages; all legacy dictionary references parse with zero failures
- `scripts/pre-push.sh --build-dir build/presets/mac-ai` passed
- independent strict review found no blocking findings

This is a prerequisite for the durable expanded-message source handoff tracked by #88; it does not close that issue by itself.
