### PR TITLE
Report dungeon object BG render routing

### DIFF
--- a/docs/internal/agents/dungeon-object-rendering-spec.md
+++ b/docs/internal/agents/dungeon-object-rendering-spec.md
@@ -98,13 +98,21 @@ Coordination: Universe task lifecycle via `scripts/agents/coord` (snapshot optio
 - Arrows down/up: any `Downwards*` routine; same sizing rules.
 - Diagonal arrow: `DiagonalAcute/Grave` and `DiagonalCeiling*`.
 - Large square badge: `4x4Floor*`, `4x4Blocks*`, `BigHole4x4`, water overlays, chest platforms; these do **not** change size with the nibble.
-- Dual-layer badge: routines with `_BothBG` in the disasm name, plus `AutoStairs*MergedLayer*` (IDs 0x132–0x133, 0x233). These must be allowed even when a “merged BG” flag is set in the header.
+- Dual-layer badge: routines with `_BothBG` in the disasm name, plus the
+  multi/separate-layer auto-stair variants (yaze IDs 0x130–0x131 and
+  0xF9B–0xF9C). The merged/swim variants (0x132–0x133, 0xF9D, and 0xFB3)
+  stay on their stored target and must not be labeled BothBG.
 
 ## Action Items for the Editor
 - Enforce the build order above so layout objects never sit above BG overlays; respect the two post-`0xFFFF` lists for BG2/BG1 overlays.
 - Update selection bounds to honor the size helpers (including the nibble-zero fallbacks and the `+4` base for diagonal ceilings).
-- Mark BothBG/merged-layer routines so layer toggles do not hide or exclude them.
-- Align palette/symbology labels with the disasm names: arrows for `Rightwards/Downwards`, diagonal for `Diagonal*`, large-square for `4x4*/SuperSquare`, dual-layer for `_BothBG`/merged stairs.
+- Mark BothBG routines and multi/separate-layer auto stairs so layer toggles do
+  not hide or exclude them.
+- Align palette/symbology labels with the disasm names: arrows for
+  `Rightwards/Downwards`, diagonal for `Diagonal*`, large-square for
+  `4x4*/SuperSquare`, dual-layer for `_BothBG` and multi-layer auto stairs,
+  and mixed-layer for 0xFA6–0xFA9. Merged/swim auto stairs remain
+  stored-placement objects.
 
 ## Implementation Status (February 2026)
 

--- a/src/app/editor/dungeon/dungeon_canvas_issue_report.cc
+++ b/src/app/editor/dungeon/dungeon_canvas_issue_report.cc
@@ -116,17 +116,23 @@ std::string BuildSelectedObjectSemanticsSummary(const zelda3::RoomObject& obj) {
   const auto semantics = zelda3::GetObjectLayerSemantics(obj);
   if (!zelda3::UsesRoomObjectStream(obj)) {
     return absl::StrFormat(
-        "storage=special-table selector=%d (%s) routine=%d both_bgs=%s",
+        "storage=special-table selector=%d (%s) routine=%d "
+        "legacy_both_bgs=%s "
+        "routing=%s",
         obj.GetLayerValue(), GetStoredPlacementLabel(obj), semantics.routine_id,
-        semantics.draws_to_both_bgs ? "yes" : "no");
+        semantics.draws_to_both_bgs ? "yes" : "no",
+        zelda3::ObjectRenderRoutingToken(semantics.render_routing));
   }
   return absl::StrFormat(
-      "stream=%s draw_layer=%d effective_bg=%s routine=%d both_bgs=%s",
+      "stream=%s draw_layer=%d effective_bg=%s routine=%d "
+      "legacy_both_bgs=%s "
+      "routing=%s",
       GetStoredPlacementLabel(obj),
       static_cast<int>(
           zelda3::MapRoomObjectListIndexToDrawLayer(obj.GetLayerValue())),
       zelda3::EffectiveBgLayerLabel(semantics.effective_bg_layer),
-      semantics.routine_id, semantics.draws_to_both_bgs ? "yes" : "no");
+      semantics.routine_id, semantics.draws_to_both_bgs ? "yes" : "no",
+      zelda3::ObjectRenderRoutingToken(semantics.render_routing));
 }
 
 const char* TraceLayerLabel(uint8_t layer) {

--- a/src/app/editor/dungeon/inspectors/object_editor_content.cc
+++ b/src/app/editor/dungeon/inspectors/object_editor_content.cc
@@ -460,7 +460,7 @@ void ObjectEditorContent::DrawSelectedObjectInfo() {
            {"Size", absl::StrFormat("0x%02X", obj.size_)},
            {zelda3::UsesRoomObjectStream(obj) ? "Draws" : "Role",
             zelda3::UsesRoomObjectStream(obj)
-                ? zelda3::EffectiveBgLayerLabel(semantics.effective_bg_layer)
+                ? zelda3::ObjectRenderRoutingDisplayLabel(semantics)
                 : "Special-table layer selector"}});
       ImGui::Spacing();
     }

