### PR TITLE
Harden vanilla message save preflight and readback

### DIFF
--- a/docs/internal/architecture/message_system.md
+++ b/docs/internal/architecture/message_system.md
@@ -1,8 +1,9 @@
 # Message System Architecture
 
 **Status**: Draft
-**Last Updated**: 2026-07-27
-**Related Code**: `src/app/editor/message/`, `src/cli/handlers/game/message.cc`
+**Last Updated**: 2026-07-28
+**Related Code**: `src/app/editor/message/`,
+`src/cli/handlers/game/message_commands.cc`
 
 This document outlines the architecture of the Message (Text) System in YAZE.
 
@@ -36,8 +37,10 @@ Represents special control codes or characters.
 
 ## ROM Layout (Vanilla)
 
-*   **Bank 0E (0xE0000)**: Primary text data block (32KB).
-*   **Bank 0E (0x75F40)**: Secondary text data block (5.3KB).
+*   **Primary block**: PC `0x0E0000-0x0E7FFF`, mapped to SNES
+    `$1C:8000-$1C:FFFF` (32KB).
+*   **Secondary block**: PC `0x075F40-0x0773FF`, mapped to SNES
+    `$0E:DF40-$0E:F3FF` (5.3KB).
 *   **Dictionary**: Pointers at `0x74703`.
 *   **Font Graphics**: 2BPP tiles at `0x70000`.
 *   **Character Widths**: Table at `0x74ADF`.
@@ -53,7 +56,15 @@ Represents special control codes or characters.
 ### Saving
 1.  **Parse**: User text is converted to bytes.
 2.  **Optimize**: `OptimizeMessageForDictionary` scans the text for dictionary phrases and replaces them with single-byte references.
-3.  **Write**: Data is written sequentially to the ROM text blocks. If the first block overflows, it spills into the second block.
+3.  **Plan**: `BuildVanillaMessageSavePlan` serializes both physical blocks,
+    requires the manifest's expected message count, and distinguishes the one
+    standalone `[BANK]` command from command arguments such as `[W:80]`.
+4.  **Preflight**: Project-backed callers analyze the plan's exact half-open PC
+    write ranges against Hack Manifest ownership and write policy before any
+    ROM mutation.
+5.  **Write**: `ApplyVanillaMessageSavePlan` applies the immutable plan through
+    an exact write fence. CLI persistence requires a backup, atomic ROM
+    replacement, and independent reopen/readback before reporting success.
 
 ASM-owned expanded banks use a separate source pipeline. A complete canonical
 `yaze-message-bundle` is merged by bank-local ID, validated against the Hack

--- a/docs/public/reference/message-bundle-format.md
+++ b/docs/public/reference/message-bundle-format.md
@@ -9,7 +9,7 @@ importing message text (vanilla + expanded) with validation.
 {
   "format": "yaze-message-bundle",
   "version": 1,
-  "counts": { "vanilla": 396, "expanded": 0 },
+  "counts": { "vanilla": 397, "expanded": 0 },
   "messages": [ ... ]
 }
 ```
@@ -74,15 +74,38 @@ z3ed message-import-bundle --file messages.json --strict
 
 Import and apply to ROM:
 ```
