### PR TITLE
Guard Object Tile Editor ROM writes

### DIFF
--- a/src/app/editor/dungeon/dungeon_editor_v2.cc
+++ b/src/app/editor/dungeon/dungeon_editor_v2.cc
@@ -848,6 +848,18 @@ absl::Status DungeonEditorV2::Load() {
       auto tile_editor_panel =
           std::make_unique<ObjectTileEditorPanel>(renderer_, rom_);
       tile_editor_panel->SetCurrentPaletteGroup(current_palette_group_);
+      tile_editor_panel->SetStandardWritePreflightCallback(
+          [this](const std::vector<std::pair<uint32_t, uint32_t>>& ranges) {
+            if (ranges.empty() || dependencies_.project == nullptr ||
+                !dependencies_.project->hack_manifest.loaded()) {
+              return absl::OkStatus();
+            }
+            return ValidateHackManifestSaveConflicts(
+                dependencies_.project->hack_manifest,
+                dependencies_.project->rom_metadata.write_policy, ranges,
+                "dungeon object tile data", "ObjectTileEditorPanel",
+                dependencies_.toast_manager);
+          });
 
       // Wire creation callback: when a new custom object is saved,
       // register it with the manager, persist to project, and refresh UI.

--- a/src/app/editor/dungeon/ui/window/object_tile_editor_panel.cc
+++ b/src/app/editor/dungeon/ui/window/object_tile_editor_panel.cc
@@ -521,6 +521,27 @@ void ObjectTileEditorPanel::DrawTileProperties() {
   }
 }
 