--- a/src/zelda3/dungeon/draw_routines/special_routines.cc
+++ b/src/zelda3/dungeon/draw_routines/special_routines.cc
@@ -9,6 +9,7 @@
 #include "zelda3/dungeon/draw_routines/draw_routine_registry.h"
 #include "zelda3/dungeon/dungeon_state.h"
 #include "zelda3/dungeon/moving_wall_semantics.h"
+#include "zelda3/dungeon/object_render_routing.h"
 #include "zelda3/dungeon/room_object.h"
 
 namespace yaze {
@@ -98,23 +99,6 @@ void DrawMany32x32Block(gfx::BackgroundBuffer& bg, int base_x, int base_y,
   // the same 4x2 stamp two tile rows lower.
   DrawRowMajor(bg, base_x, base_y, /*w=*/4, /*h=*/2, tiles);
   DrawRowMajor(bg, base_x, base_y + 2, /*w=*/4, /*h=*/2, tiles);
-}
-
-bool IsAutoStairsDualLayer(int16_t object_id) {
-  return object_id == 0x0130 || object_id == 0x0131 || object_id == 0x0F9B ||
-         object_id == 0x0F9C;
-}
-
-bool IsStraightInterroomUpper(int16_t object_id) {
-  return object_id >= 0x0F9E && object_id <= 0x0FA1;
-}
-
-bool IsStraightInterroomLower(int16_t object_id) {
-  return object_id >= 0x0FA6 && object_id <= 0x0FA9;
-}
-
-bool IsSouthLowerStraightInterroomStairs(int16_t object_id) {
-  return object_id == 0x0FA8 || object_id == 0x0FA9;
 }
 
 void DrawWaterHopStairsA(const DrawContext& ctx) {
@@ -1175,7 +1159,8 @@ void DrawAutoStairs(const DrawContext& ctx) {
 
   Draw4x4ColumnMajorTo(ctx.target_bg, ctx.object, ctx.tiles);
 
-  if (ctx.secondary_bg != nullptr && IsAutoStairsDualLayer(ctx.object.id_)) {
+  if (ctx.secondary_bg != nullptr &&
+      object_render_routing::IsFullBothAutoStairsObject(ctx.object.id_)) {
     Draw4x4ColumnMajorTo(*ctx.secondary_bg, ctx.object, ctx.tiles);
   }
 }
@@ -1187,13 +1172,17 @@ void DrawStraightInterRoomStairs(const DrawContext& ctx) {
   if (ctx.tiles.size() < 16)
     return;
 
-  if (IsStraightInterroomUpper(ctx.object.id_) || ctx.secondary_bg == nullptr ||
-      !IsStraightInterroomLower(ctx.object.id_)) {
+  if (object_render_routing::IsFixedBg1StraightInterroomObject(
+          ctx.object.id_) ||
+      ctx.secondary_bg == nullptr ||
+      !object_render_routing::IsMixedStraightInterroomObject(ctx.object.id_)) {
     Draw4x4ColumnMajorTo(ctx.target_bg, ctx.object, ctx.tiles);
     return;
   }
 
-  const bool south_lower = IsSouthLowerStraightInterroomStairs(ctx.object.id_);
+  const bool south_lower =
+      object_render_routing::IsSouthMixedStraightInterroomObject(
+          ctx.object.id_);
   size_t tile_index = 0;
   for (int col = 0; col < 4; ++col) {
     for (int row = 0; row < 4; ++row) {

--- a/src/zelda3/dungeon/dungeon_object_editor.cc
+++ b/src/zelda3/dungeon/dungeon_object_editor.cc
@@ -1720,24 +1720,25 @@ void DungeonObjectEditor::DrawPropertyUI() {
       ImGui::Spacing();
 
       const bool uses_room_stream = UsesRoomObjectStream(obj);
-      const bool draws_to_both_bgs =
-          uses_room_stream && GetObjectLayerSemantics(obj).draws_to_both_bgs;
+      const auto semantics = GetObjectLayerSemantics(obj);
+      const bool has_routine_defined_route =
+          uses_room_stream &&
+          semantics.render_routing != ObjectRenderRouting::kStoredPlacement;
       gui::SectionHeader(ICON_MD_LAYERS,
                          uses_room_stream ? "Object Stream" : "Special Layer",
                          theme.text_info);
       bool storage_changed = false;
       if (gui::BeginPropertyTable("##LayerProps")) {
         if (uses_room_stream) {
-          const auto semantics = GetObjectLayerSemantics(obj);
           ImGui::TableNextRow();
           ImGui::TableNextColumn();
           ImGui::Text("Draws To");
           ImGui::TableNextColumn();
-          if (semantics.draws_to_both_bgs) {
-            ImGui::TextColored(theme.text_warning_yellow, "Both (BG1 + BG2)");
+          if (has_routine_defined_route) {
+            ImGui::TextColored(theme.text_warning_yellow, "%s",
+                               ObjectRenderRoutingDisplayLabel(semantics));
           } else {
-            ImGui::Text("%s",
-                        EffectiveBgLayerLabel(semantics.effective_bg_layer));
+            ImGui::Text("%s", ObjectRenderRoutingDisplayLabel(semantics));
           }
         }
 
@@ -1755,11 +1756,11 @@ void DungeonObjectEditor::DrawPropertyUI() {
             storage_changed = ChangeObjectLayer(obj_idx, layer).ok();
           }
         }
-        if (draws_to_both_bgs) {
+        if (has_routine_defined_route) {
           ImGui::SameLine();
           gui::HelpMarker(
-              "This object draws to both BG1 and BG2. Its object stream still "
-              "controls draw order and ROM serialization.");
+              "This object's draw routine defines its render route. Its object "
+              "stream still controls draw order and ROM serialization.");
         }
 
         gui::EndPropertyTable();

--- a/src/zelda3/dungeon/object_layer_semantics.h
+++ b/src/zelda3/dungeon/object_layer_semantics.h
@@ -4,6 +4,7 @@
 #include <cstdint>
 
 #include "zelda3/dungeon/draw_routines/draw_routine_registry.h"
+#include "zelda3/dungeon/object_render_routing.h"
 #include "zelda3/dungeon/room_object.h"
 
 namespace yaze {
@@ -17,8 +18,12 @@ enum class EffectiveBgLayer {
 
 struct ObjectLayerSemantics {
   int routine_id = -1;
+  // Compatibility field for the legacy all_bgs_/routine-metadata decision.
+  // Object-ID-specific routing (for example auto and straight stairs) is
+  // represented by render_routing instead.
   bool draws_to_both_bgs = false;
   EffectiveBgLayer effective_bg_layer = EffectiveBgLayer::kBg1;
+  ObjectRenderRouting render_routing = ObjectRenderRouting::kStoredPlacement;
 };
 
 inline bool UsesRoomObjectStream(const RoomObject& object) {
@@ -31,6 +36,8 @@ inline bool UsesSpecialLayerSelector(const RoomObject& object) {
   return !UsesRoomObjectStream(object);
 }
 
+// Reports built-in routine routing. A project custom-object override can
+// preempt the built-in routine and use stored placement instead.
 inline ObjectLayerSemantics GetObjectLayerSemantics(const RoomObject& object) {
   ObjectLayerSemantics out;
 
@@ -42,12 +49,42 @@ inline ObjectLayerSemantics GetObjectLayerSemantics(const RoomObject& object) {
 
   if (out.draws_to_both_bgs) {
     out.effective_bg_layer = EffectiveBgLayer::kBothBg1Bg2;
+    out.render_routing = ObjectRenderRouting::kFullBothBg1Bg2;
+    return out;
+  }
+
+  if (out.routine_id == DrawRoutineIds::kAutoStairs &&
+      object_render_routing::IsFullBothAutoStairsObject(object.id_)) {
+    out.effective_bg_layer = EffectiveBgLayer::kBothBg1Bg2;
+    out.render_routing = ObjectRenderRouting::kFullBothBg1Bg2;
     return out;
   }
 
   if (out.routine_id == DrawRoutineIds::kAgahnimsAltar ||
-      out.routine_id == DrawRoutineIds::kFortuneTellerRoom) {
+      out.routine_id == DrawRoutineIds::kFortuneTellerRoom ||
+      out.routine_id == DrawRoutineIds::kSpiralStairsGoingUpUpper ||
+      out.routine_id == DrawRoutineIds::kSpiralStairsGoingDownUpper) {
     out.effective_bg_layer = EffectiveBgLayer::kBg1;
+    out.render_routing = ObjectRenderRouting::kFixedBg1;
+    return out;
+  }
+
+  if (out.routine_id == DrawRoutineIds::kSpiralStairsGoingUpLower ||
+      out.routine_id == DrawRoutineIds::kSpiralStairsGoingDownLower) {
+    out.effective_bg_layer = EffectiveBgLayer::kBg2;
+    out.render_routing = ObjectRenderRouting::kFixedBg2;
+    return out;
+  }
+
+  if (out.routine_id == DrawRoutineIds::kStraightInterRoomStairs) {
+    if (object_render_routing::IsMixedStraightInterroomObject(object.id_)) {
+      out.effective_bg_layer = EffectiveBgLayer::kBothBg1Bg2;
+      out.render_routing = ObjectRenderRouting::kMixedBg1Bg2;
+      return out;
+    }
+
+    out.effective_bg_layer = EffectiveBgLayer::kBg1;
+    out.render_routing = ObjectRenderRouting::kFixedBg1;
     return out;
   }
 
@@ -67,6 +104,48 @@ inline const char* EffectiveBgLayerLabel(EffectiveBgLayer layer) {
       return "Both BGs";
   }
   return "Unknown";
+}
+
+inline const char* ObjectRenderRoutingLabel(ObjectRenderRouting routing) {
+  switch (routing) {
+    case ObjectRenderRouting::kStoredPlacement:
+      return "Stored placement";
+    case ObjectRenderRouting::kFixedBg1:
+      return "BG1 (fixed)";
+    case ObjectRenderRouting::kFixedBg2:
+      return "BG2 (fixed)";
+    case ObjectRenderRouting::kFullBothBg1Bg2:
+      return "Both BGs (full)";
+    case ObjectRenderRouting::kMixedBg1Bg2:
+      return "Mixed BG1/BG2";
+  }
+  return "Unknown";
+}
+
+inline const char* ObjectRenderRoutingDisplayLabel(
+    const ObjectLayerSemantics& semantics) {
+  if (semantics.render_routing != ObjectRenderRouting::kStoredPlacement) {
+    return ObjectRenderRoutingLabel(semantics.render_routing);
+  }
+  return semantics.effective_bg_layer == EffectiveBgLayer::kBg2
+             ? "BG2 (stored placement)"
+             : "BG1 (stored placement)";
+}
+
+inline const char* ObjectRenderRoutingToken(ObjectRenderRouting routing) {
+  switch (routing) {
+    case ObjectRenderRouting::kStoredPlacement:
+      return "stored";
+    case ObjectRenderRouting::kFixedBg1:
+      return "fixed_bg1";
+    case ObjectRenderRouting::kFixedBg2:
+      return "fixed_bg2";
+    case ObjectRenderRouting::kFullBothBg1Bg2:
+      return "full_both";
+    case ObjectRenderRouting::kMixedBg1Bg2:
+      return "mixed";
+  }
+  return "unknown";
 }
 
 }  // namespace zelda3

--- a/src/zelda3/dungeon/object_render_routing.h
+++ b/src/zelda3/dungeon/object_render_routing.h
@@ -1,0 +1,42 @@
+#ifndef YAZE_ZELDA3_DUNGEON_OBJECT_RENDER_ROUTING_H_
+#define YAZE_ZELDA3_DUNGEON_OBJECT_RENDER_ROUTING_H_
+
+namespace yaze {
+namespace zelda3 {
+
+// Describes how a built-in object's draw routine chooses its destination
+// tilemap(s). This is intentionally separate from RoomObject::layer_, which
+// remains the stored room-object stream index used for serialization and draw
+// order. Custom-object overrides are resolved before built-in routine routing.
+enum class ObjectRenderRouting {
+  kStoredPlacement,
+  kFixedBg1,
+  kFixedBg2,
+  kFullBothBg1Bg2,
+  kMixedBg1Bg2,
+};
+
+namespace object_render_routing {
+
+inline constexpr bool IsFullBothAutoStairsObject(int object_id) {
+  return object_id == 0x130 || object_id == 0x131 || object_id == 0xF9B ||
+         object_id == 0xF9C;
+}
+
+inline constexpr bool IsFixedBg1StraightInterroomObject(int object_id) {
+  return object_id >= 0xF9E && object_id <= 0xFA1;
+}
+
+inline constexpr bool IsMixedStraightInterroomObject(int object_id) {
+  return object_id >= 0xFA6 && object_id <= 0xFA9;
+}
+
+inline constexpr bool IsSouthMixedStraightInterroomObject(int object_id) {
+  return object_id == 0xFA8 || object_id == 0xFA9;
+}
+
+}  // namespace object_render_routing
+}  // namespace zelda3
+}  // namespace yaze
+
+#endif  // YAZE_ZELDA3_DUNGEON_OBJECT_RENDER_ROUTING_H_

--- a/src/zelda3/dungeon/room.cc
+++ b/src/zelda3/dungeon/room.cc
@@ -1355,11 +1355,10 @@ void Room::RenderObjectsToBackground() {
   ObjectDrawer drawer(rom_, room_id_, current_gfx16_.data());
   drawer.SetAllowTrackCornerAliases(RoomUsesTrackCornerAliases(tile_objects_));
   drawer.SetBG1RevealMaskSource(gfx::BG1RevealMaskSource::kBG2Objects);
-  // NOTE: Routines that explicitly write both tilemaps (ceiling corners and
-  // merged stairs) are handled by DrawRoutineRegistry's draws_to_both_bgs
-  // flag. The room object stream is split here as primary -> BG2 overlay ->
-  // BG1 overlay, while the layout pass is rendered separately by
-  // RoomLayout::Draw.
+  // NOTE: Routines marked draws_to_both_bgs explicitly write both tilemaps.
+  // Object-specific stair routing is handled inside the registered routines.
+  // The room object stream is split here as primary -> BG2 overlay -> BG1
+  // overlay, while the layout pass is rendered separately by RoomLayout::Draw.
 
   // Clear object buffers before rendering
   // IMPORTANT: Fill with 255 (transparent color key) so objects overlay correctly

--- a/test/unit/zelda3/dungeon/object_layer_semantics_test.cc
+++ b/test/unit/zelda3/dungeon/object_layer_semantics_test.cc
@@ -1,5 +1,7 @@
 #include "gtest/gtest.h"
 
+#include <array>
+#include <iomanip>
 #include <vector>
 
 #include "rom/rom.h"
@@ -10,12 +12,77 @@
 namespace yaze {
 namespace zelda3 {
 
+namespace {
+
+struct AuditedRoutingCase {
+  int object_id;
+  int routine_id;
+  ObjectRenderRouting routing;
+};
+
+constexpr std::array<AuditedRoutingCase, 22> kAuditedRoutingCases = {{
+    {0x130, DrawRoutineIds::kAutoStairs, ObjectRenderRouting::kFullBothBg1Bg2},
+    {0x131, DrawRoutineIds::kAutoStairs, ObjectRenderRouting::kFullBothBg1Bg2},
+    {0xF9B, DrawRoutineIds::kAutoStairs, ObjectRenderRouting::kFullBothBg1Bg2},
+    {0xF9C, DrawRoutineIds::kAutoStairs, ObjectRenderRouting::kFullBothBg1Bg2},
+    {0x132, DrawRoutineIds::kAutoStairs, ObjectRenderRouting::kStoredPlacement},
+    {0x133, DrawRoutineIds::kAutoStairs, ObjectRenderRouting::kStoredPlacement},
+    {0xF9D, DrawRoutineIds::kAutoStairs, ObjectRenderRouting::kStoredPlacement},
+    {0xFB3, DrawRoutineIds::kAutoStairs, ObjectRenderRouting::kStoredPlacement},
+    {0x138, DrawRoutineIds::kSpiralStairsGoingUpUpper,
+     ObjectRenderRouting::kFixedBg1},
+    {0x139, DrawRoutineIds::kSpiralStairsGoingDownUpper,
+     ObjectRenderRouting::kFixedBg1},
+    {0xF9E, DrawRoutineIds::kStraightInterRoomStairs,
+     ObjectRenderRouting::kFixedBg1},
+    {0xF9F, DrawRoutineIds::kStraightInterRoomStairs,
+     ObjectRenderRouting::kFixedBg1},
+    {0xFA0, DrawRoutineIds::kStraightInterRoomStairs,
+     ObjectRenderRouting::kFixedBg1},
+    {0xFA1, DrawRoutineIds::kStraightInterRoomStairs,
+     ObjectRenderRouting::kFixedBg1},
+    {0x13A, DrawRoutineIds::kSpiralStairsGoingUpLower,
+     ObjectRenderRouting::kFixedBg2},
+    {0x13B, DrawRoutineIds::kSpiralStairsGoingDownLower,
+     ObjectRenderRouting::kFixedBg2},
+    {0xFA6, DrawRoutineIds::kStraightInterRoomStairs,
+     ObjectRenderRouting::kMixedBg1Bg2},
+    {0xFA7, DrawRoutineIds::kStraightInterRoomStairs,
+     ObjectRenderRouting::kMixedBg1Bg2},
+    {0xFA8, DrawRoutineIds::kStraightInterRoomStairs,
+     ObjectRenderRouting::kMixedBg1Bg2},
+    {0xFA9, DrawRoutineIds::kStraightInterRoomStairs,
+     ObjectRenderRouting::kMixedBg1Bg2},
+    {0xFAD, DrawRoutineIds::kAgahnimsAltar, ObjectRenderRouting::kFixedBg1},
+    {0xFD4, DrawRoutineIds::kFortuneTellerRoom, ObjectRenderRouting::kFixedBg1},
+}};
+
+EffectiveBgLayer ExpectedEffectiveLayer(ObjectRenderRouting routing,
+                                        uint8_t stored_stream) {
+  switch (routing) {
+    case ObjectRenderRouting::kStoredPlacement:
+      return stored_stream == 1 ? EffectiveBgLayer::kBg2
+                                : EffectiveBgLayer::kBg1;
+    case ObjectRenderRouting::kFixedBg1:
+      return EffectiveBgLayer::kBg1;
+    case ObjectRenderRouting::kFixedBg2:
+      return EffectiveBgLayer::kBg2;
+    case ObjectRenderRouting::kFullBothBg1Bg2:
+    case ObjectRenderRouting::kMixedBg1Bg2:
+      return EffectiveBgLayer::kBothBg1Bg2;
+  }
+  return EffectiveBgLayer::kBg1;
+}
+
+}  // namespace
+
 TEST(ObjectLayerSemanticsTest, CeilingRoutineIsSingleLayer) {
   RoomObject obj(/*id=*/0x00, /*x=*/0, /*y=*/0, /*size=*/0, /*layer=*/0);
 
   const auto sem = GetObjectLayerSemantics(obj);
   EXPECT_FALSE(sem.draws_to_both_bgs);
   EXPECT_EQ(sem.effective_bg_layer, EffectiveBgLayer::kBg1);
+  EXPECT_EQ(sem.render_routing, ObjectRenderRouting::kStoredPlacement);
 }
 
 TEST(ObjectLayerSemanticsTest, RoutineMetadataCanForceBothBgForType2Objects) {
@@ -28,6 +95,7 @@ TEST(ObjectLayerSemanticsTest, RoutineMetadataCanForceBothBgForType2Objects) {
   const auto sem = GetObjectLayerSemantics(obj);
   EXPECT_TRUE(sem.draws_to_both_bgs);
   EXPECT_EQ(sem.effective_bg_layer, EffectiveBgLayer::kBothBg1Bg2);
+  EXPECT_EQ(sem.render_routing, ObjectRenderRouting::kFullBothBg1Bg2);
 }
 
 TEST(ObjectLayerSemanticsTest, AllBgsOverrideForcesBothBg) {
@@ -37,6 +105,7 @@ TEST(ObjectLayerSemanticsTest, AllBgsOverrideForcesBothBg) {
   const auto sem = GetObjectLayerSemantics(obj);
   EXPECT_TRUE(sem.draws_to_both_bgs);
   EXPECT_EQ(sem.effective_bg_layer, EffectiveBgLayer::kBothBg1Bg2);
+  EXPECT_EQ(sem.render_routing, ObjectRenderRouting::kFullBothBg1Bg2);
 }
 
 TEST(ObjectLayerSemanticsTest, NonBothBgUsesStoredLayer) {
@@ -45,28 +114,71 @@ TEST(ObjectLayerSemanticsTest, NonBothBgUsesStoredLayer) {
   const auto sem = GetObjectLayerSemantics(obj);
   EXPECT_FALSE(sem.draws_to_both_bgs);
   EXPECT_EQ(sem.effective_bg_layer, EffectiveBgLayer::kBg2);
+  EXPECT_EQ(sem.render_routing, ObjectRenderRouting::kStoredPlacement);
 }
 
-TEST(ObjectLayerSemanticsTest, AgahnimsAltarAlwaysReportsFixedBg1) {
-  for (uint8_t layer : {uint8_t{0}, uint8_t{1}}) {
-    RoomObject obj(/*id=*/0xFAD, /*x=*/0, /*y=*/0, /*size=*/7, layer);
+TEST(ObjectLayerSemanticsTest,
+     AuditedObjectIdsReportRoutingAcrossAllStoredStreams) {
+  for (const auto& test_case : kAuditedRoutingCases) {
+    for (uint8_t stored_stream : {uint8_t{0}, uint8_t{1}, uint8_t{2}}) {
+      SCOPED_TRACE(::testing::Message()
+                   << "object=0x" << std::hex << test_case.object_id
+                   << " stored_stream=" << std::dec
+                   << static_cast<int>(stored_stream));
+      RoomObject obj(test_case.object_id, /*x=*/0, /*y=*/0, /*size=*/0,
+                     stored_stream);
 
-    const auto sem = GetObjectLayerSemantics(obj);
-    EXPECT_EQ(sem.routine_id, DrawRoutineIds::kAgahnimsAltar);
-    EXPECT_FALSE(sem.draws_to_both_bgs);
-    EXPECT_EQ(sem.effective_bg_layer, EffectiveBgLayer::kBg1);
+      const auto sem = GetObjectLayerSemantics(obj);
+      EXPECT_EQ(sem.routine_id, test_case.routine_id);
+      EXPECT_EQ(sem.render_routing, test_case.routing);
+      EXPECT_EQ(sem.effective_bg_layer,
+                ExpectedEffectiveLayer(test_case.routing, stored_stream));
+      // These object-aware routes do not rewrite the legacy all_bgs_/routine
+      // metadata compatibility field.
+      EXPECT_FALSE(sem.draws_to_both_bgs);
+    }
   }
 }
 
-TEST(ObjectLayerSemanticsTest, FortuneTellerRoomAlwaysReportsFixedBg1) {
-  for (uint8_t layer : {uint8_t{0}, uint8_t{1}}) {
-    RoomObject obj(/*id=*/0xFD4, /*x=*/0, /*y=*/0, /*size=*/7, layer);
+TEST(ObjectLayerSemanticsTest,
+     AllBgsOverrideTakesPriorityOverFixedAndMixedRouting) {
+  for (int object_id : {0xF9E, 0xFA6}) {
+    RoomObject obj(object_id, /*x=*/0, /*y=*/0, /*size=*/0, /*layer=*/1);
+    obj.all_bgs_ = true;
 
     const auto sem = GetObjectLayerSemantics(obj);
-    EXPECT_EQ(sem.routine_id, DrawRoutineIds::kFortuneTellerRoom);
-    EXPECT_FALSE(sem.draws_to_both_bgs);
-    EXPECT_EQ(sem.effective_bg_layer, EffectiveBgLayer::kBg1);
+    EXPECT_TRUE(sem.draws_to_both_bgs);
+    EXPECT_EQ(sem.render_routing, ObjectRenderRouting::kFullBothBg1Bg2);
+    EXPECT_EQ(sem.effective_bg_layer, EffectiveBgLayer::kBothBg1Bg2);
   }
+}
+
+TEST(ObjectLayerSemanticsTest, RoutingLabelsAndTokensAreStable) {
+  struct LabelCase {
+    ObjectRenderRouting routing;
+    const char* label;
+    const char* token;
+  };
+  constexpr std::array<LabelCase, 5> kCases = {{
+      {ObjectRenderRouting::kStoredPlacement, "Stored placement", "stored"},
+      {ObjectRenderRouting::kFixedBg1, "BG1 (fixed)", "fixed_bg1"},
+      {ObjectRenderRouting::kFixedBg2, "BG2 (fixed)", "fixed_bg2"},
+      {ObjectRenderRouting::kFullBothBg1Bg2, "Both BGs (full)", "full_both"},
+      {ObjectRenderRouting::kMixedBg1Bg2, "Mixed BG1/BG2", "mixed"},
+  }};
+
+  for (const auto& test_case : kCases) {
+    EXPECT_STREQ(ObjectRenderRoutingLabel(test_case.routing), test_case.label);
+    EXPECT_STREQ(ObjectRenderRoutingToken(test_case.routing), test_case.token);
+  }
+
+  ObjectLayerSemantics stored_bg1;
+  stored_bg1.effective_bg_layer = EffectiveBgLayer::kBg1;
+  EXPECT_STREQ(ObjectRenderRoutingDisplayLabel(stored_bg1),
+               "BG1 (stored placement)");
+  stored_bg1.effective_bg_layer = EffectiveBgLayer::kBg2;
+  EXPECT_STREQ(ObjectRenderRoutingDisplayLabel(stored_bg1),
+               "BG2 (stored placement)");
 }
 
 TEST(DungeonObjectLayerGuardrailsTest,
@@ -101,6 +213,43 @@ TEST(DungeonObjectLayerGuardrailsTest,
       0x00, 0x00, 0x03,       // BothBG object appended to that stream.
       0xFF, 0xFF,             // End BG2 overlay stream.
       0xF0, 0xFF, 0xFF, 0xFF  // Empty BG1 overlay and door list.
+  };
+  EXPECT_EQ(room.EncodeObjects(), expected);
+}
+
+TEST(DungeonObjectLayerGuardrailsTest,
+     FixedAndMixedRoutesKeepStoredStreamIdentityAndSelection) {
+  Rom rom;
+  Room room(/*room_id=*/0, &rom);
+  ASSERT_TRUE(room.AddObject(RoomObject(0xF9E, 0, 0, 0, 0)).ok());
+  ASSERT_TRUE(room.AddObject(RoomObject(0x21, 0, 0, 0, 0)).ok());
+  ASSERT_TRUE(room.AddObject(RoomObject(0x22, 0, 0, 0, 1)).ok());
+  ASSERT_TRUE(room.AddObject(RoomObject(0xFA6, 0, 0, 0, 0)).ok());
+
+  DungeonObjectEditor editor(&rom);
+  editor.SetExternalRoom(&room);
+  ASSERT_TRUE(editor.AddToSelection(0).ok());
+  ASSERT_TRUE(editor.AddToSelection(3).ok());
+  ASSERT_TRUE(editor.BatchChangeObjectLayer({0, 3}, /*new_layer=*/1).ok());
+
+  ASSERT_EQ(room.GetTileObjectCount(), 4);
+  EXPECT_EQ(room.GetTileObject(0).id_, 0x21);
+  EXPECT_EQ(room.GetTileObject(1).id_, 0x22);
+  EXPECT_EQ(room.GetTileObject(2).id_, 0xF9E);
+  EXPECT_EQ(room.GetTileObject(3).id_, 0xFA6);
+  EXPECT_EQ(room.GetTileObject(2).GetLayerValue(), 1);
+  EXPECT_EQ(room.GetTileObject(3).GetLayerValue(), 1);
+  EXPECT_EQ(editor.GetSelection().selected_objects,
+            (std::vector<size_t>{2, 3}));
+
+  EXPECT_EQ(GetObjectLayerSemantics(room.GetTileObject(2)).render_routing,
+            ObjectRenderRouting::kFixedBg1);
+  EXPECT_EQ(GetObjectLayerSemantics(room.GetTileObject(3)).render_routing,
+            ObjectRenderRouting::kMixedBg1Bg2);
+
+  const std::vector<uint8_t> expected = {
+      0x00, 0x00, 0x21, 0xFF, 0xFF, 0x00, 0x00, 0x22, 0x02, 0x03,
+      0xF9, 0x02, 0x01, 0xFA, 0xFF, 0xFF, 0xF0, 0xFF, 0xFF, 0xFF,
   };
   EXPECT_EQ(room.EncodeObjects(), expected);
 }


### PR DESCRIPTION
## Summary
- report built-in dungeon-object render routing separately from stored object streams
- classify full-both, fixed-BG1, fixed-BG2, and mixed stair/facade routes without changing pixels
- share object-ID predicates with the existing renderer so diagnostics cannot drift from draw behavior
- preserve stream selection, serialization, legacy metadata, and correct stale rendering documentation

## Verification
- synced onto merged `master` (`4f3c62424df9fd595040aa641b2133909ce7611d`)
- `cmake --build --preset mac-ai --target yaze_test_unit -j8`
- 22/22 focused semantics, stream guardrail, renderer replay, and mask tests at head `70adb4d4efa881ae203675b73d73a4d0f893f776`
- `scripts/pre-push.sh --build-dir build/presets/mac-ai` (build, 13/13 smoke tests, formatting; change-aware UI correctly skipped)
- `git diff --check origin/master...HEAD`

## Scope
Reporting and diagnostics only. This does not change ObjectDrawer dispatch, pixel output, masks, stream order, selection behavior, or serialization. Labels describe built-in routing; project custom-object overrides can preempt it.

Based directly on `master`; no remaining dependency on #180.
