### PR TITLE
feat(message): add durable expanded-source handoff

### DIFF
--- a/docs/internal/architecture/message_system.md
+++ b/docs/internal/architecture/message_system.md
@@ -79,3 +79,7 @@ either artifact. It never writes the ROM.
 *   **Translation**: No specific tooling for side-by-side translation.
 *   **GUI source save**: The source-sync service is currently CLI/backend only;
     the Message Editor GUI is not yet wired to publish ASM-owned source.
+*   **Filesystem metadata**: Source publication and rollback preserve exact file
+    contents and existing POSIX mode bits, not ownership, ACLs, extended
+    attributes/flags, or target-specific Windows attributes/DACLs. Source
+    artifacts with special filesystem metadata are not supported yet.

--- a/docs/internal/architecture/message_system.md
+++ b/docs/internal/architecture/message_system.md
@@ -61,8 +61,10 @@ Manifest's exact expanded range/capacity, and rendered to a deterministic
 no-`org` Asar include. `message-source-sync` is dry-run-first and publishes the
 bundle/include pair only with an exact source SHA-256 CAS and rollback-backed
 reopen verification. Write mode holds both an in-process mutex and the
-persistent project-root `.yaze-message-source-sync.lock` from canonical read
-through publication verification or rollback. It never writes the ROM.
+persistent `.yaze-message-source-sync.lock` in each distinct publication-target
+directory from canonical read through publication verification or rollback.
+This keeps nested project descriptors in the same lock domain when they share
+either artifact. It never writes the ROM.
 
 ## Editor UI
 

--- a/docs/internal/architecture/message_system.md
+++ b/docs/internal/architecture/message_system.md
@@ -1,7 +1,7 @@
 # Message System Architecture
 
 **Status**: Draft
-**Last Updated**: 2025-11-21
+**Last Updated**: 2026-07-27
 **Related Code**: `src/app/editor/message/`, `src/cli/handlers/game/message.cc`
 
 This document outlines the architecture of the Message (Text) System in YAZE.
@@ -55,6 +55,13 @@ Represents special control codes or characters.
 2.  **Optimize**: `OptimizeMessageForDictionary` scans the text for dictionary phrases and replaces them with single-byte references.
 3.  **Write**: Data is written sequentially to the ROM text blocks. If the first block overflows, it spills into the second block.
 
+ASM-owned expanded banks use a separate source pipeline. A complete canonical
+`yaze-message-bundle` is merged by bank-local ID, validated against the Hack
+Manifest's exact expanded range/capacity, and rendered to a deterministic
+no-`org` Asar include. `message-source-sync` is dry-run-first and publishes the
+bundle/include pair only with an exact source SHA-256 CAS and rollback-backed
+reopen verification. It never writes the ROM.
+
 ## Editor UI
 
 *   **Message List**: Displays all messages with ID and preview.
@@ -66,4 +73,5 @@ Represents special control codes or characters.
 
 *   **Hardcoded Limits**: The text block sizes are fixed for vanilla.
 *   **Translation**: No specific tooling for side-by-side translation.
-*   **Export**: Limited to binary "Expanded Messages" format; no JSON/YAML support.
+*   **GUI source save**: The source-sync service is currently CLI/backend only;
+    the Message Editor GUI is not yet wired to publish ASM-owned source.

--- a/docs/internal/architecture/message_system.md
+++ b/docs/internal/architecture/message_system.md
@@ -60,7 +60,9 @@ ASM-owned expanded banks use a separate source pipeline. A complete canonical
 Manifest's exact expanded range/capacity, and rendered to a deterministic
 no-`org` Asar include. `message-source-sync` is dry-run-first and publishes the
 bundle/include pair only with an exact source SHA-256 CAS and rollback-backed
-reopen verification. It never writes the ROM.
+reopen verification. Write mode holds both an in-process mutex and the
+persistent project-root `.yaze-message-source-sync.lock` from canonical read
+through publication verification or rollback. It never writes the ROM.
 
 ## Editor UI
 

--- a/docs/public/reference/message-bundle-format.md
+++ b/docs/public/reference/message-bundle-format.md
@@ -140,8 +140,9 @@ Write mode rejects stale source hashes, a drifted generated include, `[BANK]`,
 incomplete or duplicate IDs, capacity overflow, path escapes, and symlink
 targets. The bundle and include publish as one rollback-backed artifact set
 using same-directory temporary files and exact reopen/readback. Writers are
-serialized in-process and across processes with a persistent project-root
-`.yaze-message-source-sync.lock`; projects should ignore that lock file rather
-than deleting it between runs. This command does not open or mutate a ROM.
-Browser builds reject `--write` because they cannot guarantee durable atomic
-filesystem publication.
+serialized in-process and across processes with a persistent
+`.yaze-message-source-sync.lock` in each distinct publication-target directory.
+Projects should ignore that basename wherever source artifacts live rather
+than deleting lock files between runs. This command does not open or mutate a
+ROM. Browser builds reject `--write` because they cannot guarantee durable
+atomic filesystem publication.

--- a/docs/public/reference/message-bundle-format.md
+++ b/docs/public/reference/message-bundle-format.md
@@ -139,6 +139,9 @@ missing or lowercase command arguments are rejected.
 Write mode rejects stale source hashes, a drifted generated include, `[BANK]`,
 incomplete or duplicate IDs, capacity overflow, path escapes, and symlink
 targets. The bundle and include publish as one rollback-backed artifact set
-using same-directory temporary files and exact reopen/readback. This command
-does not open or mutate a ROM. Browser builds reject `--write` because they
-cannot guarantee durable atomic filesystem publication.
+using same-directory temporary files and exact reopen/readback. Writers are
+serialized in-process and across processes with a persistent project-root
+`.yaze-message-source-sync.lock`; projects should ignore that lock file rather
+than deleting it between runs. This command does not open or mutate a ROM.
+Browser builds reject `--write` because they cannot guarantee durable atomic
+filesystem publication.