+absl::Status ObjectTileEditorPanel::WriteBackCurrentLayout() {
+  if (current_layout_.is_custom) {
+    return tile_editor_->WriteBack(current_layout_);
+  }
+
+  auto plan_or = tile_editor_->BuildStandardWritePlan(current_layout_);
+  if (!plan_or.ok()) {
+    return plan_or.status();
+  }
+
+  const auto& plan = *plan_or;
+  if (standard_write_preflight_ && !plan.write_ranges.empty()) {
+    const absl::Status preflight = standard_write_preflight_(plan.write_ranges);
+    if (!preflight.ok()) {
+      return preflight;
+    }
+  }
+
+  return tile_editor_->ApplyStandardWritePlan(plan);
+}
+
 void ObjectTileEditorPanel::ApplyChanges(bool confirm_shared) {
   // Check for shared tile data and ask for confirmation
   const int shared_count = GetSharedTileDataUsageCount();
@@ -538,7 +559,7 @@ void ObjectTileEditorPanel::ApplyChanges(bool confirm_shared) {
   show_shared_confirm_ = false;
   shared_object_count_ = 0;
 
-  auto status = tile_editor_->WriteBack(current_layout_);
+  auto status = WriteBackCurrentLayout();
   if (status.ok()) {
     // Re-render room after applying changes
     if (HasRenderableRoomContext()) {

--- a/src/app/editor/dungeon/ui/window/object_tile_editor_panel.h
+++ b/src/app/editor/dungeon/ui/window/object_tile_editor_panel.h
@@ -2,10 +2,14 @@
 #define YAZE_APP_EDITOR_DUNGEON_PANELS_OBJECT_TILE_EDITOR_PANEL_H_
 
 #include <array>
+#include <cstdint>
 #include <functional>
 #include <memory>
 #include <string>
+#include <utility>
+#include <vector>
 
+#include "absl/status/status.h"
 #include "app/editor/dungeon/dungeon_room_store.h"
 #include "app/editor/system/workspace/editor_panel.h"
 #include "app/gfx/backend/irenderer.h"
@@ -34,6 +38,9 @@ struct ObjectTileEditorPanelTestAccess;
  */
 class ObjectTileEditorPanel : public WindowContent {
  public:
+  using StandardWritePreflightCallback = std::function<absl::Status(
+      const std::vector<std::pair<uint32_t, uint32_t>>&)>;
+
   ObjectTileEditorPanel(gfx::IRenderer* renderer, Rom* rom);
 
   std::string GetId() const override { return "dungeon.object_tile_editor"; }
@@ -58,6 +65,11 @@ class ObjectTileEditorPanel : public WindowContent {
   void SetObjectCreatedCallback(
       std::function<void(int, const std::string&)> cb) {
     on_object_created_ = std::move(cb);
+  }
+
+  void SetStandardWritePreflightCallback(
+      StandardWritePreflightCallback callback) {
+    standard_write_preflight_ = std::move(callback);
   }
 
  private:
@@ -88,6 +100,7 @@ class ObjectTileEditorPanel : public WindowContent {
   void RenderObjectPreview();
   void RenderTile8Atlas();
   void SyncSourceSelectionFromSelectedCell();
+  absl::Status WriteBackCurrentLayout();
 
   // Apply: write back, re-render room, reset modified flags.
   // If confirm_shared is true and tile data is shared, opens confirmation modal
@@ -122,6 +135,7 @@ class ObjectTileEditorPanel : public WindowContent {
   // New object creation state
   bool is_new_object_ = false;
   std::function<void(int, const std::string&)> on_object_created_;
+  StandardWritePreflightCallback standard_write_preflight_;
 
   // Context
   gfx::IRenderer* renderer_;

--- a/src/zelda3/dungeon/object_tile_editor.cc
+++ b/src/zelda3/dungeon/object_tile_editor.cc
@@ -442,9 +442,11 @@ absl::StatusOr<ObjectTileWritePlan> ObjectTileEditor::BuildStandardWritePlan(
     if (!cell.modified)
       continue;
 
-    const int64_t write_index = cell.write_index >= 0
-                                    ? static_cast<int64_t>(cell.write_index)
-                                    : static_cast<int64_t>(i);
+    if (cell.write_index < 0) {
+      return absl::FailedPreconditionError(
+          "Object tile cell has no editable source index");
+    }
+    const int64_t write_index = static_cast<int64_t>(cell.write_index);
     const int64_t address =
         static_cast<int64_t>(layout.tile_data_address) + write_index * 2;
     const int64_t end = address + 2;

--- a/src/zelda3/dungeon/object_tile_editor.cc
+++ b/src/zelda3/dungeon/object_tile_editor.cc
@@ -4,10 +4,12 @@
 #include <cstring>
 #include <filesystem>
 #include <fstream>
+#include <limits>
 #include <unordered_map>
 
 #include "app/gfx/types/snes_tile.h"
 #include "core/features.h"
+#include "rom/transaction.h"
 #include "util/log.h"
 #include "zelda3/dungeon/custom_object.h"
 #include "zelda3/dungeon/geometry/object_geometry.h"
@@ -408,30 +410,87 @@ absl::Status ObjectTileEditor::WriteBack(const ObjectTileLayout& layout) {
     return absl::OkStatus();
   }
 
-  // Standard object: patch ROM at tile_data_address
+  auto plan_or = BuildStandardWritePlan(layout);
+  if (!plan_or.ok()) {
+    return plan_or.status();
+  }
+  return ApplyStandardWritePlan(*plan_or);
+}
+
+absl::StatusOr<ObjectTileWritePlan> ObjectTileEditor::BuildStandardWritePlan(
+    const ObjectTileLayout& layout) const {
+  if (layout.is_custom) {
+    return absl::InvalidArgumentError(
+        "Cannot build a standard ROM write plan for a custom object");
+  }
+
+  ObjectTileWritePlan plan;
+  if (!layout.HasModifications()) {
+    return plan;
+  }
+  if (rom_ == nullptr || !rom_->is_loaded()) {
+    return absl::FailedPreconditionError("ROM not loaded");
+  }
   if (layout.tile_data_address < 0) {
     return absl::FailedPreconditionError(
         "No tile data address for ROM write-back");
   }
 
+  const int64_t rom_size = static_cast<int64_t>(rom_->size());
   for (size_t i = 0; i < layout.cells.size(); ++i) {
     const auto& cell = layout.cells[i];
     if (!cell.modified)
       continue;
 
-    const int write_index =
-        cell.write_index >= 0 ? cell.write_index : static_cast<int>(i);
-    int addr = layout.tile_data_address + write_index * 2;
-    uint16_t word = gfx::TileInfoToWord(cell.tile_info);
+    const int64_t write_index = cell.write_index >= 0
+                                    ? static_cast<int64_t>(cell.write_index)
+                                    : static_cast<int64_t>(i);
+    const int64_t address =
+        static_cast<int64_t>(layout.tile_data_address) + write_index * 2;
+    const int64_t end = address + 2;
+    if (address < 0 || end > rom_size ||
+        address > std::numeric_limits<int>::max()) {
+      return absl::OutOfRangeError(
+          "Object tile write range is outside the loaded ROM");
+    }
 
-    // Write 2 bytes (little-endian SNES tilemap word)
-    auto low = static_cast<uint8_t>(word & 0xFF);
-    auto high = static_cast<uint8_t>((word >> 8) & 0xFF);
-    RETURN_IF_ERROR(rom_->WriteByte(addr, low));
-    RETURN_IF_ERROR(rom_->WriteByte(addr + 1, high));
+    plan.writes.push_back(
+        {static_cast<int>(address), gfx::TileInfoToWord(cell.tile_info)});
+    plan.write_ranges.emplace_back(static_cast<uint32_t>(address),
+                                   static_cast<uint32_t>(end));
   }
 
-  return absl::OkStatus();
+  return plan;
+}
+
+absl::Status ObjectTileEditor::ApplyStandardWritePlan(
+    const ObjectTileWritePlan& plan) {
+  if (plan.writes.empty()) {
+    return absl::OkStatus();
+  }
+  if (rom_ == nullptr || !rom_->is_loaded()) {
+    return absl::FailedPreconditionError("ROM not loaded");
+  }
+
+  const int64_t rom_size = static_cast<int64_t>(rom_->size());
+  for (const auto& write : plan.writes) {
+    const int64_t address = static_cast<int64_t>(write.address);
+    if (address < 0 || address + 2 > rom_size) {
+      return absl::OutOfRangeError(
+          "Object tile write range is outside the loaded ROM");
+    }
+  }
+
+  const bool was_dirty = rom_->dirty();
+  Transaction transaction(*rom_);
+  for (const auto& write : plan.writes) {
+    transaction.WriteWord(write.address, write.word);
+  }
+  const absl::Status status = transaction.Commit();
+  if (!status.ok()) {
+    rom_->set_dirty(was_dirty);
+  }
+  return status;
 }
 
 int ObjectTileEditor::CountObjectsSharingTileData(int16_t object_id) const {

--- a/src/zelda3/dungeon/object_tile_editor.h
+++ b/src/zelda3/dungeon/object_tile_editor.h
@@ -3,6 +3,7 @@
 
 #include <cstdint>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "absl/status/status.h"
@@ -61,6 +62,22 @@ struct ObjectTileLayout {
 };
 
 /**
+ * @brief Fully resolved standard-object ROM writes.
+ *
+ * The exact half-open PC ranges are derived from the same entries that are
+ * applied, allowing callers to run Hack Manifest preflight before mutation.
+ */
+struct ObjectTileWritePlan {
+  struct Write {
+    int address = -1;
+    uint16_t word = 0;
+  };
+
+  std::vector<Write> writes;
+  std::vector<std::pair<uint32_t, uint32_t>> write_ranges;
+};
+
+/**
  * @brief Captures and edits the tile8 composition of dungeon objects
  *
  * Uses ObjectDrawer's trace_only mode to capture every WriteTile8 call,
@@ -98,6 +115,13 @@ class ObjectTileEditor {
 
   // Write-back: standard objects patch ROM, custom objects write .bin
   absl::Status WriteBack(const ObjectTileLayout& layout);
+
+  // Resolve and validate all standard-object writes before any ROM mutation.
+  absl::StatusOr<ObjectTileWritePlan> BuildStandardWritePlan(
+      const ObjectTileLayout& layout) const;
+
+  // Atomically apply a previously validated standard-object write plan.
+  absl::Status ApplyStandardWritePlan(const ObjectTileWritePlan& plan);
 
   // Check how many objects share the same tile data pointer
   int CountObjectsSharingTileData(int16_t object_id) const;

--- a/test/unit/editor/object_tile_editor_panel_test.cc
+++ b/test/unit/editor/object_tile_editor_panel_test.cc
@@ -6,7 +6,11 @@
 #include <string>
 #include <vector>
 
+#include "absl/strings/str_format.h"
+#include "app/editor/system/session/hack_manifest_save_validation.h"
+#include "core/project.h"
 #include "gtest/gtest.h"
+#include "rom/snes.h"
 #include "zelda3/dungeon/custom_object.h"
 
 namespace yaze::editor {
@@ -61,6 +65,11 @@ struct ObjectTileEditorPanelTestAccess {
   static bool ActionStatusIsSuccess(const ObjectTileEditorPanel& panel) {
     return panel.action_status_tone_ ==
            ObjectTileEditorPanel::ActionStatusTone::kSuccess;
+  }
+
+  static bool ActionStatusIsError(const ObjectTileEditorPanel& panel) {
+    return panel.action_status_tone_ ==
+           ObjectTileEditorPanel::ActionStatusTone::kError;
   }
 
   static const std::string& ActionStatusMessage(
@@ -289,6 +298,28 @@ int ReadWordAt(const Rom& rom, int addr) {
   const uint8_t low = rom.data()[addr];
   const uint8_t high = rom.data()[addr + 1];
   return static_cast<int>(low | (high << 8));
+}
+
+std::string ManifestProtectingPcRange(uint32_t begin, uint32_t end) {
+  return absl::StrFormat(
+      R"json(
+{
+  "manifest_version": 3,
+  "hack_name": "Synthetic object tile save guard",
+  "protected_regions": {
+    "total_hooks": 1,
+    "regions": [
+      {
+        "start": "0x%06X",
+        "end": "0x%06X",
+        "hook_count": 1,
+        "module": "SyntheticObjectTileGuard"
+      }
+    ]
+  }
+}
+)json",
+      PcToSnes(begin), PcToSnes(end));
 }
 
 std::optional<int16_t> FindCapturableObjectId(Rom* rom, DungeonRoomStore* rooms,
@@ -678,6 +709,117 @@ TEST(ObjectTileEditorPanelTest,
                               original_cell.tile_info.horizontal_mirror_,
                               original_cell.tile_info.vertical_mirror_,
                               original_cell.tile_info.over_))));
+}
+
+TEST(ObjectTileEditorPanelTest,
+     ManifestBlockedApplyPreservesRomAndModifiedRetryState) {
+  constexpr uint32_t kTileDataAddress = 0x1234;
+  Rom rom;
+  ASSERT_TRUE(rom.LoadFromData(std::vector<uint8_t>(0x200000, 0)).ok());
+
+  ObjectTileEditorPanel panel(nullptr, &rom);
+  auto layout = zelda3::ObjectTileLayout::CreateEmpty(
+      /*width=*/1, /*height=*/1, /*object_id=*/0x40, "standard.bin");
+  layout.is_custom = false;
+  layout.custom_filename.clear();
+  layout.tile_data_address = kTileDataAddress;
+  ObjectTileEditorPanelTestAccess::SetLayout(panel, std::move(layout));
+  ObjectTileEditorPanelTestAccess::SetCurrentObjectId(panel,
+                                                      /*object_id=*/0x40);
+  ObjectTileEditorPanelTestAccess::SetSharedTileDataUsageOverride(
+      panel, /*shared_count=*/1);
+  ObjectTileEditorPanelTestAccess::SetFirstCellTileAndPalette(
+      panel, /*tile_id=*/0x123, /*palette=*/3);
+
+  project::YazeProject project;
+  ASSERT_TRUE(project.hack_manifest
+                  .LoadFromString(ManifestProtectingPcRange(
+                      kTileDataAddress, kTileDataAddress + 2))
+                  .ok());
+  project.rom_metadata.write_policy = project::RomWritePolicy::kBlock;
+
+  int preflight_count = 0;
+  std::vector<std::pair<uint32_t, uint32_t>> observed_ranges;
+  panel.SetStandardWritePreflightCallback(
+      [&](const std::vector<std::pair<uint32_t, uint32_t>>& ranges) {
+        ++preflight_count;
+        observed_ranges = ranges;
+        return ValidateHackManifestSaveConflicts(
+            project.hack_manifest, project.rom_metadata.write_policy, ranges,
+            "dungeon object tile data", "ObjectTileEditorPanelTest",
+            /*toast_manager=*/nullptr);
+      });
+
+  const auto original = rom.vector();
+  const bool original_dirty = rom.dirty();
+  ObjectTileEditorPanelTestAccess::ApplyChanges(panel,
+                                                /*confirm_shared=*/false);
+
+  EXPECT_EQ(preflight_count, 1);
+  EXPECT_EQ(observed_ranges, (std::vector<std::pair<uint32_t, uint32_t>>{
+                                 {kTileDataAddress, kTileDataAddress + 2}}));
+  EXPECT_EQ(rom.vector(), original);
+  EXPECT_EQ(rom.dirty(), original_dirty);
+  EXPECT_TRUE(ObjectTileEditorPanelTestAccess::HasModifications(panel));
+  EXPECT_TRUE(ObjectTileEditorPanelTestAccess::ActionStatusIsError(panel));
+  EXPECT_NE(ObjectTileEditorPanelTestAccess::ActionStatusMessage(panel).find(
+                "Write conflict with Hack Manifest"),
+            std::string::npos);
+
+  panel.SetStandardWritePreflightCallback(
+      [](const std::vector<std::pair<uint32_t, uint32_t>>&) {
+        return absl::OkStatus();
+      });
+  ObjectTileEditorPanelTestAccess::ApplyChanges(panel,
+                                                /*confirm_shared=*/false);
+
+  EXPECT_FALSE(ObjectTileEditorPanelTestAccess::HasModifications(panel));
+  EXPECT_NE(rom.vector(), original);
+}
+
+TEST(ObjectTileEditorPanelTest, UnrelatedManifestRangeAllowsStandardApply) {
+  constexpr uint32_t kTileDataAddress = 0x1234;
+  Rom rom;
+  ASSERT_TRUE(rom.LoadFromData(std::vector<uint8_t>(0x200000, 0)).ok());
+
+  ObjectTileEditorPanel panel(nullptr, &rom);
+  auto layout = zelda3::ObjectTileLayout::CreateEmpty(
+      /*width=*/1, /*height=*/1, /*object_id=*/0x40, "standard.bin");
+  layout.is_custom = false;
+  layout.custom_filename.clear();
+  layout.tile_data_address = kTileDataAddress;
+  ObjectTileEditorPanelTestAccess::SetLayout(panel, std::move(layout));
+  ObjectTileEditorPanelTestAccess::SetCurrentObjectId(panel,
+                                                      /*object_id=*/0x40);
+  ObjectTileEditorPanelTestAccess::SetSharedTileDataUsageOverride(
+      panel, /*shared_count=*/1);
+  ObjectTileEditorPanelTestAccess::SetFirstCellTileAndPalette(
+      panel, /*tile_id=*/0x234, /*palette=*/4);
+
+  project::YazeProject project;
+  ASSERT_TRUE(project.hack_manifest
+                  .LoadFromString(ManifestProtectingPcRange(0x2000, 0x2002))
+                  .ok());
+  project.rom_metadata.write_policy = project::RomWritePolicy::kBlock;
+
+  int preflight_count = 0;
+  panel.SetStandardWritePreflightCallback(
+      [&](const std::vector<std::pair<uint32_t, uint32_t>>& ranges) {
+        ++preflight_count;
+        return ValidateHackManifestSaveConflicts(
+            project.hack_manifest, project.rom_metadata.write_policy, ranges,
+            "dungeon object tile data", "ObjectTileEditorPanelTest",
+            /*toast_manager=*/nullptr);
+      });
+
+  const int original_word = ReadWordAt(rom, kTileDataAddress);
+  ObjectTileEditorPanelTestAccess::ApplyChanges(panel,
+                                                /*confirm_shared=*/false);
+
+  EXPECT_EQ(preflight_count, 1);
+  EXPECT_FALSE(ObjectTileEditorPanelTestAccess::HasModifications(panel));
+  EXPECT_NE(ReadWordAt(rom, kTileDataAddress), original_word);
+  EXPECT_FALSE(ObjectTileEditorPanelTestAccess::ActionStatusIsError(panel));
 }
 
 TEST(ObjectTileEditorPanelTest,

--- a/test/unit/zelda3/dungeon/object_tile_editor_test.cc
+++ b/test/unit/zelda3/dungeon/object_tile_editor_test.cc
@@ -305,6 +305,7 @@ TEST(ObjectTileEditorTest, StandardObjectWriteBackRoundtrip) {
   ObjectTileLayout::Cell cell;
   cell.tile_info = gfx::TileInfo(0x123, 3, true, false, true);
   cell.original_word = 0;
+  cell.write_index = 0;
   cell.modified = true;
   layout.cells.push_back(cell);
 
@@ -315,6 +316,31 @@ TEST(ObjectTileEditorTest, StandardObjectWriteBackRoundtrip) {
   uint16_t word = static_cast<uint16_t>(low | (high << 8));
 
   EXPECT_EQ(word, gfx::TileInfoToWord(cell.tile_info));
+}
+
+TEST(ObjectTileEditorTest,
+     StandardObjectWriteBackRejectsMissingEditableSourceIndex) {
+  Rom rom;
+  ASSERT_TRUE(rom.LoadFromData(std::vector<uint8_t>(0x200000, 0)).ok());
+
+  ObjectTileEditor editor(&rom);
+  ObjectTileLayout layout;
+  layout.tile_data_address = 0x1000;
+  layout.is_custom = false;
+
+  ObjectTileLayout::Cell cell;
+  cell.tile_info = gfx::TileInfo(0x123, 3, true, false, true);
+  cell.modified = true;
+  ASSERT_EQ(cell.write_index, -1);
+  layout.cells.push_back(cell);
+
+  const auto original = rom.vector();
+  const bool original_dirty = rom.dirty();
+  const absl::Status status = editor.WriteBack(layout);
+
+  EXPECT_TRUE(absl::IsFailedPrecondition(status));
+  EXPECT_EQ(rom.vector(), original);
+  EXPECT_EQ(rom.dirty(), original_dirty);
 }
 
 TEST(ObjectTileEditorTest, StandardObjectWriteBackUsesCellWriteIndex) {

--- a/test/unit/zelda3/dungeon/object_tile_editor_test.cc
+++ b/test/unit/zelda3/dungeon/object_tile_editor_test.cc
@@ -9,6 +9,7 @@
 
 #include "core/features.h"
 #include "rom/rom.h"
+#include "rom/write_fence.h"
 #include "zelda3/dungeon/custom_object.h"
 #include "zelda3/dungeon/geometry/object_geometry.h"
 #include "zelda3/dungeon/object_drawer.h"
@@ -341,6 +342,114 @@ TEST(ObjectTileEditorTest, StandardObjectWriteBackUsesCellWriteIndex) {
   uint8_t high = rom.ReadByte(0x1003).value();
   uint16_t word = static_cast<uint16_t>(low | (high << 8));
   EXPECT_EQ(word, gfx::TileInfoToWord(cell.tile_info));
+}
+
+TEST(ObjectTileEditorTest,
+     BuildStandardWritePlanUsesSparseWriteIndicesAndExactRanges) {
+  Rom rom;
+  ASSERT_TRUE(rom.LoadFromData(std::vector<uint8_t>(0x2000, 0)).ok());
+
+  ObjectTileEditor editor(&rom);
+  ObjectTileLayout layout;
+  layout.tile_data_address = 0x1000;
+  layout.is_custom = false;
+
+  ObjectTileLayout::Cell first;
+  first.tile_info = gfx::TileInfo(0x123, 3, true, false, true);
+  first.write_index = 3;
+  first.modified = true;
+  layout.cells.push_back(first);
+
+  ObjectTileLayout::Cell unmodified;
+  unmodified.tile_info = gfx::TileInfo(0x111, 1, false, false, false);
+  unmodified.write_index = 1;
+  unmodified.modified = false;
+  layout.cells.push_back(unmodified);
+
+  ObjectTileLayout::Cell second;
+  second.tile_info = gfx::TileInfo(0x234, 4, false, true, false);
+  second.write_index = 0;
+  second.modified = true;
+  layout.cells.push_back(second);
+
+  auto plan_or = editor.BuildStandardWritePlan(layout);
+  ASSERT_TRUE(plan_or.ok()) << plan_or.status();
+  const auto& plan = *plan_or;
+  ASSERT_EQ(plan.writes.size(), 2u);
+  ASSERT_EQ(plan.write_ranges.size(), 2u);
+
+  EXPECT_EQ(plan.writes[0].address, 0x1006);
+  EXPECT_EQ(plan.writes[0].word, gfx::TileInfoToWord(first.tile_info));
+  EXPECT_EQ(plan.write_ranges[0],
+            (std::pair<uint32_t, uint32_t>{0x1006, 0x1008}));
+  EXPECT_EQ(plan.writes[1].address, 0x1000);
+  EXPECT_EQ(plan.writes[1].word, gfx::TileInfoToWord(second.tile_info));
+  EXPECT_EQ(plan.write_ranges[1],
+            (std::pair<uint32_t, uint32_t>{0x1000, 0x1002}));
+}
+
+TEST(ObjectTileEditorTest,
+     StandardObjectWriteBackRejectsAllInvalidRangesBeforeMutation) {
+  Rom rom;
+  ASSERT_TRUE(rom.LoadFromData(std::vector<uint8_t>(0x20, 0x5A)).ok());
+
+  ObjectTileEditor editor(&rom);
+  ObjectTileLayout layout;
+  layout.tile_data_address = 0x10;
+  layout.is_custom = false;
+
+  ObjectTileLayout::Cell valid;
+  valid.tile_info = gfx::TileInfo(0x123, 3, true, false, true);
+  valid.write_index = 0;
+  valid.modified = true;
+  layout.cells.push_back(valid);
+
+  ObjectTileLayout::Cell invalid;
+  invalid.tile_info = gfx::TileInfo(0x234, 4, false, true, false);
+  invalid.write_index = 8;
+  invalid.modified = true;
+  layout.cells.push_back(invalid);
+
+  const auto original = rom.vector();
+  const bool original_dirty = rom.dirty();
+  const absl::Status status = editor.WriteBack(layout);
+
+  EXPECT_TRUE(absl::IsOutOfRange(status));
+  EXPECT_EQ(rom.vector(), original);
+  EXPECT_EQ(rom.dirty(), original_dirty);
+}
+
+TEST(ObjectTileEditorTest, ApplyStandardWritePlanRollsBackWhenLaterWriteFails) {
+  Rom rom;
+  ASSERT_TRUE(rom.LoadFromData(std::vector<uint8_t>(0x40, 0x5A)).ok());
+
+  ObjectTileEditor editor(&rom);
+  ObjectTileLayout layout;
+  layout.tile_data_address = 0x10;
+  layout.is_custom = false;
+  for (int index = 0; index < 2; ++index) {
+    ObjectTileLayout::Cell cell;
+    cell.tile_info = gfx::TileInfo(static_cast<uint16_t>(0x120 + index), 3,
+                                   false, false, false);
+    cell.write_index = index;
+    cell.modified = true;
+    layout.cells.push_back(cell);
+  }
+
+  auto plan_or = editor.BuildStandardWritePlan(layout);
+  ASSERT_TRUE(plan_or.ok()) << plan_or.status();
+
+  rom::WriteFence fence;
+  ASSERT_TRUE(fence.Allow(0x10, 0x12, "first object tile word").ok());
+  rom::ScopedWriteFence fence_scope(&rom, &fence);
+
+  const auto original = rom.vector();
+  const bool original_dirty = rom.dirty();
+  const absl::Status status = editor.ApplyStandardWritePlan(*plan_or);
+
+  EXPECT_TRUE(absl::IsPermissionDenied(status));
+  EXPECT_EQ(rom.vector(), original);
+  EXPECT_EQ(rom.dirty(), original_dirty);
 }
 
 TEST(ObjectTileEditorTest, RenderLayoutToBitmapUsesThirdPaletteWhenAvailable) {


### PR DESCRIPTION
## Summary
- precompute exact standard-object tile write entries and half-open ROM ranges
- require explicit editable source indices; never infer ROM offsets from UI cell positions
- validate every full word before mutation and apply through a rollback-capable transaction
- preflight Object Tile Editor Apply against the active project Hack Manifest using live editor dependencies
- preserve ROM bytes, dirty state, and modified-cell retry state on blocked or failed writes

## Verification
- synced onto merged `master` (`6977dc4bbef46c452f0aad29e8031857632902b3`)
- `cmake --build build/presets/mac-ai --config Debug --target yaze_test_unit -j8`
- `yaze_test_unit --gtest_filter='ObjectTileEditorTest.*:ObjectTileEditorPanelTest.*'` (34/34 at head `8c3c1660ee2912418fb0a9d82f1ac3652960c8e4`)
- `scripts/pre-push.sh --build-dir build/presets/mac-ai` (build, 13/13 smoke tests, formatting; change-aware UI step skipped)
- `git diff --check origin/master...HEAD`

## Scope
Standard ROM-backed object-tile write hardening only. Custom `.bin` serialization is unchanged. Standard-object editing remains unexposed: source provenance, overlap detection, and cache/placement-ghost invalidation must land before wiring a live selector action.

Based directly on `master`; no remaining stacked dependency.
