### PR TITLE
Guard Palette Editor saves with Hack Manifest

### DIFF
--- a/src/app/editor/editor_manager.cc
+++ b/src/app/editor/editor_manager.cc
@@ -6772,9 +6772,12 @@ void EditorManager::ConfigureEditorDependencies(EditorSet* editor_set, Rom* rom,
     if (session_index.has_value()) {
       auto* session = static_cast<RomSession*>(
           session_coordinator_->GetSession(*session_index));
-      if (session && session->project_context.has_value()) {
-        deps.project = &*session->project_context;
-        deps.version_manager = session->version_manager.get();
+      if (session) {
+        deps.game_data = &session->game_data;
+        if (session->project_context.has_value()) {
+          deps.project = &*session->project_context;
+          deps.version_manager = session->version_manager.get();
+        }
       }
     }
   }

--- a/src/app/editor/palette/palette_editor.cc
+++ b/src/app/editor/palette/palette_editor.cc
@@ -8,6 +8,7 @@
 #include "absl/strings/str_format.h"
 #include "app/editor/palette/palette_category.h"
 #include "app/editor/shell/feedback/toast_manager.h"
+#include "app/editor/system/session/hack_manifest_save_validation.h"
 #include "app/editor/system/workspace/workspace_window_manager.h"
 #include "app/gfx/debug/performance/performance_profiler.h"
 #include "app/gfx/types/snes_palette.h"
@@ -472,6 +473,29 @@ class CustomPalettePanel : public WindowContent {
   std::function<void()> draw_callback_;
 };
 
+void PaletteEditor::SetDependencies(const EditorDependencies& deps) {
+  Editor::SetDependencies(deps);
+  ApplyPanelDependencies();
+}
+
+void PaletteEditor::ApplyPanelDependencies() {
+  const auto apply = [this](PaletteGroupPanel* panel) {
+    if (panel == nullptr) {
+      return;
+    }
+    panel->SetToastManager(dependencies_.toast_manager);
+    panel->SetProject(dependencies_.project);
+  };
+  apply(ow_main_panel_);
+  apply(ow_anim_panel_);
+  apply(dungeon_main_panel_);
+  apply(sprite_global_panel_);
+  apply(sprite_aux1_panel_);
+  apply(sprite_aux2_panel_);
+  apply(sprite_aux3_panel_);
+  apply(equipment_panel_);
+}
+
 absl::Status PaletteEditor::Load() {
   gfx::ScopedTimer timer("PaletteEditor::Load");
 
@@ -549,18 +573,7 @@ absl::Status PaletteEditor::Load() {
     equipment_panel_ = equipment.get();
     window_manager->RegisterWindowContent(std::move(equipment));
 
-    // Wire toast manager to all palette group panels
-    auto* toast = dependencies_.toast_manager;
-    if (toast) {
-      ow_main_panel_->SetToastManager(toast);
-      ow_anim_panel_->SetToastManager(toast);
-      dungeon_main_panel_->SetToastManager(toast);
-      sprite_global_panel_->SetToastManager(toast);
-      sprite_aux1_panel_->SetToastManager(toast);
-      sprite_aux2_panel_->SetToastManager(toast);
-      sprite_aux3_panel_->SetToastManager(toast);
-      equipment_panel_->SetToastManager(toast);
-    }
+    ApplyPanelDependencies();
 
     // Register utility panels with callbacks
     window_manager->RegisterWindowContent(std::make_unique<PaletteControlPanel>(
@@ -584,8 +597,21 @@ absl::Status PaletteEditor::Save() {
         "Cannot save palettes from an inactive ROM session");
   }
 
-  // Delegate to PaletteManager for centralized save
-  RETURN_IF_ERROR(gfx::PaletteManager::Get().SaveAllToRom());
+  auto& palette_manager = gfx::PaletteManager::Get();
+  if (dependencies_.project != nullptr &&
+      dependencies_.project->hack_manifest.loaded()) {
+    const auto ranges =
+        palette_manager.GetModifiedColorWriteRanges(game_data());
+    if (!ranges.empty()) {
+      RETURN_IF_ERROR(ValidateHackManifestSaveConflicts(
+          dependencies_.project->hack_manifest,
+          dependencies_.project->rom_metadata.write_policy, ranges, "palettes",
+          "PaletteEditor", dependencies_.toast_manager));
+    }
+  }
+
+  // Delegate to PaletteManager for centralized save.
+  RETURN_IF_ERROR(palette_manager.SaveAllToRom());
 
   // Mark ROM as needing file save
   rom_->set_dirty(true);
@@ -1042,7 +1068,7 @@ void PaletteEditor::DrawControlPanel() {
           absl::StrFormat(ICON_MD_SAVE " Save All (%zu colors)", modified_count)
               .c_str(),
           ImVec2(-1, 0))) {
-    auto status = gfx::PaletteManager::Get().SaveAllToRom();
+    auto status = Save();
     if (!status.ok()) {
       if (dependencies_.toast_manager) {
         dependencies_.toast_manager->Show(

--- a/src/app/editor/palette/palette_editor.cc
+++ b/src/app/editor/palette/palette_editor.cc
@@ -478,7 +478,54 @@ void PaletteEditor::SetDependencies(const EditorDependencies& deps) {
   ApplyPanelDependencies();
 }
 
+namespace {
+template <typename Panel>
+Panel* ResolveSessionPalettePanel(WorkspaceWindowManager* window_manager,
+                                  size_t session_id, const char* panel_id,
+                                  Rom* rom) {
+  auto* panel = dynamic_cast<Panel*>(
+      window_manager->GetWindowContent(session_id, panel_id));
+  return panel != nullptr && panel->IsOwnedByRom(rom) ? panel : nullptr;
+}
+}  // namespace
+
+void PaletteEditor::RefreshPanelReferences() {
+  auto* window_manager = dependencies_.window_manager;
+  if (window_manager == nullptr) {
+    ow_main_panel_ = nullptr;
+    ow_anim_panel_ = nullptr;
+    dungeon_main_panel_ = nullptr;
+    sprite_global_panel_ = nullptr;
+    sprite_aux1_panel_ = nullptr;
+    sprite_aux2_panel_ = nullptr;
+    sprite_aux3_panel_ = nullptr;
+    equipment_panel_ = nullptr;
+    return;
+  }
+
+  const size_t session_id = dependencies_.session_id;
+  ow_main_panel_ = ResolveSessionPalettePanel<OverworldMainPalettePanel>(
+      window_manager, session_id, "palette.ow_main", rom_);
+  ow_anim_panel_ = ResolveSessionPalettePanel<OverworldAnimatedPalettePanel>(
+      window_manager, session_id, "palette.ow_animated", rom_);
+  dungeon_main_panel_ = ResolveSessionPalettePanel<DungeonMainPalettePanel>(
+      window_manager, session_id, "palette.dungeon_main", rom_);
+  sprite_global_panel_ = ResolveSessionPalettePanel<SpritePalettePanel>(
+      window_manager, session_id, "palette.global_sprites", rom_);
+  sprite_aux1_panel_ = ResolveSessionPalettePanel<SpritesAux1PalettePanel>(
+      window_manager, session_id, "palette.sprites_aux1", rom_);
+  sprite_aux2_panel_ = ResolveSessionPalettePanel<SpritesAux2PalettePanel>(
+      window_manager, session_id, "palette.sprites_aux2", rom_);
+  sprite_aux3_panel_ = ResolveSessionPalettePanel<SpritesAux3PalettePanel>(
+      window_manager, session_id, "palette.sprites_aux3", rom_);
+  equipment_panel_ = ResolveSessionPalettePanel<EquipmentPalettePanel>(
+      window_manager, session_id, "palette.armors", rom_);
+}
+
 void PaletteEditor::ApplyPanelDependencies() {
+  // WorkspaceWindowManager owns these panels and may have already destroyed
+  // them while the session-close event is still rebinding editor dependencies.
+  RefreshPanelReferences();
   const auto apply = [this](PaletteGroupPanel* panel) {
     if (panel == nullptr) {
       return;
@@ -1003,6 +1050,8 @@ void PaletteEditor::DrawControlPanel() {
     return;
   }
 
+  RefreshPanelReferences();
+
   // Toolbar with quick toggles
   DrawToolset();
 
@@ -1329,6 +1378,7 @@ void PaletteEditor::JumpToPalette(const std::string& group_name,
   if (!dependencies_.window_manager) {
     return;
   }
+  RefreshPanelReferences();
   auto* window_manager = dependencies_.window_manager;
   const size_t session_id = dependencies_.session_id;
 

--- a/src/app/editor/palette/palette_editor.h
+++ b/src/app/editor/palette/palette_editor.h
@@ -85,6 +85,7 @@ class PaletteEditor : public Editor {
     custom_palette_.push_back(gfx::SnesColor(0x7FFF));
   }
 
+  void SetDependencies(const EditorDependencies& deps) override;
   void Initialize() override;
   absl::Status Load() override;
   absl::Status Update() override;
@@ -116,6 +117,7 @@ class PaletteEditor : public Editor {
   void DrawControlPanel();
   void DrawQuickAccessPanel();
   void DrawCustomPalettePanel();
+  void ApplyPanelDependencies();
 
   // Category and search UI methods
   void DrawCategorizedPaletteList();

--- a/src/app/editor/palette/palette_editor.h
+++ b/src/app/editor/palette/palette_editor.h
@@ -117,6 +117,7 @@ class PaletteEditor : public Editor {
   void DrawControlPanel();
   void DrawQuickAccessPanel();
   void DrawCustomPalettePanel();
+  void RefreshPanelReferences();
   void ApplyPanelDependencies();
 
   // Category and search UI methods
@@ -167,7 +168,7 @@ class PaletteEditor : public Editor {
   bool show_custom_palette_ = false;
 
   // Palette Panels (formerly Cards)
-  // We keep raw pointers to the panels which are owned by WorkspaceWindowManager
+  // Non-owning references refreshed through WorkspaceWindowManager before use.
   OverworldMainPalettePanel* ow_main_panel_ = nullptr;
   OverworldAnimatedPalettePanel* ow_anim_panel_ = nullptr;
   DungeonMainPalettePanel* dungeon_main_panel_ = nullptr;

--- a/src/app/editor/palette/palette_group_panel.cc
+++ b/src/app/editor/palette/palette_group_panel.cc
@@ -11,6 +11,7 @@
 #include "absl/strings/str_split.h"
 #include "absl/strings/strip.h"
 #include "app/editor/shell/feedback/toast_manager.h"
+#include "app/editor/system/session/hack_manifest_save_validation.h"
 #include "app/gfx/types/snes_palette.h"
 #include "app/gfx/util/palette_manager.h"
 #include "app/gui/core/color.h"
@@ -563,11 +564,6 @@ void PaletteGroupPanel::SetColor(int palette_index, int color_index,
     }
     return;
   }
-
-  // Auto-save if enabled (PaletteManager doesn't handle this)
-  if (auto_save_enabled_) {
-    WriteColorToRom(palette_index, color_index, new_color);
-  }
 }
 
 absl::Status PaletteGroupPanel::SaveToRom() {
@@ -575,8 +571,22 @@ absl::Status PaletteGroupPanel::SaveToRom() {
     return absl::FailedPreconditionError(
         "Cannot save palettes from an inactive ROM session");
   }
-  // Delegate to PaletteManager for centralized save operation
-  return gfx::PaletteManager::Get().SaveGroup(group_name_);
+  auto& palette_manager = gfx::PaletteManager::Get();
+  if (project_ != nullptr && project_->hack_manifest.loaded()) {
+    const auto ranges =
+        palette_manager.GetModifiedGroupColorWriteRanges(group_name_);
+    if (!ranges.empty()) {
+      const absl::Status preflight = ValidateHackManifestSaveConflicts(
+          project_->hack_manifest, project_->rom_metadata.write_policy, ranges,
+          display_name_, "PaletteGroupPanel", toast_manager_);
+      if (!preflight.ok()) {
+        return preflight;
+      }
+    }
+  }
+
+  // Delegate to PaletteManager for centralized save operation.
+  return palette_manager.SaveGroup(group_name_);
 }
 
 void PaletteGroupPanel::DiscardChanges() {
@@ -693,14 +703,6 @@ gfx::SnesColor PaletteGroupPanel::GetOriginalColor(int palette_index,
   // Get original color from PaletteManager's snapshots
   return gfx::PaletteManager::Get().GetColor(group_name_, palette_index,
                                              color_index);
-}
-
-absl::Status PaletteGroupPanel::WriteColorToRom(int palette_index,
-                                                int color_index,
-                                                const gfx::SnesColor& color) {
-  uint32_t address =
-      gfx::GetPaletteAddress(group_name_, palette_index, color_index);
-  return rom_->WriteColor(address, color);
 }
 
 bool PaletteGroupPanel::IsManagedSession() const {

--- a/src/app/editor/palette/palette_group_panel.h
+++ b/src/app/editor/palette/palette_group_panel.h
@@ -123,6 +123,7 @@ class PaletteGroupPanel : public WindowContent {
     toast_manager_ = toast_manager;
   }
   void SetProject(const project::YazeProject* project) { project_ = project; }
+  bool IsOwnedByRom(const Rom* rom) const { return rom_ == rom; }
 
   // ========== Palette Operations ==========
 

--- a/src/app/editor/palette/palette_group_panel.h
+++ b/src/app/editor/palette/palette_group_panel.h
@@ -18,6 +18,9 @@
 #include "zelda3/game_data.h"
 
 namespace yaze {
+namespace project {
+struct YazeProject;
+}
 namespace editor {
 
 // Forward declaration
@@ -119,6 +122,7 @@ class PaletteGroupPanel : public WindowContent {
   void SetToastManager(ToastManager* toast_manager) {
     toast_manager_ = toast_manager;
   }
+  void SetProject(const project::YazeProject* project) { project_ = project; }
 
   // ========== Palette Operations ==========
 
@@ -256,12 +260,6 @@ class PaletteGroupPanel : public WindowContent {
    */
   gfx::SnesColor GetOriginalColor(int palette_index, int color_index) const;
 
-  /**
-   * @brief Write a single color to ROM
-   */
-  absl::Status WriteColorToRom(int palette_index, int color_index,
-                               const gfx::SnesColor& color);
-
   /// Return true only while PaletteManager is bound to this panel's session.
   bool IsManagedSession() const;
 
@@ -280,8 +278,9 @@ class PaletteGroupPanel : public WindowContent {
   std::string group_name_;    // Internal name (e.g., "ow_main")
   std::string display_name_;  // Display name (e.g., "Overworld Main")
   Rom* rom_;                  // ROM instance
-  zelda3::GameData* game_data_ = nullptr;  // GameData instance
-  bool show_ = false;                      // Visibility flag
+  zelda3::GameData* game_data_ = nullptr;          // GameData instance
+  const project::YazeProject* project_ = nullptr;  // Session save policy
+  bool show_ = false;                              // Visibility flag
 
   // Selection state
   int selected_palette_ = 0;      // Currently selected palette index
@@ -289,9 +288,8 @@ class PaletteGroupPanel : public WindowContent {
   gfx::SnesColor editing_color_;  // Color being edited in picker
 
   // Settings
-  bool auto_save_enabled_ = false;  // Auto-save to ROM on every change
-  bool show_snes_format_ = true;    // Show SNES $xxxx format in info
-  bool show_hex_format_ = true;     // Show #xxxxxx hex in info
+  bool show_snes_format_ = true;  // Show SNES $xxxx format in info
+  bool show_hex_format_ = true;   // Show #xxxxxx hex in info
 
   ToastManager* toast_manager_ = nullptr;
 };

--- a/src/app/gfx/util/palette_manager.cc
+++ b/src/app/gfx/util/palette_manager.cc
@@ -13,6 +13,25 @@
 namespace yaze {
 namespace gfx {
 
+namespace {
+
+std::vector<std::pair<uint32_t, uint32_t>> CoalescePaletteWriteRanges(
+    std::vector<std::pair<uint32_t, uint32_t>> ranges) {
+  std::sort(ranges.begin(), ranges.end());
+  std::vector<std::pair<uint32_t, uint32_t>> coalesced;
+  coalesced.reserve(ranges.size());
+  for (const auto& range : ranges) {
+    if (coalesced.empty() || coalesced.back().second < range.first) {
+      coalesced.push_back(range);
+      continue;
+    }
+    coalesced.back().second = std::max(coalesced.back().second, range.second);
+  }
+  return coalesced;
+}
+
+}  // namespace
+
 PaletteManager::SessionState* PaletteManager::CurrentState() {
   if (!game_data_) {
     return &unbound_state_;
@@ -361,17 +380,27 @@ PaletteManager::GetModifiedColorWriteRanges(
     }
   }
 
-  std::sort(ranges.begin(), ranges.end());
-  std::vector<std::pair<uint32_t, uint32_t>> coalesced;
-  coalesced.reserve(ranges.size());
-  for (const auto& range : ranges) {
-    if (coalesced.empty() || coalesced.back().second < range.first) {
-      coalesced.push_back(range);
-      continue;
-    }
-    coalesced.back().second = std::max(coalesced.back().second, range.second);
+  return CoalescePaletteWriteRanges(std::move(ranges));
+}
+
+std::vector<std::pair<uint32_t, uint32_t>>
+PaletteManager::GetModifiedGroupColorWriteRanges(
+    const std::string& group_name) const {
+  std::vector<std::pair<uint32_t, uint32_t>> ranges;
+  const auto* state = CurrentState();
+  const auto group_it = state->modified_colors.find(group_name);
+  if (group_it == state->modified_colors.end()) {
+    return ranges;
   }
-  return coalesced;
+
+  for (const auto& [palette_index, color_indices] : group_it->second) {
+    for (int color_index : color_indices) {
+      const uint32_t begin =
+          GetPaletteAddress(group_name, palette_index, color_index);
+      ranges.emplace_back(begin, begin + 2u);
+    }
+  }
+  return CoalescePaletteWriteRanges(std::move(ranges));
 }
 
 // ========== Persistence ==========

--- a/src/app/gfx/util/palette_manager.h
+++ b/src/app/gfx/util/palette_manager.h
@@ -229,6 +229,15 @@ class PaletteManager {
   std::vector<std::pair<uint32_t, uint32_t>> GetModifiedColorWriteRanges(
       const zelda3::GameData* game_data) const;
 
+  /**
+   * @brief Get exact, coalesced half-open ROM ranges for one modified group.
+   *
+   * The active palette session is used. Callers must verify session ownership
+   * before using these ranges to authorize a save.
+   */
+  std::vector<std::pair<uint32_t, uint32_t>> GetModifiedGroupColorWriteRanges(
+      const std::string& group_name) const;
+
   // ========== Persistence ==========
 
   /**

--- a/test/integration/palette_manager_test.cc
+++ b/test/integration/palette_manager_test.cc
@@ -909,6 +909,9 @@ TEST_F(PaletteManagerTest,
       window_manager.GetWindowContent(0, "palette.dungeon_main"));
   ASSERT_NE(panel, nullptr);
 
+  // Panel rebinding remains ROM-owned even if a dependency caller omits the
+  // optional GameData pointer.
+  dependencies.game_data = nullptr;
   dependencies.project = &project;
   palette_editor.SetDependencies(dependencies);
 

--- a/test/integration/palette_manager_test.cc
+++ b/test/integration/palette_manager_test.cc
@@ -13,6 +13,7 @@
 #include "absl/strings/str_format.h"
 #include "app/editor/dungeon/dungeon_editor_v2.h"
 #include "app/editor/palette/palette_editor.h"
+#include "app/editor/system/workspace/workspace_window_manager.h"
 #include "app/gfx/types/snes_color.h"
 #include "app/gfx/types/snes_palette.h"
 #include "app/gui/widgets/palette_editor_widget.h"
@@ -806,6 +807,200 @@ TEST_F(PaletteManagerTest,
       manager.IsColorModified("dungeon_main", kPaletteIndex, kColorIndex));
   EXPECT_EQ(manager.GetModifiedColorCount(&game_data), 1u);
   EXPECT_EQ(manager.GetModifiedColorWriteRanges(&game_data), expected_ranges);
+}
+
+TEST_F(PaletteManagerTest,
+       PaletteEditorSaveBlocksManifestProtectedPaletteAndKeepsRetryState) {
+  Rom rom;
+  ASSERT_TRUE(rom.LoadFromData(std::vector<uint8_t>(0x100000, 0)).ok());
+  zelda3::GameData game_data(&rom);
+  SeedPaletteGroup(game_data.palette_groups.get_group("dungeon_main"), 2, 90,
+                   0x0200);
+
+  constexpr int kPaletteIndex = 1;
+  constexpr int kColorIndex = 62;
+  const SnesColor edited_color(0x3456);
+  const uint32_t color_address =
+      GetPaletteAddress("dungeon_main", kPaletteIndex, kColorIndex);
+  const std::vector<std::pair<uint32_t, uint32_t>> expected_ranges = {
+      {color_address, color_address + 2}};
+
+  auto& manager = PaletteManager::Get();
+  manager.Initialize(&game_data);
+  ASSERT_TRUE(
+      manager.SetColor("dungeon_main", kPaletteIndex, kColorIndex, edited_color)
+          .ok());
+
+  project::YazeProject project;
+  project.rom_metadata.write_policy = project::RomWritePolicy::kBlock;
+  ASSERT_TRUE(project.hack_manifest
+                  .LoadFromString(ManifestProtectingPcRange(color_address,
+                                                            color_address + 2))
+                  .ok());
+
+  editor::PaletteEditor palette_editor(&rom);
+  editor::EditorDependencies dependencies;
+  dependencies.rom = &rom;
+  dependencies.game_data = &game_data;
+  dependencies.project = &project;
+  palette_editor.SetDependencies(dependencies);
+  palette_editor.SetGameData(&game_data);
+
+  const std::vector<uint8_t> rom_before = rom.vector();
+  const bool rom_dirty_before = rom.dirty();
+  const absl::Status save_status = palette_editor.Save();
+
+  EXPECT_EQ(save_status.code(), absl::StatusCode::kPermissionDenied)
+      << save_status;
+  EXPECT_EQ(rom.vector(), rom_before);
+  EXPECT_EQ(rom.dirty(), rom_dirty_before);
+  EXPECT_EQ(manager.GetColor("dungeon_main", kPaletteIndex, kColorIndex).snes(),
+            edited_color.snes());
+  EXPECT_TRUE(manager.HasUnsavedChanges(&game_data));
+  EXPECT_TRUE(
+      manager.IsColorModified("dungeon_main", kPaletteIndex, kColorIndex));
+  EXPECT_EQ(manager.GetModifiedColorCount(&game_data), 1u);
+  EXPECT_EQ(manager.GetModifiedColorWriteRanges(&game_data), expected_ranges);
+  EXPECT_EQ(manager.GetModifiedGroupColorWriteRanges("dungeon_main"),
+            expected_ranges);
+}
+
+TEST_F(PaletteManagerTest,
+       DungeonPalettePanelSaveBlocksManifestAndKeepsRetryState) {
+  Rom rom;
+  ASSERT_TRUE(rom.LoadFromData(std::vector<uint8_t>(0x100000, 0)).ok());
+  zelda3::GameData game_data(&rom);
+  SeedPaletteGroup(game_data.palette_groups.get_group("dungeon_main"), 2, 90,
+                   0x0200);
+
+  constexpr int kPaletteIndex = 1;
+  constexpr int kColorIndex = 62;
+  const SnesColor edited_color(0x4567);
+  const uint32_t color_address =
+      GetPaletteAddress("dungeon_main", kPaletteIndex, kColorIndex);
+  const std::vector<std::pair<uint32_t, uint32_t>> expected_ranges = {
+      {color_address, color_address + 2}};
+
+  auto& manager = PaletteManager::Get();
+  manager.Initialize(&game_data);
+  ASSERT_TRUE(
+      manager.SetColor("dungeon_main", kPaletteIndex, kColorIndex, edited_color)
+          .ok());
+
+  project::YazeProject project;
+  project.rom_metadata.write_policy = project::RomWritePolicy::kBlock;
+  ASSERT_TRUE(project.hack_manifest
+                  .LoadFromString(ManifestProtectingPcRange(color_address,
+                                                            color_address + 2))
+                  .ok());
+
+  editor::WorkspaceWindowManager window_manager;
+  window_manager.RegisterSession(0);
+  window_manager.SetActiveSession(0);
+  editor::PaletteEditor palette_editor(&rom);
+  editor::EditorDependencies dependencies;
+  dependencies.rom = &rom;
+  dependencies.game_data = &game_data;
+  dependencies.window_manager = &window_manager;
+  palette_editor.SetDependencies(dependencies);
+  palette_editor.SetGameData(&game_data);
+  ASSERT_TRUE(palette_editor.Load().ok());
+  auto* panel = dynamic_cast<editor::DungeonMainPalettePanel*>(
+      window_manager.GetWindowContent(0, "palette.dungeon_main"));
+  ASSERT_NE(panel, nullptr);
+
+  dependencies.project = &project;
+  palette_editor.SetDependencies(dependencies);
+
+  const std::vector<uint8_t> rom_before = rom.vector();
+  const bool rom_dirty_before = rom.dirty();
+  const absl::Status save_status = panel->SaveToRom();
+
+  EXPECT_EQ(save_status.code(), absl::StatusCode::kPermissionDenied)
+      << save_status;
+  EXPECT_EQ(rom.vector(), rom_before);
+  EXPECT_EQ(rom.dirty(), rom_dirty_before);
+  EXPECT_EQ(manager.GetColor("dungeon_main", kPaletteIndex, kColorIndex).snes(),
+            edited_color.snes());
+  EXPECT_TRUE(manager.HasUnsavedChanges(&game_data));
+  EXPECT_TRUE(
+      manager.IsColorModified("dungeon_main", kPaletteIndex, kColorIndex));
+  EXPECT_EQ(manager.GetModifiedColorCount(&game_data), 1u);
+  EXPECT_EQ(manager.GetModifiedColorWriteRanges(&game_data), expected_ranges);
+  EXPECT_EQ(manager.GetModifiedGroupColorWriteRanges("dungeon_main"),
+            expected_ranges);
+}
+
+TEST_F(PaletteManagerTest, SafeGroupSaveIgnoresProtectedDirtyDungeonPalette) {
+  Rom rom;
+  ASSERT_TRUE(rom.LoadFromData(std::vector<uint8_t>(0x100000, 0)).ok());
+  zelda3::GameData game_data(&rom);
+  SeedPaletteGroup(game_data.palette_groups.get_group("ow_main"), 1, 16,
+                   0x0100);
+  SeedPaletteGroup(game_data.palette_groups.get_group("dungeon_main"), 2, 90,
+                   0x0200);
+
+  constexpr int kOverworldPaletteIndex = 0;
+  constexpr int kOverworldColorIndex = 4;
+  constexpr int kDungeonPaletteIndex = 1;
+  constexpr int kDungeonColorIndex = 62;
+  const SnesColor overworld_color(0x5678);
+  const SnesColor dungeon_color(0x6789);
+  const uint32_t overworld_address = GetPaletteAddress(
+      "ow_main", kOverworldPaletteIndex, kOverworldColorIndex);
+  const uint32_t dungeon_address = GetPaletteAddress(
+      "dungeon_main", kDungeonPaletteIndex, kDungeonColorIndex);
+  const std::vector<std::pair<uint32_t, uint32_t>> overworld_ranges = {
+      {overworld_address, overworld_address + 2}};
+  const std::vector<std::pair<uint32_t, uint32_t>> dungeon_ranges = {
+      {dungeon_address, dungeon_address + 2}};
+
+  auto& manager = PaletteManager::Get();
+  manager.Initialize(&game_data);
+  ASSERT_TRUE(manager
+                  .SetColor("ow_main", kOverworldPaletteIndex,
+                            kOverworldColorIndex, overworld_color)
+                  .ok());
+  ASSERT_TRUE(manager
+                  .SetColor("dungeon_main", kDungeonPaletteIndex,
+                            kDungeonColorIndex, dungeon_color)
+                  .ok());
+  EXPECT_EQ(manager.GetModifiedGroupColorWriteRanges("ow_main"),
+            overworld_ranges);
+  EXPECT_EQ(manager.GetModifiedGroupColorWriteRanges("dungeon_main"),
+            dungeon_ranges);
+
+  project::YazeProject project;
+  project.rom_metadata.write_policy = project::RomWritePolicy::kBlock;
+  ASSERT_TRUE(project.hack_manifest
+                  .LoadFromString(ManifestProtectingPcRange(
+                      dungeon_address, dungeon_address + 2))
+                  .ok());
+  ASSERT_FALSE(
+      project.hack_manifest.AnalyzePcWriteRanges(dungeon_ranges).empty());
+  EXPECT_TRUE(
+      project.hack_manifest.AnalyzePcWriteRanges(overworld_ranges).empty());
+
+  const uint16_t dungeon_rom_before = *rom.ReadWord(dungeon_address);
+  editor::OverworldMainPalettePanel panel(&rom, &game_data);
+  panel.SetProject(&project);
+
+  const absl::Status save_status = panel.SaveToRom();
+
+  EXPECT_TRUE(save_status.ok()) << save_status;
+  EXPECT_EQ(*rom.ReadWord(overworld_address), overworld_color.snes());
+  EXPECT_EQ(*rom.ReadWord(dungeon_address), dungeon_rom_before);
+  EXPECT_FALSE(manager.IsGroupModified("ow_main"));
+  EXPECT_FALSE(manager.IsColorModified("ow_main", kOverworldPaletteIndex,
+                                       kOverworldColorIndex));
+  EXPECT_TRUE(manager.IsGroupModified("dungeon_main"));
+  EXPECT_TRUE(manager.IsColorModified("dungeon_main", kDungeonPaletteIndex,
+                                      kDungeonColorIndex));
+  EXPECT_EQ(manager.GetModifiedColorCount(&game_data), 1u);
+  EXPECT_TRUE(manager.GetModifiedGroupColorWriteRanges("ow_main").empty());
+  EXPECT_EQ(manager.GetModifiedGroupColorWriteRanges("dungeon_main"),
+            dungeon_ranges);
+  EXPECT_EQ(manager.GetModifiedColorWriteRanges(&game_data), dungeon_ranges);
 }
 
 TEST_F(PaletteManagerTest,

--- a/test/unit/editor/editor_manager_write_conflict_test.cc
+++ b/test/unit/editor/editor_manager_write_conflict_test.cc
@@ -1781,6 +1781,40 @@ TEST(EditorManagerWriteConflictTest,
 }
 
 TEST(EditorManagerWriteConflictTest,
+     ConfigureSessionKeepsPaletteEditorSaveActive) {
+  ScopedImGuiContext imgui;
+  gfx::PaletteManager::Get().ResetForTesting();
+
+  auto renderer = std::make_unique<gfx::NullRenderer>();
+  auto manager = std::make_unique<EditorManager>();
+  manager->Initialize(renderer.get(), "");
+  manager->SetAssetLoadMode(AssetLoadMode::kLazy);
+
+  const auto rom_path = CreateMinimalRomFile(
+      "yaze_palette_dependency_rebind.sfc", "PALETTE REBIND", 1024 * 1024);
+  ScopedFileCleanup cleanup{rom_path};
+
+  ASSERT_OK(manager->OpenRomOrProject(rom_path.string()));
+  ASSERT_OK(manager->EnsureEditorAssetsLoaded(EditorType::kPalette));
+  auto* palette_editor =
+      manager->GetCurrentEditorSet()->GetExistingEditor(EditorType::kPalette);
+  auto* game_data = manager->GetCurrentGameData();
+  auto* session = manager->session_coordinator()->GetActiveRomSession();
+  ASSERT_NE(palette_editor, nullptr);
+  ASSERT_NE(game_data, nullptr);
+  ASSERT_NE(session, nullptr);
+  ASSERT_EQ(palette_editor->game_data(), game_data);
+
+  manager->ConfigureSession(session);
+
+  EXPECT_EQ(palette_editor->game_data(), game_data);
+  EXPECT_OK(palette_editor->Save());
+
+  manager.reset();
+  gfx::PaletteManager::Get().ResetForTesting();
+}
+
+TEST(EditorManagerWriteConflictTest,
      PalettePanelsSurviveCloseFirstThenOpenNewSession) {
   ScopedImGuiContext imgui;
   gfx::PaletteManager::Get().ResetForTesting();


### PR DESCRIPTION
## Summary

- apply Hack Manifest preflight to standalone Palette Editor Save and Quick Save All
- validate Palette Group saves against exact group-only modified-color ranges, avoiding unrelated-group overblocking
- propagate current project/toast dependencies to long-lived palette panels on initial load and every dependency rebind
- resolve workspace-owned palette panels through live session + ROM identity before every cached-pointer use
- preserve the session GameData dependency across project/session reconfiguration
- remove the dormant direct per-color autosave bypass
- preserve protected edits and retry metadata while still allowing an unrelated safe group to save

## Why

PR #179 closed the Dungeon Editor palette path. The standalone Palette Editor still called `SaveAllToRom()` / `SaveGroup()` directly, which could mutate protected ROM ranges and clear retry state before the later disk-save gate. Group saves also need group-scoped ranges so a dirty protected dungeon palette does not block an unrelated safe palette group.

The first full CI run also exposed a real close-session use-after-free: `WorkspaceWindowManager` destroyed session panels before the closing `PaletteEditor` received its final dependency rebind. The editor now refreshes all non-owning panel references from live manager state and rejects cross-session fallback by ROM identity. The same audit found that `ConfigureEditorDependencies()` omitted `game_data`, which disabled standalone palette saves after a normal rebind; the resolved `RomSession` now supplies it.

## Validation

- focused palette session lifecycle + dependency-rebind tests: 4/4 passed
- the same 4 tests under local AddressSanitizer: 4/4 passed (`detect_leaks=0` because Apple ASan does not support leak detection)
- focused manifest save-policy tests: 3/3 passed
- pre-push gate passed: build, 13/13 smoke tests, formatting, change-aware UI check
- `git diff --check` and focused `clang-format --dry-run --Werror` passed
- two independent final reviews found no blocking issues
- hosted Linux Memory Sanitizer and full exact-head CI are required before merge

## Stack

- base: `master`
- PR #179 is merged

Progresses #115.