--- a/docs/public/reference/message-bundle-format.md
+++ b/docs/public/reference/message-bundle-format.md
@@ -83,3 +83,62 @@ can validate the active ROM, manifest ownership, and project write policy:
 z3ed message-import-bundle --file messages.json --apply \
   --rom path/to/rom.sfc --project path/to/project.yaze
 ```
+
+## ASM-Owned Expanded Message Source
+
+Projects that rebuild expanded messages from ASM can opt into a durable source
+handoff by adding this metadata beneath the Hack Manifest's existing
+`messages` object:
+
+```json
+"source": {
+  "format": "yaze-message-bundle",
+  "version": 1,
+  "canonical_bundle_path": "Data/Messages/expanded.json",
+  "generated_asm_include_path": "Core/generated/messages.asm"
+}
+```
+
+Both paths are project-relative and must remain inside the project root after
+symlink resolution. The sibling `messages.expanded_range`, `data_start`, and
+`data_end` fields remain authoritative for IDs and capacity.
+
+Preview a validated subset merge:
+
+```bash
+z3ed message-source-sync \
+  --project Oracle-of-Secrets.yaze \
+  --file /tmp/message-edits.json \
+  --format json
+```
+
+Publication is explicit and compare-and-swap protected:
+
+```bash
+z3ed message-source-sync \
+  --project Oracle-of-Secrets.yaze \
+  --file /tmp/message-edits.json \
+  --expected-source-sha256 <sha256-from-preview> \
+  --write --format json
+```
+
+The canonical source is always rewritten deterministically as one complete,
+expanded-only bank with contiguous bank-local IDs. Source sync treats an
+explicit `text` field as authoritative over export-time `raw`/`parsed`
+metadata, normalizes dictionary tokens to uppercase `[D:XX]`, and emits only
+`bank`, `id`, and `text` per entry. The generated Asar include has absolute
+`Message_XXX` labels, no `org`, appends one `$7F` terminator per message, and
+has one final `$FF`. Its header binds both the exact canonical bundle bytes and
+the exact generated ASM body bytes with SHA-256.
+
+Argument command tokens are case-sensitive and accept one or two uppercase
+hex digits without a `$` prefix (for example, `[W:7]`, `[W:7F]`, and
+`[W:FF]`). Source sync preserves those spellings rather than zero-padding them;
+missing or lowercase command arguments are rejected.
+
+Write mode rejects stale source hashes, a drifted generated include, `[BANK]`,
+incomplete or duplicate IDs, capacity overflow, path escapes, and symlink
+targets. The bundle and include publish as one rollback-backed artifact set
+using same-directory temporary files and exact reopen/readback. This command
+does not open or mutate a ROM. Browser builds reject `--write` because they
+cannot guarantee durable atomic filesystem publication.

--- a/docs/public/reference/message-bundle-format.md
+++ b/docs/public/reference/message-bundle-format.md
@@ -142,7 +142,14 @@ targets. The bundle and include publish as one rollback-backed artifact set
 using same-directory temporary files and exact reopen/readback. Writers are
 serialized in-process and across processes with a persistent
 `.yaze-message-source-sync.lock` in each distinct publication-target directory.
-Projects should ignore that basename wherever source artifacts live rather
-than deleting lock files between runs. This command does not open or mutate a
-ROM. Browser builds reject `--write` because they cannot guarantee durable
-atomic filesystem publication.
+Lock files must be regular, single-link files; hard-linked locks fail closed
+before permissions or source artifacts change. Projects should ignore that
+basename wherever source artifacts live rather than deleting lock files
+between runs.
+
+Publication and rollback preserve exact file contents and existing POSIX mode
+bits. Rename-based replacement does not preserve ownership, ACLs, extended
+attributes/flags, or target-specific Windows attributes/DACLs, so source
+artifacts with special filesystem metadata are not supported yet. This command
+does not open or mutate a ROM. Browser builds reject `--write` because they
+cannot guarantee durable atomic filesystem publication.

--- a/docs/public/usage/z3ed-cli.md
+++ b/docs/public/usage/z3ed-cli.md
@@ -77,6 +77,7 @@ scripts/dev/ai-provider-matrix-smoke.sh \
 | Describe overworld map | `z3ed overworld-describe-map --map=80 --rom=zelda3.sfc` |
 | List messages | `z3ed message-list --rom=zelda3.sfc` |
 | Search messages | `z3ed message-search --query="sword" --rom=zelda3.sfc` |
+| Preview ASM-owned message source sync | `z3ed message-source-sync --project=project.yaze --file=message-edits.json --format=json` |
 
 Most commands follow the `<noun>-<verb>` convention (dashes, not spaces), and
 some use subcommands like `rom read` or `debug state`. Use `--help` for flag details:
@@ -124,6 +125,27 @@ externally reopens the file before reporting verified success.
 `palette-set-color --write` is intentionally rejected; its legacy mode is
 preview-only. Browser-terminal palette writes are unavailable because
 Emscripten cannot guarantee durable filesystem synchronization.
+
+### ASM-Owned Expanded Message Source
+
+`message-source-sync` provides the source-side handoff for projects whose
+expanded message bank is rebuilt by Asar. It merges an expanded-only bundle
+subset into the complete canonical project bundle and renders the configured
+no-`org` include. It is dry-run by default and never mutates a ROM:
+
+```bash
+z3ed message-source-sync \
+  --project=Oracle-of-Secrets.yaze \
+  --file=/tmp/message-edits.json \
+  --format=json
+```
+
+Use the reported `source_sha256_before` as the exact write CAS, then repeat the
+same command with `--expected-source-sha256=<hash> --write`. See
+[Message Bundle JSON Format](../reference/message-bundle-format.md) for the
+manifest schema, deterministic output contract, and fail-closed guarantees.
+Browser builds reject source-sync `--write` because they cannot guarantee
+durable atomic filesystem publication.
 
 ---
 

--- a/src/app/editor/editor_library.cmake
+++ b/src/app/editor/editor_library.cmake
@@ -78,6 +78,7 @@ set(
   app/editor/message/message_data.cc
   app/editor/message/message_editor.cc
   app/editor/message/message_preview.cc
+  app/editor/message/message_source_sync.cc
   app/editor/music/music_editor.cc
   app/editor/music/music_player.cc
   app/editor/music/instrument_editor_view.cc

--- a/src/app/editor/message/message_source_sync.cc
+++ b/src/app/editor/message/message_source_sync.cc
@@ -14,6 +14,8 @@
 #include <iterator>
 #include <limits>
 #include <map>
+#include <memory>
+#include <mutex>
 #include <optional>
 #include <string>
 #include <string_view>
@@ -36,8 +38,10 @@
 #define NOMINMAX
 #endif
 #include <windows.h>
-#else
+#elif !defined(__EMSCRIPTEN__)
 #include <fcntl.h>
+#include <sys/file.h>
+#include <sys/stat.h>
 #include <unistd.h>
 #endif
 
@@ -54,6 +58,8 @@ struct ExpandedSourceMessage {
 
 using ExpandedSourceBank = std::map<int, ExpandedSourceMessage>;
 
+constexpr char kSourceSyncLockFilename[] = ".yaze-message-source-sync.lock";
+
 struct PublicationArtifact {
   fs::path target;
   std::string content;
@@ -61,6 +67,129 @@ struct PublicationArtifact {
   fs::path temp;
   std::optional<fs::path> backup;
   bool published = false;
+};
+
+std::mutex& MessageSourceWriteMutex() {
+  static std::mutex mutex;
+  return mutex;
+}
+
+class MessageSourceWriteLock {
+ public:
+  static absl::StatusOr<std::unique_ptr<MessageSourceWriteLock>> Acquire(
+      const fs::path& project_root) {
+    auto lock =
+        std::unique_ptr<MessageSourceWriteLock>(new MessageSourceWriteLock());
+    lock->process_lock_ =
+        std::unique_lock<std::mutex>(MessageSourceWriteMutex());
+    lock->path_ = project_root / kSourceSyncLockFilename;
+
+#if defined(_WIN32)
+    lock->handle_ =
+        CreateFileW(lock->path_.wstring().c_str(), GENERIC_READ | GENERIC_WRITE,
+                    FILE_SHARE_READ | FILE_SHARE_WRITE, nullptr, OPEN_ALWAYS,
+                    FILE_ATTRIBUTE_NORMAL, nullptr);
+    if (lock->handle_ == INVALID_HANDLE_VALUE) {
+      const DWORD error = GetLastError();
+      return absl::PermissionDeniedError(absl::StrFormat(
+          "Cannot open message source lock %s: %s", lock->path_.string(),
+          std::error_code(static_cast<int>(error), std::system_category())
+              .message()));
+    }
+    if (!LockFileEx(lock->handle_, LOCKFILE_EXCLUSIVE_LOCK, 0, MAXDWORD,
+                    MAXDWORD, &lock->overlapped_)) {
+      const DWORD error = GetLastError();
+      CloseHandle(lock->handle_);
+      lock->handle_ = INVALID_HANDLE_VALUE;
+      return absl::UnavailableError(absl::StrFormat(
+          "Cannot acquire message source lock %s: %s", lock->path_.string(),
+          std::error_code(static_cast<int>(error), std::system_category())
+              .message()));
+    }
+#elif defined(__EMSCRIPTEN__)
+    return absl::FailedPreconditionError(
+        "Durable message source locking is unavailable in browser builds");
+#else
+    int open_flags = O_RDWR | O_CREAT;
+#ifdef O_CLOEXEC
+    open_flags |= O_CLOEXEC;
+#endif
+#ifdef O_NOFOLLOW
+    open_flags |= O_NOFOLLOW;
+#endif
+    lock->fd_ = open(lock->path_.c_str(), open_flags, S_IRUSR | S_IWUSR);
+    if (lock->fd_ < 0) {
+      return absl::PermissionDeniedError(absl::StrFormat(
+          "Cannot open message source lock %s: %s", lock->path_.string(),
+          std::error_code(errno, std::generic_category()).message()));
+    }
+    struct stat lock_stat{};
+    if (fstat(lock->fd_, &lock_stat) != 0) {
+      const int error = errno;
+      close(lock->fd_);
+      lock->fd_ = -1;
+      return absl::FailedPreconditionError(absl::StrFormat(
+          "Cannot inspect message source lock %s: %s", lock->path_.string(),
+          std::error_code(error, std::generic_category()).message()));
+    }
+    if (!S_ISREG(lock_stat.st_mode)) {
+      close(lock->fd_);
+      lock->fd_ = -1;
+      return absl::FailedPreconditionError(
+          absl::StrFormat("Message source lock must be a regular file: %s",
+                          lock->path_.string()));
+    }
+    if (fchmod(lock->fd_, S_IRUSR | S_IWUSR) != 0) {
+      const int error = errno;
+      close(lock->fd_);
+      lock->fd_ = -1;
+      return absl::PermissionDeniedError(absl::StrFormat(
+          "Cannot secure message source lock %s: %s", lock->path_.string(),
+          std::error_code(error, std::generic_category()).message()));
+    }
+    while (flock(lock->fd_, LOCK_EX) != 0) {
+      if (errno == EINTR) {
+        continue;
+      }
+      const int error = errno;
+      close(lock->fd_);
+      lock->fd_ = -1;
+      return absl::UnavailableError(absl::StrFormat(
+          "Cannot acquire message source lock %s: %s", lock->path_.string(),
+          std::error_code(error, std::generic_category()).message()));
+    }
+#endif
+    return lock;
+  }
+
+  ~MessageSourceWriteLock() {
+#if defined(_WIN32)
+    if (handle_ != INVALID_HANDLE_VALUE) {
+      UnlockFileEx(handle_, 0, MAXDWORD, MAXDWORD, &overlapped_);
+      CloseHandle(handle_);
+    }
+#elif !defined(__EMSCRIPTEN__)
+    if (fd_ >= 0) {
+      while (flock(fd_, LOCK_UN) != 0 && errno == EINTR) {}
+      close(fd_);
+    }
+#endif
+  }
+
+  MessageSourceWriteLock(const MessageSourceWriteLock&) = delete;
+  MessageSourceWriteLock& operator=(const MessageSourceWriteLock&) = delete;
+
+ private:
+  MessageSourceWriteLock() = default;
+
+  fs::path path_;
+  std::unique_lock<std::mutex> process_lock_;
+#if defined(_WIN32)
+  HANDLE handle_ = INVALID_HANDLE_VALUE;
+  OVERLAPPED overlapped_ = {};
+#elif !defined(__EMSCRIPTEN__)
+  int fd_ = -1;
+#endif
 };
 
 constexpr uint32_t kSha256Constants[64] = {
@@ -593,6 +722,24 @@ fs::path NextSiblingPath(const fs::path& target, absl::string_view purpose) {
 absl::StatusOr<fs::path> WriteExclusiveTemp(const fs::path& target,
                                             std::string_view content) {
   constexpr int kMaxAttempts = 100;
+#if !defined(_WIN32) && !defined(__EMSCRIPTEN__)
+  mode_t create_mode =
+      S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP | S_IROTH | S_IWOTH;
+  bool preserve_mode = false;
+  struct stat target_stat{};
+  if (stat(target.c_str(), &target_stat) == 0) {
+    if (!S_ISREG(target_stat.st_mode)) {
+      return absl::FailedPreconditionError(absl::StrFormat(
+          "Publication target must be a regular file: %s", target.string()));
+    }
+    create_mode = target_stat.st_mode & 07777;
+    preserve_mode = true;
+  } else if (errno != ENOENT) {
+    return absl::FailedPreconditionError(absl::StrFormat(
+        "Cannot inspect publication target mode %s: %s", target.string(),
+        std::error_code(errno, std::generic_category()).message()));
+  }
+#endif
   for (int attempt = 0; attempt < kMaxAttempts; ++attempt) {
     const fs::path temp = NextSiblingPath(target, "tmp");
 #if defined(_WIN32)
@@ -647,9 +794,23 @@ absl::StatusOr<fs::path> WriteExclusiveTemp(const fs::path& target,
           std::error_code(static_cast<int>(error), std::system_category())
               .message()));
     }
+#elif defined(__EMSCRIPTEN__)
+    std::ofstream output(temp, std::ios::binary | std::ios::trunc);
+    if (!output.is_open()) {
+      return absl::PermissionDeniedError(absl::StrFormat(
+          "Cannot create temporary file for %s", target.string()));
+    }
+    output.write(content.data(), static_cast<std::streamsize>(content.size()));
+    if (!output.good()) {
+      output.close();
+      std::error_code cleanup_ec;
+      fs::remove(temp, cleanup_ec);
+      return absl::InternalError(absl::StrFormat(
+          "Failed to write temporary file for %s", target.string()));
+    }
+    output.close();
 #else
-    const int fd =
-        open(temp.c_str(), O_WRONLY | O_CREAT | O_EXCL, S_IRUSR | S_IWUSR);
+    const int fd = open(temp.c_str(), O_WRONLY | O_CREAT | O_EXCL, create_mode);
     if (fd < 0) {
       if (errno == EEXIST) {
         continue;
@@ -657,6 +818,15 @@ absl::StatusOr<fs::path> WriteExclusiveTemp(const fs::path& target,
       return absl::PermissionDeniedError(absl::StrFormat(
           "Cannot create temporary file for %s: %s", target.string(),
           std::error_code(errno, std::generic_category()).message()));
+    }
+    if (preserve_mode && fchmod(fd, create_mode) != 0) {
+      const int error = errno;
+      close(fd);
+      std::error_code cleanup_ec;
+      fs::remove(temp, cleanup_ec);
+      return absl::InternalError(absl::StrFormat(
+          "Cannot preserve publication target mode for %s: %s", target.string(),
+          std::error_code(error, std::generic_category()).message()));
     }
     size_t written_total = 0;
     while (written_total < content.size()) {
@@ -701,21 +871,76 @@ absl::StatusOr<fs::path> WriteExclusiveTemp(const fs::path& target,
       "Could not allocate a unique temporary file for %s", target.string()));
 }
 
-absl::Status ReplaceFromTemp(const fs::path& temp, const fs::path& target) {
+absl::Status SyncParentDirectory(const fs::path& target) {
+#if defined(_WIN32) || defined(__EMSCRIPTEN__)
+  return absl::OkStatus();
+#else
+  int open_flags = O_RDONLY;
+#ifdef O_CLOEXEC
+  open_flags |= O_CLOEXEC;
+#endif
+#ifdef O_DIRECTORY
+  open_flags |= O_DIRECTORY;
+#endif
+  const fs::path parent = target.parent_path();
+  const int fd = open(parent.c_str(), open_flags);
+  if (fd < 0) {
+    return absl::InternalError(absl::StrFormat(
+        "Cannot open parent directory for durable publication %s: %s",
+        parent.string(),
+        std::error_code(errno, std::generic_category()).message()));
+  }
+  int sync_result = 0;
+  do {
+    sync_result = fsync(fd);
+  } while (sync_result != 0 && errno == EINTR);
+  const int sync_error = sync_result == 0 ? 0 : errno;
+  const int close_result = close(fd);
+  const int close_error = close_result == 0 ? 0 : errno;
+  if (sync_error != 0) {
+    return absl::InternalError(absl::StrFormat(
+        "Cannot sync parent directory after publishing %s: %s", target.string(),
+        std::error_code(sync_error, std::generic_category()).message()));
+  }
+  if (close_result != 0) {
+    return absl::InternalError(absl::StrFormat(
+        "Cannot close parent directory after publishing %s: %s",
+        target.string(),
+        std::error_code(close_error, std::generic_category()).message()));
+  }
+  return absl::OkStatus();
+#endif
+}
+
+absl::Status ReplaceFromTemp(const fs::path& temp, const fs::path& target,
+                             bool* replaced = nullptr) {
+  if (replaced != nullptr) {
+    *replaced = false;
+  }
+#if defined(_WIN32)
+  if (!MoveFileExW(temp.wstring().c_str(), target.wstring().c_str(),
+                   MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH)) {
+    const DWORD error = GetLastError();
+    return absl::InternalError(absl::StrFormat(
+        "Failed to publish %s: %s", target.string(),
+        std::error_code(static_cast<int>(error), std::system_category())
+            .message()));
+  }
+  if (replaced != nullptr) {
+    *replaced = true;
+  }
+#else
   std::error_code rename_ec;
   fs::rename(temp, target, rename_ec);
-#if defined(_WIN32)
-  if (rename_ec &&
-      MoveFileExW(temp.wstring().c_str(), target.wstring().c_str(),
-                  MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH)) {
-    rename_ec.clear();
-  }
-#endif
   if (rename_ec) {
     return absl::InternalError(absl::StrFormat(
         "Failed to publish %s: %s", target.string(), rename_ec.message()));
   }
-  return absl::OkStatus();
+  if (replaced != nullptr) {
+    *replaced = true;
+  }
+#endif
+  return SyncParentDirectory(target);
 }
 
 absl::StatusOr<fs::path> CreateBackup(const fs::path& target) {
@@ -777,7 +1002,7 @@ absl::Status RestoreArtifact(const PublicationArtifact& artifact) {
         artifact.target.string(),
         remove_ec ? remove_ec.message() : "file was missing"));
   }
-  return absl::OkStatus();
+  return SyncParentDirectory(artifact.target);
 }
 
 absl::Status RollBackPublication(std::vector<PublicationArtifact>* artifacts,
@@ -800,6 +1025,7 @@ absl::Status RollBackPublication(std::vector<PublicationArtifact>* artifacts,
         "Original backups were preserved.",
         publication_failure.message(), rollback_failure.message()));
   }
+  CleanupBackups(*artifacts);
   return publication_failure;
 }
 
@@ -872,13 +1098,14 @@ absl::Status PublishArtifactSet(std::vector<PublicationArtifact>* artifacts,
   }
 
   for (auto& artifact : *artifacts) {
+    bool replaced = false;
     const absl::Status replace_status =
-        ReplaceFromTemp(artifact.temp, artifact.target);
+        ReplaceFromTemp(artifact.temp, artifact.target, &replaced);
+    artifact.published = replaced;
     if (!replace_status.ok()) {
       return RollBackPublication(artifacts, replace_status);
     }
     artifact.temp.clear();
-    artifact.published = true;
   }
 
   for (const auto& artifact : *artifacts) {
@@ -952,6 +1179,13 @@ absl::StatusOr<MessageSourceSyncResult> SyncMessageSource(
                        /*must_exist=*/false, "Generated message ASM include"));
   RETURN_IF_ERROR(
       ValidateDistinctTargets(canonical_bundle_path, asm_include_path));
+  const fs::path source_lock_path = project_root / kSourceSyncLockFilename;
+  if (canonical_bundle_path == source_lock_path ||
+      asm_include_path == source_lock_path) {
+    return absl::InvalidArgumentError(absl::StrFormat(
+        "Message source targets may not use the persistent lock path: %s",
+        source_lock_path.string()));
+  }
 
   std::error_code incoming_ec;
   const fs::path resolved_incoming =
@@ -961,6 +1195,18 @@ absl::StatusOr<MessageSourceSyncResult> SyncMessageSource(
     return absl::NotFoundError(absl::StrFormat(
         "Incoming message bundle must be an existing regular file: %s",
         incoming_bundle_path.string()));
+  }
+
+  std::string expected_sha;
+  std::unique_ptr<MessageSourceWriteLock> write_lock;
+  if (options.write) {
+    if (options.expected_source_sha256.empty()) {
+      return absl::InvalidArgumentError(
+          "--write requires --expected-source-sha256");
+    }
+    ASSIGN_OR_RETURN(expected_sha,
+                     NormalizeExpectedSha256(options.expected_source_sha256));
+    ASSIGN_OR_RETURN(write_lock, MessageSourceWriteLock::Acquire(project_root));
   }
 
   std::string canonical_before;
@@ -1048,13 +1294,6 @@ absl::StatusOr<MessageSourceSyncResult> SyncMessageSource(
   if (!options.write) {
     return result;
   }
-  if (options.expected_source_sha256.empty()) {
-    return absl::InvalidArgumentError(
-        "--write requires --expected-source-sha256");
-  }
-  std::string expected_sha;
-  ASSIGN_OR_RETURN(expected_sha,
-                   NormalizeExpectedSha256(options.expected_source_sha256));
   if (expected_sha != source_sha_before) {
     return absl::AbortedError(absl::StrFormat(
         "Canonical message source SHA-256 CAS failed: expected %s, got %s",
@@ -1079,14 +1318,18 @@ absl::StatusOr<MessageSourceSyncResult> SyncMessageSource(
 
   // Reopen the canonical bundle through the strict source parser, not just as
   // bytes, before reporting a successful two-file publication.
-  std::string reopened_canonical;
-  ASSIGN_OR_RETURN(reopened_canonical,
-                   ReadTextFile(canonical_bundle_path,
-                                "published canonical message bundle"));
-  Json reopened_document;
-  ASSIGN_OR_RETURN(reopened_document,
-                   ParseBundleDocument(reopened_canonical,
-                                       "Published canonical message bundle"));
+  auto reopened_canonical_or =
+      ReadTextFile(canonical_bundle_path, "published canonical message bundle");
+  if (!reopened_canonical_or.ok()) {
+    return RollBackPublication(&artifacts, reopened_canonical_or.status());
+  }
+  std::string reopened_canonical = std::move(*reopened_canonical_or);
+  auto reopened_document_or = ParseBundleDocument(
+      reopened_canonical, "Published canonical message bundle");
+  if (!reopened_document_or.ok()) {
+    return RollBackPublication(&artifacts, reopened_document_or.status());
+  }
+  Json reopened_document = std::move(*reopened_document_or);
   auto reopened_bank_or = ParseExpandedBank(
       reopened_document, layout.expanded_count,
       /*require_complete=*/true, "Published canonical message bundle");
@@ -1100,11 +1343,7 @@ absl::StatusOr<MessageSourceSyncResult> SyncMessageSource(
             "Published canonical message bundle SHA-256 readback failed"));
   }
 
-  for (const auto& artifact : artifacts) {
-    if (artifact.backup.has_value()) {
-      result.backup_paths.push_back(*artifact.backup);
-    }
-  }
+  CleanupBackups(artifacts);
   result.wrote = true;
   return result;
 }

--- a/src/app/editor/message/message_source_sync.cc
+++ b/src/app/editor/message/message_source_sync.cc
@@ -58,7 +58,7 @@ struct ExpandedSourceMessage {
 
 using ExpandedSourceBank = std::map<int, ExpandedSourceMessage>;
 
-constexpr char kSourceSyncLockFilename[] = ".yaze-message-source-sync.lock";
+constexpr char kSourceSyncLockBasename[] = ".yaze-message-source-sync.lock";
 
 struct PublicationArtifact {
   fs::path target;
@@ -74,121 +74,126 @@ std::mutex& MessageSourceWriteMutex() {
   return mutex;
 }
 
-class MessageSourceWriteLock {
+class MessageSourceWriteLocks {
  public:
-  static absl::StatusOr<std::unique_ptr<MessageSourceWriteLock>> Acquire(
-      const fs::path& project_root) {
+  static absl::StatusOr<std::unique_ptr<MessageSourceWriteLocks>> Acquire(
+      const std::vector<fs::path>& lock_paths) {
+    if (lock_paths.empty()) {
+      return absl::InvalidArgumentError(
+          "Message source publication requires at least one lock");
+    }
     auto lock =
-        std::unique_ptr<MessageSourceWriteLock>(new MessageSourceWriteLock());
+        std::unique_ptr<MessageSourceWriteLocks>(new MessageSourceWriteLocks());
     lock->process_lock_ =
         std::unique_lock<std::mutex>(MessageSourceWriteMutex());
-    lock->path_ = project_root / kSourceSyncLockFilename;
 
 #if defined(_WIN32)
-    lock->handle_ =
-        CreateFileW(lock->path_.wstring().c_str(), GENERIC_READ | GENERIC_WRITE,
-                    FILE_SHARE_READ | FILE_SHARE_WRITE, nullptr, OPEN_ALWAYS,
-                    FILE_ATTRIBUTE_NORMAL, nullptr);
-    if (lock->handle_ == INVALID_HANDLE_VALUE) {
-      const DWORD error = GetLastError();
-      return absl::PermissionDeniedError(absl::StrFormat(
-          "Cannot open message source lock %s: %s", lock->path_.string(),
-          std::error_code(static_cast<int>(error), std::system_category())
-              .message()));
-    }
-    if (!LockFileEx(lock->handle_, LOCKFILE_EXCLUSIVE_LOCK, 0, MAXDWORD,
-                    MAXDWORD, &lock->overlapped_)) {
-      const DWORD error = GetLastError();
-      CloseHandle(lock->handle_);
-      lock->handle_ = INVALID_HANDLE_VALUE;
-      return absl::UnavailableError(absl::StrFormat(
-          "Cannot acquire message source lock %s: %s", lock->path_.string(),
-          std::error_code(static_cast<int>(error), std::system_category())
-              .message()));
+    lock->handles_.reserve(lock_paths.size());
+    for (const fs::path& path : lock_paths) {
+      HANDLE handle =
+          CreateFileW(path.wstring().c_str(), GENERIC_READ | GENERIC_WRITE,
+                      FILE_SHARE_READ | FILE_SHARE_WRITE, nullptr, OPEN_ALWAYS,
+                      FILE_ATTRIBUTE_NORMAL, nullptr);
+      if (handle == INVALID_HANDLE_VALUE) {
+        const DWORD error = GetLastError();
+        return absl::PermissionDeniedError(absl::StrFormat(
+            "Cannot open message source lock %s: %s", path.string(),
+            std::error_code(static_cast<int>(error), std::system_category())
+                .message()));
+      }
+      OVERLAPPED overlapped = {};
+      if (!LockFileEx(handle, LOCKFILE_EXCLUSIVE_LOCK, 0, MAXDWORD, MAXDWORD,
+                      &overlapped)) {
+        const DWORD error = GetLastError();
+        CloseHandle(handle);
+        return absl::UnavailableError(absl::StrFormat(
+            "Cannot acquire message source lock %s: %s", path.string(),
+            std::error_code(static_cast<int>(error), std::system_category())
+                .message()));
+      }
+      lock->handles_.push_back(handle);
     }
 #elif defined(__EMSCRIPTEN__)
     return absl::FailedPreconditionError(
         "Durable message source locking is unavailable in browser builds");
 #else
-    int open_flags = O_RDWR | O_CREAT;
+    lock->fds_.reserve(lock_paths.size());
+    for (const fs::path& path : lock_paths) {
+      int open_flags = O_RDWR | O_CREAT;
 #ifdef O_CLOEXEC
-    open_flags |= O_CLOEXEC;
+      open_flags |= O_CLOEXEC;
 #endif
 #ifdef O_NOFOLLOW
-    open_flags |= O_NOFOLLOW;
+      open_flags |= O_NOFOLLOW;
 #endif
-    lock->fd_ = open(lock->path_.c_str(), open_flags, S_IRUSR | S_IWUSR);
-    if (lock->fd_ < 0) {
-      return absl::PermissionDeniedError(absl::StrFormat(
-          "Cannot open message source lock %s: %s", lock->path_.string(),
-          std::error_code(errno, std::generic_category()).message()));
-    }
-    struct stat lock_stat{};
-    if (fstat(lock->fd_, &lock_stat) != 0) {
-      const int error = errno;
-      close(lock->fd_);
-      lock->fd_ = -1;
-      return absl::FailedPreconditionError(absl::StrFormat(
-          "Cannot inspect message source lock %s: %s", lock->path_.string(),
-          std::error_code(error, std::generic_category()).message()));
-    }
-    if (!S_ISREG(lock_stat.st_mode)) {
-      close(lock->fd_);
-      lock->fd_ = -1;
-      return absl::FailedPreconditionError(
-          absl::StrFormat("Message source lock must be a regular file: %s",
-                          lock->path_.string()));
-    }
-    if (fchmod(lock->fd_, S_IRUSR | S_IWUSR) != 0) {
-      const int error = errno;
-      close(lock->fd_);
-      lock->fd_ = -1;
-      return absl::PermissionDeniedError(absl::StrFormat(
-          "Cannot secure message source lock %s: %s", lock->path_.string(),
-          std::error_code(error, std::generic_category()).message()));
-    }
-    while (flock(lock->fd_, LOCK_EX) != 0) {
-      if (errno == EINTR) {
-        continue;
+      const int fd = open(path.c_str(), open_flags, S_IRUSR | S_IWUSR);
+      if (fd < 0) {
+        return absl::PermissionDeniedError(absl::StrFormat(
+            "Cannot open message source lock %s: %s", path.string(),
+            std::error_code(errno, std::generic_category()).message()));
       }
-      const int error = errno;
-      close(lock->fd_);
-      lock->fd_ = -1;
-      return absl::UnavailableError(absl::StrFormat(
-          "Cannot acquire message source lock %s: %s", lock->path_.string(),
-          std::error_code(error, std::generic_category()).message()));
+      struct stat lock_stat{};
+      if (fstat(fd, &lock_stat) != 0) {
+        const int error = errno;
+        close(fd);
+        return absl::FailedPreconditionError(absl::StrFormat(
+            "Cannot inspect message source lock %s: %s", path.string(),
+            std::error_code(error, std::generic_category()).message()));
+      }
+      if (!S_ISREG(lock_stat.st_mode)) {
+        close(fd);
+        return absl::FailedPreconditionError(absl::StrFormat(
+            "Message source lock must be a regular file: %s", path.string()));
+      }
+      if (fchmod(fd, S_IRUSR | S_IWUSR) != 0) {
+        const int error = errno;
+        close(fd);
+        return absl::PermissionDeniedError(absl::StrFormat(
+            "Cannot secure message source lock %s: %s", path.string(),
+            std::error_code(error, std::generic_category()).message()));
+      }
+      while (flock(fd, LOCK_EX) != 0) {
+        if (errno == EINTR) {
+          continue;
+        }
+        const int error = errno;
+        close(fd);
+        return absl::UnavailableError(absl::StrFormat(
+            "Cannot acquire message source lock %s: %s", path.string(),
+            std::error_code(error, std::generic_category()).message()));
+      }
+      lock->fds_.push_back(fd);
     }
 #endif
     return lock;
   }
 
-  ~MessageSourceWriteLock() {
+  ~MessageSourceWriteLocks() {
 #if defined(_WIN32)
-    if (handle_ != INVALID_HANDLE_VALUE) {
-      UnlockFileEx(handle_, 0, MAXDWORD, MAXDWORD, &overlapped_);
-      CloseHandle(handle_);
+    for (auto it = handles_.rbegin(); it != handles_.rend(); ++it) {
+      OVERLAPPED overlapped = {};
+      UnlockFileEx(*it, 0, MAXDWORD, MAXDWORD, &overlapped);
+      CloseHandle(*it);
     }
 #elif !defined(__EMSCRIPTEN__)
-    if (fd_ >= 0) {
-      while (flock(fd_, LOCK_UN) != 0 && errno == EINTR) {}
-      close(fd_);
+    for (auto it = fds_.rbegin(); it != fds_.rend(); ++it) {
+      while (flock(*it, LOCK_UN) != 0 && errno == EINTR) {}
+      close(*it);
     }
 #endif
   }
 
-  MessageSourceWriteLock(const MessageSourceWriteLock&) = delete;
-  MessageSourceWriteLock& operator=(const MessageSourceWriteLock&) = delete;
+  MessageSourceWriteLocks(const MessageSourceWriteLocks&) = delete;
+  MessageSourceWriteLocks& operator=(const MessageSourceWriteLocks&) = delete;
 
  private:
-  MessageSourceWriteLock() = default;
+  MessageSourceWriteLocks() = default;
 
-  fs::path path_;
   std::unique_lock<std::mutex> process_lock_;
 #if defined(_WIN32)
-  HANDLE handle_ = INVALID_HANDLE_VALUE;
-  OVERLAPPED overlapped_ = {};
+  std::vector<HANDLE> handles_;
 #elif !defined(__EMSCRIPTEN__)
-  int fd_ = -1;
+  std::vector<int> fds_;
 #endif
 };
 
@@ -316,6 +321,27 @@ absl::StatusOr<std::string> ReadTextFile(const fs::path& path,
   return content;
 }
 
+bool ReadBoundedNonnegativeInteger(const Json& value, uint64_t maximum,
+                                   uint64_t* parsed) {
+  if (value.is_number_unsigned()) {
+    const uint64_t candidate = value.get<uint64_t>();
+    if (candidate > maximum) {
+      return false;
+    }
+    *parsed = candidate;
+    return true;
+  }
+  if (!value.is_number_integer()) {
+    return false;
+  }
+  const int64_t candidate = value.get<int64_t>();
+  if (candidate < 0 || static_cast<uint64_t>(candidate) > maximum) {
+    return false;
+  }
+  *parsed = static_cast<uint64_t>(candidate);
+  return true;
+}
+
 absl::StatusOr<Json> ParseBundleDocument(std::string_view content,
                                          absl::string_view label) {
   Json document;
@@ -334,15 +360,36 @@ absl::StatusOr<Json> ParseBundleDocument(std::string_view content,
     return absl::InvalidArgumentError(
         absl::StrFormat("%s format must be 'yaze-message-bundle'", label));
   }
+  uint64_t version = 0;
   if (!document.contains("version") ||
-      !document["version"].is_number_integer() ||
-      document["version"].get<int>() != kMessageBundleVersion) {
+      !ReadBoundedNonnegativeInteger(
+          document["version"],
+          static_cast<uint64_t>(std::numeric_limits<int>::max()), &version) ||
+      version != static_cast<uint64_t>(kMessageBundleVersion)) {
     return absl::InvalidArgumentError(absl::StrFormat(
         "%s version must be integer %d", label, kMessageBundleVersion));
   }
   if (!document.contains("messages") || !document["messages"].is_array()) {
     return absl::InvalidArgumentError(
         absl::StrFormat("%s must contain a messages array", label));
+  }
+  if (document.contains("counts")) {
+    uint64_t expanded_count = 0;
+    uint64_t vanilla_count = 0;
+    if (!document["counts"].is_object() ||
+        !document["counts"].contains("expanded") ||
+        !ReadBoundedNonnegativeInteger(
+            document["counts"]["expanded"],
+            static_cast<uint64_t>(std::numeric_limits<int>::max()),
+            &expanded_count) ||
+        !document["counts"].contains("vanilla") ||
+        !ReadBoundedNonnegativeInteger(
+            document["counts"]["vanilla"],
+            static_cast<uint64_t>(std::numeric_limits<int>::max()),
+            &vanilla_count)) {
+      return absl::InvalidArgumentError(absl::StrFormat(
+          "%s counts must use bounded non-negative integers", label));
+    }
   }
   return document;
 }
@@ -411,17 +458,16 @@ absl::StatusOr<ExpandedSourceBank> ParseExpandedBank(const Json& document,
       return absl::InvalidArgumentError(
           absl::StrFormat("%s message entry must be an object", label));
     }
-    if (!entry.contains("id") || !entry["id"].is_number_integer()) {
+    uint64_t id_value = 0;
+    if (!entry.contains("id") ||
+        !ReadBoundedNonnegativeInteger(
+            entry["id"], static_cast<uint64_t>(expected_count - 1),
+            &id_value)) {
       return absl::InvalidArgumentError(
-          absl::StrFormat("%s message entry has no integer id", label));
+          absl::StrFormat("%s message entry ID must be an integer in [0, %d)",
+                          label, expected_count));
     }
-    const int64_t id64 = entry["id"].get<int64_t>();
-    if (id64 < 0 || id64 >= expected_count) {
-      return absl::OutOfRangeError(absl::StrFormat(
-          "%s expanded message ID %d is outside bank-local range [0, %d)",
-          label, id64, expected_count));
-    }
-    const int id = static_cast<int>(id64);
+    const int id = static_cast<int>(id_value);
     if (!entry.contains("bank") || !entry["bank"].is_string() ||
         entry["bank"].get<std::string>() != "expanded") {
       return absl::InvalidArgumentError(absl::StrFormat(
@@ -473,7 +519,7 @@ absl::StatusOr<ExpandedSourceBank> ParseExpandedBank(const Json& document,
         absl::StrFormat("%s has no expanded messages", label));
   }
   if (require_complete) {
-    if (static_cast<int>(bank.size()) != expected_count) {
+    if (bank.size() != static_cast<size_t>(expected_count)) {
       return absl::FailedPreconditionError(absl::StrFormat(
           "%s must contain the complete expanded bank: expected %d entries, "
           "found %zu",
@@ -485,13 +531,21 @@ absl::StatusOr<ExpandedSourceBank> ParseExpandedBank(const Json& document,
             "%s is missing bank-local expanded message ID %d", label, id));
       }
     }
+    uint64_t expanded_count = 0;
+    uint64_t vanilla_count = 0;
     if (!document.contains("counts") || !document["counts"].is_object() ||
         !document["counts"].contains("expanded") ||
-        !document["counts"]["expanded"].is_number_integer() ||
-        document["counts"]["expanded"].get<int>() != expected_count ||
+        !ReadBoundedNonnegativeInteger(
+            document["counts"]["expanded"],
+            static_cast<uint64_t>(std::numeric_limits<int>::max()),
+            &expanded_count) ||
+        expanded_count != static_cast<uint64_t>(expected_count) ||
         !document["counts"].contains("vanilla") ||
-        !document["counts"]["vanilla"].is_number_integer() ||
-        document["counts"]["vanilla"].get<int>() != 0) {
+        !ReadBoundedNonnegativeInteger(
+            document["counts"]["vanilla"],
+            static_cast<uint64_t>(std::numeric_limits<int>::max()),
+            &vanilla_count) ||
+        vanilla_count != 0) {
       return absl::FailedPreconditionError(
           absl::StrFormat("%s counts must declare vanilla=0 and expanded=%d",
                           label, expected_count));
@@ -546,7 +600,7 @@ std::string RenderAsmInclude(const ExpandedSourceBank& bank,
              "; Source bundle SHA-256: %s\n"
              "; Generated ASM body SHA-256: %s\n"
              "; Generated by yaze message-source-sync. Do not edit.\n\n",
-             source_sha256, Sha256Hex(body)) +
+             std::string(source_sha256), Sha256Hex(body)) +
          body;
 }
 
@@ -709,51 +763,98 @@ absl::Status ValidateDistinctTargets(const fs::path& bundle_path,
   return absl::OkStatus();
 }
 
-absl::Status ValidateTargetsDoNotAliasLock(const fs::path& lock_path,
-                                           const fs::path& bundle_path,
-                                           const fs::path& include_path) {
+absl::StatusOr<std::vector<fs::path>> PublicationLockPaths(
+    const fs::path& bundle_path, const fs::path& include_path) {
+  std::vector<fs::path> lock_paths;
   for (const fs::path* target : {&bundle_path, &include_path}) {
-    if (*target == lock_path ||
-        LowercasePath(*target) == LowercasePath(lock_path)) {
-      return absl::InvalidArgumentError(absl::StrFormat(
-          "Message source targets may not use the persistent lock path: %s",
-          lock_path.string()));
+    std::error_code canonical_ec;
+    const fs::path parent = fs::canonical(target->parent_path(), canonical_ec);
+    if (canonical_ec) {
+      return absl::FailedPreconditionError(absl::StrFormat(
+          "Cannot resolve message source target directory %s: %s",
+          target->parent_path().string(), canonical_ec.message()));
+    }
+
+    bool duplicate = false;
+    for (const fs::path& existing_lock : lock_paths) {
+      std::error_code equivalent_ec;
+      const bool equivalent =
+          fs::equivalent(parent, existing_lock.parent_path(), equivalent_ec);
+      if (equivalent_ec) {
+        return absl::FailedPreconditionError(absl::StrFormat(
+            "Cannot compare message source target directories %s and %s: %s",
+            parent.string(), existing_lock.parent_path().string(),
+            equivalent_ec.message()));
+      }
+      if (equivalent) {
+        duplicate = true;
+        break;
+      }
+    }
+    if (!duplicate) {
+      lock_paths.push_back(parent / kSourceSyncLockBasename);
     }
   }
 
-  std::error_code lock_exists_ec;
-  const bool lock_exists = fs::exists(lock_path, lock_exists_ec);
-  if (lock_exists_ec) {
-    return absl::FailedPreconditionError(
-        absl::StrFormat("Cannot inspect persistent message source lock %s: %s",
-                        lock_path.string(), lock_exists_ec.message()));
-  }
-  if (!lock_exists) {
-    return absl::OkStatus();
-  }
+  std::sort(lock_paths.begin(), lock_paths.end(),
+            [](const fs::path& left, const fs::path& right) {
+              const std::string left_lower = LowercasePath(left);
+              const std::string right_lower = LowercasePath(right);
+              return left_lower == right_lower
+                         ? left.generic_string() < right.generic_string()
+                         : left_lower < right_lower;
+            });
+  return lock_paths;
+}
 
-  for (const fs::path* target : {&bundle_path, &include_path}) {
-    std::error_code target_exists_ec;
-    const bool target_exists = fs::exists(*target, target_exists_ec);
-    if (target_exists_ec) {
-      return absl::FailedPreconditionError(
-          absl::StrFormat("Cannot inspect message source target %s: %s",
-                          target->string(), target_exists_ec.message()));
+absl::Status ValidateTargetsDoNotAliasLocks(
+    const std::vector<fs::path>& lock_paths, const fs::path& bundle_path,
+    const fs::path& include_path) {
+  for (const fs::path& lock_path : lock_paths) {
+    for (const fs::path* target : {&bundle_path, &include_path}) {
+      if (*target == lock_path ||
+          LowercasePath(*target) == LowercasePath(lock_path)) {
+        return absl::InvalidArgumentError(absl::StrFormat(
+            "Message source targets may not use a persistent lock path: %s",
+            lock_path.string()));
+      }
     }
-    if (!target_exists) {
+
+    std::error_code lock_exists_ec;
+    const bool lock_exists = fs::exists(lock_path, lock_exists_ec);
+    if (lock_exists_ec) {
+      return absl::FailedPreconditionError(absl::StrFormat(
+          "Cannot inspect persistent message source lock %s: %s",
+          lock_path.string(), lock_exists_ec.message()));
+    }
+    if (!lock_exists) {
       continue;
     }
-    std::error_code equivalent_ec;
-    const bool equivalent = fs::equivalent(lock_path, *target, equivalent_ec);
-    if (equivalent_ec) {
-      return absl::FailedPreconditionError(absl::StrFormat(
-          "Cannot compare message source target %s with persistent lock %s: %s",
-          target->string(), lock_path.string(), equivalent_ec.message()));
-    }
-    if (equivalent) {
-      return absl::InvalidArgumentError(absl::StrFormat(
-          "Message source target aliases the persistent lock path: %s",
-          target->string()));
+
+    for (const fs::path* target : {&bundle_path, &include_path}) {
+      std::error_code target_exists_ec;
+      const bool target_exists = fs::exists(*target, target_exists_ec);
+      if (target_exists_ec) {
+        return absl::FailedPreconditionError(
+            absl::StrFormat("Cannot inspect message source target %s: %s",
+                            target->string(), target_exists_ec.message()));
+      }
+      if (!target_exists) {
+        continue;
+      }
+      std::error_code equivalent_ec;
+      const bool equivalent = fs::equivalent(lock_path, *target, equivalent_ec);
+      if (equivalent_ec) {
+        return absl::FailedPreconditionError(absl::StrFormat(
+            "Cannot compare message source target %s with persistent lock %s: "
+            "%s",
+            target->string(), lock_path.string(), equivalent_ec.message()));
+      }
+      if (equivalent) {
+        return absl::InvalidArgumentError(absl::StrFormat(
+            "Message source target aliases a persistent lock path: %s",
+            target->string()));
+      }
     }
   }
   return absl::OkStatus();
@@ -1322,9 +1423,12 @@ absl::StatusOr<MessageSourceSyncResult> SyncMessageSource(
                        /*must_exist=*/false, "Generated message ASM include"));
   RETURN_IF_ERROR(
       ValidateDistinctTargets(canonical_bundle_path, asm_include_path));
-  const fs::path source_lock_path = project_root / kSourceSyncLockFilename;
-  RETURN_IF_ERROR(ValidateTargetsDoNotAliasLock(
-      source_lock_path, canonical_bundle_path, asm_include_path));
+  std::vector<fs::path> publication_lock_paths;
+  ASSIGN_OR_RETURN(
+      publication_lock_paths,
+      PublicationLockPaths(canonical_bundle_path, asm_include_path));
+  RETURN_IF_ERROR(ValidateTargetsDoNotAliasLocks(
+      publication_lock_paths, canonical_bundle_path, asm_include_path));
 
   std::error_code incoming_ec;
   const fs::path resolved_incoming =
@@ -1337,7 +1441,7 @@ absl::StatusOr<MessageSourceSyncResult> SyncMessageSource(
   }
 
   std::string expected_sha;
-  std::unique_ptr<MessageSourceWriteLock> write_lock;
+  std::unique_ptr<MessageSourceWriteLocks> write_locks;
   if (options.write) {
     if (options.expected_source_sha256.empty()) {
       return absl::InvalidArgumentError(
@@ -1345,7 +1449,8 @@ absl::StatusOr<MessageSourceSyncResult> SyncMessageSource(
     }
     ASSIGN_OR_RETURN(expected_sha,
                      NormalizeExpectedSha256(options.expected_source_sha256));
-    ASSIGN_OR_RETURN(write_lock, MessageSourceWriteLock::Acquire(project_root));
+    ASSIGN_OR_RETURN(write_locks,
+                     MessageSourceWriteLocks::Acquire(publication_lock_paths));
   }
 
   std::string canonical_before;

--- a/src/app/editor/message/message_source_sync.cc
+++ b/src/app/editor/message/message_source_sync.cc
@@ -1,0 +1,1112 @@
+#include "app/editor/message/message_source_sync.h"
+
+#include <algorithm>
+#include <array>
+#include <atomic>
+#include <cctype>
+#include <cerrno>
+#include <chrono>
+#include <cstdint>
+#include <cstring>
+#include <exception>
+#include <filesystem>
+#include <fstream>
+#include <iterator>
+#include <limits>
+#include <map>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <system_error>
+#include <utility>
+#include <vector>
+
+#include "absl/status/status.h"
+#include "absl/strings/ascii.h"
+#include "absl/strings/match.h"
+#include "absl/strings/str_cat.h"
+#include "absl/strings/str_format.h"
+#include "app/editor/message/message_data.h"
+#include "nlohmann/json.hpp"
+#include "rom/snes.h"
+#include "util/macro.h"
+
+#if defined(_WIN32)
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+#include <windows.h>
+#else
+#include <fcntl.h>
+#include <unistd.h>
+#endif
+
+namespace yaze::editor {
+namespace {
+
+namespace fs = std::filesystem;
+using Json = nlohmann::json;
+
+struct ExpandedSourceMessage {
+  std::string text;
+  std::vector<uint8_t> bytes;
+};
+
+using ExpandedSourceBank = std::map<int, ExpandedSourceMessage>;
+
+struct PublicationArtifact {
+  fs::path target;
+  std::string content;
+  std::optional<std::string> original_content;
+  fs::path temp;
+  std::optional<fs::path> backup;
+  bool published = false;
+};
+
+constexpr uint32_t kSha256Constants[64] = {
+    0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5, 0x3956c25b, 0x59f111f1,
+    0x923f82a4, 0xab1c5ed5, 0xd807aa98, 0x12835b01, 0x243185be, 0x550c7dc3,
+    0x72be5d74, 0x80deb1fe, 0x9bdc06a7, 0xc19bf174, 0xe49b69c1, 0xefbe4786,
+    0x0fc19dc6, 0x240ca1cc, 0x2de92c6f, 0x4a7484aa, 0x5cb0a9dc, 0x76f988da,
+    0x983e5152, 0xa831c66d, 0xb00327c8, 0xbf597fc7, 0xc6e00bf3, 0xd5a79147,
+    0x06ca6351, 0x14292967, 0x27b70a85, 0x2e1b2138, 0x4d2c6dfc, 0x53380d13,
+    0x650a7354, 0x766a0abb, 0x81c2c92e, 0x92722c85, 0xa2bfe8a1, 0xa81a664b,
+    0xc24b8b70, 0xc76c51a3, 0xd192e819, 0xd6990624, 0xf40e3585, 0x106aa070,
+    0x19a4c116, 0x1e376c08, 0x2748774c, 0x34b0bcb5, 0x391c0cb3, 0x4ed8aa4a,
+    0x5b9cca4f, 0x682e6ff3, 0x748f82ee, 0x78a5636f, 0x84c87814, 0x8cc70208,
+    0x90befffa, 0xa4506ceb, 0xbef9a3f7, 0xc67178f2};
+
+constexpr uint32_t RotateRight(uint32_t value, uint32_t count) {
+  return (value >> count) | (value << (32 - count));
+}
+
+void TransformSha256(uint32_t state[8], const uint8_t block[64]) {
+  uint32_t schedule[64];
+  for (int index = 0; index < 16; ++index) {
+    schedule[index] = (static_cast<uint32_t>(block[index * 4]) << 24) |
+                      (static_cast<uint32_t>(block[index * 4 + 1]) << 16) |
+                      (static_cast<uint32_t>(block[index * 4 + 2]) << 8) |
+                      static_cast<uint32_t>(block[index * 4 + 3]);
+  }
+  for (int index = 16; index < 64; ++index) {
+    const uint32_t low = RotateRight(schedule[index - 15], 7) ^
+                         RotateRight(schedule[index - 15], 18) ^
+                         (schedule[index - 15] >> 3);
+    const uint32_t high = RotateRight(schedule[index - 2], 17) ^
+                          RotateRight(schedule[index - 2], 19) ^
+                          (schedule[index - 2] >> 10);
+    schedule[index] = schedule[index - 16] + low + schedule[index - 7] + high;
+  }
+
+  uint32_t a = state[0];
+  uint32_t b = state[1];
+  uint32_t c = state[2];
+  uint32_t d = state[3];
+  uint32_t e = state[4];
+  uint32_t f = state[5];
+  uint32_t g = state[6];
+  uint32_t h = state[7];
+  for (int index = 0; index < 64; ++index) {
+    const uint32_t sigma1 =
+        RotateRight(e, 6) ^ RotateRight(e, 11) ^ RotateRight(e, 25);
+    const uint32_t choose = (e & f) ^ ((~e) & g);
+    const uint32_t temp1 =
+        h + sigma1 + choose + kSha256Constants[index] + schedule[index];
+    const uint32_t sigma0 =
+        RotateRight(a, 2) ^ RotateRight(a, 13) ^ RotateRight(a, 22);
+    const uint32_t majority = (a & b) ^ (a & c) ^ (b & c);
+    const uint32_t temp2 = sigma0 + majority;
+    h = g;
+    g = f;
+    f = e;
+    e = d + temp1;
+    d = c;
+    c = b;
+    b = a;
+    a = temp1 + temp2;
+  }
+
+  state[0] += a;
+  state[1] += b;
+  state[2] += c;
+  state[3] += d;
+  state[4] += e;
+  state[5] += f;
+  state[6] += g;
+  state[7] += h;
+}
+
+std::string Sha256Hex(std::string_view content) {
+  uint32_t state[8] = {0x6a09e667, 0xbb67ae85, 0x3c6ef372, 0xa54ff53a,
+                       0x510e527f, 0x9b05688c, 0x1f83d9ab, 0x5be0cd19};
+  const auto* cursor = reinterpret_cast<const uint8_t*>(content.data());
+  size_t remaining = content.size();
+  while (remaining >= 64) {
+    TransformSha256(state, cursor);
+    cursor += 64;
+    remaining -= 64;
+  }
+
+  uint8_t block[64] = {};
+  if (remaining > 0) {
+    std::memcpy(block, cursor, remaining);
+  }
+  block[remaining] = 0x80;
+  if (remaining >= 56) {
+    TransformSha256(state, block);
+    std::memset(block, 0, sizeof(block));
+  }
+  const uint64_t bit_length = static_cast<uint64_t>(content.size()) * 8;
+  for (int index = 0; index < 8; ++index) {
+    block[63 - index] =
+        static_cast<uint8_t>(bit_length >> (static_cast<uint64_t>(index) * 8));
+  }
+  TransformSha256(state, block);
+
+  std::string digest;
+  digest.reserve(64);
+  for (uint32_t value : state) {
+    absl::StrAppend(&digest, absl::StrFormat("%08x", value));
+  }
+  return digest;
+}
+
+absl::StatusOr<std::string> ReadTextFile(const fs::path& path,
+                                         absl::string_view label) {
+  std::ifstream input(path, std::ios::binary);
+  if (!input.is_open()) {
+    return absl::NotFoundError(
+        absl::StrFormat("Cannot open %s: %s", label, path.string()));
+  }
+  std::string content{std::istreambuf_iterator<char>(input),
+                      std::istreambuf_iterator<char>()};
+  if (!input.good() && !input.eof()) {
+    return absl::DataLossError(
+        absl::StrFormat("Failed while reading %s: %s", label, path.string()));
+  }
+  return content;
+}
+
+absl::StatusOr<Json> ParseBundleDocument(std::string_view content,
+                                         absl::string_view label) {
+  Json document;
+  try {
+    document = Json::parse(content);
+  } catch (const std::exception& error) {
+    return absl::InvalidArgumentError(
+        absl::StrFormat("%s is not valid JSON: %s", label, error.what()));
+  }
+  if (!document.is_object()) {
+    return absl::InvalidArgumentError(
+        absl::StrFormat("%s must be a JSON object", label));
+  }
+  if (!document.contains("format") || !document["format"].is_string() ||
+      document["format"].get<std::string>() != "yaze-message-bundle") {
+    return absl::InvalidArgumentError(
+        absl::StrFormat("%s format must be 'yaze-message-bundle'", label));
+  }
+  if (!document.contains("version") ||
+      !document["version"].is_number_integer() ||
+      document["version"].get<int>() != kMessageBundleVersion) {
+    return absl::InvalidArgumentError(absl::StrFormat(
+        "%s version must be integer %d", label, kMessageBundleVersion));
+  }
+  if (!document.contains("messages") || !document["messages"].is_array()) {
+    return absl::InvalidArgumentError(
+        absl::StrFormat("%s must contain a messages array", label));
+  }
+  return document;
+}
+
+absl::StatusOr<std::string> SelectEntryText(const Json& entry, int id,
+                                            absl::string_view label) {
+  // `text` is the editable canonical field. Rich exports may retain stale
+  // raw/parsed diagnostics beside a deliberately changed text value.
+  for (absl::string_view key : {"text", "raw", "parsed"}) {
+    const std::string key_string(key);
+    if (!entry.contains(key_string)) {
+      continue;
+    }
+    if (!entry[key_string].is_string()) {
+      return absl::InvalidArgumentError(
+          absl::StrFormat("%s expanded message %d field '%s' must be a string",
+                          label, id, key));
+    }
+    return entry[key_string].get<std::string>();
+  }
+  return absl::InvalidArgumentError(absl::StrFormat(
+      "%s expanded message %d has no raw, text, or parsed string", label, id));
+}
+
+std::string NormalizeLegacyDictionaryTokens(std::string text) {
+  size_t search_from = 0;
+  while (true) {
+    const size_t token_start = text.find("[D:", search_from);
+    if (token_start == std::string::npos) {
+      break;
+    }
+    size_t value_start = token_start + 3;
+    if (value_start < text.size() && text[value_start] == '$') {
+      ++value_start;
+    }
+    const size_t token_end = text.find(']', value_start);
+    if (token_end == std::string::npos) {
+      break;
+    }
+    const size_t digit_count = token_end - value_start;
+    const bool valid_digits =
+        digit_count >= 1 && digit_count <= 2 &&
+        std::all_of(text.begin() + static_cast<std::ptrdiff_t>(value_start),
+                    text.begin() + static_cast<std::ptrdiff_t>(token_end),
+                    [](unsigned char c) { return std::isxdigit(c) != 0; });
+    if (!valid_digits) {
+      search_from = token_end + 1;
+      continue;
+    }
+    const int dictionary_id =
+        std::stoi(text.substr(value_start, digit_count), nullptr, 16);
+    const std::string normalized = absl::StrFormat("[D:%02X]", dictionary_id);
+    text.replace(token_start, token_end - token_start + 1, normalized);
+    search_from = token_start + normalized.size();
+  }
+  return text;
+}
+
+absl::StatusOr<ExpandedSourceBank> ParseExpandedBank(const Json& document,
+                                                     int expected_count,
+                                                     bool require_complete,
+                                                     absl::string_view label) {
+  ExpandedSourceBank bank;
+  for (const Json& entry : document["messages"]) {
+    if (!entry.is_object()) {
+      return absl::InvalidArgumentError(
+          absl::StrFormat("%s message entry must be an object", label));
+    }
+    if (!entry.contains("id") || !entry["id"].is_number_integer()) {
+      return absl::InvalidArgumentError(
+          absl::StrFormat("%s message entry has no integer id", label));
+    }
+    const int64_t id64 = entry["id"].get<int64_t>();
+    if (id64 < 0 || id64 >= expected_count) {
+      return absl::OutOfRangeError(absl::StrFormat(
+          "%s expanded message ID %d is outside bank-local range [0, %d)",
+          label, id64, expected_count));
+    }
+    const int id = static_cast<int>(id64);
+    if (!entry.contains("bank") || !entry["bank"].is_string() ||
+        entry["bank"].get<std::string>() != "expanded") {
+      return absl::InvalidArgumentError(absl::StrFormat(
+          "%s message %d must declare bank 'expanded'", label, id));
+    }
+    if (bank.contains(id)) {
+      return absl::InvalidArgumentError(absl::StrFormat(
+          "%s contains duplicate expanded message ID %d", label, id));
+    }
+
+    std::string text;
+    ASSIGN_OR_RETURN(text, SelectEntryText(entry, id, label));
+    text = NormalizeLegacyDictionaryTokens(std::move(text));
+    if (absl::StrContains(text, "[BANK]")) {
+      return absl::InvalidArgumentError(absl::StrFormat(
+          "%s expanded message %d contains [BANK], which is only valid in "
+          "the vanilla message stream",
+          label, id));
+    }
+    MessageParseResult parsed;
+    try {
+      parsed = ParseMessageToDataWithDiagnostics(text);
+    } catch (const std::exception& error) {
+      return absl::InvalidArgumentError(
+          absl::StrFormat("%s expanded message %d cannot be parsed safely: %s",
+                          label, id, error.what()));
+    } catch (...) {
+      return absl::InvalidArgumentError(absl::StrFormat(
+          "%s expanded message %d cannot be parsed safely", label, id));
+    }
+    if (!parsed.ok()) {
+      return absl::InvalidArgumentError(
+          absl::StrFormat("%s expanded message %d is invalid: %s", label, id,
+                          parsed.errors.front()));
+    }
+    if (!parsed.warnings.empty()) {
+      return absl::InvalidArgumentError(
+          absl::StrFormat("%s expanded message %d is not source-stable: %s",
+                          label, id, parsed.warnings.front()));
+    }
+    bank.emplace(id, ExpandedSourceMessage{
+                         .text = std::move(text),
+                         .bytes = std::move(parsed.bytes),
+                     });
+  }
+
+  if (bank.empty()) {
+    return absl::InvalidArgumentError(
+        absl::StrFormat("%s has no expanded messages", label));
+  }
+  if (require_complete) {
+    if (static_cast<int>(bank.size()) != expected_count) {
+      return absl::FailedPreconditionError(absl::StrFormat(
+          "%s must contain the complete expanded bank: expected %d entries, "
+          "found %zu",
+          label, expected_count, bank.size()));
+    }
+    for (int id = 0; id < expected_count; ++id) {
+      if (!bank.contains(id)) {
+        return absl::FailedPreconditionError(absl::StrFormat(
+            "%s is missing bank-local expanded message ID %d", label, id));
+      }
+    }
+    if (!document.contains("counts") || !document["counts"].is_object() ||
+        !document["counts"].contains("expanded") ||
+        !document["counts"]["expanded"].is_number_integer() ||
+        document["counts"]["expanded"].get<int>() != expected_count ||
+        !document["counts"].contains("vanilla") ||
+        !document["counts"]["vanilla"].is_number_integer() ||
+        document["counts"]["vanilla"].get<int>() != 0) {
+      return absl::FailedPreconditionError(
+          absl::StrFormat("%s counts must declare vanilla=0 and expanded=%d",
+                          label, expected_count));
+    }
+  }
+  return bank;
+}
+
+std::string SerializeCanonicalBundle(const ExpandedSourceBank& bank) {
+  Json document;
+  document["format"] = "yaze-message-bundle";
+  document["version"] = kMessageBundleVersion;
+  document["counts"] = {{"vanilla", 0}, {"expanded", bank.size()}};
+  document["messages"] = Json::array();
+  for (const auto& [id, message] : bank) {
+    document["messages"].push_back(
+        {{"id", id}, {"bank", "expanded"}, {"text", message.text}});
+  }
+  return document.dump(2) + "\n";
+}
+
+std::string RenderAsmBody(const ExpandedSourceBank& bank,
+                          int first_expanded_id) {
+  std::string output;
+  for (const auto& [local_id, message] : bank) {
+    absl::StrAppend(&output, absl::StrFormat("Message_%03X:\n",
+                                             first_expanded_id + local_id));
+    std::vector<uint8_t> terminated = message.bytes;
+    terminated.push_back(kMessageTerminator);
+    for (size_t offset = 0; offset < terminated.size(); offset += 16) {
+      absl::StrAppend(&output, "  db ");
+      const size_t line_end = std::min(terminated.size(), offset + 16);
+      for (size_t index = offset; index < line_end; ++index) {
+        if (index != offset) {
+          absl::StrAppend(&output, ", ");
+        }
+        absl::StrAppend(&output, absl::StrFormat("$%02X", terminated[index]));
+      }
+      absl::StrAppend(&output, "\n");
+    }
+    absl::StrAppend(&output, "\n");
+  }
+  absl::StrAppend(&output, "db $FF\n");
+  return output;
+}
+
+std::string RenderAsmInclude(const ExpandedSourceBank& bank,
+                             int first_expanded_id,
+                             std::string_view source_sha256) {
+  const std::string body = RenderAsmBody(bank, first_expanded_id);
+  return absl::StrFormat(
+             "; Source bundle SHA-256: %s\n"
+             "; Generated ASM body SHA-256: %s\n"
+             "; Generated by yaze message-source-sync. Do not edit.\n\n",
+             source_sha256, Sha256Hex(body)) +
+         body;
+}
+
+bool IsCanonicalMappedLoRomAddress(uint32_t address) {
+  const uint8_t bank = static_cast<uint8_t>((address >> 16) & 0xFFu);
+  return bank != 0x7E && bank != 0x7F && (address & 0xFFFFu) >= 0x8000u &&
+         PcToSnes(SnesToPc(address)) == address;
+}
+
+absl::StatusOr<size_t> ValidateLayoutAndGetCapacity(
+    const core::MessageLayout& layout) {
+  if (layout.expanded_count <= 0 ||
+      layout.last_expanded_id < layout.first_expanded_id) {
+    return absl::FailedPreconditionError(
+        "Hack manifest must define a non-empty expanded message range");
+  }
+  const int range_count =
+      static_cast<int>(layout.last_expanded_id - layout.first_expanded_id) + 1;
+  if (layout.expanded_count != range_count) {
+    return absl::FailedPreconditionError(absl::StrFormat(
+        "Hack manifest expanded range is not contiguous: first=0x%03X, "
+        "last=0x%03X implies %d messages, but count=%d",
+        layout.first_expanded_id, layout.last_expanded_id, range_count,
+        layout.expanded_count));
+  }
+  if (!IsCanonicalMappedLoRomAddress(layout.data_start) ||
+      !IsCanonicalMappedLoRomAddress(layout.data_end)) {
+    return absl::FailedPreconditionError(
+        "Hack manifest expanded data range must use canonical mapped LoROM "
+        "addresses");
+  }
+  const uint32_t start_pc = SnesToPc(layout.data_start);
+  const uint32_t end_pc = SnesToPc(layout.data_end);
+  if (end_pc < start_pc) {
+    return absl::FailedPreconditionError(
+        "Hack manifest expanded data range ends before it starts");
+  }
+  return static_cast<size_t>(end_pc - start_pc) + 1;
+}
+
+bool IsWithinRoot(const fs::path& root, const fs::path& candidate) {
+  const fs::path relative = candidate.lexically_relative(root);
+  if (relative.empty() || relative.is_absolute()) {
+    return false;
+  }
+  const auto first = relative.begin();
+  return first != relative.end() && *first != "..";
+}
+
+absl::StatusOr<fs::path> ResolveProjectTarget(
+    const fs::path& project_root, const std::string& configured_path,
+    bool must_exist, absl::string_view label) {
+  const fs::path relative(configured_path);
+  if (relative.empty() || relative.is_absolute() || relative.has_root_name()) {
+    return absl::InvalidArgumentError(
+        absl::StrFormat("%s must be a non-empty project-relative path", label));
+  }
+
+  const fs::path joined = (project_root / relative).lexically_normal();
+  std::error_code status_ec;
+  const auto link_status = fs::symlink_status(joined, status_ec);
+  if (status_ec != std::errc::no_such_file_or_directory && status_ec) {
+    return absl::FailedPreconditionError(
+        absl::StrFormat("Cannot inspect %s path %s: %s", label, joined.string(),
+                        status_ec.message()));
+  }
+  if (!status_ec && fs::is_symlink(link_status)) {
+    return absl::FailedPreconditionError(absl::StrFormat(
+        "%s may not be a symbolic link: %s", label, joined.string()));
+  }
+
+  std::error_code canonical_ec;
+  fs::path resolved = must_exist ? fs::canonical(joined, canonical_ec)
+                                 : fs::weakly_canonical(joined, canonical_ec);
+  if (canonical_ec) {
+    return absl::FailedPreconditionError(
+        absl::StrFormat("Cannot resolve %s path %s: %s", label, joined.string(),
+                        canonical_ec.message()));
+  }
+  resolved = resolved.lexically_normal();
+  if (!IsWithinRoot(project_root, resolved)) {
+    return absl::PermissionDeniedError(
+        absl::StrFormat("%s escapes project root %s: %s", label,
+                        project_root.string(), resolved.string()));
+  }
+
+  std::error_code parent_ec;
+  const auto parent_status = fs::status(resolved.parent_path(), parent_ec);
+  if (parent_ec || !fs::is_directory(parent_status)) {
+    return absl::FailedPreconditionError(
+        absl::StrFormat("%s parent directory must already exist: %s", label,
+                        resolved.parent_path().string()));
+  }
+  if (must_exist) {
+    std::error_code file_ec;
+    if (!fs::is_regular_file(resolved, file_ec) || file_ec) {
+      return absl::FailedPreconditionError(absl::StrFormat(
+          "%s must be an existing regular file: %s", label, resolved.string()));
+    }
+  } else if (!status_ec && fs::exists(link_status) &&
+             !fs::is_regular_file(link_status)) {
+    return absl::FailedPreconditionError(
+        absl::StrFormat("%s must be a regular file or a new path: %s", label,
+                        resolved.string()));
+  }
+  return resolved;
+}
+
+absl::StatusOr<fs::path> CanonicalProjectRoot(
+    const project::YazeProject& project) {
+  if (project.filepath.empty()) {
+    return absl::FailedPreconditionError(
+        "Project has no descriptor path; open the project before source sync");
+  }
+  std::error_code ec;
+  fs::path descriptor = fs::absolute(project.filepath, ec);
+  if (ec) {
+    return absl::FailedPreconditionError(
+        absl::StrFormat("Cannot resolve project descriptor %s: %s",
+                        project.filepath, ec.message()));
+  }
+  fs::path root = fs::canonical(descriptor.parent_path(), ec);
+  if (ec) {
+    return absl::FailedPreconditionError(
+        absl::StrFormat("Cannot resolve project root for %s: %s",
+                        project.filepath, ec.message()));
+  }
+  return root.lexically_normal();
+}
+
+std::string LowercasePath(const fs::path& path) {
+  return absl::AsciiStrToLower(path.generic_string());
+}
+
+absl::Status ValidateDistinctTargets(const fs::path& bundle_path,
+                                     const fs::path& include_path) {
+  if (bundle_path == include_path ||
+      LowercasePath(bundle_path) == LowercasePath(include_path)) {
+    return absl::InvalidArgumentError(
+        "Canonical bundle and generated ASM include paths must be distinct");
+  }
+  std::error_code exists_ec;
+  const bool include_exists = fs::exists(include_path, exists_ec);
+  if (exists_ec) {
+    return absl::FailedPreconditionError(absl::StrFormat(
+        "Cannot inspect generated ASM include path: %s", exists_ec.message()));
+  }
+  if (include_exists) {
+    std::error_code equivalent_ec;
+    if (fs::equivalent(bundle_path, include_path, equivalent_ec)) {
+      return absl::InvalidArgumentError(
+          "Canonical bundle and generated ASM include paths alias each other");
+    }
+    if (equivalent_ec) {
+      return absl::FailedPreconditionError(
+          absl::StrFormat("Cannot compare source publication paths: %s",
+                          equivalent_ec.message()));
+    }
+  }
+  return absl::OkStatus();
+}
+
+fs::path NextSiblingPath(const fs::path& target, absl::string_view purpose) {
+  static std::atomic<uint64_t> sequence{0};
+  const uint64_t tick = static_cast<uint64_t>(
+      std::chrono::steady_clock::now().time_since_epoch().count());
+  const uint64_t id = sequence.fetch_add(1, std::memory_order_relaxed);
+  fs::path name = target.filename();
+  name += absl::StrFormat(".yaze-%s-%016x-%016x", purpose, tick, id);
+  return target.parent_path() / name;
+}
+
+absl::StatusOr<fs::path> WriteExclusiveTemp(const fs::path& target,
+                                            std::string_view content) {
+  constexpr int kMaxAttempts = 100;
+  for (int attempt = 0; attempt < kMaxAttempts; ++attempt) {
+    const fs::path temp = NextSiblingPath(target, "tmp");
+#if defined(_WIN32)
+    HANDLE file = CreateFileW(
+        temp.wstring().c_str(), GENERIC_WRITE, 0, nullptr, CREATE_NEW,
+        FILE_ATTRIBUTE_NORMAL | FILE_FLAG_WRITE_THROUGH, nullptr);
+    if (file == INVALID_HANDLE_VALUE) {
+      const DWORD error = GetLastError();
+      if (error == ERROR_FILE_EXISTS || error == ERROR_ALREADY_EXISTS) {
+        continue;
+      }
+      return absl::PermissionDeniedError(absl::StrFormat(
+          "Cannot create temporary file for %s: %s", target.string(),
+          std::error_code(static_cast<int>(error), std::system_category())
+              .message()));
+    }
+    size_t written_total = 0;
+    while (written_total < content.size()) {
+      const DWORD chunk = static_cast<DWORD>(std::min<size_t>(
+          content.size() - written_total, std::numeric_limits<DWORD>::max()));
+      DWORD written = 0;
+      if (!WriteFile(file, content.data() + written_total, chunk, &written,
+                     nullptr) ||
+          written == 0) {
+        const DWORD error = GetLastError();
+        CloseHandle(file);
+        std::error_code cleanup_ec;
+        fs::remove(temp, cleanup_ec);
+        return absl::InternalError(absl::StrFormat(
+            "Failed to write temporary file for %s: %s", target.string(),
+            std::error_code(static_cast<int>(error), std::system_category())
+                .message()));
+      }
+      written_total += written;
+    }
+    if (!FlushFileBuffers(file)) {
+      const DWORD error = GetLastError();
+      CloseHandle(file);
+      std::error_code cleanup_ec;
+      fs::remove(temp, cleanup_ec);
+      return absl::InternalError(absl::StrFormat(
+          "Failed to flush temporary file for %s: %s", target.string(),
+          std::error_code(static_cast<int>(error), std::system_category())
+              .message()));
+    }
+    if (!CloseHandle(file)) {
+      const DWORD error = GetLastError();
+      std::error_code cleanup_ec;
+      fs::remove(temp, cleanup_ec);
+      return absl::InternalError(absl::StrFormat(
+          "Failed to flush temporary file for %s: %s", target.string(),
+          std::error_code(static_cast<int>(error), std::system_category())
+              .message()));
+    }
+#else
+    const int fd =
+        open(temp.c_str(), O_WRONLY | O_CREAT | O_EXCL, S_IRUSR | S_IWUSR);
+    if (fd < 0) {
+      if (errno == EEXIST) {
+        continue;
+      }
+      return absl::PermissionDeniedError(absl::StrFormat(
+          "Cannot create temporary file for %s: %s", target.string(),
+          std::error_code(errno, std::generic_category()).message()));
+    }
+    size_t written_total = 0;
+    while (written_total < content.size()) {
+      const ssize_t written =
+          write(fd, content.data() + written_total,
+                std::min<size_t>(content.size() - written_total, 1024 * 1024));
+      if (written < 0 && errno == EINTR) {
+        continue;
+      }
+      if (written <= 0) {
+        const int error = written < 0 ? errno : EIO;
+        close(fd);
+        std::error_code cleanup_ec;
+        fs::remove(temp, cleanup_ec);
+        return absl::InternalError(absl::StrFormat(
+            "Failed to write temporary file for %s: %s", target.string(),
+            std::error_code(error, std::generic_category()).message()));
+      }
+      written_total += static_cast<size_t>(written);
+    }
+    if (fsync(fd) != 0) {
+      const int error = errno;
+      close(fd);
+      std::error_code cleanup_ec;
+      fs::remove(temp, cleanup_ec);
+      return absl::InternalError(absl::StrFormat(
+          "Failed to flush temporary file for %s: %s", target.string(),
+          std::error_code(error, std::generic_category()).message()));
+    }
+    if (close(fd) != 0) {
+      const int error = errno;
+      std::error_code cleanup_ec;
+      fs::remove(temp, cleanup_ec);
+      return absl::InternalError(absl::StrFormat(
+          "Failed to flush temporary file for %s: %s", target.string(),
+          std::error_code(error, std::generic_category()).message()));
+    }
+#endif
+    return temp;
+  }
+  return absl::ResourceExhaustedError(absl::StrFormat(
+      "Could not allocate a unique temporary file for %s", target.string()));
+}
+
+absl::Status ReplaceFromTemp(const fs::path& temp, const fs::path& target) {
+  std::error_code rename_ec;
+  fs::rename(temp, target, rename_ec);
+#if defined(_WIN32)
+  if (rename_ec &&
+      MoveFileExW(temp.wstring().c_str(), target.wstring().c_str(),
+                  MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH)) {
+    rename_ec.clear();
+  }
+#endif
+  if (rename_ec) {
+    return absl::InternalError(absl::StrFormat(
+        "Failed to publish %s: %s", target.string(), rename_ec.message()));
+  }
+  return absl::OkStatus();
+}
+
+absl::StatusOr<fs::path> CreateBackup(const fs::path& target) {
+  constexpr int kMaxAttempts = 100;
+  for (int attempt = 0; attempt < kMaxAttempts; ++attempt) {
+    const fs::path backup = NextSiblingPath(target, "backup");
+    std::error_code copy_ec;
+    fs::copy_file(target, backup, fs::copy_options::none, copy_ec);
+    if (!copy_ec) {
+      return backup;
+    }
+    if (copy_ec != std::errc::file_exists) {
+      std::error_code cleanup_ec;
+      fs::remove(backup, cleanup_ec);
+      return absl::FailedPreconditionError(absl::StrFormat(
+          "Cannot back up %s: %s", target.string(), copy_ec.message()));
+    }
+  }
+  return absl::ResourceExhaustedError(absl::StrFormat(
+      "Could not allocate a backup path for %s", target.string()));
+}
+
+void CleanupTemps(const std::vector<PublicationArtifact>& artifacts) {
+  for (const auto& artifact : artifacts) {
+    if (!artifact.temp.empty()) {
+      std::error_code ec;
+      fs::remove(artifact.temp, ec);
+    }
+  }
+}
+
+void CleanupBackups(const std::vector<PublicationArtifact>& artifacts) {
+  for (const auto& artifact : artifacts) {
+    if (artifact.backup.has_value()) {
+      std::error_code ec;
+      fs::remove(*artifact.backup, ec);
+    }
+  }
+}
+
+absl::Status RestoreArtifact(const PublicationArtifact& artifact) {
+  if (artifact.original_content.has_value()) {
+    fs::path restore_temp;
+    ASSIGN_OR_RETURN(
+        restore_temp,
+        WriteExclusiveTemp(artifact.target, *artifact.original_content));
+    const absl::Status status = ReplaceFromTemp(restore_temp, artifact.target);
+    if (!status.ok()) {
+      std::error_code cleanup_ec;
+      fs::remove(restore_temp, cleanup_ec);
+    }
+    return status;
+  }
+  std::error_code remove_ec;
+  const bool removed = fs::remove(artifact.target, remove_ec);
+  if (remove_ec || !removed) {
+    return absl::InternalError(absl::StrFormat(
+        "Could not remove newly published file %s during rollback: %s",
+        artifact.target.string(),
+        remove_ec ? remove_ec.message() : "file was missing"));
+  }
+  return absl::OkStatus();
+}
+
+absl::Status RollBackPublication(std::vector<PublicationArtifact>* artifacts,
+                                 const absl::Status& publication_failure) {
+  absl::Status rollback_failure = absl::OkStatus();
+  for (auto it = artifacts->rbegin(); it != artifacts->rend(); ++it) {
+    if (!it->published) {
+      continue;
+    }
+    const absl::Status restore_status = RestoreArtifact(*it);
+    if (!restore_status.ok() && rollback_failure.ok()) {
+      rollback_failure = restore_status;
+    }
+    it->published = false;
+  }
+  CleanupTemps(*artifacts);
+  if (!rollback_failure.ok()) {
+    return absl::DataLossError(absl::StrFormat(
+        "Message source publication failed (%s) and rollback failed (%s). "
+        "Original backups were preserved.",
+        publication_failure.message(), rollback_failure.message()));
+  }
+  return publication_failure;
+}
+
+absl::Status VerifyUnchangedBeforePublication(
+    const std::vector<PublicationArtifact>& artifacts,
+    std::string_view expected_source_sha256) {
+  for (const auto& artifact : artifacts) {
+    std::error_code exists_ec;
+    const bool exists = fs::exists(artifact.target, exists_ec);
+    if (exists_ec) {
+      return absl::FailedPreconditionError(
+          absl::StrFormat("Cannot recheck publication target %s: %s",
+                          artifact.target.string(), exists_ec.message()));
+    }
+    if (artifact.original_content.has_value()) {
+      if (!exists) {
+        return absl::AbortedError(absl::StrFormat(
+            "Publication target disappeared after preflight: %s",
+            artifact.target.string()));
+      }
+      std::string current;
+      ASSIGN_OR_RETURN(current,
+                       ReadTextFile(artifact.target, "publication target"));
+      if (current != *artifact.original_content) {
+        return absl::AbortedError(
+            absl::StrFormat("Publication target changed after preflight: %s",
+                            artifact.target.string()));
+      }
+    } else if (exists) {
+      return absl::AbortedError(
+          absl::StrFormat("Publication target appeared after preflight: %s",
+                          artifact.target.string()));
+    }
+  }
+  if (Sha256Hex(*artifacts.front().original_content) !=
+      expected_source_sha256) {
+    return absl::AbortedError(
+        "Canonical message source changed after SHA-256 preflight");
+  }
+  return absl::OkStatus();
+}
+
+absl::Status PublishArtifactSet(std::vector<PublicationArtifact>* artifacts,
+                                std::string_view expected_source_sha256) {
+  for (auto& artifact : *artifacts) {
+    auto temp_or = WriteExclusiveTemp(artifact.target, artifact.content);
+    if (!temp_or.ok()) {
+      CleanupTemps(*artifacts);
+      CleanupBackups(*artifacts);
+      return temp_or.status();
+    }
+    artifact.temp = std::move(*temp_or);
+    if (artifact.original_content.has_value()) {
+      auto backup_or = CreateBackup(artifact.target);
+      if (!backup_or.ok()) {
+        CleanupTemps(*artifacts);
+        CleanupBackups(*artifacts);
+        return backup_or.status();
+      }
+      artifact.backup = std::move(*backup_or);
+    }
+  }
+
+  const absl::Status unchanged_status =
+      VerifyUnchangedBeforePublication(*artifacts, expected_source_sha256);
+  if (!unchanged_status.ok()) {
+    CleanupTemps(*artifacts);
+    CleanupBackups(*artifacts);
+    return unchanged_status;
+  }
+
+  for (auto& artifact : *artifacts) {
+    const absl::Status replace_status =
+        ReplaceFromTemp(artifact.temp, artifact.target);
+    if (!replace_status.ok()) {
+      return RollBackPublication(artifacts, replace_status);
+    }
+    artifact.temp.clear();
+    artifact.published = true;
+  }
+
+  for (const auto& artifact : *artifacts) {
+    std::string reopened;
+    auto reopened_or = ReadTextFile(artifact.target, "published message file");
+    if (!reopened_or.ok()) {
+      return RollBackPublication(artifacts, reopened_or.status());
+    }
+    reopened = std::move(*reopened_or);
+    if (reopened != artifact.content) {
+      return RollBackPublication(
+          artifacts, absl::DataLossError(absl::StrFormat(
+                         "Published message file failed exact readback: %s",
+                         artifact.target.string())));
+    }
+  }
+  CleanupTemps(*artifacts);
+  return absl::OkStatus();
+}
+
+absl::StatusOr<std::string> NormalizeExpectedSha256(std::string hash) {
+  if (hash.size() != 64 ||
+      !std::all_of(hash.begin(), hash.end(),
+                   [](unsigned char c) { return std::isxdigit(c) != 0; })) {
+    return absl::InvalidArgumentError(
+        "--expected-source-sha256 must be exactly 64 hexadecimal characters");
+  }
+  return absl::AsciiStrToLower(std::move(hash));
+}
+
+}  // namespace
+
+std::string ComputeMessageSourceSha256(std::string_view content) {
+  return Sha256Hex(content);
+}
+
+absl::StatusOr<MessageSourceSyncResult> SyncMessageSource(
+    const project::YazeProject& project, const fs::path& incoming_bundle_path,
+    const MessageSourceSyncOptions& options) {
+  if (!project.hack_manifest.loaded()) {
+    return absl::FailedPreconditionError(
+        "Project must load a hack manifest before message source sync");
+  }
+#if defined(__EMSCRIPTEN__)
+  if (options.write) {
+    return absl::FailedPreconditionError(
+        "message-source-sync --write is unavailable in browser builds because "
+        "durable atomic filesystem publication cannot be guaranteed");
+  }
+#endif
+  const core::MessageLayout& layout = project.hack_manifest.message_layout();
+  if (!layout.source.has_value()) {
+    return absl::FailedPreconditionError(
+        "Hack manifest does not define messages.source");
+  }
+
+  size_t capacity = 0;
+  ASSIGN_OR_RETURN(capacity, ValidateLayoutAndGetCapacity(layout));
+  fs::path project_root;
+  ASSIGN_OR_RETURN(project_root, CanonicalProjectRoot(project));
+
+  fs::path canonical_bundle_path;
+  ASSIGN_OR_RETURN(
+      canonical_bundle_path,
+      ResolveProjectTarget(project_root, layout.source->canonical_bundle_path,
+                           /*must_exist=*/true, "Canonical message bundle"));
+  fs::path asm_include_path;
+  ASSIGN_OR_RETURN(asm_include_path,
+                   ResolveProjectTarget(
+                       project_root, layout.source->generated_asm_include_path,
+                       /*must_exist=*/false, "Generated message ASM include"));
+  RETURN_IF_ERROR(
+      ValidateDistinctTargets(canonical_bundle_path, asm_include_path));
+
+  std::error_code incoming_ec;
+  const fs::path resolved_incoming =
+      fs::canonical(incoming_bundle_path, incoming_ec);
+  if (incoming_ec || !fs::is_regular_file(resolved_incoming, incoming_ec) ||
+      incoming_ec) {
+    return absl::NotFoundError(absl::StrFormat(
+        "Incoming message bundle must be an existing regular file: %s",
+        incoming_bundle_path.string()));
+  }
+
+  std::string canonical_before;
+  ASSIGN_OR_RETURN(canonical_before, ReadTextFile(canonical_bundle_path,
+                                                  "canonical message bundle"));
+  const std::string source_sha_before = Sha256Hex(canonical_before);
+  Json canonical_document;
+  ASSIGN_OR_RETURN(
+      canonical_document,
+      ParseBundleDocument(canonical_before, "Canonical message bundle"));
+  ExpandedSourceBank merged_bank;
+  ASSIGN_OR_RETURN(
+      merged_bank,
+      ParseExpandedBank(canonical_document, layout.expanded_count,
+                        /*require_complete=*/true, "Canonical message bundle"));
+  const std::string expected_current_asm = RenderAsmInclude(
+      merged_bank, layout.first_expanded_id, source_sha_before);
+
+  std::string incoming_content;
+  ASSIGN_OR_RETURN(incoming_content,
+                   ReadTextFile(resolved_incoming, "incoming message bundle"));
+  Json incoming_document;
+  ASSIGN_OR_RETURN(
+      incoming_document,
+      ParseBundleDocument(incoming_content, "Incoming message bundle"));
+  ExpandedSourceBank incoming_bank;
+  ASSIGN_OR_RETURN(
+      incoming_bank,
+      ParseExpandedBank(incoming_document, layout.expanded_count,
+                        /*require_complete=*/false, "Incoming message bundle"));
+  for (auto& [id, message] : incoming_bank) {
+    merged_bank[id] = std::move(message);
+  }
+
+  size_t encoded_size = 1;  // Final $FF.
+  for (const auto& entry : merged_bank) {
+    encoded_size += entry.second.bytes.size() + 1;  // Per-message $7F.
+  }
+  if (encoded_size > capacity) {
+    return absl::ResourceExhaustedError(absl::StrFormat(
+        "Expanded message source needs %zu bytes including terminators, but "
+        "manifest capacity is %zu bytes [0x%06X, 0x%06X]",
+        encoded_size, capacity, layout.data_start, layout.data_end));
+  }
+
+  const std::string canonical_after = SerializeCanonicalBundle(merged_bank);
+  const std::string proposed_source_sha = Sha256Hex(canonical_after);
+  const std::string asm_after = RenderAsmInclude(
+      merged_bank, layout.first_expanded_id, proposed_source_sha);
+
+  std::optional<std::string> asm_before;
+  std::error_code include_exists_ec;
+  if (fs::exists(asm_include_path, include_exists_ec)) {
+    std::string existing_include;
+    ASSIGN_OR_RETURN(
+        existing_include,
+        ReadTextFile(asm_include_path, "generated message ASM include"));
+    asm_before = std::move(existing_include);
+  } else if (include_exists_ec) {
+    return absl::FailedPreconditionError(
+        absl::StrFormat("Cannot inspect generated message ASM include: %s",
+                        include_exists_ec.message()));
+  }
+  if (asm_before.has_value() && *asm_before != expected_current_asm) {
+    return absl::FailedPreconditionError(absl::StrFormat(
+        "Generated message ASM include drifted from the current canonical "
+        "bundle: %s",
+        asm_include_path.string()));
+  }
+
+  MessageSourceSyncResult result{
+      .canonical_bundle_path = canonical_bundle_path,
+      .generated_asm_include_path = asm_include_path,
+      .first_expanded_id = layout.first_expanded_id,
+      .last_expanded_id = layout.last_expanded_id,
+      .expanded_count = layout.expanded_count,
+      .incoming_updates = static_cast<int>(incoming_bank.size()),
+      .encoded_size = encoded_size,
+      .capacity = capacity,
+      .source_sha256_before = source_sha_before,
+      .proposed_source_sha256 = proposed_source_sha,
+      .changed = canonical_before != canonical_after ||
+                 !asm_before.has_value() || *asm_before != asm_after,
+  };
+  if (!options.write) {
+    return result;
+  }
+  if (options.expected_source_sha256.empty()) {
+    return absl::InvalidArgumentError(
+        "--write requires --expected-source-sha256");
+  }
+  std::string expected_sha;
+  ASSIGN_OR_RETURN(expected_sha,
+                   NormalizeExpectedSha256(options.expected_source_sha256));
+  if (expected_sha != source_sha_before) {
+    return absl::AbortedError(absl::StrFormat(
+        "Canonical message source SHA-256 CAS failed: expected %s, got %s",
+        expected_sha, source_sha_before));
+  }
+  if (!result.changed) {
+    return result;
+  }
+
+  std::vector<PublicationArtifact> artifacts;
+  artifacts.push_back(PublicationArtifact{
+      .target = canonical_bundle_path,
+      .content = canonical_after,
+      .original_content = canonical_before,
+  });
+  artifacts.push_back(PublicationArtifact{
+      .target = asm_include_path,
+      .content = asm_after,
+      .original_content = asm_before,
+  });
+  RETURN_IF_ERROR(PublishArtifactSet(&artifacts, expected_sha));
+
+  // Reopen the canonical bundle through the strict source parser, not just as
+  // bytes, before reporting a successful two-file publication.
+  std::string reopened_canonical;
+  ASSIGN_OR_RETURN(reopened_canonical,
+                   ReadTextFile(canonical_bundle_path,
+                                "published canonical message bundle"));
+  Json reopened_document;
+  ASSIGN_OR_RETURN(reopened_document,
+                   ParseBundleDocument(reopened_canonical,
+                                       "Published canonical message bundle"));
+  auto reopened_bank_or = ParseExpandedBank(
+      reopened_document, layout.expanded_count,
+      /*require_complete=*/true, "Published canonical message bundle");
+  if (!reopened_bank_or.ok()) {
+    return RollBackPublication(&artifacts, reopened_bank_or.status());
+  }
+  if (Sha256Hex(reopened_canonical) != proposed_source_sha) {
+    return RollBackPublication(
+        &artifacts,
+        absl::DataLossError(
+            "Published canonical message bundle SHA-256 readback failed"));
+  }
+
+  for (const auto& artifact : artifacts) {
+    if (artifact.backup.has_value()) {
+      result.backup_paths.push_back(*artifact.backup);
+    }
+  }
+  result.wrote = true;
+  return result;
+}
+
+}  // namespace yaze::editor

--- a/src/app/editor/message/message_source_sync.cc
+++ b/src/app/editor/message/message_source_sync.cc
@@ -1054,15 +1054,29 @@ absl::Status CleanupTemps(const std::vector<PublicationArtifact>& artifacts) {
   return CleanupPublicationPaths(paths, "temporary files");
 }
 
-absl::Status CleanupBackups(const std::vector<PublicationArtifact>& artifacts) {
-  std::vector<fs::path> paths;
-  paths.reserve(artifacts.size());
-  for (const auto& artifact : artifacts) {
-    if (artifact.backup.has_value()) {
-      paths.push_back(*artifact.backup);
+absl::Status CleanupBackups(std::vector<PublicationArtifact>* artifacts) {
+  std::string failures;
+  for (auto& artifact : *artifacts) {
+    if (!artifact.backup.has_value()) {
+      continue;
     }
+    std::error_code ec;
+    fs::remove(*artifact.backup, ec);
+    if (!ec) {
+      artifact.backup.reset();
+      continue;
+    }
+    if (!failures.empty()) {
+      absl::StrAppend(&failures, "; ");
+    }
+    absl::StrAppend(&failures, artifact.backup->string(), " (", ec.message(),
+                    ")");
   }
-  return CleanupPublicationPaths(paths, "backup files");
+  if (!failures.empty()) {
+    return absl::InternalError(absl::StrFormat(
+        "Could not remove message source backup files: %s", failures));
+  }
+  return absl::OkStatus();
 }
 
 std::string BackupRecoveryPaths(
@@ -1085,9 +1099,9 @@ std::string CleanupStatusSummary(const absl::Status& status) {
 }
 
 absl::Status ReturnFailureAfterCleanup(
-    const std::vector<PublicationArtifact>& artifacts,
+    std::vector<PublicationArtifact>* artifacts,
     const absl::Status& publication_failure) {
-  const absl::Status temp_cleanup = CleanupTemps(artifacts);
+  const absl::Status temp_cleanup = CleanupTemps(*artifacts);
   const absl::Status backup_cleanup = CleanupBackups(artifacts);
   if (temp_cleanup.ok() && backup_cleanup.ok()) {
     return publication_failure;
@@ -1150,7 +1164,7 @@ absl::Status RollBackPublication(std::vector<PublicationArtifact>* artifacts,
         publication_failure.message(), rollback_failure.message(),
         CleanupStatusSummary(temp_cleanup), BackupRecoveryPaths(*artifacts)));
   }
-  const absl::Status backup_cleanup = CleanupBackups(*artifacts);
+  const absl::Status backup_cleanup = CleanupBackups(artifacts);
   if (!temp_cleanup.ok() || !backup_cleanup.ok()) {
     return absl::DataLossError(absl::StrFormat(
         "Message source publication failed (%s); rollback completed, but "
@@ -1205,13 +1219,13 @@ absl::Status PublishArtifactSet(std::vector<PublicationArtifact>* artifacts,
   for (auto& artifact : *artifacts) {
     auto temp_or = WriteExclusiveTemp(artifact.target, artifact.content);
     if (!temp_or.ok()) {
-      return ReturnFailureAfterCleanup(*artifacts, temp_or.status());
+      return ReturnFailureAfterCleanup(artifacts, temp_or.status());
     }
     artifact.temp = std::move(*temp_or);
     if (artifact.original_content.has_value()) {
       auto backup_or = CreateBackup(artifact.target);
       if (!backup_or.ok()) {
-        return ReturnFailureAfterCleanup(*artifacts, backup_or.status());
+        return ReturnFailureAfterCleanup(artifacts, backup_or.status());
       }
       artifact.backup = std::move(*backup_or);
     }
@@ -1220,7 +1234,7 @@ absl::Status PublishArtifactSet(std::vector<PublicationArtifact>* artifacts,
   const absl::Status unchanged_status =
       VerifyUnchangedBeforePublication(*artifacts, expected_source_sha256);
   if (!unchanged_status.ok()) {
-    return ReturnFailureAfterCleanup(*artifacts, unchanged_status);
+    return ReturnFailureAfterCleanup(artifacts, unchanged_status);
   }
 
   for (auto& artifact : *artifacts) {
@@ -1468,7 +1482,7 @@ absl::StatusOr<MessageSourceSyncResult> SyncMessageSource(
             "Published canonical message bundle SHA-256 readback failed"));
   }
 
-  const absl::Status backup_cleanup = CleanupBackups(artifacts);
+  const absl::Status backup_cleanup = CleanupBackups(&artifacts);
   if (!backup_cleanup.ok()) {
     return RollBackPublication(&artifacts, backup_cleanup);
   }

--- a/src/app/editor/message/message_source_sync.cc
+++ b/src/app/editor/message/message_source_sync.cc
@@ -709,6 +709,56 @@ absl::Status ValidateDistinctTargets(const fs::path& bundle_path,
   return absl::OkStatus();
 }
 
+absl::Status ValidateTargetsDoNotAliasLock(const fs::path& lock_path,
+                                           const fs::path& bundle_path,
+                                           const fs::path& include_path) {
+  for (const fs::path* target : {&bundle_path, &include_path}) {
+    if (*target == lock_path ||
+        LowercasePath(*target) == LowercasePath(lock_path)) {
+      return absl::InvalidArgumentError(absl::StrFormat(
+          "Message source targets may not use the persistent lock path: %s",
+          lock_path.string()));
+    }
+  }
+
+  std::error_code lock_exists_ec;
+  const bool lock_exists = fs::exists(lock_path, lock_exists_ec);
+  if (lock_exists_ec) {
+    return absl::FailedPreconditionError(
+        absl::StrFormat("Cannot inspect persistent message source lock %s: %s",
+                        lock_path.string(), lock_exists_ec.message()));
+  }
+  if (!lock_exists) {
+    return absl::OkStatus();
+  }
+
+  for (const fs::path* target : {&bundle_path, &include_path}) {
+    std::error_code target_exists_ec;
+    const bool target_exists = fs::exists(*target, target_exists_ec);
+    if (target_exists_ec) {
+      return absl::FailedPreconditionError(
+          absl::StrFormat("Cannot inspect message source target %s: %s",
+                          target->string(), target_exists_ec.message()));
+    }
+    if (!target_exists) {
+      continue;
+    }
+    std::error_code equivalent_ec;
+    const bool equivalent = fs::equivalent(lock_path, *target, equivalent_ec);
+    if (equivalent_ec) {
+      return absl::FailedPreconditionError(absl::StrFormat(
+          "Cannot compare message source target %s with persistent lock %s: %s",
+          target->string(), lock_path.string(), equivalent_ec.message()));
+    }
+    if (equivalent) {
+      return absl::InvalidArgumentError(absl::StrFormat(
+          "Message source target aliases the persistent lock path: %s",
+          target->string()));
+    }
+  }
+  return absl::OkStatus();
+}
+
 fs::path NextSiblingPath(const fs::path& target, absl::string_view purpose) {
   static std::atomic<uint64_t> sequence{0};
   const uint64_t tick = static_cast<uint64_t>(
@@ -955,6 +1005,12 @@ absl::StatusOr<fs::path> CreateBackup(const fs::path& target) {
     if (copy_ec != std::errc::file_exists) {
       std::error_code cleanup_ec;
       fs::remove(backup, cleanup_ec);
+      if (cleanup_ec) {
+        return absl::DataLossError(absl::StrFormat(
+            "Cannot back up %s (%s) or remove incomplete backup %s (%s)",
+            target.string(), copy_ec.message(), backup.string(),
+            cleanup_ec.message()));
+      }
       return absl::FailedPreconditionError(absl::StrFormat(
           "Cannot back up %s: %s", target.string(), copy_ec.message()));
     }
@@ -963,22 +1019,84 @@ absl::StatusOr<fs::path> CreateBackup(const fs::path& target) {
       "Could not allocate a backup path for %s", target.string()));
 }
 
-void CleanupTemps(const std::vector<PublicationArtifact>& artifacts) {
-  for (const auto& artifact : artifacts) {
-    if (!artifact.temp.empty()) {
-      std::error_code ec;
-      fs::remove(artifact.temp, ec);
+absl::Status CleanupPublicationPaths(const std::vector<fs::path>& paths,
+                                     absl::string_view artifact_kind) {
+  std::string failures;
+  for (const fs::path& path : paths) {
+    if (path.empty()) {
+      continue;
     }
+    std::error_code ec;
+    fs::remove(path, ec);
+    if (!ec) {
+      continue;
+    }
+    if (!failures.empty()) {
+      absl::StrAppend(&failures, "; ");
+    }
+    absl::StrAppend(&failures, path.string(), " (", ec.message(), ")");
   }
+  if (!failures.empty()) {
+    return absl::InternalError(absl::StrFormat(
+        "Could not remove message source %s: %s", artifact_kind, failures));
+  }
+  return absl::OkStatus();
 }
 
-void CleanupBackups(const std::vector<PublicationArtifact>& artifacts) {
+absl::Status CleanupTemps(const std::vector<PublicationArtifact>& artifacts) {
+  std::vector<fs::path> paths;
+  paths.reserve(artifacts.size());
   for (const auto& artifact : artifacts) {
-    if (artifact.backup.has_value()) {
-      std::error_code ec;
-      fs::remove(*artifact.backup, ec);
+    if (!artifact.temp.empty()) {
+      paths.push_back(artifact.temp);
     }
   }
+  return CleanupPublicationPaths(paths, "temporary files");
+}
+
+absl::Status CleanupBackups(const std::vector<PublicationArtifact>& artifacts) {
+  std::vector<fs::path> paths;
+  paths.reserve(artifacts.size());
+  for (const auto& artifact : artifacts) {
+    if (artifact.backup.has_value()) {
+      paths.push_back(*artifact.backup);
+    }
+  }
+  return CleanupPublicationPaths(paths, "backup files");
+}
+
+std::string BackupRecoveryPaths(
+    const std::vector<PublicationArtifact>& artifacts) {
+  std::string paths;
+  for (const auto& artifact : artifacts) {
+    if (!artifact.backup.has_value()) {
+      continue;
+    }
+    if (!paths.empty()) {
+      absl::StrAppend(&paths, ", ");
+    }
+    absl::StrAppend(&paths, artifact.backup->string());
+  }
+  return paths.empty() ? "<none>" : paths;
+}
+
+std::string CleanupStatusSummary(const absl::Status& status) {
+  return status.ok() ? "ok" : std::string(status.message());
+}
+
+absl::Status ReturnFailureAfterCleanup(
+    const std::vector<PublicationArtifact>& artifacts,
+    const absl::Status& publication_failure) {
+  const absl::Status temp_cleanup = CleanupTemps(artifacts);
+  const absl::Status backup_cleanup = CleanupBackups(artifacts);
+  if (temp_cleanup.ok() && backup_cleanup.ok()) {
+    return publication_failure;
+  }
+  return absl::DataLossError(absl::StrFormat(
+      "Message source publication failed (%s), then artifact cleanup failed "
+      "(temporary files: %s; backup files: %s)",
+      publication_failure.message(), CleanupStatusSummary(temp_cleanup),
+      CleanupStatusSummary(backup_cleanup)));
 }
 
 absl::Status RestoreArtifact(const PublicationArtifact& artifact) {
@@ -991,6 +1109,12 @@ absl::Status RestoreArtifact(const PublicationArtifact& artifact) {
     if (!status.ok()) {
       std::error_code cleanup_ec;
       fs::remove(restore_temp, cleanup_ec);
+      if (cleanup_ec) {
+        return absl::DataLossError(absl::StrFormat(
+            "Could not restore %s (%s) or remove restore file %s (%s)",
+            artifact.target.string(), status.message(), restore_temp.string(),
+            cleanup_ec.message()));
+      }
     }
     return status;
   }
@@ -1018,14 +1142,22 @@ absl::Status RollBackPublication(std::vector<PublicationArtifact>* artifacts,
     }
     it->published = false;
   }
-  CleanupTemps(*artifacts);
+  const absl::Status temp_cleanup = CleanupTemps(*artifacts);
   if (!rollback_failure.ok()) {
     return absl::DataLossError(absl::StrFormat(
         "Message source publication failed (%s) and rollback failed (%s). "
-        "Original backups were preserved.",
-        publication_failure.message(), rollback_failure.message()));
+        "Temporary-file cleanup: %s. Preserved recovery backups: %s",
+        publication_failure.message(), rollback_failure.message(),
+        CleanupStatusSummary(temp_cleanup), BackupRecoveryPaths(*artifacts)));
   }
-  CleanupBackups(*artifacts);
+  const absl::Status backup_cleanup = CleanupBackups(*artifacts);
+  if (!temp_cleanup.ok() || !backup_cleanup.ok()) {
+    return absl::DataLossError(absl::StrFormat(
+        "Message source publication failed (%s); rollback completed, but "
+        "artifact cleanup failed (temporary files: %s; backup files: %s)",
+        publication_failure.message(), CleanupStatusSummary(temp_cleanup),
+        CleanupStatusSummary(backup_cleanup)));
+  }
   return publication_failure;
 }
 
@@ -1073,17 +1205,13 @@ absl::Status PublishArtifactSet(std::vector<PublicationArtifact>* artifacts,
   for (auto& artifact : *artifacts) {
     auto temp_or = WriteExclusiveTemp(artifact.target, artifact.content);
     if (!temp_or.ok()) {
-      CleanupTemps(*artifacts);
-      CleanupBackups(*artifacts);
-      return temp_or.status();
+      return ReturnFailureAfterCleanup(*artifacts, temp_or.status());
     }
     artifact.temp = std::move(*temp_or);
     if (artifact.original_content.has_value()) {
       auto backup_or = CreateBackup(artifact.target);
       if (!backup_or.ok()) {
-        CleanupTemps(*artifacts);
-        CleanupBackups(*artifacts);
-        return backup_or.status();
+        return ReturnFailureAfterCleanup(*artifacts, backup_or.status());
       }
       artifact.backup = std::move(*backup_or);
     }
@@ -1092,9 +1220,7 @@ absl::Status PublishArtifactSet(std::vector<PublicationArtifact>* artifacts,
   const absl::Status unchanged_status =
       VerifyUnchangedBeforePublication(*artifacts, expected_source_sha256);
   if (!unchanged_status.ok()) {
-    CleanupTemps(*artifacts);
-    CleanupBackups(*artifacts);
-    return unchanged_status;
+    return ReturnFailureAfterCleanup(*artifacts, unchanged_status);
   }
 
   for (auto& artifact : *artifacts) {
@@ -1122,7 +1248,10 @@ absl::Status PublishArtifactSet(std::vector<PublicationArtifact>* artifacts,
                          artifact.target.string())));
     }
   }
-  CleanupTemps(*artifacts);
+  const absl::Status temp_cleanup = CleanupTemps(*artifacts);
+  if (!temp_cleanup.ok()) {
+    return RollBackPublication(artifacts, temp_cleanup);
+  }
   return absl::OkStatus();
 }
 
@@ -1180,12 +1309,8 @@ absl::StatusOr<MessageSourceSyncResult> SyncMessageSource(
   RETURN_IF_ERROR(
       ValidateDistinctTargets(canonical_bundle_path, asm_include_path));
   const fs::path source_lock_path = project_root / kSourceSyncLockFilename;
-  if (canonical_bundle_path == source_lock_path ||
-      asm_include_path == source_lock_path) {
-    return absl::InvalidArgumentError(absl::StrFormat(
-        "Message source targets may not use the persistent lock path: %s",
-        source_lock_path.string()));
-  }
+  RETURN_IF_ERROR(ValidateTargetsDoNotAliasLock(
+      source_lock_path, canonical_bundle_path, asm_include_path));
 
   std::error_code incoming_ec;
   const fs::path resolved_incoming =
@@ -1343,7 +1468,10 @@ absl::StatusOr<MessageSourceSyncResult> SyncMessageSource(
             "Published canonical message bundle SHA-256 readback failed"));
   }
 
-  CleanupBackups(artifacts);
+  const absl::Status backup_cleanup = CleanupBackups(artifacts);
+  if (!backup_cleanup.ok()) {
+    return RollBackPublication(&artifacts, backup_cleanup);
+  }
   result.wrote = true;
   return result;
 }

--- a/src/app/editor/message/message_source_sync.cc
+++ b/src/app/editor/message/message_source_sync.cc
@@ -89,17 +89,61 @@ class MessageSourceWriteLocks {
 
 #if defined(_WIN32)
     lock->handles_.reserve(lock_paths.size());
+    struct WindowsFileIdentity {
+      DWORD volume_serial;
+      DWORD file_index_high;
+      DWORD file_index_low;
+    };
+    std::vector<WindowsFileIdentity> lock_identities;
+    lock_identities.reserve(lock_paths.size());
     for (const fs::path& path : lock_paths) {
-      HANDLE handle =
-          CreateFileW(path.wstring().c_str(), GENERIC_READ | GENERIC_WRITE,
-                      FILE_SHARE_READ | FILE_SHARE_WRITE, nullptr, OPEN_ALWAYS,
-                      FILE_ATTRIBUTE_NORMAL, nullptr);
+      HANDLE handle = CreateFileW(
+          path.wstring().c_str(), GENERIC_READ | GENERIC_WRITE,
+          FILE_SHARE_READ | FILE_SHARE_WRITE, nullptr, OPEN_ALWAYS,
+          FILE_ATTRIBUTE_NORMAL | FILE_FLAG_OPEN_REPARSE_POINT, nullptr);
       if (handle == INVALID_HANDLE_VALUE) {
         const DWORD error = GetLastError();
         return absl::PermissionDeniedError(absl::StrFormat(
             "Cannot open message source lock %s: %s", path.string(),
             std::error_code(static_cast<int>(error), std::system_category())
                 .message()));
+      }
+      BY_HANDLE_FILE_INFORMATION file_info = {};
+      if (!GetFileInformationByHandle(handle, &file_info)) {
+        const DWORD error = GetLastError();
+        CloseHandle(handle);
+        return absl::FailedPreconditionError(absl::StrFormat(
+            "Cannot inspect message source lock %s: %s", path.string(),
+            std::error_code(static_cast<int>(error), std::system_category())
+                .message()));
+      }
+      if ((file_info.dwFileAttributes &
+           (FILE_ATTRIBUTE_REPARSE_POINT | FILE_ATTRIBUTE_DIRECTORY)) != 0) {
+        CloseHandle(handle);
+        return absl::FailedPreconditionError(absl::StrFormat(
+            "Message source lock must be a regular file: %s", path.string()));
+      }
+      if (file_info.nNumberOfLinks != 1) {
+        CloseHandle(handle);
+        return absl::FailedPreconditionError(absl::StrFormat(
+            "Message source lock must have exactly one hard link: %s",
+            path.string()));
+      }
+      const WindowsFileIdentity identity = {file_info.dwVolumeSerialNumber,
+                                            file_info.nFileIndexHigh,
+                                            file_info.nFileIndexLow};
+      const bool duplicate_identity = std::any_of(
+          lock_identities.begin(), lock_identities.end(),
+          [&](const WindowsFileIdentity& existing) {
+            return existing.volume_serial == identity.volume_serial &&
+                   existing.file_index_high == identity.file_index_high &&
+                   existing.file_index_low == identity.file_index_low;
+          });
+      if (duplicate_identity) {
+        CloseHandle(handle);
+        return absl::InvalidArgumentError(
+            absl::StrFormat("Message source lock aliases another lock path: %s",
+                            path.string()));
       }
       OVERLAPPED overlapped = {};
       if (!LockFileEx(handle, LOCKFILE_EXCLUSIVE_LOCK, 0, MAXDWORD, MAXDWORD,
@@ -111,6 +155,7 @@ class MessageSourceWriteLocks {
             std::error_code(static_cast<int>(error), std::system_category())
                 .message()));
       }
+      lock_identities.push_back(identity);
       lock->handles_.push_back(handle);
     }
 #elif defined(__EMSCRIPTEN__)
@@ -118,6 +163,12 @@ class MessageSourceWriteLocks {
         "Durable message source locking is unavailable in browser builds");
 #else
     lock->fds_.reserve(lock_paths.size());
+    struct PosixFileIdentity {
+      dev_t device;
+      ino_t inode;
+    };
+    std::vector<PosixFileIdentity> lock_identities;
+    lock_identities.reserve(lock_paths.size());
     for (const fs::path& path : lock_paths) {
       int open_flags = O_RDWR | O_CREAT;
 #ifdef O_CLOEXEC
@@ -145,6 +196,25 @@ class MessageSourceWriteLocks {
         return absl::FailedPreconditionError(absl::StrFormat(
             "Message source lock must be a regular file: %s", path.string()));
       }
+      if (lock_stat.st_nlink != 1) {
+        close(fd);
+        return absl::FailedPreconditionError(absl::StrFormat(
+            "Message source lock must have exactly one hard link: %s",
+            path.string()));
+      }
+      const PosixFileIdentity identity = {lock_stat.st_dev, lock_stat.st_ino};
+      const bool duplicate_identity =
+          std::any_of(lock_identities.begin(), lock_identities.end(),
+                      [&](const PosixFileIdentity& existing) {
+                        return existing.device == identity.device &&
+                               existing.inode == identity.inode;
+                      });
+      if (duplicate_identity) {
+        close(fd);
+        return absl::InvalidArgumentError(
+            absl::StrFormat("Message source lock aliases another lock path: %s",
+                            path.string()));
+      }
       if (fchmod(fd, S_IRUSR | S_IWUSR) != 0) {
         const int error = errno;
         close(fd);
@@ -162,6 +232,7 @@ class MessageSourceWriteLocks {
             "Cannot acquire message source lock %s: %s", path.string(),
             std::error_code(error, std::generic_category()).message()));
       }
+      lock_identities.push_back(identity);
       lock->fds_.push_back(fd);
     }
 #endif

--- a/src/app/editor/message/message_source_sync.h
+++ b/src/app/editor/message/message_source_sync.h
@@ -1,0 +1,58 @@
+#ifndef YAZE_APP_EDITOR_MESSAGE_MESSAGE_SOURCE_SYNC_H_
+#define YAZE_APP_EDITOR_MESSAGE_MESSAGE_SOURCE_SYNC_H_
+
+#include <cstddef>
+#include <filesystem>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include "absl/status/statusor.h"
+#include "core/project.h"
+
+namespace yaze::editor {
+
+struct MessageSourceSyncOptions {
+  // Source synchronization is a dry-run unless this is explicitly enabled.
+  bool write = false;
+
+  // Required in write mode. This is compared with the SHA-256 of the exact
+  // canonical bundle bytes immediately before publication.
+  std::string expected_source_sha256;
+};
+
+struct MessageSourceSyncResult {
+  std::filesystem::path canonical_bundle_path;
+  std::filesystem::path generated_asm_include_path;
+  std::vector<std::filesystem::path> backup_paths;
+
+  int first_expanded_id = 0;
+  int last_expanded_id = 0;
+  int expanded_count = 0;
+  int incoming_updates = 0;
+  size_t encoded_size = 0;
+  size_t capacity = 0;
+
+  std::string source_sha256_before;
+  std::string proposed_source_sha256;
+  bool changed = false;
+  bool wrote = false;
+};
+
+// Compute the lowercase SHA-256 used by canonical source/include provenance.
+std::string ComputeMessageSourceSha256(std::string_view content);
+
+// Merge a validated expanded-message subset into the complete canonical
+// project bundle and render its deterministic, no-org Asar include.
+//
+// Both publication targets come from messages.source in the project's loaded
+// hack manifest. The paths must remain within the project root after symlink
+// resolution. No ROM is opened or mutated by this service.
+absl::StatusOr<MessageSourceSyncResult> SyncMessageSource(
+    const project::YazeProject& project,
+    const std::filesystem::path& incoming_bundle_path,
+    const MessageSourceSyncOptions& options = {});
+
+}  // namespace yaze::editor
+
+#endif  // YAZE_APP_EDITOR_MESSAGE_MESSAGE_SOURCE_SYNC_H_

--- a/src/app/editor/message/message_source_sync.h
+++ b/src/app/editor/message/message_source_sync.h
@@ -5,7 +5,6 @@
 #include <filesystem>
 #include <string>
 #include <string_view>
-#include <vector>
 
 #include "absl/status/statusor.h"
 #include "core/project.h"
@@ -24,7 +23,6 @@ struct MessageSourceSyncOptions {
 struct MessageSourceSyncResult {
   std::filesystem::path canonical_bundle_path;
   std::filesystem::path generated_asm_include_path;
-  std::vector<std::filesystem::path> backup_paths;
 
   int first_expanded_id = 0;
   int last_expanded_id = 0;

--- a/src/cli/cli_core.cmake
+++ b/src/cli/cli_core.cmake
@@ -88,6 +88,7 @@ set(YAZE_CLI_CORE_SOURCES
 if(NOT YAZE_PLATFORM_IOS)
   list(APPEND YAZE_CLI_CORE_SOURCES
     app/editor/message/message_data.cc
+    app/editor/message/message_source_sync.cc
   )
 endif()
 

--- a/src/cli/handlers/command_handlers.cc
+++ b/src/cli/handlers/command_handlers.cc
@@ -96,6 +96,7 @@ CreateCliCommandHandlers() {
   handlers.push_back(std::make_unique<MessageWriteCommandHandler>());
   handlers.push_back(std::make_unique<MessageExportBinCommandHandler>());
   handlers.push_back(std::make_unique<MessageExportAsmCommandHandler>());
+  handlers.push_back(std::make_unique<MessageSourceSyncCommandHandler>());
 
   // Project bundle management
   handlers.push_back(std::make_unique<ProjectBundleVerifyCommandHandler>());

--- a/src/cli/handlers/game/message_commands.cc
+++ b/src/cli/handlers/game/message_commands.cc
@@ -17,6 +17,7 @@
 #include "absl/strings/str_format.h"
 
 #include "app/editor/message/message_data.h"
+#include "app/editor/message/message_source_sync.h"
 #include "rom/snes.h"
 #include "rom/transaction.h"
 #include "zelda3/resource_labels.h"
@@ -1144,6 +1145,74 @@ absl::Status MessageExportAsmCommandHandler::Execute(
   formatter.AddField("status", "success");
   formatter.EndObject();
 
+  return absl::OkStatus();
+}
+
+absl::Status MessageSourceSyncCommandHandler::Execute(
+    Rom* rom, const resources::ArgumentParser& parser,
+    resources::OutputFormatter& formatter) {
+  const std::string project_path = parser.GetString("project").value();
+  const std::string incoming_path = parser.GetString("file").value();
+  const bool write = parser.HasFlag("write");
+
+  project::YazeProject source_project;
+  auto& resource_labels = zelda3::GetResourceLabels();
+  absl::Status open_status;
+  {
+    ScopedHackManifestBindingRestore restore_manifest(resource_labels);
+    try {
+      open_status = source_project.Open(project_path);
+    } catch (const std::exception& error) {
+      return absl::InvalidArgumentError(absl::StrFormat(
+          "Cannot load project '%s': %s", project_path, error.what()));
+    } catch (...) {
+      return absl::InvalidArgumentError(absl::StrFormat(
+          "Cannot load project '%s': unknown project parse error",
+          project_path));
+    }
+  }
+  if (!open_status.ok()) {
+    return absl::Status(open_status.code(),
+                        absl::StrFormat("Cannot load project '%s': %s",
+                                        project_path, open_status.message()));
+  }
+
+  editor::MessageSourceSyncOptions options{
+      .write = write,
+      .expected_source_sha256 =
+          parser.GetString("expected-source-sha256").value_or(""),
+  };
+  auto result_or =
+      editor::SyncMessageSource(source_project, incoming_path, options);
+  if (!result_or.ok()) {
+    return result_or.status();
+  }
+  const auto& result = *result_or;
+
+  formatter.BeginObject("Message Source Sync");
+  formatter.AddField("status", "success");
+  formatter.AddField("mode", write ? "write" : "dry-run");
+  formatter.AddField("changed", result.changed);
+  formatter.AddField("wrote", result.wrote);
+  formatter.AddField("canonical_bundle", result.canonical_bundle_path.string());
+  formatter.AddField("generated_asm_include",
+                     result.generated_asm_include_path.string());
+  formatter.AddHexField("first_expanded_id", result.first_expanded_id, 3);
+  formatter.AddHexField("last_expanded_id", result.last_expanded_id, 3);
+  formatter.AddField("expanded_count", result.expanded_count);
+  formatter.AddField("incoming_updates", result.incoming_updates);
+  formatter.AddField("encoded_size", static_cast<int>(result.encoded_size));
+  formatter.AddField("capacity", static_cast<int>(result.capacity));
+  formatter.AddField("source_sha256_before", result.source_sha256_before);
+  formatter.AddField("proposed_source_sha256", result.proposed_source_sha256);
+  if (!result.backup_paths.empty()) {
+    formatter.BeginArray("backups");
+    for (const auto& path : result.backup_paths) {
+      formatter.AddArrayItem(path.string());
+    }
+    formatter.EndArray();
+  }
+  formatter.EndObject();
   return absl::OkStatus();
 }
 

--- a/src/cli/handlers/game/message_commands.cc
+++ b/src/cli/handlers/game/message_commands.cc
@@ -1205,13 +1205,6 @@ absl::Status MessageSourceSyncCommandHandler::Execute(
   formatter.AddField("capacity", static_cast<int>(result.capacity));
   formatter.AddField("source_sha256_before", result.source_sha256_before);
   formatter.AddField("proposed_source_sha256", result.proposed_source_sha256);
-  if (!result.backup_paths.empty()) {
-    formatter.BeginArray("backups");
-    for (const auto& path : result.backup_paths) {
-      formatter.AddArrayItem(path.string());
-    }
-    formatter.EndArray();
-  }
   formatter.EndObject();
   return absl::OkStatus();
 }

--- a/src/cli/handlers/game/message_commands.cc
+++ b/src/cli/handlers/game/message_commands.cc
@@ -108,6 +108,25 @@ absl::StatusOr<std::filesystem::path> CanonicalExistingPath(
   return canonical_path;
 }
 
+absl::Status EnsureConfiguredHackManifestLoaded(
+    project::YazeProject* project, absl::string_view project_path) {
+  if (project->hack_manifest.loaded() || project->hack_manifest_file.empty()) {
+    return absl::OkStatus();
+  }
+
+  const std::string manifest_path =
+      project->GetAbsolutePath(project->hack_manifest_file);
+  const absl::Status manifest_status =
+      project->hack_manifest.LoadFromFile(manifest_path);
+  if (manifest_status.ok()) {
+    return absl::OkStatus();
+  }
+  return absl::Status(
+      manifest_status.code(),
+      absl::StrFormat("Cannot load project '%s': hack manifest '%s': %s",
+                      project_path, manifest_path, manifest_status.message()));
+}
+
 std::string FormatManifestConflict(const core::WriteConflict& conflict) {
   std::string result =
       absl::StrFormat("address 0x%06X is %s", conflict.address,
@@ -162,6 +181,11 @@ absl::StatusOr<ExpandedMutationContext> PreflightExpandedMutation(
     return absl::Status(open_status.code(),
                         absl::StrFormat("Cannot load project '%s': %s",
                                         *project_path, open_status.message()));
+  }
+  if (absl::Status manifest_status =
+          EnsureConfiguredHackManifestLoaded(&context.project, *project_path);
+      !manifest_status.ok()) {
+    return manifest_status;
   }
 
   auto active_rom_path_or = CanonicalExistingPath(rom.filename(), "active ROM");
@@ -1175,6 +1199,11 @@ absl::Status MessageSourceSyncCommandHandler::Execute(
     return absl::Status(open_status.code(),
                         absl::StrFormat("Cannot load project '%s': %s",
                                         project_path, open_status.message()));
+  }
+  if (absl::Status manifest_status =
+          EnsureConfiguredHackManifestLoaded(&source_project, project_path);
+      !manifest_status.ok()) {
+    return manifest_status;
   }
 
   editor::MessageSourceSyncOptions options{

--- a/src/cli/handlers/game/message_commands.h
+++ b/src/cli/handlers/game/message_commands.h
@@ -258,6 +258,30 @@ class MessageExportAsmCommandHandler : public resources::CommandHandler {
                        resources::OutputFormatter& formatter) override;
 };
 
+/**
+ * @brief Merge an expanded-message subset into project-owned source artifacts.
+ *
+ * This command never mutates a ROM. It is dry-run by default; write mode
+ * requires an exact SHA-256 CAS for the canonical source bundle.
+ */
+class MessageSourceSyncCommandHandler : public resources::CommandHandler {
+ public:
+  std::string GetName() const override { return "message-source-sync"; }
+  std::string GetUsage() const override {
+    return "message-source-sync --project <path> --file <bundle.json> "
+           "[--expected-source-sha256 <sha256>] [--write] "
+           "[--format <json|text>]";
+  }
+  bool RequiresRom() const override { return false; }
+
+  absl::Status ValidateArgs(const resources::ArgumentParser& parser) override {
+    return parser.RequireArgs({"project", "file"});
+  }
+
+  absl::Status Execute(Rom* rom, const resources::ArgumentParser& parser,
+                       resources::OutputFormatter& formatter) override;
+};
+
 }  // namespace handlers
 }  // namespace cli
 }  // namespace yaze

--- a/src/cli/service/agent/tool_registration.cc
+++ b/src/cli/service/agent/tool_registration.cc
@@ -284,6 +284,12 @@ void RegisterBuiltinAgentTools(ToolRegistry& registry) {
   REGISTER_BUILTIN_AGENT_TOOL("message-search", "message", "Search messages",
                               "message-search --query=<text>", {}, true, false,
                               MessageSearchCommandHandler)
+  REGISTER_BUILTIN_AGENT_TOOL(
+      "message-source-sync", "message",
+      "Dry-run or publish canonical expanded-message source artifacts",
+      "message-source-sync --project=<path> --file=<bundle.json> "
+      "[--expected-source-sha256=<sha256>] [--write]",
+      {}, false, true, MessageSourceSyncCommandHandler)
   REGISTER_BUILTIN_AGENT_TOOL("dialogue-list", "dialogue", "List dialogues",
                               "dialogue-list", {}, true, false,
                               DialogueListCommandHandler)

--- a/src/cli/service/agent/tool_registration.cc
+++ b/src/cli/service/agent/tool_registration.cc
@@ -289,7 +289,7 @@ void RegisterBuiltinAgentTools(ToolRegistry& registry) {
       "Dry-run or publish canonical expanded-message source artifacts",
       "message-source-sync --project=<path> --file=<bundle.json> "
       "[--expected-source-sha256=<sha256>] [--write]",
-      {}, false, true, MessageSourceSyncCommandHandler)
+      {}, false, false, MessageSourceSyncCommandHandler)
   REGISTER_BUILTIN_AGENT_TOOL("dialogue-list", "dialogue", "List dialogues",
                               "dialogue-list", {}, true, false,
                               DialogueListCommandHandler)

--- a/src/cli/service/agent/tool_registry.cc
+++ b/src/cli/service/agent/tool_registry.cc
@@ -128,6 +128,7 @@ ToolAccess InferToolAccess(const std::string& tool_name) {
       "gui-click",
       "gui-place-tile",
       "gui-type",
+      "message-source-sync",
       "overworld-set-tile",
       "project-export",
       "project-import",

--- a/src/cli/service/command_registry.cc
+++ b/src/cli/service/command_registry.cc
@@ -324,6 +324,17 @@ void CommandRegistry::RegisterHandlers(
       metadata.category = "game";
       metadata.description = name.find("message-") == 0 ? "Message inspection"
                                                         : "Dialogue inspection";
+      if (name == "message-source-sync") {
+        metadata.description =
+            "Dry-run or CAS-publish a complete canonical expanded-message "
+            "bundle and deterministic no-org Asar include";
+        metadata.examples = {
+            "z3ed message-source-sync --project=Oracle-of-Secrets.yaze "
+            "--file=/tmp/message-edits.json --format=json",
+            "z3ed message-source-sync --project=Oracle-of-Secrets.yaze "
+            "--file=/tmp/message-edits.json "
+            "--expected-source-sha256=<sha256> --write --format=json"};
+      }
     } else if (name.find("music-") == 0) {
       metadata.category = "game";
       metadata.description = "Music/audio inspection";

--- a/src/core/hack_manifest.cc
+++ b/src/core/hack_manifest.cc
@@ -180,6 +180,31 @@ absl::StatusOr<int> ParseManifestVersion(const Json& root) {
   return static_cast<int>(version);
 }
 
+absl::StatusOr<int> ParseBoundedNonnegativeInteger(const Json& value,
+                                                   absl::string_view field,
+                                                   uint64_t maximum) {
+  uint64_t parsed = 0;
+  if (value.is_number_unsigned()) {
+    parsed = value.get<uint64_t>();
+  } else if (value.is_number_integer()) {
+    const int64_t signed_value = value.get<int64_t>();
+    if (signed_value < 0) {
+      return absl::InvalidArgumentError(
+          absl::StrFormat("%s must be a non-negative integer", field));
+    }
+    parsed = static_cast<uint64_t>(signed_value);
+  } else {
+    return absl::InvalidArgumentError(
+        absl::StrFormat("%s must be a non-negative integer", field));
+  }
+  if (parsed > maximum ||
+      parsed > static_cast<uint64_t>(std::numeric_limits<int>::max())) {
+    return absl::InvalidArgumentError(
+        absl::StrFormat("%s is too large", field));
+  }
+  return static_cast<int>(parsed);
+}
+
 absl::StatusOr<uint32_t> ParseLoRomAddress(const Json& object,
                                            const std::string& key,
                                            const std::string& path) {
@@ -798,9 +823,21 @@ absl::Status HackManifest::LoadFromString(const std::string& json_content) {
                        ParseHexAddress(msg.value("data_end", "0x000000")));
       message_layout_.data_end = NormalizeSnesAddress(message_layout_.data_end);
     }
-    message_layout_.vanilla_count = msg.value("vanilla_count", 397);
+    if (msg.contains("vanilla_count")) {
+      ASSIGN_OR_RETURN(
+          message_layout_.vanilla_count,
+          ParseBoundedNonnegativeInteger(
+              msg["vanilla_count"], "messages.vanilla_count",
+              static_cast<uint64_t>(std::numeric_limits<int>::max())));
+    } else {
+      message_layout_.vanilla_count = 397;
+    }
     if (msg.contains("expanded_range")) {
       auto& expanded = msg["expanded_range"];
+      if (!expanded.is_object()) {
+        return absl::InvalidArgumentError(
+            "messages.expanded_range must be an object");
+      }
       uint32_t first_id = 0;
       uint32_t last_id = 0;
       ASSIGN_OR_RETURN(first_id,
@@ -811,7 +848,16 @@ absl::Status HackManifest::LoadFromString(const std::string& json_content) {
           static_cast<uint16_t>(first_id & 0xFFFF);
       message_layout_.last_expanded_id =
           static_cast<uint16_t>(last_id & 0xFFFF);
-      message_layout_.expanded_count = expanded.value("count", 0);
+      if (expanded.contains("count")) {
+        constexpr uint64_t kMaximumExpandedMessageCount =
+            static_cast<uint64_t>(std::numeric_limits<uint16_t>::max()) + 1;
+        ASSIGN_OR_RETURN(message_layout_.expanded_count,
+                         ParseBoundedNonnegativeInteger(
+                             expanded["count"], "messages.expanded_range.count",
+                             kMaximumExpandedMessageCount));
+      } else {
+        message_layout_.expanded_count = 0;
+      }
     }
     if (msg.contains("source")) {
       const auto& source = msg["source"];
@@ -839,11 +885,15 @@ absl::Status HackManifest::LoadFromString(const std::string& json_content) {
         return absl::InvalidArgumentError(
             "messages.source.format must be 'yaze-message-bundle'");
       }
-      if (!source["version"].is_number_integer() ||
-          source["version"].get<int>() != 1) {
+      int source_version = 0;
+      auto source_version_or = ParseBoundedNonnegativeInteger(
+          source["version"], "messages.source.version",
+          static_cast<uint64_t>(std::numeric_limits<int>::max()));
+      if (!source_version_or.ok() || *source_version_or != 1) {
         return absl::InvalidArgumentError(
             "messages.source.version must be integer 1");
       }
+      source_version = *source_version_or;
       if (!source["canonical_bundle_path"].is_string() ||
           source["canonical_bundle_path"].get<std::string>().empty()) {
         return absl::InvalidArgumentError(
@@ -858,7 +908,7 @@ absl::Status HackManifest::LoadFromString(const std::string& json_content) {
       }
       message_layout_.source = MessageLayout::Source{
           .format = source["format"].get<std::string>(),
-          .version = source["version"].get<int>(),
+          .version = source_version,
           .canonical_bundle_path =
               source["canonical_bundle_path"].get<std::string>(),
           .generated_asm_include_path =

--- a/src/core/hack_manifest.cc
+++ b/src/core/hack_manifest.cc
@@ -778,6 +778,9 @@ absl::Status HackManifest::LoadFromString(const std::string& json_content) {
   // Message layout
   if (root.contains("messages")) {
     auto& msg = root["messages"];
+    if (!msg.is_object()) {
+      return absl::InvalidArgumentError("messages must be an object");
+    }
     if (msg.contains("hook_address") && msg["hook_address"].is_string()) {
       ASSIGN_OR_RETURN(message_layout_.hook_address,
                        ParseHexAddress(msg["hook_address"].get<std::string>()));
@@ -809,6 +812,58 @@ absl::Status HackManifest::LoadFromString(const std::string& json_content) {
       message_layout_.last_expanded_id =
           static_cast<uint16_t>(last_id & 0xFFFF);
       message_layout_.expanded_count = expanded.value("count", 0);
+    }
+    if (msg.contains("source")) {
+      const auto& source = msg["source"];
+      if (!source.is_object()) {
+        return absl::InvalidArgumentError("messages.source must be an object");
+      }
+      constexpr std::array<absl::string_view, 4> kSourceKeys = {
+          "format", "version", "canonical_bundle_path",
+          "generated_asm_include_path"};
+      for (const auto& item : source.items()) {
+        if (std::find(kSourceKeys.begin(), kSourceKeys.end(), item.key()) ==
+            kSourceKeys.end()) {
+          return absl::InvalidArgumentError(absl::StrFormat(
+              "messages.source contains unknown field '%s'", item.key()));
+        }
+      }
+      for (absl::string_view key : kSourceKeys) {
+        if (!source.contains(key)) {
+          return absl::InvalidArgumentError(
+              absl::StrFormat("messages.source.%s is required", key));
+        }
+      }
+      if (!source["format"].is_string() ||
+          source["format"].get<std::string>() != "yaze-message-bundle") {
+        return absl::InvalidArgumentError(
+            "messages.source.format must be 'yaze-message-bundle'");
+      }
+      if (!source["version"].is_number_integer() ||
+          source["version"].get<int>() != 1) {
+        return absl::InvalidArgumentError(
+            "messages.source.version must be integer 1");
+      }
+      if (!source["canonical_bundle_path"].is_string() ||
+          source["canonical_bundle_path"].get<std::string>().empty()) {
+        return absl::InvalidArgumentError(
+            "messages.source.canonical_bundle_path must be a non-empty "
+            "string");
+      }
+      if (!source["generated_asm_include_path"].is_string() ||
+          source["generated_asm_include_path"].get<std::string>().empty()) {
+        return absl::InvalidArgumentError(
+            "messages.source.generated_asm_include_path must be a non-empty "
+            "string");
+      }
+      message_layout_.source = MessageLayout::Source{
+          .format = source["format"].get<std::string>(),
+          .version = source["version"].get<int>(),
+          .canonical_bundle_path =
+              source["canonical_bundle_path"].get<std::string>(),
+          .generated_asm_include_path =
+              source["generated_asm_include_path"].get<std::string>(),
+      };
     }
   }
 

--- a/src/core/hack_manifest.h
+++ b/src/core/hack_manifest.h
@@ -92,6 +92,13 @@ struct SramVariable {
  * @brief Message range information for the expanded message system.
  */
 struct MessageLayout {
+  struct Source {
+    std::string format;
+    int version = 0;
+    std::string canonical_bundle_path;
+    std::string generated_asm_include_path;
+  };
+
   uint32_t hook_address;       // $0ED436
   uint32_t data_start;         // $2F8000
   uint32_t data_end;           // $2FFFFF
@@ -99,6 +106,7 @@ struct MessageLayout {
   uint16_t last_expanded_id;   // $1D1
   int expanded_count;
   int vanilla_count;  // 397
+  std::optional<Source> source;
 };
 
 /**

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -240,6 +240,7 @@ if(YAZE_BUILD_TESTS)
     unit/editor/message/message_data_test.cc
     unit/editor/message/message_id_resolver_test.cc
     unit/editor/message/message_expanded_write_test.cc
+    unit/editor/message/message_source_sync_test.cc
     unit/editor/oracle_validation_view_model_test.cc
     unit/editor/hack_workflow_backend_factory_test.cc
     unit/editor/rom_file_manager_test.cc
@@ -563,6 +564,7 @@ if(YAZE_BUILD_TESTS)
     unit/editor/editor_activator_test.cc
     unit/editor/story_event_graph_navigation_test.cc
     unit/editor/message/message_expanded_write_test.cc
+    unit/editor/message/message_source_sync_test.cc
     unit/editor/undo_manager_test.cc
     unit/editor/background_command_task_test.cc
     unit/editor/content_registry_workflow_history_test.cc

--- a/test/unit/cli/tool_dispatcher_test.cc
+++ b/test/unit/cli/tool_dispatcher_test.cc
@@ -141,6 +141,10 @@ TEST(ToolDispatcherUnitTest, MessageSourceSyncIsClassifiedAsMutating) {
       ToolRegistry::Get().GetToolDefinition("message-source-sync");
   ASSERT_TRUE(definition.has_value());
   EXPECT_EQ(definition->access, ToolAccess::kMutating);
+  EXPECT_FALSE(definition->requires_rom);
+  EXPECT_FALSE(definition->requires_project);
+  EXPECT_THAT(definition->required_args, Contains("project"));
+  EXPECT_THAT(definition->required_args, Contains("file"));
 }
 
 TEST(ToolDispatcherUnitTest, SharedValidationRejectsMissingRequiredArgs) {

--- a/test/unit/cli/tool_dispatcher_test.cc
+++ b/test/unit/cli/tool_dispatcher_test.cc
@@ -136,6 +136,13 @@ TEST(ToolDispatcherUnitTest,
   EXPECT_THAT(setter->flag_args, Contains("write"));
 }
 
+TEST(ToolDispatcherUnitTest, MessageSourceSyncIsClassifiedAsMutating) {
+  const auto definition =
+      ToolRegistry::Get().GetToolDefinition("message-source-sync");
+  ASSERT_TRUE(definition.has_value());
+  EXPECT_EQ(definition->access, ToolAccess::kMutating);
+}
+
 TEST(ToolDispatcherUnitTest, SharedValidationRejectsMissingRequiredArgs) {
   ToolRegistry::Get().RegisterTool(
       {"test-required-arg",

--- a/test/unit/core/hack_manifest_test.cc
+++ b/test/unit/core/hack_manifest_test.cc
@@ -482,6 +482,55 @@ TEST(HackManifestTest, ParsesMessageLayout) {
   EXPECT_FALSE(manifest.IsExpandedMessage(0x1D2));
 }
 
+TEST(HackManifestTest, ParsesOptionalMessageSourceMetadata) {
+  constexpr const char* kJson = R"json(
+{
+  "manifest_version": 3,
+  "messages": {
+    "data_start": "0x2F8026",
+    "data_end": "0x2FFFFF",
+    "expanded_range": {"first":"0x18D","last":"0x1F9","count":109},
+    "source": {
+      "format": "yaze-message-bundle",
+      "version": 1,
+      "canonical_bundle_path": "Data/Messages/expanded.json",
+      "generated_asm_include_path": "Core/generated/messages.asm"
+    }
+  }
+}
+)json";
+
+  HackManifest manifest;
+  ASSERT_TRUE(manifest.LoadFromString(kJson).ok());
+  ASSERT_TRUE(manifest.message_layout().source.has_value());
+  EXPECT_EQ(manifest.message_layout().source->format, "yaze-message-bundle");
+  EXPECT_EQ(manifest.message_layout().source->version, 1);
+  EXPECT_EQ(manifest.message_layout().source->canonical_bundle_path,
+            "Data/Messages/expanded.json");
+  EXPECT_EQ(manifest.message_layout().source->generated_asm_include_path,
+            "Core/generated/messages.asm");
+}
+
+TEST(HackManifestTest, RejectsMalformedMessageSourceMetadata) {
+  const std::pair<const char*, const char*> invalid_manifests[] = {
+      {R"json({"manifest_version":3,"messages":{"source":[]}})json",
+       "must be an object"},
+      {R"json({"manifest_version":3,"messages":{"source":{"format":"other","version":1,"canonical_bundle_path":"messages.json","generated_asm_include_path":"messages.asm"}}})json",
+       "format must be"},
+      {R"json({"manifest_version":3,"messages":{"source":{"format":"yaze-message-bundle","version":"1","canonical_bundle_path":"messages.json","generated_asm_include_path":"messages.asm"}}})json",
+       "version must be integer 1"},
+      {R"json({"manifest_version":3,"messages":{"source":{"format":"yaze-message-bundle","version":1,"canonical_bundle_path":"","generated_asm_include_path":"messages.asm"}}})json",
+       "canonical_bundle_path must be"},
+      {R"json({"manifest_version":3,"messages":{"source":{"format":"yaze-message-bundle","version":1,"canonical_bundle_path":"messages.json","generated_asm_include_path":"messages.asm","extra":true}}})json",
+       "unknown field"},
+  };
+
+  for (const auto& [json, expected_message] : invalid_manifests) {
+    SCOPED_TRACE(json);
+    ExpectManifestLoadFailure(json, expected_message);
+  }
+}
+
 TEST(HackManifestTest, ParsesDungeonStreamLayouts) {
   constexpr const char* kJson = R"json(
 {

--- a/test/unit/core/hack_manifest_test.cc
+++ b/test/unit/core/hack_manifest_test.cc
@@ -519,10 +519,26 @@ TEST(HackManifestTest, RejectsMalformedMessageSourceMetadata) {
        "format must be"},
       {R"json({"manifest_version":3,"messages":{"source":{"format":"yaze-message-bundle","version":"1","canonical_bundle_path":"messages.json","generated_asm_include_path":"messages.asm"}}})json",
        "version must be integer 1"},
+      {R"json({"manifest_version":3,"messages":{"source":{"format":"yaze-message-bundle","version":4294967297,"canonical_bundle_path":"messages.json","generated_asm_include_path":"messages.asm"}}})json",
+       "version must be integer 1"},
       {R"json({"manifest_version":3,"messages":{"source":{"format":"yaze-message-bundle","version":1,"canonical_bundle_path":"","generated_asm_include_path":"messages.asm"}}})json",
        "canonical_bundle_path must be"},
       {R"json({"manifest_version":3,"messages":{"source":{"format":"yaze-message-bundle","version":1,"canonical_bundle_path":"messages.json","generated_asm_include_path":"messages.asm","extra":true}}})json",
        "unknown field"},
+  };
+
+  for (const auto& [json, expected_message] : invalid_manifests) {
+    SCOPED_TRACE(json);
+    ExpectManifestLoadFailure(json, expected_message);
+  }
+}
+
+TEST(HackManifestTest, RejectsModuloNarrowingMessageLayoutCounts) {
+  const std::pair<const char*, const char*> invalid_manifests[] = {
+      {R"json({"manifest_version":3,"messages":{"expanded_range":{"first":"0x18D","last":"0x18F","count":4294967299}}})json",
+       "messages.expanded_range.count is too large"},
+      {R"json({"manifest_version":3,"messages":{"vanilla_count":4294967693}})json",
+       "messages.vanilla_count is too large"},
   };
 
   for (const auto& [json, expected_message] : invalid_manifests) {

--- a/test/unit/editor/message/message_source_sync_test.cc
+++ b/test/unit/editor/message/message_source_sync_test.cc
@@ -478,6 +478,44 @@ TEST(MessageSourceSyncTest, RejectsManifestCapacityOverflow) {
               HasSubstr("manifest capacity"));
 }
 
+TEST(MessageSourceSyncTest, RejectsCaseVariantOfPersistentLockAsTarget) {
+  ScopedTempDir temp;
+  auto project =
+      MakeProject(temp.path(), Manifest(".YAZE-MESSAGE-SOURCE-SYNC.LOCK"));
+  const fs::path canonical = temp.path() / "Data/Messages/expanded.json";
+  const fs::path incoming = temp.path() / "incoming.json";
+  WriteText(canonical, Bundle({{0, "A"}, {1, "B"}, {2, "C"}}));
+  WriteText(incoming, Subset(1, "X"));
+
+  auto result_or = SyncMessageSource(project, incoming);
+
+  ASSERT_FALSE(result_or.ok());
+  EXPECT_EQ(result_or.status().code(), absl::StatusCode::kInvalidArgument);
+  EXPECT_THAT(std::string(result_or.status().message()),
+              HasSubstr("persistent lock path"));
+  EXPECT_FALSE(fs::exists(temp.path() / ".yaze-message-source-sync.lock"));
+}
+
+TEST(MessageSourceSyncTest, RejectsExistingHardLinkAliasOfPersistentLock) {
+  ScopedTempDir temp;
+  SourceFixture fixture(temp.path());
+  const fs::path lock = temp.path() / ".yaze-message-source-sync.lock";
+  WriteText(lock, "");
+  std::error_code link_ec;
+  fs::create_hard_link(lock, fixture.include, link_ec);
+  if (link_ec) {
+    GTEST_SKIP() << "Cannot create hard link: " << link_ec.message();
+  }
+  WriteText(fixture.incoming, Subset(1, "X"));
+
+  auto result_or = SyncMessageSource(fixture.project, fixture.incoming);
+
+  ASSERT_FALSE(result_or.ok());
+  EXPECT_EQ(result_or.status().code(), absl::StatusCode::kInvalidArgument);
+  EXPECT_THAT(std::string(result_or.status().message()),
+              HasSubstr("aliases the persistent lock"));
+}
+
 #if !defined(_WIN32)
 TEST(MessageSourceSyncTest, RejectsSymlinkParentEscape) {
   ScopedTempDir temp;

--- a/test/unit/editor/message/message_source_sync_test.cc
+++ b/test/unit/editor/message/message_source_sync_test.cc
@@ -15,6 +15,7 @@
 #include <nlohmann/json.hpp>
 
 #include "absl/strings/match.h"
+#include "absl/strings/str_format.h"
 #include "absl/strings/string_view.h"
 #include "cli/handlers/game/message_commands.h"
 #include "zelda3/dungeon/oracle_rom_safety_preflight.h"

--- a/test/unit/editor/message/message_source_sync_test.cc
+++ b/test/unit/editor/message/message_source_sync_test.cc
@@ -744,5 +744,77 @@ TEST(MessageSourceSyncTest, CliHandlerIsRomIndependentAndReportsDryRun) {
   zelda3::GetResourceLabels().SetHackManifest(nullptr);
 }
 
+TEST(MessageSourceSyncTest,
+     CliHandlerRejectsMalformedManifestAndRestoresPriorBinding) {
+  ScopedTempDir temp;
+  const fs::path manifest_path = temp.path() / "hack_manifest.json";
+  const fs::path project_path = temp.path() / "project.yaze";
+  const fs::path incoming_path = temp.path() / "incoming.json";
+  Json malformed_manifest = Json::parse(Manifest());
+  malformed_manifest["messages"]["expanded_range"]["count"] = "three";
+  WriteText(manifest_path, malformed_manifest.dump(2));
+  WriteText(project_path,
+            "[project]\nname=MalformedMessageSourceCliTest\n\n"
+            "[files]\nhack_manifest_file=hack_manifest.json\n");
+  WriteText(incoming_path, Subset(1, "X"));
+
+  core::HackManifest prior_manifest;
+  ASSERT_TRUE(prior_manifest
+                  .LoadFromString(
+                      R"json({"manifest_version":3,"hack_name":"Prior"})json")
+                  .ok());
+  auto& resource_labels = zelda3::GetResourceLabels();
+  resource_labels.SetHackManifest(&prior_manifest);
+
+  cli::handlers::MessageSourceSyncCommandHandler handler;
+  std::string output;
+  const absl::Status status =
+      handler.Run({"--project=" + project_path.string(),
+                   "--file=" + incoming_path.string(), "--format=json"},
+                  nullptr, &output);
+
+  EXPECT_EQ(resource_labels.hack_manifest(), &prior_manifest);
+  resource_labels.SetHackManifest(nullptr);
+  EXPECT_EQ(status.code(), absl::StatusCode::kInvalidArgument) << output;
+  EXPECT_THAT(std::string(status.message()), HasSubstr("Cannot load project"));
+  EXPECT_THAT(std::string(status.message()),
+              HasSubstr("messages.expanded_range.count"));
+  ExpectNoPublicationArtifacts(temp.path());
+}
+
+TEST(MessageSourceSyncTest,
+     CliHandlerRejectsMissingManifestAndRestoresPriorBinding) {
+  ScopedTempDir temp;
+  const fs::path project_path = temp.path() / "project.yaze";
+  const fs::path incoming_path = temp.path() / "incoming.json";
+  WriteText(project_path,
+            "[project]\nname=MissingMessageSourceCliTest\n\n"
+            "[files]\nhack_manifest_file=missing_manifest.json\n");
+  WriteText(incoming_path, Subset(1, "X"));
+
+  core::HackManifest prior_manifest;
+  ASSERT_TRUE(prior_manifest
+                  .LoadFromString(
+                      R"json({"manifest_version":3,"hack_name":"Prior"})json")
+                  .ok());
+  auto& resource_labels = zelda3::GetResourceLabels();
+  resource_labels.SetHackManifest(&prior_manifest);
+
+  cli::handlers::MessageSourceSyncCommandHandler handler;
+  std::string output;
+  const absl::Status status =
+      handler.Run({"--project=" + project_path.string(),
+                   "--file=" + incoming_path.string(), "--format=json"},
+                  nullptr, &output);
+
+  EXPECT_EQ(resource_labels.hack_manifest(), &prior_manifest);
+  resource_labels.SetHackManifest(nullptr);
+  EXPECT_EQ(status.code(), absl::StatusCode::kNotFound) << output;
+  EXPECT_THAT(std::string(status.message()), HasSubstr("Cannot load project"));
+  EXPECT_THAT(std::string(status.message()),
+              HasSubstr("Could not open manifest"));
+  ExpectNoPublicationArtifacts(temp.path());
+}
+
 }  // namespace
 }  // namespace yaze::editor

--- a/test/unit/editor/message/message_source_sync_test.cc
+++ b/test/unit/editor/message/message_source_sync_test.cc
@@ -1,0 +1,442 @@
+#include "app/editor/message/message_source_sync.h"
+
+#include <chrono>
+#include <filesystem>
+#include <fstream>
+#include <iterator>
+#include <string>
+#include <vector>
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include <nlohmann/json.hpp>
+
+#include "absl/strings/match.h"
+#include "absl/strings/string_view.h"
+#include "cli/handlers/game/message_commands.h"
+#include "zelda3/dungeon/oracle_rom_safety_preflight.h"
+#include "zelda3/resource_labels.h"
+
+namespace yaze::editor {
+namespace {
+
+namespace fs = std::filesystem;
+using ::testing::HasSubstr;
+using Json = nlohmann::json;
+
+class ScopedTempDir {
+ public:
+  ScopedTempDir() {
+    const auto nonce =
+        std::chrono::steady_clock::now().time_since_epoch().count();
+    path_ = fs::temp_directory_path() /
+            ("yaze_message_source_sync_" + std::to_string(nonce));
+    fs::create_directories(path_);
+  }
+
+  ~ScopedTempDir() {
+    std::error_code ec;
+    fs::remove_all(path_, ec);
+  }
+
+  const fs::path& path() const { return path_; }
+
+ private:
+  fs::path path_;
+};
+
+void WriteText(const fs::path& path, const std::string& content) {
+  std::ofstream output(path, std::ios::binary | std::ios::trunc);
+  ASSERT_TRUE(output.is_open()) << path;
+  output << content;
+  ASSERT_TRUE(output.good()) << path;
+}
+
+std::string ReadText(const fs::path& path) {
+  std::ifstream input(path, std::ios::binary);
+  EXPECT_TRUE(input.is_open()) << path;
+  return {std::istreambuf_iterator<char>(input),
+          std::istreambuf_iterator<char>()};
+}
+
+std::string Bundle(const std::vector<std::pair<int, std::string>>& messages,
+                   int count = -1) {
+  if (count < 0) {
+    count = static_cast<int>(messages.size());
+  }
+  Json document;
+  document["format"] = "yaze-message-bundle";
+  document["version"] = 1;
+  document["counts"] = {{"vanilla", 0}, {"expanded", count}};
+  document["messages"] = Json::array();
+  for (const auto& [id, text] : messages) {
+    document["messages"].push_back(
+        {{"id", id}, {"bank", "expanded"}, {"text", text}});
+  }
+  return document.dump(2) + "\n";
+}
+
+std::string Subset(int id, const std::string& text,
+                   absl::string_view text_field = "text") {
+  Json document;
+  document["format"] = "yaze-message-bundle";
+  document["version"] = 1;
+  document["counts"] = {{"vanilla", 0}, {"expanded", 1}};
+  Json entry;
+  entry["id"] = id;
+  entry["bank"] = "expanded";
+  entry[std::string(text_field)] = text;
+  document["messages"] = Json::array({std::move(entry)});
+  return document.dump(2) + "\n";
+}
+
+std::string Manifest(
+    absl::string_view include_path = "Core/generated/messages.asm",
+    absl::string_view data_end = "0x2F80FF",
+    absl::string_view range_last = "0x18F", int count = 3) {
+  Json manifest = {
+      {"manifest_version", 3},
+      {"hack_name", "Message Source Test"},
+      {"messages",
+       {{"data_start", "0x2F8026"},
+        {"data_end", data_end},
+        {"expanded_range",
+         {{"first", "0x18D"}, {"last", range_last}, {"count", count}}},
+        {"source",
+         {{"format", "yaze-message-bundle"},
+          {"version", 1},
+          {"canonical_bundle_path", "Data/Messages/expanded.json"},
+          {"generated_asm_include_path", include_path}}}}}};
+  return manifest.dump(2);
+}
+
+project::YazeProject MakeProject(const fs::path& root,
+                                 const std::string& manifest = Manifest()) {
+  fs::create_directories(root / "Data/Messages");
+  fs::create_directories(root / "Core/generated");
+  project::YazeProject project;
+  project.filepath = (root / "project.yaze").string();
+  EXPECT_TRUE(project.hack_manifest.LoadFromString(manifest).ok());
+  return project;
+}
+
+struct SourceFixture {
+  explicit SourceFixture(const fs::path& root)
+      : project(MakeProject(root)),
+        canonical(root / "Data/Messages/expanded.json"),
+        include(root / "Core/generated/messages.asm"),
+        incoming(root / "incoming.json") {
+    WriteText(canonical, Bundle({{0, "A"}, {1, "B"}, {2, "C"}}));
+  }
+
+  project::YazeProject project;
+  fs::path canonical;
+  fs::path include;
+  fs::path incoming;
+};
+
+TEST(MessageSourceSyncTest, DryRunDoesNotPublishEitherArtifact) {
+  ScopedTempDir temp;
+  SourceFixture fixture(temp.path());
+  WriteText(fixture.incoming, Subset(1, "X"));
+  const std::string before = ReadText(fixture.canonical);
+
+  auto result_or = SyncMessageSource(fixture.project, fixture.incoming);
+
+  ASSERT_TRUE(result_or.ok()) << result_or.status();
+  EXPECT_TRUE(result_or->changed);
+  EXPECT_FALSE(result_or->wrote);
+  EXPECT_EQ(result_or->incoming_updates, 1);
+  EXPECT_EQ(result_or->expanded_count, 3);
+  EXPECT_EQ(ReadText(fixture.canonical), before);
+  EXPECT_FALSE(fs::exists(fixture.include));
+}
+
+TEST(MessageSourceSyncTest, Sha256MatchesPublishedKnownVectors) {
+  EXPECT_EQ(ComputeMessageSourceSha256(""),
+            "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855");
+  EXPECT_EQ(ComputeMessageSourceSha256("abc"),
+            "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad");
+}
+
+TEST(MessageSourceSyncTest,
+     WritePublishesDeterministicBundleAndHashBoundInclude) {
+  ScopedTempDir temp;
+  SourceFixture fixture(temp.path());
+  Json incoming = Json::parse(Subset(1, "[D:$a]X"));
+  incoming["messages"][0]["raw"] = "stale";
+  WriteText(fixture.incoming, incoming.dump(2) + "\n");
+  auto preview_or = SyncMessageSource(fixture.project, fixture.incoming);
+  ASSERT_TRUE(preview_or.ok()) << preview_or.status();
+
+  auto write_or = SyncMessageSource(
+      fixture.project, fixture.incoming,
+      {.write = true,
+       .expected_source_sha256 = preview_or->source_sha256_before});
+
+  ASSERT_TRUE(write_or.ok()) << write_or.status();
+  EXPECT_TRUE(write_or->wrote);
+  ASSERT_EQ(write_or->backup_paths.size(), 1u);
+  EXPECT_TRUE(fs::exists(write_or->backup_paths.front()));
+  EXPECT_EQ(ReadText(write_or->backup_paths.front()),
+            Bundle({{0, "A"}, {1, "B"}, {2, "C"}}));
+
+  const std::string canonical = ReadText(fixture.canonical);
+  EXPECT_EQ(canonical, Bundle({{0, "A"}, {1, "[D:0A]X"}, {2, "C"}}));
+  EXPECT_EQ(canonical.back(), '\n');
+
+  const std::string include = ReadText(fixture.include);
+  EXPECT_TRUE(absl::StartsWith(
+      include,
+      "; Source bundle SHA-256: " + write_or->proposed_source_sha256 + "\n"));
+  const size_t body_start = include.find("Message_18D:");
+  ASSERT_NE(body_start, std::string::npos);
+  const std::string body = include.substr(body_start);
+  const fs::path body_path = temp.path() / "body.asm";
+  WriteText(body_path, body);
+  auto body_hash_or = zelda3::ComputeSha256(body_path.string());
+  ASSERT_TRUE(body_hash_or.ok()) << body_hash_or.status();
+  EXPECT_THAT(
+      include,
+      HasSubstr("; Generated ASM body SHA-256: " + *body_hash_or + "\n"));
+  EXPECT_THAT(include, HasSubstr("Message_18D:\n  db $00, $7F\n\n"));
+  EXPECT_THAT(include, HasSubstr("Message_18E:\n  db $92, $17, $7F\n\n"));
+  EXPECT_THAT(include, HasSubstr("Message_18F:\n  db $02, $7F\n\n"));
+  EXPECT_TRUE(absl::EndsWith(include, "db $FF\n"));
+  EXPECT_EQ(include.find("\norg "), std::string::npos);
+}
+
+TEST(MessageSourceSyncTest,
+     WritePreservesEmptyMessageAndAcceptedCommandArgumentSpellings) {
+  ScopedTempDir temp;
+  SourceFixture fixture(temp.path());
+  WriteText(fixture.incoming, Bundle({{0, ""}, {1, "[W:7][W:7F][W:FF]"}}, 2));
+  auto preview_or = SyncMessageSource(fixture.project, fixture.incoming);
+  ASSERT_TRUE(preview_or.ok()) << preview_or.status();
+
+  auto write_or = SyncMessageSource(
+      fixture.project, fixture.incoming,
+      {.write = true,
+       .expected_source_sha256 = preview_or->source_sha256_before});
+
+  ASSERT_TRUE(write_or.ok()) << write_or.status();
+  EXPECT_EQ(ReadText(fixture.canonical),
+            Bundle({{0, ""}, {1, "[W:7][W:7F][W:FF]"}, {2, "C"}}));
+  const std::string include = ReadText(fixture.include);
+  EXPECT_THAT(include, HasSubstr("Message_18D:\n  db $7F\n\n"));
+  EXPECT_THAT(include, HasSubstr("Message_18E:\n"
+                                 "  db $6B, $07, $6B, $7F, $6B, $FF, $7F\n\n"));
+}
+
+TEST(MessageSourceSyncTest, RejectsMissingAndLowercaseCommandArguments) {
+  for (const std::string& invalid_text : {"[W]", "[W:ff]"}) {
+    SCOPED_TRACE(invalid_text);
+    ScopedTempDir temp;
+    SourceFixture fixture(temp.path());
+    WriteText(fixture.incoming, Subset(1, invalid_text));
+    const std::string before = ReadText(fixture.canonical);
+
+    auto result_or = SyncMessageSource(fixture.project, fixture.incoming);
+
+    ASSERT_FALSE(result_or.ok());
+    EXPECT_EQ(result_or.status().code(), absl::StatusCode::kInvalidArgument);
+    EXPECT_EQ(ReadText(fixture.canonical), before);
+    EXPECT_FALSE(fs::exists(fixture.include));
+  }
+}
+
+TEST(MessageSourceSyncTest, WriteRequiresMatchingSourceCas) {
+  ScopedTempDir temp;
+  SourceFixture fixture(temp.path());
+  WriteText(fixture.incoming, Subset(0, "X"));
+  const std::string before = ReadText(fixture.canonical);
+
+  auto result_or = SyncMessageSource(
+      fixture.project, fixture.incoming,
+      {.write = true,
+       .expected_source_sha256 =
+           "0000000000000000000000000000000000000000000000000000000000000000"});
+
+  ASSERT_FALSE(result_or.ok());
+  EXPECT_EQ(result_or.status().code(), absl::StatusCode::kAborted);
+  EXPECT_THAT(std::string(result_or.status().message()), HasSubstr("CAS"));
+  EXPECT_EQ(ReadText(fixture.canonical), before);
+  EXPECT_FALSE(fs::exists(fixture.include));
+}
+
+TEST(MessageSourceSyncTest, DriftedGeneratedIncludeFailsClosed) {
+  ScopedTempDir temp;
+  SourceFixture fixture(temp.path());
+  WriteText(fixture.incoming, Subset(1, "X"));
+  auto first_preview = SyncMessageSource(fixture.project, fixture.incoming);
+  ASSERT_TRUE(first_preview.ok()) << first_preview.status();
+  auto first_write = SyncMessageSource(
+      fixture.project, fixture.incoming,
+      {.write = true,
+       .expected_source_sha256 = first_preview->source_sha256_before});
+  ASSERT_TRUE(first_write.ok()) << first_write.status();
+
+  WriteText(fixture.include, ReadText(fixture.include) + "; manual edit\n");
+  const std::string canonical_before = ReadText(fixture.canonical);
+  const std::string include_before = ReadText(fixture.include);
+  WriteText(fixture.incoming, Subset(2, "Y"));
+  auto next_preview = SyncMessageSource(fixture.project, fixture.incoming);
+  ASSERT_FALSE(next_preview.ok());
+  EXPECT_EQ(next_preview.status().code(),
+            absl::StatusCode::kFailedPrecondition);
+  EXPECT_THAT(std::string(next_preview.status().message()),
+              HasSubstr("drifted"));
+
+  auto result_or = SyncMessageSource(
+      fixture.project, fixture.incoming,
+      {.write = true,
+       .expected_source_sha256 = first_write->proposed_source_sha256});
+
+  ASSERT_FALSE(result_or.ok());
+  EXPECT_EQ(result_or.status().code(), absl::StatusCode::kFailedPrecondition);
+  EXPECT_THAT(std::string(result_or.status().message()), HasSubstr("drifted"));
+  EXPECT_EQ(ReadText(fixture.canonical), canonical_before);
+  EXPECT_EQ(ReadText(fixture.include), include_before);
+}
+
+#if !defined(_WIN32)
+TEST(MessageSourceSyncTest, PreparationFailureCleansTempsAndBackups) {
+  ScopedTempDir temp;
+  SourceFixture fixture(temp.path());
+  WriteText(fixture.incoming, Subset(1, "X"));
+  auto preview = SyncMessageSource(fixture.project, fixture.incoming);
+  ASSERT_TRUE(preview.ok()) << preview.status();
+
+  const fs::path include_dir = fixture.include.parent_path();
+  fs::permissions(include_dir,
+                  fs::perms::owner_read | fs::perms::owner_exec |
+                      fs::perms::group_read | fs::perms::group_exec |
+                      fs::perms::others_read | fs::perms::others_exec);
+  auto result_or = SyncMessageSource(
+      fixture.project, fixture.incoming,
+      {.write = true, .expected_source_sha256 = preview->source_sha256_before});
+  fs::permissions(include_dir, fs::perms::owner_all);
+
+  ASSERT_FALSE(result_or.ok());
+  EXPECT_EQ(ReadText(fixture.canonical),
+            Bundle({{0, "A"}, {1, "B"}, {2, "C"}}));
+  EXPECT_FALSE(fs::exists(fixture.include));
+  for (const auto& entry : fs::recursive_directory_iterator(temp.path())) {
+    EXPECT_EQ(entry.path().filename().string().find(".yaze-tmp-"),
+              std::string::npos)
+        << entry.path();
+    EXPECT_EQ(entry.path().filename().string().find(".yaze-backup-"),
+              std::string::npos)
+        << entry.path();
+  }
+}
+#endif
+
+TEST(MessageSourceSyncTest, RejectsBankSwitchAndIncompleteCanonicalBank) {
+  ScopedTempDir temp;
+  SourceFixture fixture(temp.path());
+  WriteText(fixture.incoming, Subset(1, "A[BANK]B"));
+  auto bank_result = SyncMessageSource(fixture.project, fixture.incoming);
+  ASSERT_FALSE(bank_result.ok());
+  EXPECT_EQ(bank_result.status().code(), absl::StatusCode::kInvalidArgument);
+  EXPECT_THAT(std::string(bank_result.status().message()), HasSubstr("[BANK]"));
+
+  WriteText(fixture.canonical, Bundle({{0, "A"}, {2, "C"}}, 3));
+  WriteText(fixture.incoming, Subset(1, "B"));
+  auto incomplete_result = SyncMessageSource(fixture.project, fixture.incoming);
+  ASSERT_FALSE(incomplete_result.ok());
+  EXPECT_EQ(incomplete_result.status().code(),
+            absl::StatusCode::kFailedPrecondition);
+  EXPECT_THAT(std::string(incomplete_result.status().message()),
+              HasSubstr("complete expanded bank"));
+}
+
+TEST(MessageSourceSyncTest, RejectsLiteralNewlinesThatEncoderWouldIgnore) {
+  ScopedTempDir temp;
+  SourceFixture fixture(temp.path());
+  WriteText(fixture.incoming, Subset(1, "A\nB"));
+  const std::string before = ReadText(fixture.canonical);
+
+  auto result_or = SyncMessageSource(fixture.project, fixture.incoming);
+
+  ASSERT_FALSE(result_or.ok());
+  EXPECT_EQ(result_or.status().code(), absl::StatusCode::kInvalidArgument);
+  EXPECT_THAT(std::string(result_or.status().message()),
+              HasSubstr("Literal newlines are ignored"));
+  EXPECT_EQ(ReadText(fixture.canonical), before);
+  EXPECT_FALSE(fs::exists(fixture.include));
+}
+
+TEST(MessageSourceSyncTest, RejectsManifestCapacityOverflow) {
+  ScopedTempDir temp;
+  auto project =
+      MakeProject(temp.path(), Manifest("Core/generated/messages.asm",
+                                        /*data_end=*/"0x2F802A"));
+  const fs::path canonical = temp.path() / "Data/Messages/expanded.json";
+  const fs::path incoming = temp.path() / "incoming.json";
+  WriteText(canonical, Bundle({{0, "A"}, {1, "B"}, {2, "C"}}));
+  WriteText(incoming, Subset(1, "B"));
+
+  auto result_or = SyncMessageSource(project, incoming);
+
+  ASSERT_FALSE(result_or.ok());
+  EXPECT_EQ(result_or.status().code(), absl::StatusCode::kResourceExhausted);
+  EXPECT_THAT(std::string(result_or.status().message()),
+              HasSubstr("manifest capacity"));
+}
+
+#if !defined(_WIN32)
+TEST(MessageSourceSyncTest, RejectsSymlinkParentEscape) {
+  ScopedTempDir temp;
+  const fs::path outside = temp.path() / "outside";
+  const fs::path project_root = temp.path() / "project";
+  fs::create_directories(outside);
+  auto project = MakeProject(project_root, Manifest("escape/generated.asm"));
+  std::error_code link_ec;
+  fs::create_directory_symlink(outside, project_root / "escape", link_ec);
+  if (link_ec) {
+    GTEST_SKIP() << "Cannot create directory symlink: " << link_ec.message();
+  }
+  const fs::path canonical = project_root / "Data/Messages/expanded.json";
+  const fs::path incoming = project_root / "incoming.json";
+  WriteText(canonical, Bundle({{0, "A"}, {1, "B"}, {2, "C"}}));
+  WriteText(incoming, Subset(1, "X"));
+
+  auto result_or = SyncMessageSource(project, incoming);
+
+  ASSERT_FALSE(result_or.ok());
+  EXPECT_EQ(result_or.status().code(), absl::StatusCode::kPermissionDenied);
+  EXPECT_THAT(std::string(result_or.status().message()),
+              HasSubstr("escapes project root"));
+  EXPECT_FALSE(fs::exists(outside / "generated.asm"));
+}
+#endif
+
+TEST(MessageSourceSyncTest, CliHandlerIsRomIndependentAndReportsDryRun) {
+  ScopedTempDir temp;
+  SourceFixture fixture(temp.path());
+  const fs::path manifest_path = temp.path() / "hack_manifest.json";
+  const fs::path project_path = temp.path() / "project.yaze";
+  WriteText(manifest_path, Manifest());
+  WriteText(project_path,
+            "[project]\nname=MessageSourceCliTest\n\n"
+            "[files]\nhack_manifest_file=hack_manifest.json\n");
+  WriteText(fixture.incoming, Subset(1, "X"));
+
+  cli::handlers::MessageSourceSyncCommandHandler handler;
+  EXPECT_FALSE(handler.RequiresRom());
+  std::string output;
+  auto status =
+      handler.Run({"--project=" + project_path.string(),
+                   "--file=" + fixture.incoming.string(), "--format=json"},
+                  nullptr, &output);
+
+  ASSERT_TRUE(status.ok()) << status << "\n" << output;
+  EXPECT_THAT(output, HasSubstr("\"mode\": \"dry-run\""));
+  EXPECT_THAT(output, HasSubstr("\"wrote\": false"));
+  EXPECT_FALSE(fs::exists(fixture.include));
+  zelda3::GetResourceLabels().SetHackManifest(nullptr);
+}
+
+}  // namespace
+}  // namespace yaze::editor

--- a/test/unit/editor/message/message_source_sync_test.cc
+++ b/test/unit/editor/message/message_source_sync_test.cc
@@ -1,10 +1,12 @@
 #include "app/editor/message/message_source_sync.h"
 
+#include <barrier>
 #include <chrono>
 #include <filesystem>
 #include <fstream>
 #include <iterator>
 #include <string>
+#include <thread>
 #include <vector>
 
 #include <gmock/gmock.h>
@@ -57,6 +59,15 @@ std::string ReadText(const fs::path& path) {
   EXPECT_TRUE(input.is_open()) << path;
   return {std::istreambuf_iterator<char>(input),
           std::istreambuf_iterator<char>()};
+}
+
+void ExpectNoPublicationArtifacts(const fs::path& root) {
+  for (const auto& entry : fs::recursive_directory_iterator(root)) {
+    const std::string filename = entry.path().filename().string();
+    EXPECT_EQ(filename.find(".yaze-tmp-"), std::string::npos) << entry.path();
+    EXPECT_EQ(filename.find(".yaze-backup-"), std::string::npos)
+        << entry.path();
+  }
 }
 
 std::string Bundle(const std::vector<std::pair<int, std::string>>& messages,
@@ -176,10 +187,7 @@ TEST(MessageSourceSyncTest,
 
   ASSERT_TRUE(write_or.ok()) << write_or.status();
   EXPECT_TRUE(write_or->wrote);
-  ASSERT_EQ(write_or->backup_paths.size(), 1u);
-  EXPECT_TRUE(fs::exists(write_or->backup_paths.front()));
-  EXPECT_EQ(ReadText(write_or->backup_paths.front()),
-            Bundle({{0, "A"}, {1, "B"}, {2, "C"}}));
+  ExpectNoPublicationArtifacts(temp.path());
 
   const std::string canonical = ReadText(fixture.canonical);
   EXPECT_EQ(canonical, Bundle({{0, "A"}, {1, "[D:0A]X"}, {2, "C"}}));
@@ -205,6 +213,98 @@ TEST(MessageSourceSyncTest,
   EXPECT_TRUE(absl::EndsWith(include, "db $FF\n"));
   EXPECT_EQ(include.find("\norg "), std::string::npos);
 }
+
+TEST(MessageSourceSyncTest,
+     ConcurrentSameCasWritersPublishExactlyOneCompletePair) {
+  ScopedTempDir temp;
+  SourceFixture fixture(temp.path());
+  const fs::path incoming_x = temp.path() / "incoming-x.json";
+  const fs::path incoming_y = temp.path() / "incoming-y.json";
+  WriteText(incoming_x, Subset(1, "X"));
+  WriteText(incoming_y, Subset(1, "Y"));
+  const std::string expected_sha =
+      ComputeMessageSourceSha256(ReadText(fixture.canonical));
+
+  std::barrier rendezvous(3);
+  absl::StatusOr<MessageSourceSyncResult> result_x =
+      absl::UnknownError("writer X did not run");
+  absl::StatusOr<MessageSourceSyncResult> result_y =
+      absl::UnknownError("writer Y did not run");
+  std::thread writer_x([&] {
+    rendezvous.arrive_and_wait();
+    result_x = SyncMessageSource(
+        fixture.project, incoming_x,
+        {.write = true, .expected_source_sha256 = expected_sha});
+  });
+  std::thread writer_y([&] {
+    rendezvous.arrive_and_wait();
+    result_y = SyncMessageSource(
+        fixture.project, incoming_y,
+        {.write = true, .expected_source_sha256 = expected_sha});
+  });
+  rendezvous.arrive_and_wait();
+  writer_x.join();
+  writer_y.join();
+
+  const int successes =
+      static_cast<int>(result_x.ok()) + static_cast<int>(result_y.ok());
+  ASSERT_EQ(successes, 1);
+  const auto& loser = result_x.ok() ? result_y : result_x;
+  EXPECT_EQ(loser.status().code(), absl::StatusCode::kAborted);
+
+  const std::string canonical = ReadText(fixture.canonical);
+  const std::string expected_x = Bundle({{0, "A"}, {1, "X"}, {2, "C"}});
+  const std::string expected_y = Bundle({{0, "A"}, {1, "Y"}, {2, "C"}});
+  EXPECT_TRUE(canonical == expected_x || canonical == expected_y);
+  const std::string include = ReadText(fixture.include);
+  EXPECT_TRUE(absl::StartsWith(
+      include, "; Source bundle SHA-256: " +
+                   ComputeMessageSourceSha256(canonical) + "\n"));
+  EXPECT_THAT(include,
+              HasSubstr(canonical == expected_x ? "$17, $7F" : "$18, $7F"));
+  EXPECT_TRUE(fs::exists(temp.path() / ".yaze-message-source-sync.lock"));
+  ExpectNoPublicationArtifacts(temp.path());
+}
+
+#if !defined(_WIN32)
+TEST(MessageSourceSyncTest, WritePreservesExistingPosixModes) {
+  ScopedTempDir temp;
+  SourceFixture fixture(temp.path());
+  WriteText(fixture.incoming, Subset(1, "X"));
+  auto first_preview = SyncMessageSource(fixture.project, fixture.incoming);
+  ASSERT_TRUE(first_preview.ok()) << first_preview.status();
+  auto first_write = SyncMessageSource(
+      fixture.project, fixture.incoming,
+      {.write = true,
+       .expected_source_sha256 = first_preview->source_sha256_before});
+  ASSERT_TRUE(first_write.ok()) << first_write.status();
+
+  constexpr fs::perms kCanonicalMode =
+      fs::perms::owner_read | fs::perms::owner_write | fs::perms::group_read;
+  constexpr fs::perms kIncludeMode =
+      fs::perms::owner_read | fs::perms::owner_write | fs::perms::group_read |
+      fs::perms::group_write | fs::perms::others_read;
+  fs::permissions(fixture.canonical, kCanonicalMode, fs::perm_options::replace);
+  fs::permissions(fixture.include, kIncludeMode, fs::perm_options::replace);
+
+  WriteText(fixture.incoming, Subset(2, "Y"));
+  auto next_preview = SyncMessageSource(fixture.project, fixture.incoming);
+  ASSERT_TRUE(next_preview.ok()) << next_preview.status();
+  auto next_write = SyncMessageSource(
+      fixture.project, fixture.incoming,
+      {.write = true,
+       .expected_source_sha256 = next_preview->source_sha256_before});
+  ASSERT_TRUE(next_write.ok()) << next_write.status();
+
+  constexpr fs::perms kPermissionMask =
+      fs::perms::owner_all | fs::perms::group_all | fs::perms::others_all;
+  EXPECT_EQ(fs::status(fixture.canonical).permissions() & kPermissionMask,
+            kCanonicalMode);
+  EXPECT_EQ(fs::status(fixture.include).permissions() & kPermissionMask,
+            kIncludeMode);
+  ExpectNoPublicationArtifacts(temp.path());
+}
+#endif
 
 TEST(MessageSourceSyncTest,
      WritePreservesEmptyMessageAndAcceptedCommandArgumentSpellings) {
@@ -321,14 +421,7 @@ TEST(MessageSourceSyncTest, PreparationFailureCleansTempsAndBackups) {
   EXPECT_EQ(ReadText(fixture.canonical),
             Bundle({{0, "A"}, {1, "B"}, {2, "C"}}));
   EXPECT_FALSE(fs::exists(fixture.include));
-  for (const auto& entry : fs::recursive_directory_iterator(temp.path())) {
-    EXPECT_EQ(entry.path().filename().string().find(".yaze-tmp-"),
-              std::string::npos)
-        << entry.path();
-    EXPECT_EQ(entry.path().filename().string().find(".yaze-backup-"),
-              std::string::npos)
-        << entry.path();
-  }
+  ExpectNoPublicationArtifacts(temp.path());
 }
 #endif
 

--- a/test/unit/editor/message/message_source_sync_test.cc
+++ b/test/unit/editor/message/message_source_sync_test.cc
@@ -22,6 +22,7 @@
 #include "zelda3/resource_labels.h"
 
 #if !defined(_WIN32) && !defined(__EMSCRIPTEN__)
+#include <sys/stat.h>
 #include <sys/wait.h>
 #include <unistd.h>
 #endif
@@ -690,6 +691,92 @@ TEST(MessageSourceSyncTest, RejectsExistingHardLinkAliasOfPersistentLock) {
   EXPECT_THAT(std::string(result_or.status().message()),
               HasSubstr("aliases a persistent lock"));
 }
+
+#if !defined(__EMSCRIPTEN__)
+TEST(MessageSourceSyncTest,
+     RejectsHardLinkedPersistentLocksWithoutChangingExternalFile) {
+  ScopedTempDir temp;
+  SourceFixture fixture(temp.path());
+  const fs::path external = temp.path() / "unrelated.txt";
+  const fs::path canonical_lock =
+      fixture.canonical.parent_path() / ".yaze-message-source-sync.lock";
+  const fs::path include_lock =
+      fixture.include.parent_path() / ".yaze-message-source-sync.lock";
+  WriteText(external, "unrelated");
+#if !defined(_WIN32)
+  ASSERT_EQ(chmod(external.c_str(), 0644), 0);
+#endif
+  std::error_code link_ec;
+  fs::create_hard_link(external, canonical_lock, link_ec);
+  if (link_ec) {
+    GTEST_SKIP() << "Cannot create canonical lock hard link: "
+                 << link_ec.message();
+  }
+  fs::create_hard_link(external, include_lock, link_ec);
+  if (link_ec) {
+    GTEST_SKIP() << "Cannot create include lock hard link: "
+                 << link_ec.message();
+  }
+  WriteText(fixture.incoming, Subset(1, "X"));
+  const std::string canonical_before = ReadText(fixture.canonical);
+  const MessageSourceSyncOptions options{
+      .write = true,
+      .expected_source_sha256 = ComputeMessageSourceSha256(canonical_before),
+  };
+#if !defined(_WIN32)
+  struct stat mode_before{};
+  ASSERT_EQ(stat(external.c_str(), &mode_before), 0);
+#endif
+
+  auto result_or =
+      SyncMessageSource(fixture.project, fixture.incoming, options);
+
+  ASSERT_FALSE(result_or.ok());
+  EXPECT_EQ(result_or.status().code(), absl::StatusCode::kFailedPrecondition);
+  EXPECT_THAT(std::string(result_or.status().message()),
+              HasSubstr("exactly one hard link"));
+#if !defined(_WIN32)
+  struct stat mode_after{};
+  ASSERT_EQ(stat(external.c_str(), &mode_after), 0);
+  EXPECT_EQ(mode_after.st_mode & 07777, mode_before.st_mode & 07777);
+#endif
+  EXPECT_EQ(ReadText(external), "unrelated");
+  EXPECT_EQ(ReadText(fixture.canonical), canonical_before);
+  EXPECT_FALSE(fs::exists(fixture.include));
+  ExpectNoPublicationArtifacts(temp.path());
+}
+
+TEST(MessageSourceSyncTest,
+     RejectsSymlinkedPersistentLockWithoutChangingExternalFile) {
+  ScopedTempDir temp;
+  SourceFixture fixture(temp.path());
+  const fs::path external = temp.path() / "unrelated.txt";
+  const fs::path canonical_lock =
+      fixture.canonical.parent_path() / ".yaze-message-source-sync.lock";
+  WriteText(external, "unrelated");
+  std::error_code symlink_ec;
+  fs::create_symlink(external, canonical_lock, symlink_ec);
+  if (symlink_ec) {
+    GTEST_SKIP() << "Cannot create lock symlink: " << symlink_ec.message();
+  }
+  WriteText(fixture.incoming, Subset(1, "X"));
+  const std::string canonical_before = ReadText(fixture.canonical);
+  const MessageSourceSyncOptions options{
+      .write = true,
+      .expected_source_sha256 = ComputeMessageSourceSha256(canonical_before),
+  };
+
+  auto result_or =
+      SyncMessageSource(fixture.project, fixture.incoming, options);
+
+  ASSERT_FALSE(result_or.ok());
+  EXPECT_THAT(std::string(result_or.status().message()), HasSubstr("lock"));
+  EXPECT_EQ(ReadText(external), "unrelated");
+  EXPECT_EQ(ReadText(fixture.canonical), canonical_before);
+  EXPECT_FALSE(fs::exists(fixture.include));
+  ExpectNoPublicationArtifacts(temp.path());
+}
+#endif
 
 #if !defined(_WIN32)
 TEST(MessageSourceSyncTest, RejectsSymlinkParentEscape) {

--- a/test/unit/editor/message/message_source_sync_test.cc
+++ b/test/unit/editor/message/message_source_sync_test.cc
@@ -2,6 +2,7 @@
 
 #include <barrier>
 #include <chrono>
+#include <cstdint>
 #include <filesystem>
 #include <fstream>
 #include <iterator>
@@ -18,6 +19,11 @@
 #include "cli/handlers/game/message_commands.h"
 #include "zelda3/dungeon/oracle_rom_safety_preflight.h"
 #include "zelda3/resource_labels.h"
+
+#if !defined(_WIN32) && !defined(__EMSCRIPTEN__)
+#include <sys/wait.h>
+#include <unistd.h>
+#endif
 
 namespace yaze::editor {
 namespace {
@@ -104,7 +110,8 @@ std::string Subset(int id, const std::string& text,
 std::string Manifest(
     absl::string_view include_path = "Core/generated/messages.asm",
     absl::string_view data_end = "0x2F80FF",
-    absl::string_view range_last = "0x18F", int count = 3) {
+    absl::string_view range_last = "0x18F", int count = 3,
+    absl::string_view canonical_path = "Data/Messages/expanded.json") {
   Json manifest = {
       {"manifest_version", 3},
       {"hack_name", "Message Source Test"},
@@ -116,7 +123,7 @@ std::string Manifest(
         {"source",
          {{"format", "yaze-message-bundle"},
           {"version", 1},
-          {"canonical_bundle_path", "Data/Messages/expanded.json"},
+          {"canonical_bundle_path", canonical_path},
           {"generated_asm_include_path", include_path}}}}}};
   return manifest.dump(2);
 }
@@ -168,6 +175,60 @@ TEST(MessageSourceSyncTest, Sha256MatchesPublishedKnownVectors) {
             "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855");
   EXPECT_EQ(ComputeMessageSourceSha256("abc"),
             "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad");
+}
+
+TEST(MessageSourceSyncTest, RejectsModuloNarrowingBundleVersionAndId) {
+  {
+    ScopedTempDir temp;
+    SourceFixture fixture(temp.path());
+    Json incoming = Json::parse(Subset(1, "X"));
+    incoming["version"] = uint64_t{4294967297};
+    WriteText(fixture.incoming, incoming.dump(2) + "\n");
+
+    auto result_or = SyncMessageSource(fixture.project, fixture.incoming);
+
+    ASSERT_FALSE(result_or.ok());
+    EXPECT_EQ(result_or.status().code(), absl::StatusCode::kInvalidArgument);
+    EXPECT_THAT(std::string(result_or.status().message()),
+                HasSubstr("version must be integer 1"));
+  }
+  {
+    ScopedTempDir temp;
+    SourceFixture fixture(temp.path());
+    Json incoming = Json::parse(Subset(1, "X"));
+    incoming["messages"][0]["id"] = uint64_t{4294967297};
+    WriteText(fixture.incoming, incoming.dump(2) + "\n");
+
+    auto result_or = SyncMessageSource(fixture.project, fixture.incoming);
+
+    ASSERT_FALSE(result_or.ok());
+    EXPECT_EQ(result_or.status().code(), absl::StatusCode::kInvalidArgument);
+    EXPECT_THAT(std::string(result_or.status().message()),
+                HasSubstr("ID must be an integer"));
+  }
+}
+
+TEST(MessageSourceSyncTest, RejectsModuloNarrowingBundleCounts) {
+  const std::pair<const char*, uint64_t> cases[] = {
+      {"expanded", uint64_t{4294967299}},
+      {"vanilla", uint64_t{4294967296}},
+  };
+  for (const auto& [field, value] : cases) {
+    SCOPED_TRACE(field);
+    ScopedTempDir temp;
+    SourceFixture fixture(temp.path());
+    Json canonical = Json::parse(ReadText(fixture.canonical));
+    canonical["counts"][field] = value;
+    WriteText(fixture.canonical, canonical.dump(2) + "\n");
+    WriteText(fixture.incoming, Subset(1, "X"));
+
+    auto result_or = SyncMessageSource(fixture.project, fixture.incoming);
+
+    ASSERT_FALSE(result_or.ok());
+    EXPECT_EQ(result_or.status().code(), absl::StatusCode::kInvalidArgument);
+    EXPECT_THAT(std::string(result_or.status().message()),
+                HasSubstr("bounded non-negative integers"));
+  }
 }
 
 TEST(MessageSourceSyncTest,
@@ -262,9 +323,120 @@ TEST(MessageSourceSyncTest,
                    ComputeMessageSourceSha256(canonical) + "\n"));
   EXPECT_THAT(include,
               HasSubstr(canonical == expected_x ? "$17, $7F" : "$18, $7F"));
-  EXPECT_TRUE(fs::exists(temp.path() / ".yaze-message-source-sync.lock"));
+  EXPECT_TRUE(fs::exists(fixture.canonical.parent_path() /
+                         ".yaze-message-source-sync.lock"));
+  EXPECT_TRUE(fs::exists(fixture.include.parent_path() /
+                         ".yaze-message-source-sync.lock"));
+  EXPECT_FALSE(fs::exists(temp.path() / ".yaze-message-source-sync.lock"));
   ExpectNoPublicationArtifacts(temp.path());
 }
+
+#if !defined(_WIN32) && !defined(__EMSCRIPTEN__)
+TEST(MessageSourceSyncTest,
+     NestedProjectsSharingTargetsSerializeAcrossProcesses) {
+  constexpr int kMessageCount = 4096;
+  ScopedTempDir temp;
+  const fs::path shared_root = temp.path() / "shared";
+  const std::string range_last =
+      absl::StrFormat("0x%X", 0x18D + kMessageCount - 1);
+  auto outer_project =
+      MakeProject(temp.path(), Manifest("shared/Core/generated/messages.asm",
+                                        "0x2FFFFF", range_last, kMessageCount,
+                                        "shared/Data/Messages/expanded.json"));
+  auto nested_project =
+      MakeProject(shared_root, Manifest("Core/generated/messages.asm",
+                                        "0x2FFFFF", range_last, kMessageCount));
+
+  std::vector<std::pair<int, std::string>> messages;
+  messages.reserve(kMessageCount);
+  for (int id = 0; id < kMessageCount; ++id) {
+    messages.emplace_back(id, "");
+  }
+  const fs::path canonical = shared_root / "Data/Messages/expanded.json";
+  const fs::path include = shared_root / "Core/generated/messages.asm";
+  const fs::path incoming_outer = temp.path() / "incoming-outer.json";
+  const fs::path incoming_nested = temp.path() / "incoming-nested.json";
+  WriteText(canonical, Bundle(messages));
+  WriteText(incoming_outer, Subset(0, "X"));
+  WriteText(incoming_nested, Subset(1, "Y"));
+  const std::string expected_sha =
+      ComputeMessageSourceSha256(ReadText(canonical));
+
+  int ready_pipe[2] = {-1, -1};
+  int start_pipe[2] = {-1, -1};
+  ASSERT_EQ(pipe(ready_pipe), 0);
+  ASSERT_EQ(pipe(start_pipe), 0);
+
+  auto launch_writer = [&](const project::YazeProject& project,
+                           const fs::path& incoming) {
+    const pid_t pid = fork();
+    if (pid != 0) {
+      return pid;
+    }
+    close(ready_pipe[0]);
+    close(start_pipe[1]);
+    const char ready = 'r';
+    if (write(ready_pipe[1], &ready, 1) != 1) {
+      _exit(20);
+    }
+    char start = '\0';
+    if (read(start_pipe[0], &start, 1) != 1) {
+      _exit(21);
+    }
+    auto result_or = SyncMessageSource(
+        project, incoming,
+        {.write = true, .expected_source_sha256 = expected_sha});
+    if (result_or.ok()) {
+      _exit(0);
+    }
+    _exit(result_or.status().code() == absl::StatusCode::kAborted ? 10 : 22);
+  };
+
+  const pid_t outer_pid = launch_writer(outer_project, incoming_outer);
+  ASSERT_GT(outer_pid, 0);
+  const pid_t nested_pid = launch_writer(nested_project, incoming_nested);
+  ASSERT_GT(nested_pid, 0);
+  close(ready_pipe[1]);
+  close(start_pipe[0]);
+  char ready[2] = {};
+  size_t ready_total = 0;
+  while (ready_total < sizeof(ready)) {
+    const ssize_t count =
+        read(ready_pipe[0], ready + ready_total, sizeof(ready) - ready_total);
+    ASSERT_GT(count, 0);
+    ready_total += static_cast<size_t>(count);
+  }
+  ASSERT_EQ(write(start_pipe[1], "gg", 2), 2);
+  close(ready_pipe[0]);
+  close(start_pipe[1]);
+
+  int outer_status = 0;
+  int nested_status = 0;
+  ASSERT_EQ(waitpid(outer_pid, &outer_status, 0), outer_pid);
+  ASSERT_EQ(waitpid(nested_pid, &nested_status, 0), nested_pid);
+  ASSERT_TRUE(WIFEXITED(outer_status));
+  ASSERT_TRUE(WIFEXITED(nested_status));
+  const int outer_exit = WEXITSTATUS(outer_status);
+  const int nested_exit = WEXITSTATUS(nested_status);
+  EXPECT_EQ((outer_exit == 0) + (nested_exit == 0), 1)
+      << outer_exit << ", " << nested_exit;
+  EXPECT_EQ((outer_exit == 10) + (nested_exit == 10), 1)
+      << outer_exit << ", " << nested_exit;
+
+  EXPECT_TRUE(
+      fs::exists(canonical.parent_path() / ".yaze-message-source-sync.lock"));
+  EXPECT_TRUE(
+      fs::exists(include.parent_path() / ".yaze-message-source-sync.lock"));
+  EXPECT_FALSE(fs::exists(temp.path() / ".yaze-message-source-sync.lock"));
+  EXPECT_FALSE(fs::exists(shared_root / ".yaze-message-source-sync.lock"));
+  const std::string final_canonical = ReadText(canonical);
+  const std::string final_include = ReadText(include);
+  EXPECT_TRUE(absl::StartsWith(
+      final_include, "; Source bundle SHA-256: " +
+                         ComputeMessageSourceSha256(final_canonical) + "\n"));
+  ExpectNoPublicationArtifacts(temp.path());
+}
+#endif
 
 #if !defined(_WIN32)
 TEST(MessageSourceSyncTest, WritePreservesExistingPosixModes) {
@@ -480,8 +652,8 @@ TEST(MessageSourceSyncTest, RejectsManifestCapacityOverflow) {
 
 TEST(MessageSourceSyncTest, RejectsCaseVariantOfPersistentLockAsTarget) {
   ScopedTempDir temp;
-  auto project =
-      MakeProject(temp.path(), Manifest(".YAZE-MESSAGE-SOURCE-SYNC.LOCK"));
+  auto project = MakeProject(
+      temp.path(), Manifest("Core/generated/.YAZE-MESSAGE-SOURCE-SYNC.LOCK"));
   const fs::path canonical = temp.path() / "Data/Messages/expanded.json";
   const fs::path incoming = temp.path() / "incoming.json";
   WriteText(canonical, Bundle({{0, "A"}, {1, "B"}, {2, "C"}}));
@@ -493,13 +665,15 @@ TEST(MessageSourceSyncTest, RejectsCaseVariantOfPersistentLockAsTarget) {
   EXPECT_EQ(result_or.status().code(), absl::StatusCode::kInvalidArgument);
   EXPECT_THAT(std::string(result_or.status().message()),
               HasSubstr("persistent lock path"));
-  EXPECT_FALSE(fs::exists(temp.path() / ".yaze-message-source-sync.lock"));
+  EXPECT_FALSE(fs::exists(temp.path() / "Core/generated" /
+                          ".yaze-message-source-sync.lock"));
 }
 
 TEST(MessageSourceSyncTest, RejectsExistingHardLinkAliasOfPersistentLock) {
   ScopedTempDir temp;
   SourceFixture fixture(temp.path());
-  const fs::path lock = temp.path() / ".yaze-message-source-sync.lock";
+  const fs::path lock =
+      fixture.include.parent_path() / ".yaze-message-source-sync.lock";
   WriteText(lock, "");
   std::error_code link_ec;
   fs::create_hard_link(lock, fixture.include, link_ec);
@@ -513,7 +687,7 @@ TEST(MessageSourceSyncTest, RejectsExistingHardLinkAliasOfPersistentLock) {
   ASSERT_FALSE(result_or.ok());
   EXPECT_EQ(result_or.status().code(), absl::StatusCode::kInvalidArgument);
   EXPECT_THAT(std::string(result_or.status().message()),
-              HasSubstr("aliases the persistent lock"));
+              HasSubstr("aliases a persistent lock"));
 }
 
 #if !defined(_WIN32)


### PR DESCRIPTION
## Summary

- add manifest metadata for a canonical expanded-message bundle and generated no-`org` Asar include
- add `z3ed message-source-sync`, dry-run by default, to merge strict bundle edits and publish the source/include pair without opening or mutating a ROM
- require exact source SHA-256 compare-and-swap for writes and fail closed on include drift, invalid or out-of-range metadata, incomplete banks, capacity overflow, path escapes, symlink/lock aliases, and cleanup failures
- serialize writers with an in-process mutex plus deterministic persistent locks in each publication-target directory, preserve file modes, fsync file/directory updates, verify exact readback, and rollback failed publication
- register the CLI/agent surface and document the source-owned expanded-message workflow

## Why

Oracle of Secrets' expanded dialogue is ASM-owned. Previously, an editor export could not be handed back to that source safely and reproducibly. This makes the canonical bundle—not an edited ROM—the durable source of truth while keeping ROM assembly as a separate build step.

## Verification

- built focused targets: `yaze_test_unit` and `z3ed`
- 69 focused source-sync, manifest, mutation-policy, token, and registration tests passed, including malformed/missing configured-manifest and hard-linked/symlinked lock fail-closed regressions
- repository pre-push validation passed against `build/presets/mac-ai`
- independent strict review found no remaining publication blocker
- post-merge real Oracle fixture parity: 109 messages, 13,676 encoded bytes, unchanged source/include hashes, and 110 canonical `[D:2C]` tokens parsed successfully
- five external-process nested-project races sharing the same source/include each produced exactly one writer and one CAS loser; final artifacts matched the winner
- two additional disposable Oracle races passed source/include hash binding, mode checks, no-op readback, and the Oracle source validator; no temp/backup artifacts leaked

## Scope note

The command deliberately does not write a ROM or wire the GUI Save action yet. Two separate file renames cannot be fully crash-atomic; the command fsyncs each publication and detects source/include drift on the next run rather than continuing silently.

Refs #88