-z3ed message-import-bundle --file messages.json --apply --range vanilla
+z3ed message-import-bundle --file messages.json --apply --range vanilla \
+  --rom path/to/rom.sfc --project path/to/project.yaze
 ```
 
-Applying expanded entries also requires the matching Yaze project so `z3ed`
-can validate the active ROM, manifest ownership, and project write policy:
+Every `--apply` mutation requires the matching Yaze project so `z3ed` can
+validate the active headerless ROM, manifest ownership, and project write
+policy:
 ```
 z3ed message-import-bundle --file messages.json --apply \
   --rom path/to/rom.sfc --project path/to/project.yaze
 ```
+
+Before the first in-memory write, apply mode validates all selected IDs and
+the complete vanilla replacement plan. Vanilla imports must match the
+manifest's `messages.vanilla_count`, contain one standalone `[BANK]` command,
+fit both physical text blocks, and pass ownership checks for the plan's exact
+half-open ROM write ranges. An argument byte such as the `80` in `[W:80]` is
+not treated as a bank switch. Expanded IDs and declared bank limits are checked
+in the same preflight; final expanded serialization and the vanilla apply share
+one rollback transaction, so a later expanded-capacity failure cannot leave a
+partial mixed update.
+
+A successful apply requires a backup of the existing ROM, uses atomic
+replacement, independently reopens the saved file, and compares every planned
+write byte-for-byte. JSON output reports `readback_verified=true` only after
+that external readback succeeds. Validation-only imports do not require a
+project and never mutate the ROM. Apply mode is native-only; WebAssembly builds
+fail closed because browser storage cannot provide the same durable backup and
+readback contract.
+
+For Oracle of Secrets, apply vanilla entries with `--range vanilla`; expanded
+messages remain ASM-owned and use the source-sync workflow below.
 
 ## ASM-Owned Expanded Message Source
 

--- a/docs/public/reference/z3ed-command-reference.md
+++ b/docs/public/reference/z3ed-command-reference.md
@@ -299,12 +299,24 @@ Check test execution status.
 - `message-encode --text <text>`, `message-decode --hex <hex_bytes>`
 - `message-export-org --output <path>`, `message-import-org --file <path>`
 - `message-export-bundle --output <path> [--range <all|vanilla|expanded>]`
-- `message-import-bundle --file <path> [--apply] [--strict] [--range <all|vanilla|expanded>] [--project <path>]` (expanded apply requires a project)
+- `message-import-bundle --file <path> [--apply] [--strict] [--range <all|vanilla|expanded>] [--project <path>]` (`--apply` requires the matching project)
 - `message-write --id <id> --text <text> --project <path>`
 - `message-export-bin --output <path> [--range expanded]`
 - `message-export-asm --output <path> [--range expanded]`
 - `dialogue-list`, `dialogue-read`, `dialogue-search --query <text>`
 - `hex-search --pattern <hex>`
+
+`message-import-bundle --apply` fails closed unless `--project` identifies the
+active headerless ROM and provides a loaded Hack Manifest. Before changing
+either bank,
+the command validates every selected ID, the manifest's vanilla count and
+expanded bounds, the vanilla stream's single standalone `[BANK]`, and the
+exact half-open ROM write ranges against the project write policy. A command
+argument such as `[W:80]` is not a bank switch. A successful apply creates a
+required backup, atomically replaces the ROM, reopens it independently, and
+reports `readback_verified=true` only after every planned byte matches.
+WebAssembly builds reject apply mode because browser storage cannot satisfy
+that durability contract.
 
 ## CLI Discovery Flow
 

--- a/src/app/editor/message/message_data.cc
+++ b/src/app/editor/message/message_data.cc
@@ -198,13 +198,10 @@ std::vector<uint8_t> ParseMessageToData(std::string str) {
       ParsedElement parsedElement =
           FindMatchingElement(temp_string.substr(pos, next - pos + 1));
 
-      const auto dictionary_element =
-          TextElement(0x80, DICTIONARYTOKEN, true, "Dictionary");
-
       if (!parsedElement.Active) {
         util::logf("Error parsing message: %s", temp_string);
         break;
-      } else if (parsedElement.Parent == dictionary_element) {
+      } else if (parsedElement.Parent.Token == DICTIONARYTOKEN) {
         bytes.push_back(parsedElement.Value);
       } else {
         bytes.push_back(parsedElement.Parent.ID);
@@ -257,8 +254,6 @@ MessageParseResult ParseMessageToDataWithDiagnostics(std::string_view str) {
 
       std::string token = temp_string.substr(pos, close - pos + 1);
       ParsedElement parsed_element = FindMatchingElement(token);
-      const auto dictionary_element =
-          TextElement(0x80, DICTIONARYTOKEN, true, "Dictionary");
 
       if (!parsed_element.Active) {
         result.errors.push_back(absl::StrFormat("Unknown token: %s", token));
@@ -274,7 +269,7 @@ MessageParseResult ParseMessageToDataWithDiagnostics(std::string_view str) {
         }
       }
 
-      if (parsed_element.Parent == dictionary_element) {
+      if (parsed_element.Parent.Token == DICTIONARYTOKEN) {
         result.bytes.push_back(parsed_element.Value);
       } else {
         result.bytes.push_back(parsed_element.Parent.ID);
@@ -1261,58 +1256,139 @@ absl::Status WriteExpandedTextData(uint8_t* rom, int start, int end,
   return absl::OkStatus();
 }
 
-absl::Status WriteAllTextData(Rom* rom,
-                              const std::vector<MessageData>& messages) {
-  if (rom == nullptr || !rom->is_loaded()) {
-    return absl::InvalidArgumentError("ROM not loaded");
+std::vector<std::pair<uint32_t, uint32_t>>
+VanillaMessageSavePlan::write_ranges() const {
+  std::vector<std::pair<uint32_t, uint32_t>> ranges;
+  ranges.reserve(writes_.size());
+  for (const VanillaMessageWrite& write : writes_) {
+    ranges.emplace_back(write.start(), write.end());
+  }
+  return ranges;
+}
+
+absl::StatusOr<VanillaMessageSavePlan> BuildVanillaMessageSavePlan(
+    const std::vector<MessageData>& messages,
+    std::optional<size_t> expected_message_count) {
+  if (expected_message_count.has_value() &&
+      messages.size() != *expected_message_count) {
+    return absl::FailedPreconditionError(
+        absl::StrFormat("Vanilla message count mismatch: expected %zu, got %zu",
+                        *expected_message_count, messages.size()));
   }
 
-  ScopedRomTransaction transaction(*rom);
+  constexpr size_t kPrimaryCapacity = kTextDataEnd - kTextData + 1;
+  constexpr size_t kSecondaryCapacity = kTextData2End - kTextData2 + 1;
+  std::vector<uint8_t> primary;
+  std::vector<uint8_t> secondary;
+  primary.reserve(kPrimaryCapacity);
+  secondary.reserve(kSecondaryCapacity);
 
-  int pos = kTextData;
   bool in_second_bank = false;
+  size_t bank_switch_count = 0;
+  auto append_byte = [&](uint8_t value, size_t message_index) -> absl::Status {
+    auto& destination = in_second_bank ? secondary : primary;
+    const size_t capacity =
+        in_second_bank ? kSecondaryCapacity : kPrimaryCapacity;
+    if (destination.size() >= capacity) {
+      const uint32_t address =
+          static_cast<uint32_t>(in_second_bank ? kTextData2 : kTextData) +
+          static_cast<uint32_t>(destination.size());
+      return absl::ResourceExhaustedError(absl::StrFormat(
+          "Vanilla message %zu exceeds %s bank capacity at 0x%06X",
+          message_index, in_second_bank ? "second" : "first", address));
+    }
+    destination.push_back(value);
+    return absl::OkStatus();
+  };
 
-  for (const auto& message : messages) {
+  for (size_t message_index = 0; message_index < messages.size();
+       ++message_index) {
     bool next_byte_is_command_argument = false;
-    for (uint8_t value : message.Data) {
-      RETURN_IF_ERROR(rom->WriteByte(pos, value));
-
+    for (uint8_t value : messages[message_index].Data) {
       const bool is_command_argument = next_byte_is_command_argument;
       next_byte_is_command_argument = false;
-      if (!is_command_argument && value == kBankSwitchCommand) {
-        if (!in_second_bank && pos > kTextDataEnd) {
-          return absl::ResourceExhaustedError(absl::StrFormat(
-              "Text data exceeds first bank (pos 0x%06X)", pos));
-        }
-        pos = kTextData2 - 1;
-        in_second_bank = true;
+      if (!is_command_argument &&
+          (value == kMessageTerminator || value == 0xFF)) {
+        return absl::InvalidArgumentError(absl::StrFormat(
+            "Vanilla message %zu contains reserved stream marker 0x%02X",
+            message_index, value));
+      }
+      const bool is_bank_switch =
+          !is_command_argument && value == kBankSwitchCommand;
+      if (is_bank_switch && bank_switch_count != 0) {
+        return absl::InvalidArgumentError(absl::StrFormat(
+            "Vanilla message %zu contains a duplicate [BANK] command",
+            message_index));
       }
 
-      if (!is_command_argument) {
+      RETURN_IF_ERROR(append_byte(value, message_index));
+      if (is_bank_switch) {
+        ++bank_switch_count;
+        in_second_bank = true;
+      } else if (!is_command_argument) {
         const auto command = FindMatchingCommand(value);
         next_byte_is_command_argument =
             command.has_value() && command->HasArgument;
       }
-
-      pos++;
     }
-
-    RETURN_IF_ERROR(rom->WriteByte(pos++, kMessageTerminator));
+    if (next_byte_is_command_argument) {
+      return absl::InvalidArgumentError(absl::StrFormat(
+          "Vanilla message %zu ends with a command missing its argument",
+          message_index));
+    }
+    RETURN_IF_ERROR(append_byte(kMessageTerminator, message_index));
   }
 
-  if (!in_second_bank && pos > kTextDataEnd) {
-    return absl::ResourceExhaustedError(
-        absl::StrFormat("Text data exceeds first bank (pos 0x%06X)", pos));
+  if (bank_switch_count != 1) {
+    return absl::InvalidArgumentError(
+        "Vanilla message stream is missing the required [BANK] command");
+  }
+  RETURN_IF_ERROR(append_byte(0xFF, messages.size()));
+
+  std::vector<VanillaMessageWrite> writes;
+  writes.reserve(in_second_bank ? 2 : 1);
+  writes.emplace_back(static_cast<uint32_t>(kTextData), std::move(primary));
+  if (in_second_bank) {
+    writes.emplace_back(static_cast<uint32_t>(kTextData2),
+                        std::move(secondary));
+  }
+  return VanillaMessageSavePlan(std::move(writes), messages.size(),
+                                bank_switch_count);
+}
+
+absl::Status ApplyVanillaMessageSavePlan(Rom* rom,
+                                         const VanillaMessageSavePlan& plan) {
+  if (rom == nullptr || !rom->is_loaded()) {
+    return absl::InvalidArgumentError("ROM not loaded");
   }
 
-  if (in_second_bank && pos > kTextData2End) {
-    return absl::ResourceExhaustedError(
-        absl::StrFormat("Text data exceeds second bank (pos 0x%06X)", pos));
+  yaze::rom::WriteFence fence;
+  for (const VanillaMessageWrite& write : plan.writes()) {
+    if (write.end() > rom->size()) {
+      return absl::OutOfRangeError(absl::StrFormat(
+          "Vanilla message write range [0x%06X, 0x%06X) is outside the ROM",
+          write.start(), write.end()));
+    }
+    RETURN_IF_ERROR(
+        fence.Allow(write.start(), write.end(), "VanillaMessageBank"));
   }
 
-  RETURN_IF_ERROR(rom->WriteByte(pos, 0xFF));
+  ScopedRomTransaction transaction(*rom);
+  yaze::rom::ScopedWriteFence fence_scope(rom, &fence);
+  for (const VanillaMessageWrite& write : plan.writes()) {
+    RETURN_IF_ERROR(
+        rom->WriteVector(static_cast<int>(write.start()), write.bytes()));
+  }
   transaction.Commit();
   return absl::OkStatus();
+}
+
+absl::Status WriteAllTextData(Rom* rom,
+                              const std::vector<MessageData>& messages) {
+  ASSIGN_OR_RETURN(
+      const VanillaMessageSavePlan plan,
+      BuildVanillaMessageSavePlan(messages, /*expected_message_count=*/{}));
+  return ApplyVanillaMessageSavePlan(rom, plan);
 }
 
 }  // namespace editor

--- a/src/app/editor/message/message_data.h
+++ b/src/app/editor/message/message_data.h
@@ -78,11 +78,14 @@
 //
 // ===========================================================================
 
+#include <cstddef>
+#include <cstdint>
 #include <optional>
 #include <regex>
 #include <string>
 #include <string_view>
 #include <unordered_map>
+#include <utility>
 #include <vector>
 
 #include <nlohmann/json.hpp>
@@ -349,7 +352,7 @@ struct TextElement {
     Description = description;
     if (arg) {
       Pattern = absl::StrFormat(
-          "\\[%s(:[0-9A-F]{1,2})?\\]",
+          "\\[%s(:[0-9A-F]{1,2})\\]",
           absl::StrReplaceAll(Token, {{"[", "\\["}, {"]", "\\]"}}));
     } else {
       Pattern = absl::StrFormat(
@@ -497,6 +500,58 @@ std::vector<std::string> ParseMessageData(
 constexpr int kTextData2 = 0x75F40;
 constexpr int kTextData2End = 0x773FF;
 
+// One exact, half-open ROM write in a vanilla-message save plan.
+class VanillaMessageWrite {
+ public:
+  VanillaMessageWrite(uint32_t start, std::vector<uint8_t> bytes)
+      : start_(start), bytes_(std::move(bytes)) {}
+
+  uint32_t start() const { return start_; }
+  uint32_t end() const { return start_ + static_cast<uint32_t>(bytes_.size()); }
+  const std::vector<uint8_t>& bytes() const { return bytes_; }
+
+  bool operator==(const VanillaMessageWrite&) const = default;
+
+ private:
+  uint32_t start_ = 0;
+  std::vector<uint8_t> bytes_;
+};
+
+// Immutable serialization result for the split vanilla message stream.
+//
+// Exactly one standalone [BANK] command is required. `bank_switch_count()`
+// excludes byte value 0x80 when used as an argument (for example, [W:80]).
+class VanillaMessageSavePlan {
+ public:
+  VanillaMessageSavePlan(const VanillaMessageSavePlan&) = default;
+  VanillaMessageSavePlan(VanillaMessageSavePlan&&) = default;
+  VanillaMessageSavePlan& operator=(const VanillaMessageSavePlan&) = default;
+  VanillaMessageSavePlan& operator=(VanillaMessageSavePlan&&) = default;
+
+  const std::vector<VanillaMessageWrite>& writes() const { return writes_; }
+  size_t message_count() const { return message_count_; }
+  size_t bank_switch_count() const { return bank_switch_count_; }
+
+  std::vector<std::pair<uint32_t, uint32_t>> write_ranges() const;
+
+  bool operator==(const VanillaMessageSavePlan&) const = default;
+
+ private:
+  friend absl::StatusOr<VanillaMessageSavePlan> BuildVanillaMessageSavePlan(
+      const std::vector<MessageData>& messages,
+      std::optional<size_t> expected_message_count);
+
+  VanillaMessageSavePlan(std::vector<VanillaMessageWrite> writes,
+                         size_t message_count, size_t bank_switch_count)
+      : writes_(std::move(writes)),
+        message_count_(message_count),
+        bank_switch_count_(bank_switch_count) {}
+
+  std::vector<VanillaMessageWrite> writes_;
+  size_t message_count_ = 0;
+  size_t bank_switch_count_ = 0;
+};
+
 // Reads all text data from the ROM and returns a vector of MessageData objects.
 // When max_pos > 0, the parser stops if pos exceeds max_pos (safety bound).
 // Set allow_bank_switch=false for contiguous banks such as expanded messages.
@@ -605,7 +660,20 @@ absl::Status WriteExpandedTextData(Rom* rom, int start, int end,
 absl::Status WriteExpandedTextData(uint8_t* rom, int start, int end,
                                    const std::vector<std::string>& messages);
 
+// Builds a complete vanilla-message serialization without mutating a ROM.
+// If expected_message_count is present, a mismatch fails closed.
+absl::StatusOr<VanillaMessageSavePlan> BuildVanillaMessageSavePlan(
+    const std::vector<MessageData>& messages,
+    std::optional<size_t> expected_message_count = std::nullopt);
+
+// Applies an immutable vanilla-message plan atomically through an exact write
+// fence. Callers remain responsible for project/manifest policy preflight
+// against plan.write_ranges().
+absl::Status ApplyVanillaMessageSavePlan(Rom* rom,
+                                         const VanillaMessageSavePlan& plan);
+
 // Writes all vanilla message data back to the ROM with bank switching.
+// Delegates to BuildVanillaMessageSavePlan and ApplyVanillaMessageSavePlan.
 absl::Status WriteAllTextData(Rom* rom,
                               const std::vector<MessageData>& messages);
 

--- a/src/app/editor/message/message_editor.cc
+++ b/src/app/editor/message/message_editor.cc
@@ -36,21 +36,6 @@
 namespace yaze {
 namespace editor {
 
-namespace {
-std::string DisplayTextOverflowError(int pos, bool bank) {
-  int space = bank ? kTextDataEnd - kTextData : kTextData2End - kTextData2;
-  std::string bankSTR = bank ? "1st" : "2nd";
-  std::string posSTR =
-      bank ? absl::StrFormat("%X4", pos & 0xFFFF)
-           : absl::StrFormat("%X4", (pos - kTextData2) & 0xFFFF);
-  std::string message = absl::StrFormat(
-      "There is too much text data in the %s block to save.\n"
-      "Available: %X4 | Used: %s",
-      bankSTR, space, posSTR);
-  return message;
-}
-}  // namespace
-
 using ImGui::BeginChild;
 using ImGui::BeginTable;
 using ImGui::Button;
@@ -110,7 +95,10 @@ void MessageEditor::Initialize() {
   }
 
   message_preview_.all_dictionaries_ = BuildDictionaryEntries(rom());
-  list_of_texts_ = ReadAllTextData(rom()->mutable_data());
+  const int message_read_limit = static_cast<int>(std::min(
+      rom()->size(), static_cast<size_t>(std::numeric_limits<int>::max())));
+  list_of_texts_ =
+      ReadAllTextData(rom()->mutable_data(), kTextData, message_read_limit);
   LOG_INFO("MessageEditor", "Loaded %zu messages from ROM",
            list_of_texts_.size());
 
@@ -1151,57 +1139,23 @@ absl::StatusOr<MessageEditor::SavePlan> MessageEditor::BuildSavePlan(
   }
 
   if (include_vanilla_messages && dirty_state_.vanilla_messages) {
-    std::vector<uint8_t> primary;
-    std::vector<uint8_t> secondary;
-    constexpr size_t kPrimaryCapacity = kTextDataEnd - kTextData + 1;
-    constexpr size_t kSecondaryCapacity = kTextData2End - kTextData2 + 1;
-    primary.reserve(kPrimaryCapacity);
-    secondary.reserve(kSecondaryCapacity);
-
-    bool in_second_bank = false;
-    auto append_byte = [&](uint8_t value, bool is_bank_switch) -> absl::Status {
-      auto& destination = in_second_bank ? secondary : primary;
-      const size_t capacity =
-          in_second_bank ? kSecondaryCapacity : kPrimaryCapacity;
-      if (destination.size() >= capacity) {
-        const int overflow_pos = (in_second_bank ? kTextData2 : kTextData) +
-                                 static_cast<int>(destination.size());
-        return absl::ResourceExhaustedError(
-            DisplayTextOverflowError(overflow_pos, !in_second_bank));
+    std::optional<size_t> expected_message_count;
+    if (dependencies_.project &&
+        dependencies_.project->hack_manifest.loaded()) {
+      const int manifest_count =
+          dependencies_.project->hack_manifest.message_layout().vanilla_count;
+      if (manifest_count > 0) {
+        expected_message_count = static_cast<size_t>(manifest_count);
       }
-      destination.push_back(value);
-      if (!in_second_bank && is_bank_switch) {
-        in_second_bank = true;
-      }
-      return absl::OkStatus();
-    };
-
-    for (const auto& message : list_of_texts_) {
-      bool next_byte_is_command_argument = false;
-      for (uint8_t value : message.Data) {
-        const bool is_command_argument = next_byte_is_command_argument;
-        next_byte_is_command_argument = false;
-        RETURN_IF_ERROR(append_byte(
-            value, !is_command_argument && value == kBankSwitchCommand));
-        if (!is_command_argument) {
-          const auto command = FindMatchingCommand(value);
-          next_byte_is_command_argument =
-              command.has_value() && command->HasArgument;
-        }
-      }
-      RETURN_IF_ERROR(
-          append_byte(kMessageTerminator, /*is_bank_switch=*/false));
     }
-    RETURN_IF_ERROR(append_byte(0xFF, /*is_bank_switch=*/false));
+    ASSIGN_OR_RETURN(
+        const VanillaMessageSavePlan vanilla_plan,
+        BuildVanillaMessageSavePlan(list_of_texts_, expected_message_count));
 
     plan.saves_vanilla_messages = true;
-    if (!primary.empty()) {
+    for (const auto& write : vanilla_plan.writes()) {
       plan.writes.push_back(
-          {SaveDomain::kVanillaMessages, kTextData, std::move(primary)});
-    }
-    if (!secondary.empty()) {
-      plan.writes.push_back(
-          {SaveDomain::kVanillaMessages, kTextData2, std::move(secondary)});
+          {SaveDomain::kVanillaMessages, write.start(), write.bytes()});
     }
   }
 

--- a/src/app/editor/message/message_editor.cc
+++ b/src/app/editor/message/message_editor.cc
@@ -95,8 +95,9 @@ void MessageEditor::Initialize() {
   }
 
   message_preview_.all_dictionaries_ = BuildDictionaryEntries(rom());
-  const int message_read_limit = static_cast<int>(std::min(
-      rom()->size(), static_cast<size_t>(std::numeric_limits<int>::max())));
+  const int message_read_limit = static_cast<int>(
+      std::min(static_cast<size_t>(rom()->size()),
+               static_cast<size_t>(std::numeric_limits<int>::max())));
   list_of_texts_ =
       ReadAllTextData(rom()->mutable_data(), kTextData, message_read_limit);
   LOG_INFO("MessageEditor", "Loaded %zu messages from ROM",

--- a/src/cli/handlers/game/message_commands.cc
+++ b/src/cli/handlers/game/message_commands.cc
@@ -66,8 +66,12 @@ std::vector<editor::MessageData> ReadExpandedMessages(const Rom& rom, int start,
                                       end);
 }
 
-struct ExpandedMutationContext {
+struct ProjectMutationContext {
   project::YazeProject project;
+  std::filesystem::path canonical_rom_path;
+};
+
+struct ExpandedMutationContext {
   int start = 0;
   int end = 0;
   int message_limit = -1;
@@ -145,19 +149,21 @@ bool IsCanonicalMappedLoRomAddress(uint32_t address) {
   return PcToSnes(SnesToPc(address)) == address;
 }
 
-absl::StatusOr<ExpandedMutationContext> PreflightExpandedMutation(
-    const resources::ArgumentParser& parser, const Rom& rom) {
+absl::StatusOr<ProjectMutationContext> LoadProjectMutationContext(
+    const resources::ArgumentParser& parser, const Rom& rom,
+    absl::string_view mutation_scope) {
   auto project_path = parser.GetString("project");
   if (!project_path.has_value() || project_path->empty()) {
-    return absl::FailedPreconditionError(
-        "Expanded message mutation requires explicit --project so Yaze can "
-        "verify ROM ownership and write policy");
+    return absl::FailedPreconditionError(absl::StrFormat(
+        "%s requires explicit --project so Yaze can verify ROM ownership and "
+        "write policy",
+        mutation_scope));
   }
   if (!rom.is_loaded()) {
     return absl::FailedPreconditionError("ROM is not loaded");
   }
 
-  ExpandedMutationContext context;
+  ProjectMutationContext context;
   auto& resource_labels = zelda3::GetResourceLabels();
   absl::Status open_status;
   {
@@ -203,15 +209,45 @@ absl::StatusOr<ExpandedMutationContext> PreflightExpandedMutation(
         "Project ROM mismatch: active ROM is '%s' but --project binds to '%s'",
         active_rom_path_or->string(), project_rom_path_or->string()));
   }
+  std::error_code file_size_ec;
+  const uintmax_t raw_file_size =
+      std::filesystem::file_size(*active_rom_path_or, file_size_ec);
+  if (file_size_ec) {
+    return absl::FailedPreconditionError(
+        absl::StrFormat("Cannot inspect active ROM size '%s': %s",
+                        active_rom_path_or->string(), file_size_ec.message()));
+  }
+  constexpr uintmax_t kSnesBankSize = 0x8000;
+  constexpr uintmax_t kCopierHeaderSize = 0x200;
+  if (raw_file_size >= kCopierHeaderSize &&
+      raw_file_size % kSnesBankSize == kCopierHeaderSize) {
+    return absl::FailedPreconditionError(
+        "Message mutation requires a headerless ROM file; remove the "
+        "512-byte copier header and reopen the ROM");
+  }
+  if (raw_file_size != rom.size()) {
+    return absl::FailedPreconditionError(absl::StrFormat(
+        "Message mutation requires a headerless ROM file: disk size is 0x%zX "
+        "but the loaded ROM is 0x%zX bytes",
+        static_cast<size_t>(raw_file_size), rom.size()));
+  }
+  context.canonical_rom_path = *active_rom_path_or;
 
   const auto& manifest = context.project.hack_manifest;
   if (!manifest.loaded()) {
     return absl::FailedPreconditionError(absl::StrFormat(
         "Project '%s' has no loaded hack manifest; configure a valid "
-        "hack_manifest_file before mutating expanded messages",
+        "hack_manifest_file before mutating messages",
         *project_path));
   }
 
+  return context;
+}
+
+absl::StatusOr<ExpandedMutationContext> PreflightExpandedMutation(
+    const project::YazeProject& yaze_project, const Rom& rom) {
+  ExpandedMutationContext context;
+  const auto& manifest = yaze_project.hack_manifest;
   const auto& layout = manifest.message_layout();
   if (layout.data_start == 0 || layout.data_end == 0 ||
       layout.data_end < layout.data_start ||
@@ -255,7 +291,7 @@ absl::StatusOr<ExpandedMutationContext> PreflightExpandedMutation(
 
   const std::string lowered_hack_name =
       absl::AsciiStrToLower(manifest.hack_name());
-  if (context.project.rom_metadata.write_policy ==
+  if (yaze_project.rom_metadata.write_policy ==
           project::RomWritePolicy::kBlock &&
       absl::StrContains(lowered_hack_name, "oracle of secrets")) {
     return absl::PermissionDeniedError(
@@ -268,12 +304,12 @@ absl::StatusOr<ExpandedMutationContext> PreflightExpandedMutation(
       manifest.AnalyzePcWriteRanges({{start, static_cast<uint32_t>(end + 1u)}});
   if (!conflicts.empty()) {
     const std::string detail = FormatManifestConflict(conflicts.front());
-    if (context.project.rom_metadata.write_policy ==
+    if (yaze_project.rom_metadata.write_policy ==
         project::RomWritePolicy::kBlock) {
       return absl::PermissionDeniedError(absl::StrFormat(
           "Expanded message mutation blocked by hack manifest: %s", detail));
     }
-    if (context.project.rom_metadata.write_policy ==
+    if (yaze_project.rom_metadata.write_policy ==
         project::RomWritePolicy::kWarn) {
       context.policy_warning = absl::StrFormat(
           "Expanded message region conflicts with hack manifest: %s", detail);
@@ -281,6 +317,148 @@ absl::StatusOr<ExpandedMutationContext> PreflightExpandedMutation(
   }
 
   return context;
+}
+
+absl::StatusOr<ExpandedMutationContext> PreflightExpandedMutation(
+    const resources::ArgumentParser& parser, const Rom& rom) {
+  auto project_context_or =
+      LoadProjectMutationContext(parser, rom, "Expanded message mutation");
+  if (!project_context_or.ok()) {
+    return project_context_or.status();
+  }
+  ProjectMutationContext project_context =
+      std::move(project_context_or.value());
+  return PreflightExpandedMutation(project_context.project, rom);
+}
+
+absl::Status VerifyCleanDiskSnapshot(const Rom& rom,
+                                     std::vector<uint8_t>* baseline) {
+  if (rom.dirty()) {
+    return absl::FailedPreconditionError(
+        "Message bundle apply requires a clean ROM; save or discard existing "
+        "in-memory changes before retrying");
+  }
+
+  Rom disk_rom;
+  Rom::LoadOptions load_options;
+  load_options.load_resource_labels = false;
+  const absl::Status load_status =
+      disk_rom.LoadFromFile(rom.filename(), load_options);
+  if (!load_status.ok()) {
+    return load_status;
+  }
+  if (disk_rom.vector() != rom.vector()) {
+    return absl::FailedPreconditionError(
+        "Active ROM no longer matches the file on disk; reopen it before "
+        "applying a message bundle");
+  }
+  if (baseline != nullptr) {
+    *baseline = disk_rom.vector();
+  }
+  return absl::OkStatus();
+}
+
+absl::Status VerifyDiskSnapshotUnchanged(
+    const std::filesystem::path& rom_path,
+    const std::vector<uint8_t>& expected_bytes) {
+  std::error_code file_size_ec;
+  const uintmax_t raw_file_size =
+      std::filesystem::file_size(rom_path, file_size_ec);
+  if (file_size_ec ||
+      raw_file_size != static_cast<uintmax_t>(expected_bytes.size())) {
+    return absl::AbortedError(
+        "ROM size changed on disk after message preflight; no bytes were "
+        "saved. Reopen the ROM and retry");
+  }
+  Rom disk_rom;
+  Rom::LoadOptions load_options;
+  load_options.load_resource_labels = false;
+  const absl::Status load_status =
+      disk_rom.LoadFromFile(rom_path.string(), load_options);
+  if (!load_status.ok()) {
+    return load_status;
+  }
+  if (disk_rom.vector() != expected_bytes) {
+    return absl::AbortedError(
+        "ROM changed on disk after message preflight; no bytes were saved. "
+        "Reopen the ROM and retry");
+  }
+  return absl::OkStatus();
+}
+
+absl::Status ValidateVanillaMutation(const project::YazeProject& yaze_project,
+                                     const editor::VanillaMessageSavePlan& plan,
+                                     std::string* policy_warning) {
+  const auto conflicts =
+      yaze_project.hack_manifest.AnalyzePcWriteRanges(plan.write_ranges());
+  if (conflicts.empty()) {
+    return absl::OkStatus();
+  }
+
+  const std::string detail = FormatManifestConflict(conflicts.front());
+  if (yaze_project.rom_metadata.write_policy ==
+      project::RomWritePolicy::kBlock) {
+    return absl::PermissionDeniedError(absl::StrFormat(
+        "Vanilla message mutation blocked by hack manifest: %s; no message "
+        "bytes were written",
+        detail));
+  }
+  if (yaze_project.rom_metadata.write_policy ==
+          project::RomWritePolicy::kWarn &&
+      policy_warning != nullptr) {
+    *policy_warning = absl::StrFormat(
+        "Vanilla message write conflicts with hack manifest: %s", detail);
+  }
+  return absl::OkStatus();
+}
+
+absl::Status VerifySavedRom(
+    const Rom& active_rom, const std::filesystem::path& saved_rom_path,
+    const std::optional<editor::VanillaMessageSavePlan>& vanilla_plan,
+    std::optional<size_t> expected_vanilla_count) {
+  Rom reopened_rom;
+  Rom::LoadOptions load_options;
+  load_options.load_resource_labels = false;
+  const absl::Status reopen_status =
+      reopened_rom.LoadFromFile(saved_rom_path.string(), load_options);
+  if (!reopen_status.ok()) {
+    return absl::DataLossError(absl::StrFormat(
+        "ROM was saved but could not be reopened for verification: %s. "
+        "Restore the required backup before retrying",
+        reopen_status.message()));
+  }
+  if (reopened_rom.vector() != active_rom.vector()) {
+    return absl::DataLossError(
+        "ROM was saved but external readback differs from the planned bytes. "
+        "Restore the required backup before retrying");
+  }
+
+  if (vanilla_plan.has_value()) {
+    if (reopened_rom.size() >
+        static_cast<size_t>(std::numeric_limits<int>::max())) {
+      return absl::DataLossError(
+          "ROM was saved but is too large for bounded vanilla-message "
+          "readback. Restore the required backup before retrying");
+    }
+    const auto reopened_messages =
+        editor::ReadAllTextData(reopened_rom.mutable_data(), editor::kTextData,
+                                static_cast<int>(reopened_rom.size()));
+    auto readback_plan_or = editor::BuildVanillaMessageSavePlan(
+        reopened_messages, expected_vanilla_count);
+    if (!readback_plan_or.ok() ||
+        readback_plan_or.value() != vanilla_plan.value()) {
+      const std::string detail =
+          readback_plan_or.ok()
+              ? "serialized message bytes differ from the save plan"
+              : std::string(readback_plan_or.status().message());
+      return absl::DataLossError(absl::StrFormat(
+          "ROM was saved but vanilla-message readback failed: %s. Restore the "
+          "required backup before retrying",
+          detail));
+    }
+  }
+
+  return absl::OkStatus();
 }
 
 absl::Status ValidateExpandedMessageId(int id,
@@ -704,6 +882,14 @@ absl::Status MessageImportBundleCommandHandler::Execute(
   auto file_path = parser.GetString("file").value();
   const bool apply = parser.HasFlag("apply");
   const bool strict = parser.HasFlag("strict");
+#ifdef __EMSCRIPTEN__
+  if (apply) {
+    return absl::FailedPreconditionError(
+        "message-import-bundle --apply is unavailable in WebAssembly because "
+        "the browser filesystem cannot provide durable backup and readback "
+        "guarantees");
+  }
+#endif
   auto range = NormalizeRange(parser.GetString("range").value_or("all"));
   if (!IncludeVanilla(range) && !IncludeExpanded(range)) {
     return absl::InvalidArgumentError(
@@ -845,9 +1031,40 @@ absl::Status MessageImportBundleCommandHandler::Execute(
       return absl::OkStatus();
     }
 
+    std::optional<ProjectMutationContext> project_context;
+    std::vector<uint8_t> disk_baseline;
+    if (has_vanilla_entries || has_expanded_entries) {
+      const absl::Status snapshot_status =
+          VerifyCleanDiskSnapshot(*active_rom, &disk_baseline);
+      if (!snapshot_status.ok()) {
+        error_count++;
+        formatter.AddField("status", "error");
+        formatter.AddField("error", std::string(snapshot_status.message()));
+        formatter.AddField("parse_error_count", parse_error_count);
+        formatter.AddField("error_count", error_count);
+        formatter.EndObject();
+        return snapshot_status;
+      }
+
+      auto project_context_or = LoadProjectMutationContext(
+          parser, *active_rom, "Message bundle apply");
+      if (!project_context_or.ok()) {
+        error_count++;
+        formatter.AddField("status", "error");
+        formatter.AddField("error",
+                           std::string(project_context_or.status().message()));
+        formatter.AddField("parse_error_count", parse_error_count);
+        formatter.AddField("error_count", error_count);
+        formatter.EndObject();
+        return project_context_or.status();
+      }
+      project_context.emplace(std::move(project_context_or.value()));
+    }
+
     std::optional<ExpandedMutationContext> expanded_context;
     if (IncludeExpanded(range) && has_expanded_entries) {
-      auto context_or = PreflightExpandedMutation(parser, *active_rom);
+      auto context_or =
+          PreflightExpandedMutation(project_context->project, *active_rom);
       if (!context_or.ok()) {
         error_count++;
         formatter.AddField("status", "error");
@@ -858,10 +1075,6 @@ absl::Status MessageImportBundleCommandHandler::Execute(
         return context_or.status();
       }
       expanded_context.emplace(std::move(context_or.value()));
-      if (!expanded_context->policy_warning.empty()) {
-        formatter.AddField("write_policy_warning",
-                           expanded_context->policy_warning);
-      }
     }
 
     // Build both replacement banks and validate every selected ID before the
@@ -869,8 +1082,14 @@ absl::Status MessageImportBundleCommandHandler::Execute(
     // successful vanilla mutation in a mixed bundle.
     std::vector<editor::MessageData> vanilla_messages;
     if (IncludeVanilla(range) && has_vanilla_entries) {
+      if (active_rom->size() >
+          static_cast<size_t>(std::numeric_limits<int>::max())) {
+        return absl::OutOfRangeError(
+            "ROM is too large for bounded vanilla-message parsing");
+      }
       vanilla_messages = editor::ReadAllTextData(
-          const_cast<uint8_t*>(active_rom->data()), editor::kTextData);
+          const_cast<uint8_t*>(active_rom->data()), editor::kTextData,
+          static_cast<int>(active_rom->size()));
     }
 
     std::vector<std::string> expanded_texts;
@@ -923,13 +1142,60 @@ absl::Status MessageImportBundleCommandHandler::Execute(
       applied_updates++;
     }
 
+    std::optional<editor::VanillaMessageSavePlan> vanilla_plan;
+    std::optional<size_t> expected_vanilla_count;
+    std::string write_policy_warning;
+    if (!has_errors && IncludeVanilla(range) && has_vanilla_entries) {
+      const int manifest_count =
+          project_context->project.hack_manifest.message_layout().vanilla_count;
+      if (manifest_count <= 0) {
+        const absl::Status status = absl::FailedPreconditionError(
+            "Hack manifest must declare a positive messages.vanilla_count "
+            "before applying vanilla messages");
+        formatter.AddField("status", "error");
+        formatter.AddField("error", std::string(status.message()));
+        formatter.EndObject();
+        return status;
+      }
+      expected_vanilla_count = static_cast<size_t>(manifest_count);
+      auto plan_or = editor::BuildVanillaMessageSavePlan(
+          vanilla_messages, expected_vanilla_count);
+      if (!plan_or.ok()) {
+        formatter.AddField("status", "error");
+        formatter.AddField("error", std::string(plan_or.status().message()));
+        formatter.EndObject();
+        return plan_or.status();
+      }
+      vanilla_plan.emplace(std::move(plan_or.value()));
+      const absl::Status policy_status = ValidateVanillaMutation(
+          project_context->project, *vanilla_plan, &write_policy_warning);
+      if (!policy_status.ok()) {
+        formatter.AddField("status", "error");
+        formatter.AddField("error", std::string(policy_status.message()));
+        formatter.EndObject();
+        return policy_status;
+      }
+    }
+
+    if (expanded_context.has_value() &&
+        !expanded_context->policy_warning.empty()) {
+      if (!write_policy_warning.empty()) {
+        absl::StrAppend(&write_policy_warning, "; ");
+      }
+      absl::StrAppend(&write_policy_warning, expanded_context->policy_warning);
+    }
+    if (!write_policy_warning.empty()) {
+      formatter.AddField("write_policy_warning", write_policy_warning);
+    }
+
     if (has_errors) {
       formatter.AddField("status", "error");
       formatter.AddField("error", "Invalid message IDs; no changes applied");
     } else {
       ScopedRomTransaction transaction(*active_rom);
-      if (IncludeVanilla(range) && has_vanilla_entries) {
-        auto status = editor::WriteAllTextData(active_rom, vanilla_messages);
+      if (vanilla_plan.has_value()) {
+        auto status =
+            editor::ApplyVanillaMessageSavePlan(active_rom, *vanilla_plan);
         if (!status.ok()) {
           formatter.AddField("status", "error");
           formatter.AddField("error", std::string(status.message()));
@@ -950,8 +1216,20 @@ absl::Status MessageImportBundleCommandHandler::Execute(
         }
       }
 
-      if (active_rom->dirty()) {
-        auto save_status = active_rom->SaveToFile({.save_new = false});
+      if (active_rom->dirty() && project_context.has_value()) {
+        const absl::Status unchanged_status = VerifyDiskSnapshotUnchanged(
+            project_context->canonical_rom_path, disk_baseline);
+        if (!unchanged_status.ok()) {
+          formatter.AddField("status", "error");
+          formatter.AddField("error", std::string(unchanged_status.message()));
+          formatter.EndObject();
+          return unchanged_status;
+        }
+        Rom::SaveSettings save_settings;
+        save_settings.save_new = false;
+        save_settings.require_backup = true;
+        save_settings.filename = project_context->canonical_rom_path.string();
+        auto save_status = active_rom->SaveToFile(save_settings);
         if (!save_status.ok()) {
           formatter.AddField("status", "error");
           formatter.AddField("error", std::string(save_status.message()));
@@ -960,8 +1238,23 @@ absl::Status MessageImportBundleCommandHandler::Execute(
         }
       }
       transaction.Commit();
+
+      if (project_context.has_value()) {
+        const absl::Status readback_status =
+            VerifySavedRom(*active_rom, project_context->canonical_rom_path,
+                           vanilla_plan, expected_vanilla_count);
+        if (!readback_status.ok()) {
+          formatter.AddField("status", "error");
+          formatter.AddField("error", std::string(readback_status.message()));
+          formatter.EndObject();
+          return readback_status;
+        }
+      }
       formatter.AddField("status", "success");
       formatter.AddField("applied_messages", applied_updates);
+      if (project_context.has_value()) {
+        formatter.AddField("readback_verified", true);
+      }
     }
   } else {
     formatter.AddField("status", has_errors ? "error" : "success");

--- a/src/cli/handlers/game/message_commands.cc
+++ b/src/cli/handlers/game/message_commands.cc
@@ -1084,6 +1084,7 @@ absl::Status MessageImportBundleCommandHandler::Execute(
     if (IncludeVanilla(range) && has_vanilla_entries) {
       if (active_rom->size() >
           static_cast<size_t>(std::numeric_limits<int>::max())) {
+        formatter.EndObject();
         return absl::OutOfRangeError(
             "ROM is too large for bounded vanilla-message parsing");
       }

--- a/src/cli/handlers/game/message_commands.h
+++ b/src/cli/handlers/game/message_commands.h
@@ -184,7 +184,7 @@ class MessageImportBundleCommandHandler : public resources::CommandHandler {
   std::string GetUsage() const override {
     return "message-import-bundle --file <path> [--apply] [--strict]"
            " [--range <all|vanilla|expanded>] [--project <path>]"
-           " [--format <json|text>] (expanded --apply requires --project)";
+           " [--format <json|text>] (--apply requires --project)";
   }
   bool RequiresRom() const override { return false; }
 

--- a/test/unit/cli/message_commands_policy_test.cc
+++ b/test/unit/cli/message_commands_policy_test.cc
@@ -500,6 +500,74 @@ TEST(MessageCommandsPolicyTest, VanillaApplyWithoutProjectFailsClosed) {
 }
 
 TEST(MessageCommandsPolicyTest,
+     VanillaApplyRejectsDirtyInMemoryRomBeforeMutation) {
+  ScopedTempDir temp;
+  const fs::path rom_path = temp.path() / "active.sfc";
+  const auto disk_before = MakeMessageRomData();
+  WriteBinaryFile(rom_path, disk_before);
+  const fs::path project_path =
+      CreateProject(temp.path(), rom_path, "Other Hack", "allow", false);
+  const fs::path bundle_path =
+      WriteBundle(temp.path(),
+                  nlohmann::json::array(
+                      {{{"id", 0}, {"bank", "vanilla"}, {"text", "B[BANK]"}}}));
+  Rom rom = LoadRom(rom_path);
+  ASSERT_TRUE(rom.WriteByte(0x10, 0x5A).ok());
+  ASSERT_TRUE(rom.dirty());
+  const auto in_memory_before = rom.vector();
+
+  handlers::MessageImportBundleCommandHandler handler;
+  const resources::ArgumentParser parser(
+      {"--file=" + bundle_path.string(), "--apply", "--range=vanilla",
+       "--project=" + project_path.string(), "--format=json"});
+  resources::OutputFormatter formatter(
+      resources::OutputFormatter::Format::kJson);
+  const auto status = handler.Execute(&rom, parser, formatter);
+
+  EXPECT_EQ(status.code(), absl::StatusCode::kFailedPrecondition);
+  EXPECT_THAT(std::string(status.message()), HasSubstr("requires a clean ROM"));
+  EXPECT_EQ(rom.vector(), in_memory_before);
+  EXPECT_TRUE(rom.dirty());
+  EXPECT_EQ(ReadBinaryFile(rom_path), disk_before);
+  EXPECT_EQ(CountBackupArtifacts(rom_path), 0);
+}
+
+TEST(MessageCommandsPolicyTest,
+     VanillaApplyRejectsDiskDivergenceBeforeMutation) {
+  ScopedTempDir temp;
+  const fs::path rom_path = temp.path() / "active.sfc";
+  const auto loaded_bytes = MakeMessageRomData();
+  WriteBinaryFile(rom_path, loaded_bytes);
+  const fs::path project_path =
+      CreateProject(temp.path(), rom_path, "Other Hack", "allow", false);
+  const fs::path bundle_path =
+      WriteBundle(temp.path(),
+                  nlohmann::json::array(
+                      {{{"id", 0}, {"bank", "vanilla"}, {"text", "B[BANK]"}}}));
+  Rom rom = LoadRom(rom_path);
+  ASSERT_FALSE(rom.dirty());
+  auto diverged_disk_bytes = loaded_bytes;
+  diverged_disk_bytes[0x10] = 0x5A;
+  WriteBinaryFile(rom_path, diverged_disk_bytes);
+
+  handlers::MessageImportBundleCommandHandler handler;
+  const resources::ArgumentParser parser(
+      {"--file=" + bundle_path.string(), "--apply", "--range=vanilla",
+       "--project=" + project_path.string(), "--format=json"});
+  resources::OutputFormatter formatter(
+      resources::OutputFormatter::Format::kJson);
+  const auto status = handler.Execute(&rom, parser, formatter);
+
+  EXPECT_EQ(status.code(), absl::StatusCode::kFailedPrecondition);
+  EXPECT_THAT(std::string(status.message()),
+              HasSubstr("no longer matches the file on disk"));
+  EXPECT_EQ(rom.vector(), loaded_bytes);
+  EXPECT_FALSE(rom.dirty());
+  EXPECT_EQ(ReadBinaryFile(rom_path), diverged_disk_bytes);
+  EXPECT_EQ(CountBackupArtifacts(rom_path), 0);
+}
+
+TEST(MessageCommandsPolicyTest,
      ProjectBackedVanillaApplyBacksUpSavesAndVerifiesReadback) {
   ScopedTempDir temp;
   const fs::path rom_path = temp.path() / "active.sfc";

--- a/test/unit/cli/message_commands_policy_test.cc
+++ b/test/unit/cli/message_commands_policy_test.cc
@@ -69,8 +69,9 @@ std::vector<uint8_t> ReadBinaryFile(const fs::path& path) {
 std::vector<uint8_t> MakeMessageRomData(int expanded_message_count = 1) {
   std::vector<uint8_t> data(0x180000, 0xA5);
   data[editor::kTextData] = editor::FindMatchingCharacter('A');
-  data[editor::kTextData + 1] = editor::kMessageTerminator;
-  data[editor::kTextData + 2] = 0xFF;
+  data[editor::kTextData + 1] = editor::kBankSwitchCommand;
+  data[editor::kTextData2] = editor::kMessageTerminator;
+  data[editor::kTextData2 + 1] = 0xFF;
   int expanded_pos = editor::kExpandedTextDataDefault;
   for (int i = 0; i < expanded_message_count; ++i) {
     data[expanded_pos++] = editor::FindMatchingCharacter('X');
@@ -134,6 +135,25 @@ fs::path WriteBundle(const fs::path& root, const nlohmann::json& messages) {
   return path;
 }
 
+std::vector<fs::path> FindBackupArtifacts(const fs::path& rom_path) {
+  std::error_code ec;
+  const std::string prefix = rom_path.filename().string() + "_backup_";
+  std::vector<fs::path> backups;
+  for (const auto& entry : fs::directory_iterator(rom_path.parent_path(), ec)) {
+    if (ec || !entry.is_regular_file()) {
+      continue;
+    }
+    if (entry.path().filename().string().rfind(prefix, 0) == 0) {
+      backups.push_back(entry.path());
+    }
+  }
+  return backups;
+}
+
+int CountBackupArtifacts(const fs::path& rom_path) {
+  return static_cast<int>(FindBackupArtifacts(rom_path).size());
+}
+
 Rom LoadRom(const fs::path& path) {
   Rom rom;
   auto status = rom.LoadFromFile(path.string());
@@ -177,6 +197,23 @@ TEST(MessageCommandsPolicyTest, ExpandedBundleApplyWithoutProjectFailsClosed) {
   EXPECT_EQ(status.code(), absl::StatusCode::kFailedPrecondition) << output;
   EXPECT_THAT(std::string(status.message()), HasSubstr("explicit --project"));
   EXPECT_EQ(ReadBinaryFile(rom_path), before);
+}
+
+TEST(MessageCommandsPolicyTest,
+     ArgumentCommandWithoutArgumentReturnsStrictValidationError) {
+  ScopedTempDir temp;
+  const fs::path bundle_path = WriteBundle(
+      temp.path(), nlohmann::json::array(
+                       {{{"id", 0}, {"bank", "vanilla"}, {"text", "[W]"}}}));
+
+  handlers::MessageImportBundleCommandHandler handler;
+  std::string output;
+  const auto status = handler.Run(
+      {"--file=" + bundle_path.string(), "--strict", "--format=json"}, nullptr,
+      &output);
+
+  EXPECT_EQ(status.code(), absl::StatusCode::kFailedPrecondition) << output;
+  EXPECT_THAT(output, HasSubstr("Unknown token: [W]"));
 }
 
 TEST(MessageCommandsPolicyTest,
@@ -260,7 +297,7 @@ TEST(MessageCommandsPolicyTest, MixedApplyLateFailureLeavesRomUnchanged) {
   const fs::path bundle_path = WriteBundle(
       temp.path(),
       nlohmann::json::array(
-          {{{"id", 0}, {"bank", "vanilla"}, {"text", "B"}},
+          {{{"id", 0}, {"bank", "vanilla"}, {"text", "B[BANK]"}},
            {{"id", 0}, {"bank", "expanded"}, {"text", "A[BANK]B"}}}));
   const auto before = ReadBinaryFile(rom_path);
 
@@ -439,13 +476,15 @@ TEST(MessageCommandsPolicyTest,
   EXPECT_EQ(rom.vector(), before);
 }
 
-TEST(MessageCommandsPolicyTest, VanillaOnlyApplyStillWorksWithoutProject) {
+TEST(MessageCommandsPolicyTest, VanillaApplyWithoutProjectFailsClosed) {
   ScopedTempDir temp;
   const fs::path rom_path = temp.path() / "active.sfc";
   WriteBinaryFile(rom_path, MakeMessageRomData());
-  const fs::path bundle_path = WriteBundle(
-      temp.path(),
-      nlohmann::json::array({{{"id", 0}, {"bank", "vanilla"}, {"text", "B"}}}));
+  const auto disk_before = ReadBinaryFile(rom_path);
+  const fs::path bundle_path =
+      WriteBundle(temp.path(),
+                  nlohmann::json::array(
+                      {{{"id", 0}, {"bank", "vanilla"}, {"text", "B[BANK]"}}}));
 
   handlers::MessageImportBundleCommandHandler handler;
   std::string output;
@@ -454,9 +493,214 @@ TEST(MessageCommandsPolicyTest, VanillaOnlyApplyStillWorksWithoutProject) {
        "--rom=" + rom_path.string(), "--format=json"},
       nullptr, &output);
 
+  EXPECT_EQ(status.code(), absl::StatusCode::kFailedPrecondition) << output;
+  EXPECT_THAT(std::string(status.message()), HasSubstr("explicit --project"));
+  EXPECT_EQ(ReadBinaryFile(rom_path), disk_before);
+  EXPECT_EQ(CountBackupArtifacts(rom_path), 0);
+}
+
+TEST(MessageCommandsPolicyTest,
+     ProjectBackedVanillaApplyBacksUpSavesAndVerifiesReadback) {
+  ScopedTempDir temp;
+  const fs::path rom_path = temp.path() / "active.sfc";
+  const auto disk_before = MakeMessageRomData();
+  WriteBinaryFile(rom_path, disk_before);
+  const fs::path project_path =
+      CreateProject(temp.path(), rom_path, "Other Hack", "allow", false);
+  const fs::path bundle_path =
+      WriteBundle(temp.path(),
+                  nlohmann::json::array(
+                      {{{"id", 0}, {"bank", "vanilla"}, {"text", "B[BANK]"}}}));
+
+  handlers::MessageImportBundleCommandHandler handler;
+  std::string output;
+  const auto status =
+      handler.Run({"--file=" + bundle_path.string(), "--apply",
+                   "--range=vanilla", "--rom=" + rom_path.string(),
+                   "--project=" + project_path.string(), "--format=json"},
+                  nullptr, &output);
+
   ASSERT_TRUE(status.ok()) << status << "\n" << output;
-  const auto after = ReadBinaryFile(rom_path);
-  EXPECT_EQ(after[editor::kTextData], editor::FindMatchingCharacter('B'));
+  const auto result = nlohmann::json::parse(output).at("Message Bundle Import");
+  EXPECT_EQ(result.at("readback_verified"), true);
+  const auto backups = FindBackupArtifacts(rom_path);
+  ASSERT_EQ(backups.size(), 1);
+  EXPECT_EQ(ReadBinaryFile(backups.front()), disk_before);
+
+  Rom reopened = LoadRom(rom_path);
+  EXPECT_EQ(reopened.vector()[editor::kTextData],
+            editor::FindMatchingCharacter('B'));
+  EXPECT_EQ(reopened.vector()[editor::kTextData + 1],
+            editor::kBankSwitchCommand);
+  EXPECT_EQ(reopened.vector()[editor::kTextData2], editor::kMessageTerminator);
+  EXPECT_EQ(reopened.vector()[editor::kTextData2 + 1], 0xFF);
+}
+
+TEST(MessageCommandsPolicyTest,
+     ProjectBackedVanillaApplyPreservesRomSymlinkAndWritesCanonicalTarget) {
+  ScopedTempDir temp;
+  const fs::path rom_path = temp.path() / "canonical.sfc";
+  const fs::path rom_alias = temp.path() / "active-alias.sfc";
+  WriteBinaryFile(rom_path, MakeMessageRomData());
+  std::error_code symlink_ec;
+  fs::create_symlink(rom_path.filename(), rom_alias, symlink_ec);
+  if (symlink_ec) {
+    GTEST_SKIP() << "ROM symlink unavailable: " << symlink_ec.message();
+  }
+
+  const fs::path project_path =
+      CreateProject(temp.path(), rom_path, "Other Hack", "allow", false);
+  const fs::path bundle_path =
+      WriteBundle(temp.path(),
+                  nlohmann::json::array(
+                      {{{"id", 0}, {"bank", "vanilla"}, {"text", "B[BANK]"}}}));
+
+  handlers::MessageImportBundleCommandHandler handler;
+  std::string output;
+  const auto status =
+      handler.Run({"--file=" + bundle_path.string(), "--apply",
+                   "--range=vanilla", "--rom=" + rom_alias.string(),
+                   "--project=" + project_path.string(), "--format=json"},
+                  nullptr, &output);
+
+  ASSERT_TRUE(status.ok()) << status << "\n" << output;
+  EXPECT_TRUE(fs::is_symlink(rom_alias));
+  EXPECT_EQ(ReadBinaryFile(rom_path)[editor::kTextData],
+            editor::FindMatchingCharacter('B'));
+  EXPECT_EQ(FindBackupArtifacts(rom_path).size(), 1);
+  EXPECT_TRUE(FindBackupArtifacts(rom_alias).empty());
+}
+
+TEST(MessageCommandsPolicyTest, VanillaApplyRejectsCopierHeaderedRom) {
+  ScopedTempDir temp;
+  const fs::path rom_path = temp.path() / "headered.sfc";
+  auto headered_rom = MakeMessageRomData();
+  headered_rom.insert(headered_rom.begin(), 512, 0);
+  WriteBinaryFile(rom_path, headered_rom);
+  const fs::path project_path =
+      CreateProject(temp.path(), rom_path, "Other Hack", "allow", false);
+  const fs::path bundle_path =
+      WriteBundle(temp.path(),
+                  nlohmann::json::array(
+                      {{{"id", 0}, {"bank", "vanilla"}, {"text", "B[BANK]"}}}));
+
+  handlers::MessageImportBundleCommandHandler handler;
+  std::string output;
+  const auto status =
+      handler.Run({"--file=" + bundle_path.string(), "--apply",
+                   "--range=vanilla", "--rom=" + rom_path.string(),
+                   "--project=" + project_path.string(), "--format=json"},
+                  nullptr, &output);
+
+  EXPECT_EQ(status.code(), absl::StatusCode::kFailedPrecondition) << output;
+  EXPECT_THAT(std::string(status.message()), HasSubstr("headerless ROM"));
+  EXPECT_EQ(ReadBinaryFile(rom_path), headered_rom);
+  EXPECT_TRUE(FindBackupArtifacts(rom_path).empty());
+}
+
+TEST(MessageCommandsPolicyTest,
+     VanillaApplyRejectsManifestMessageCountMismatchBeforeMutation) {
+  ScopedTempDir temp;
+  const fs::path rom_path = temp.path() / "active.sfc";
+  WriteBinaryFile(rom_path, MakeMessageRomData());
+  const fs::path project_path =
+      CreateProject(temp.path(), rom_path, "Other Hack", "allow", false);
+  auto manifest = nlohmann::json::parse(MakeManifest("Other Hack", false));
+  manifest["messages"]["vanilla_count"] = 2;
+  WriteTextFile(temp.path() / "hack_manifest.json", manifest.dump(2));
+  const auto disk_before = ReadBinaryFile(rom_path);
+  const fs::path bundle_path =
+      WriteBundle(temp.path(),
+                  nlohmann::json::array(
+                      {{{"id", 0}, {"bank", "vanilla"}, {"text", "B[BANK]"}}}));
+
+  handlers::MessageImportBundleCommandHandler handler;
+  std::string output;
+  const auto status =
+      handler.Run({"--file=" + bundle_path.string(), "--apply",
+                   "--range=vanilla", "--rom=" + rom_path.string(),
+                   "--project=" + project_path.string(), "--format=json"},
+                  nullptr, &output);
+
+  EXPECT_EQ(status.code(), absl::StatusCode::kFailedPrecondition) << output;
+  EXPECT_THAT(std::string(status.message()),
+              HasSubstr("Vanilla message count mismatch"));
+  EXPECT_EQ(ReadBinaryFile(rom_path), disk_before);
+  EXPECT_EQ(CountBackupArtifacts(rom_path), 0);
+}
+
+TEST(MessageCommandsPolicyTest,
+     VanillaApplyBlockPolicyRejectsExactProtectedHookOverlap) {
+  ScopedTempDir temp;
+  const fs::path rom_path = temp.path() / "active.sfc";
+  WriteBinaryFile(rom_path, MakeMessageRomData());
+  const fs::path project_path =
+      CreateProject(temp.path(), rom_path, "Other Hack", "block", false);
+  auto manifest = nlohmann::json::parse(MakeManifest("Other Hack", false));
+  manifest["protected_regions"] = {{"regions",
+                                    {{{"start", "0x0EEE75"},
+                                      {"end", "0x0EEE7D"},
+                                      {"module", "Core/message.asm"}}}}};
+  WriteTextFile(temp.path() / "hack_manifest.json", manifest.dump(2));
+  const auto disk_before = ReadBinaryFile(rom_path);
+  constexpr size_t kProtectedHookOffset = 0x076E75 - editor::kTextData2;
+  const std::string overlapping_text =
+      "[BANK]" + std::string(kProtectedHookOffset - 1, 'A');
+  const fs::path bundle_path = WriteBundle(
+      temp.path(),
+      nlohmann::json::array(
+          {{{"id", 0}, {"bank", "vanilla"}, {"text", overlapping_text}}}));
+
+  handlers::MessageImportBundleCommandHandler handler;
+  std::string output;
+  const auto status =
+      handler.Run({"--file=" + bundle_path.string(), "--apply",
+                   "--range=vanilla", "--rom=" + rom_path.string(),
+                   "--project=" + project_path.string(), "--format=json"},
+                  nullptr, &output);
+
+  EXPECT_EQ(status.code(), absl::StatusCode::kPermissionDenied) << output;
+  EXPECT_THAT(std::string(status.message()),
+              HasSubstr("blocked by hack manifest"));
+  EXPECT_THAT(std::string(status.message()), HasSubstr("Core/message.asm"));
+  EXPECT_EQ(ReadBinaryFile(rom_path), disk_before);
+  EXPECT_EQ(CountBackupArtifacts(rom_path), 0);
+}
+
+TEST(MessageCommandsPolicyTest,
+     VanillaApplyAllowsExactHalfOpenBoundaryBeforeProtectedHook) {
+  ScopedTempDir temp;
+  const fs::path rom_path = temp.path() / "active.sfc";
+  WriteBinaryFile(rom_path, MakeMessageRomData());
+  const fs::path project_path =
+      CreateProject(temp.path(), rom_path, "Other Hack", "block", false);
+  auto manifest = nlohmann::json::parse(MakeManifest("Other Hack", false));
+  manifest["protected_regions"] = {{"regions",
+                                    {{{"start", "0x0EEE75"},
+                                      {"end", "0x0EEE7D"},
+                                      {"module", "Core/message.asm"}}}}};
+  WriteTextFile(temp.path() / "hack_manifest.json", manifest.dump(2));
+
+  constexpr size_t kProtectedHookOffset = 0x076E75 - editor::kTextData2;
+  const std::string boundary_safe_text =
+      "[BANK]" + std::string(kProtectedHookOffset - 2, 'A');
+  const fs::path bundle_path = WriteBundle(
+      temp.path(),
+      nlohmann::json::array(
+          {{{"id", 0}, {"bank", "vanilla"}, {"text", boundary_safe_text}}}));
+
+  handlers::MessageImportBundleCommandHandler handler;
+  std::string output;
+  const auto status =
+      handler.Run({"--file=" + bundle_path.string(), "--apply",
+                   "--range=vanilla", "--rom=" + rom_path.string(),
+                   "--project=" + project_path.string(), "--format=json"},
+                  nullptr, &output);
+
+  ASSERT_TRUE(status.ok()) << status << "\n" << output;
+  Rom reopened = LoadRom(rom_path);
+  EXPECT_EQ(reopened.vector()[0x076E75], 0xA5);
+  EXPECT_EQ(FindBackupArtifacts(rom_path).size(), 1);
 }
 
 }  // namespace

--- a/test/unit/editor/message/message_data_test.cc
+++ b/test/unit/editor/message/message_data_test.cc
@@ -752,10 +752,9 @@ TEST(TextElementTest, MatchMeWithArg) {
   auto match = elem.MatchMe("[W:02]");
   EXPECT_GT(match.size(), 0);
 
-  // Should not match without arg format
+  // Argument commands fail closed without an explicit byte.
   match = elem.MatchMe("[W]");
-  // W has HasArgument=true, pattern allows optional arg
-  // This may or may not match depending on regex - just verify no crash
+  EXPECT_EQ(match.size(), 0);
 }
 
 TEST(TextElementTest, MatchMeNoMatch) {

--- a/test/unit/editor/message/message_expanded_write_test.cc
+++ b/test/unit/editor/message/message_expanded_write_test.cc
@@ -203,19 +203,185 @@ TEST(ExpandedMessageWriteTest, LegacyWriterPreflightsBankCommand) {
   EXPECT_EQ(data, before);
 }
 
+TEST(MessageBankTokenParseTest, LegacyParserDistinguishesBankFromDictionary) {
+  EXPECT_EQ(ParseMessageToData("[BANK]"),
+            (std::vector<uint8_t>{kBankSwitchCommand}));
+  EXPECT_EQ(ParseMessageToData("[D:00]"), (std::vector<uint8_t>{DICTOFF}));
+}
+
+TEST(MessageBankTokenParseTest,
+     DiagnosticsParserDistinguishesBankFromDictionary) {
+  const auto bank = ParseMessageToDataWithDiagnostics("[BANK]");
+  const auto dictionary = ParseMessageToDataWithDiagnostics("[D:00]");
+
+  ASSERT_TRUE(bank.ok());
+  ASSERT_TRUE(dictionary.ok());
+  EXPECT_EQ(bank.bytes, (std::vector<uint8_t>{kBankSwitchCommand}));
+  EXPECT_EQ(dictionary.bytes, (std::vector<uint8_t>{DICTOFF}));
+}
+
+TEST(MessageBankTokenParseTest, ArgumentCommandWithoutArgumentFailsClosed) {
+  const auto parsed = ParseMessageToDataWithDiagnostics("[W]");
+
+  EXPECT_FALSE(parsed.ok());
+  EXPECT_TRUE(parsed.bytes.empty());
+}
+
 TEST(VanillaMessageWriteTest, CommandArgument80DoesNotSwitchBanks) {
   Rom rom = MakeRom(/*size=*/0x180100, /*fill=*/0xA5);
   MessageData message;
-  message.Data = ParseMessageToData("[W:80]");
-  ASSERT_EQ(message.Data, (std::vector<uint8_t>{0x6B, 0x80}));
+  message.Data = ParseMessageToData("[W:80][BANK]");
+  ASSERT_EQ(message.Data,
+            (std::vector<uint8_t>{0x6B, 0x80, kBankSwitchCommand}));
 
   ASSERT_TRUE(WriteAllTextData(&rom, {message}).ok());
 
   EXPECT_EQ(rom.vector()[kTextData], 0x6B);
   EXPECT_EQ(rom.vector()[kTextData + 1], 0x80);
-  EXPECT_EQ(rom.vector()[kTextData + 2], kMessageTerminator);
-  EXPECT_EQ(rom.vector()[kTextData + 3], 0xFF);
-  EXPECT_EQ(rom.vector()[kTextData2], 0xA5);
+  EXPECT_EQ(rom.vector()[kTextData + 2], kBankSwitchCommand);
+  EXPECT_EQ(rom.vector()[kTextData2], kMessageTerminator);
+  EXPECT_EQ(rom.vector()[kTextData2 + 1], 0xFF);
+}
+
+TEST(VanillaMessageSavePlanTest, ExposesExactSplitWritesAndCounts) {
+  MessageData message;
+  message.Data = {0x00, kBankSwitchCommand, 0x01};
+
+  auto plan_or =
+      BuildVanillaMessageSavePlan({message}, /*expected_message_count=*/1);
+  ASSERT_TRUE(plan_or.ok()) << plan_or.status();
+  const VanillaMessageSavePlan& plan = *plan_or;
+
+  EXPECT_EQ(plan.message_count(), 1);
+  EXPECT_EQ(plan.bank_switch_count(), 1);
+  ASSERT_EQ(plan.writes().size(), 2);
+  EXPECT_EQ(plan.writes()[0].start(), kTextData);
+  EXPECT_EQ(plan.writes()[0].bytes(),
+            (std::vector<uint8_t>{0x00, kBankSwitchCommand}));
+  EXPECT_EQ(plan.writes()[1].start(), kTextData2);
+  EXPECT_EQ(plan.writes()[1].bytes(),
+            (std::vector<uint8_t>{0x01, kMessageTerminator, 0xFF}));
+  EXPECT_EQ(plan.write_ranges(),
+            (std::vector<std::pair<uint32_t, uint32_t>>{
+                {kTextData, kTextData + 2}, {kTextData2, kTextData2 + 3}}));
+}
+
+TEST(VanillaMessageSavePlanTest, CommandArgument80DoesNotSwitchBanks) {
+  MessageData message;
+  message.Data = ParseMessageToData("[W:80][BANK]");
+  ASSERT_EQ(message.Data,
+            (std::vector<uint8_t>{0x6B, 0x80, kBankSwitchCommand}));
+
+  auto plan_or = BuildVanillaMessageSavePlan({message});
+  ASSERT_TRUE(plan_or.ok()) << plan_or.status();
+  const VanillaMessageSavePlan& plan = *plan_or;
+
+  EXPECT_EQ(plan.bank_switch_count(), 1);
+  ASSERT_EQ(plan.writes().size(), 2);
+  EXPECT_EQ(plan.writes()[0].bytes(),
+            (std::vector<uint8_t>{0x6B, 0x80, kBankSwitchCommand}));
+  EXPECT_EQ(plan.writes()[1].bytes(),
+            (std::vector<uint8_t>{kMessageTerminator, 0xFF}));
+}
+
+TEST(VanillaMessageSavePlanTest, RejectsDuplicateBankCommand) {
+  MessageData message;
+  message.Data = {kBankSwitchCommand, 0x00, kBankSwitchCommand};
+
+  auto plan_or = BuildVanillaMessageSavePlan({message});
+
+  ASSERT_FALSE(plan_or.ok());
+  EXPECT_EQ(plan_or.status().code(), absl::StatusCode::kInvalidArgument);
+}
+
+TEST(VanillaMessageSavePlanTest, RejectsMissingBankCommand) {
+  MessageData message;
+  message.Data = ParseMessageToData("[W:80]");
+
+  auto plan_or = BuildVanillaMessageSavePlan({message});
+
+  ASSERT_FALSE(plan_or.ok());
+  EXPECT_EQ(plan_or.status().code(), absl::StatusCode::kInvalidArgument);
+}
+
+TEST(VanillaMessageSavePlanTest, RejectsBareStreamMarkersInsideMessageData) {
+  for (const uint8_t marker : {kMessageTerminator, uint8_t{0xFF}}) {
+    MessageData message;
+    message.Data = {kBankSwitchCommand, marker};
+
+    auto plan_or = BuildVanillaMessageSavePlan({message});
+
+    ASSERT_FALSE(plan_or.ok()) << "marker=" << static_cast<int>(marker);
+    EXPECT_EQ(plan_or.status().code(), absl::StatusCode::kInvalidArgument)
+        << "marker=" << static_cast<int>(marker);
+  }
+}
+
+TEST(VanillaMessageSavePlanTest, RejectsCommandMissingItsArgument) {
+  MessageData message;
+  message.Data = {kBankSwitchCommand, 0x6B};
+
+  auto plan_or = BuildVanillaMessageSavePlan({message});
+
+  ASSERT_FALSE(plan_or.ok());
+  EXPECT_EQ(plan_or.status().code(), absl::StatusCode::kInvalidArgument);
+}
+
+TEST(VanillaMessageSavePlanTest,
+     RejectsVanillaMessageCountsOnBothSidesOfExpected) {
+  constexpr size_t kExpectedVanillaMessageCount = 397;
+  for (const size_t actual_count : {size_t{396}, size_t{398}}) {
+    std::vector<MessageData> messages(actual_count);
+
+    auto plan_or = BuildVanillaMessageSavePlan(
+        messages, /*expected_message_count=*/kExpectedVanillaMessageCount);
+
+    ASSERT_FALSE(plan_or.ok()) << "actual_count=" << actual_count;
+    EXPECT_EQ(plan_or.status().code(), absl::StatusCode::kFailedPrecondition)
+        << "actual_count=" << actual_count;
+  }
+}
+
+TEST(VanillaMessageSavePlanTest, RejectsPrimaryBankOverflow) {
+  constexpr size_t kPrimaryCapacity = kTextDataEnd - kTextData + 1;
+  MessageData message;
+  message.Data.assign(kPrimaryCapacity, 0x00);
+  message.Data.push_back(kBankSwitchCommand);
+
+  auto plan_or = BuildVanillaMessageSavePlan({message});
+
+  ASSERT_FALSE(plan_or.ok());
+  EXPECT_EQ(plan_or.status().code(), absl::StatusCode::kResourceExhausted);
+}
+
+TEST(VanillaMessageSavePlanTest, RejectsSecondaryBankOverflow) {
+  constexpr size_t kSecondaryCapacity = kTextData2End - kTextData2 + 1;
+  MessageData message;
+  message.Data.assign(kSecondaryCapacity, 0x00);
+  message.Data.front() = kBankSwitchCommand;
+
+  auto plan_or = BuildVanillaMessageSavePlan({message});
+
+  ASSERT_FALSE(plan_or.ok());
+  EXPECT_EQ(plan_or.status().code(), absl::StatusCode::kResourceExhausted);
+}
+
+TEST(VanillaMessageSavePlanTest, ApplyRollsBackWhenOuterFenceRejectsLaterRun) {
+  Rom rom = MakeRom(/*size=*/0x180100, /*fill=*/0xA5);
+  MessageData message;
+  message.Data = {0x00, kBankSwitchCommand, 0x01};
+  auto plan_or = BuildVanillaMessageSavePlan({message});
+  ASSERT_TRUE(plan_or.ok()) << plan_or.status();
+  const auto before = rom.vector();
+
+  yaze::rom::WriteFence outer;
+  ASSERT_TRUE(outer.Allow(kTextData, kTextData + 2, "primary only").ok());
+  yaze::rom::ScopedWriteFence scope(&rom, &outer);
+
+  const auto status = ApplyVanillaMessageSavePlan(&rom, *plan_or);
+
+  EXPECT_EQ(status.code(), absl::StatusCode::kPermissionDenied) << status;
+  EXPECT_EQ(rom.vector(), before);
 }
 
 TEST(MessageEditorSavePlanTest,
@@ -224,8 +390,8 @@ TEST(MessageEditorSavePlanTest,
   MessageEditor editor(&rom, MakeDependencies(&rom));
   MessageEditorSaveTestPeer::SetExpandedMessages(editor, {"EXPANDED"},
                                                  /*dirty=*/false);
-  MessageEditorSaveTestPeer::SetVanillaMessages(editor, {{0x00}},
-                                                /*dirty=*/true);
+  MessageEditorSaveTestPeer::SetVanillaMessages(
+      editor, {{0x00, kBankSwitchCommand}}, /*dirty=*/true);
 
   const auto expanded_before =
       rom.ReadByteVector(kExpandedTextDataDefault, /*length=*/32).value();
@@ -269,8 +435,8 @@ TEST(MessageEditorSavePlanTest,
                   .empty());
 
   MessageEditor editor(&rom, MakeDependencies(&rom, &yaze_project));
-  MessageEditorSaveTestPeer::SetVanillaMessages(editor, {{0x00}},
-                                                /*dirty=*/true);
+  MessageEditorSaveTestPeer::SetVanillaMessages(
+      editor, {{0x00, kBankSwitchCommand}}, /*dirty=*/true);
   MessageEditorSaveTestPeer::SetExpandedMessages(editor, {"DRAFT"},
                                                  /*dirty=*/true);
   MessageEditorSaveTestPeer::SetFontWidthDirty(editor, 0x0C);
@@ -380,23 +546,23 @@ TEST(MessageEditorSavePlanTest,
      CommandArgument80StaysPrimaryWithExactHalfOpenRange) {
   Rom rom = MakeRom(/*size=*/0x180100, /*fill=*/0xA5);
   MessageEditor editor(&rom, MakeDependencies(&rom));
-  const auto encoded = ParseMessageToData("[W:80]");
-  ASSERT_EQ(encoded, (std::vector<uint8_t>{0x6B, 0x80}));
+  const auto encoded = ParseMessageToData("[W:80][BANK]");
+  ASSERT_EQ(encoded, (std::vector<uint8_t>{0x6B, 0x80, kBankSwitchCommand}));
   MessageEditorSaveTestPeer::SetVanillaMessages(editor, {encoded},
                                                 /*dirty=*/true);
 
   auto ranges_or = MessageEditorSaveTestPeer::PlannedRanges(editor);
   ASSERT_TRUE(ranges_or.ok()) << ranges_or.status();
-  EXPECT_EQ(
-      ranges_or.value(),
-      (std::vector<std::pair<uint32_t, uint32_t>>{{kTextData, kTextData + 4}}));
+  EXPECT_EQ(ranges_or.value(),
+            (std::vector<std::pair<uint32_t, uint32_t>>{
+                {kTextData, kTextData + 3}, {kTextData2, kTextData2 + 2}}));
 
   ASSERT_TRUE(editor.Save().ok());
   EXPECT_EQ(rom.vector()[kTextData], 0x6B);
   EXPECT_EQ(rom.vector()[kTextData + 1], 0x80);
-  EXPECT_EQ(rom.vector()[kTextData + 2], kMessageTerminator);
-  EXPECT_EQ(rom.vector()[kTextData + 3], 0xFF);
-  EXPECT_EQ(rom.vector()[kTextData2], 0xA5);
+  EXPECT_EQ(rom.vector()[kTextData + 2], kBankSwitchCommand);
+  EXPECT_EQ(rom.vector()[kTextData2], kMessageTerminator);
+  EXPECT_EQ(rom.vector()[kTextData2 + 1], 0xFF);
 }
 
 TEST(MessageEditorSavePlanTest, TruncatedExpandedRegionFailsBeforeMutation) {


### PR DESCRIPTION
## Summary

- add a shared immutable vanilla-message save plan with exact half-open write ranges
- enforce one standalone `[BANK]`, manifest message counts, bank capacities, reserved-marker safety, and complete command arguments
- fix `[BANK]` being confused with dictionary token `0x80`, while preserving `[W:80]` as a command argument
- reuse the shared plan in the GUI and bound vanilla message reads by ROM size
- require a matching project and loaded Hack Manifest for every CLI bundle apply
- save only to the canonical, headerless project ROM after an exact manifest-policy preflight
- recheck the on-disk baseline, require a backup, use atomic replacement, reopen independently, and verify planned bytes before reporting success
- fail closed for apply mode in WebAssembly, where the durable backup/readback contract is unavailable

## Why

Vanilla bundle apply previously bypassed project ownership checks and wrote directly to the ROM. That could cross the Oracle of Secrets hook at SNES `$0E:EE75`, and the GUI and CLI used separate serializers with different validation behavior. The token parser also treated `[BANK]` as a dictionary sentinel because both use byte `0x80`.

This change makes serialization a precomputed shared artifact and makes persistent CLI mutation project-bound, backed up, atomic, and externally verified.

## Validation

- `yaze_test_unit` focused gate: 73/73 passed
  - CLI clean-memory/disk snapshot rejection, project/manifest policy, backup, symlink, header, protected-hook boundary, and readback tests
  - vanilla save-plan, parser, capacity, write-fence, and GUI save-plan tests
  - message source-sync regression tests
- pre-push gate passed: build, 13/13 smoke tests, formatting, change-aware UI check
- `clang-format --dry-run --Werror` passed for all changed C++ files
- `git diff --check` passed
- two independent adversarial reviews found no remaining blockers

## Follow-ups

- close the remaining narrow cross-process race with a filesystem lock or compare-and-swap inside the ROM save layer
- add Windows case-alias coverage for canonical project-ROM matching
- add an expanded-message immutable save plan so mixed bundles can precompute both serialized banks before any in-memory write

Progresses #88 and #115.