### PR TITLE
Require provenance for dungeon object tile writes

### DIFF
--- a/src/app/editor/dungeon/ui/window/object_tile_editor_panel.cc
+++ b/src/app/editor/dungeon/ui/window/object_tile_editor_panel.cc
@@ -532,8 +532,9 @@ absl::Status ObjectTileEditorPanel::WriteBackCurrentLayout() {
   }
 
   const auto& plan = *plan_or;
-  if (standard_write_preflight_ && !plan.write_ranges.empty()) {
-    const absl::Status preflight = standard_write_preflight_(plan.write_ranges);
+  if (standard_write_preflight_ && !plan.write_ranges().empty()) {
+    const absl::Status preflight =
+        standard_write_preflight_(plan.write_ranges());
     if (!preflight.ok()) {
       return preflight;
     }

--- a/src/zelda3/dungeon/object_tile_editor.cc
+++ b/src/zelda3/dungeon/object_tile_editor.cc
@@ -60,6 +60,21 @@ int ResolvePaletteIndex(const gfx::PaletteGroup& palette, int requested) {
 
 constexpr std::array<int16_t, 2> kEditableStandardObjectIds = {0x11F, 0x120};
 constexpr size_t kFixed2x2SourceWordCount = 4;
+// The subtype tile-descriptor and routine-pointer tables are contiguous from
+// the first Type-1 descriptor through the two 128-word Type-3 tables. None of
+// this metadata is tile data, so an audited object source must never alias it.
+constexpr int64_t kObjectMetadataStart = kRoomObjectSubtype1;
+constexpr int64_t kObjectMetadataEnd = kRoomObjectSubtype3 + 0x200;
+
+bool RangesOverlap(int64_t lhs_start, int64_t lhs_end, int64_t rhs_start,
+                   int64_t rhs_end) {
+  return lhs_start < rhs_end && rhs_start < lhs_end;
+}
+
+bool WordRangesOverlap(int64_t lhs_address, int64_t rhs_address) {
+  return RangesOverlap(lhs_address, lhs_address + 2, rhs_address,
+                       rhs_address + 2);
+}
 
 absl::StatusOr<size_t> ResolveFixed2x2SourceWordIndex(
     const ObjectTileLayout::Cell& cell) {
@@ -307,22 +322,6 @@ absl::StatusOr<ObjectTileLayout> ObjectTileEditor::CaptureEditableObjectLayout(
     return absl::FailedPreconditionError("ROM not loaded");
   }
 
-  auto layout_or = CaptureObjectLayout(object_id, room, palette);
-  if (!layout_or.ok()) {
-    return layout_or.status();
-  }
-  ObjectTileLayout layout = std::move(*layout_or);
-  if (layout.is_custom) {
-    return absl::FailedPreconditionError(
-        "Custom objects do not use standard ROM source provenance");
-  }
-  if (layout.object_id != object_id ||
-      layout.cells.size() != kFixed2x2SourceWordCount ||
-      layout.bounds_width != 2 || layout.bounds_height != 2) {
-    return absl::FailedPreconditionError(
-        "Object draw does not match the audited fixed 2x2 layout");
-  }
-
   const uint32_t descriptor_pc_address =
       static_cast<uint32_t>(kRoomObjectSubtype2 + (object_id - 0x100) * 2);
   auto descriptor_or = rom_->ReadWord(static_cast<int>(descriptor_pc_address));
@@ -338,6 +337,30 @@ absl::StatusOr<ObjectTileLayout> ObjectTileEditor::CaptureEditableObjectLayout(
       source_address > std::numeric_limits<int>::max()) {
     return absl::OutOfRangeError(
         "Editable object tile source is outside the loaded ROM");
+  }
+  const int64_t source_end =
+      source_address + static_cast<int64_t>(kFixed2x2SourceWordCount * 2);
+  if (RangesOverlap(source_address, source_end, kObjectMetadataStart,
+                    kObjectMetadataEnd)) {
+    return absl::FailedPreconditionError(
+        "Editable object tile source overlaps object descriptor or routine "
+        "metadata");
+  }
+
+  auto layout_or = CaptureObjectLayout(object_id, room, palette);
+  if (!layout_or.ok()) {
+    return layout_or.status();
+  }
+  ObjectTileLayout layout = std::move(*layout_or);
+  if (layout.is_custom) {
+    return absl::FailedPreconditionError(
+        "Custom objects do not use standard ROM source provenance");
+  }
+  if (layout.object_id != object_id ||
+      layout.cells.size() != kFixed2x2SourceWordCount ||
+      layout.bounds_width != 2 || layout.bounds_height != 2) {
+    return absl::FailedPreconditionError(
+        "Object draw does not match the audited fixed 2x2 layout");
   }
 
   ObjectTileSourceSpan span;
@@ -606,19 +629,33 @@ absl::StatusOr<ObjectTileWritePlan> ObjectTileEditor::BuildStandardWritePlan(
         "Object tile source span is outside the loaded ROM");
   }
 
-  std::unordered_set<int> precondition_addresses;
+  const int64_t span_start = static_cast<int64_t>(span.pc_address);
+  const int64_t span_end =
+      span_start + static_cast<int64_t>(span.expected_words.size() * 2);
+  if (RangesOverlap(span_start, span_end, kObjectMetadataStart,
+                    kObjectMetadataEnd)) {
+    return absl::FailedPreconditionError(
+        "Object tile source span overlaps object descriptor or routine "
+        "metadata");
+  }
+
+  std::vector<int> precondition_addresses;
   const int descriptor_address =
       static_cast<int>(provenance.descriptor_pc_address);
-  precondition_addresses.insert(descriptor_address);
-  plan.preconditions.push_back(
+  precondition_addresses.push_back(descriptor_address);
+  plan.preconditions_.push_back(
       {descriptor_address, provenance.expected_descriptor_word});
   for (size_t word_index = 0; word_index < span.expected_words.size();
        ++word_index) {
     const int address = static_cast<int>(span.pc_address + word_index * 2);
-    if (!precondition_addresses.insert(address).second) {
+    if (std::any_of(precondition_addresses.begin(),
+                    precondition_addresses.end(), [&](int existing_address) {
+                      return WordRangesOverlap(existing_address, address);
+                    })) {
       return absl::FailedPreconditionError(
-          "Object tile descriptor and source preconditions alias");
+          "Object tile descriptor and source preconditions overlap");
     }
+    precondition_addresses.push_back(address);
     auto current_word_or = rom_->ReadWord(address);
     if (!current_word_or.ok()) {
       return current_word_or.status();
@@ -627,7 +664,7 @@ absl::StatusOr<ObjectTileWritePlan> ObjectTileEditor::BuildStandardWritePlan(
       return absl::FailedPreconditionError(
           "Object tile source word changed after capture");
     }
-    plan.preconditions.push_back({address, span.expected_words[word_index]});
+    plan.preconditions_.push_back({address, span.expected_words[word_index]});
   }
 
   if (layout.cells.size() != kFixed2x2SourceWordCount ||
@@ -691,9 +728,9 @@ absl::StatusOr<ObjectTileWritePlan> ObjectTileEditor::BuildStandardWritePlan(
       continue;
     }
 
-    plan.writes.push_back({address, expected_word, current_layout_word});
-    plan.write_ranges.emplace_back(static_cast<uint32_t>(address),
-                                   static_cast<uint32_t>(address + 2));
+    plan.writes_.push_back({address, expected_word, current_layout_word});
+    plan.write_ranges_.emplace_back(static_cast<uint32_t>(address),
+                                    static_cast<uint32_t>(address + 2));
   }
 
   return plan;
@@ -701,14 +738,14 @@ absl::StatusOr<ObjectTileWritePlan> ObjectTileEditor::BuildStandardWritePlan(
 
 absl::Status ObjectTileEditor::ApplyStandardWritePlan(
     const ObjectTileWritePlan& plan) {
-  if (plan.writes.empty()) {
+  if (plan.writes_.empty()) {
     return absl::OkStatus();
   }
-  if (plan.write_ranges.size() != plan.writes.size()) {
+  if (plan.write_ranges_.size() != plan.writes_.size()) {
     return absl::FailedPreconditionError(
         "Object tile write plan ranges do not match its writes");
   }
-  if (plan.preconditions.empty()) {
+  if (plan.preconditions_.empty()) {
     return absl::FailedPreconditionError(
         "Object tile write plan has no source provenance preconditions");
   }
@@ -718,12 +755,22 @@ absl::Status ObjectTileEditor::ApplyStandardWritePlan(
 
   const int64_t rom_size = static_cast<int64_t>(rom_->size());
   std::unordered_map<int, uint16_t> precondition_words;
-  for (const auto& precondition : plan.preconditions) {
+  std::vector<int> precondition_addresses;
+  for (const auto& precondition : plan.preconditions_) {
     const int64_t address = static_cast<int64_t>(precondition.address);
     if (address < 0 || address + 2 > rom_size) {
       return absl::OutOfRangeError(
           "Object tile precondition is outside the loaded ROM");
     }
+    if (std::any_of(precondition_addresses.begin(),
+                    precondition_addresses.end(), [&](int existing_address) {
+                      return WordRangesOverlap(existing_address,
+                                               precondition.address);
+                    })) {
+      return absl::FailedPreconditionError(
+          "Object tile plan has overlapping CAS preconditions");
+    }
+    precondition_addresses.push_back(precondition.address);
     if (!precondition_words
              .emplace(precondition.address, precondition.expected_word)
              .second) {
@@ -733,14 +780,23 @@ absl::Status ObjectTileEditor::ApplyStandardWritePlan(
   }
 
   std::unordered_set<int> write_addresses;
-  for (size_t write_index = 0; write_index < plan.writes.size();
+  std::vector<int> validated_write_addresses;
+  for (size_t write_index = 0; write_index < plan.writes_.size();
        ++write_index) {
-    const auto& write = plan.writes[write_index];
+    const auto& write = plan.writes_[write_index];
     const int64_t address = static_cast<int64_t>(write.address);
     if (address < 0 || address + 2 > rom_size) {
       return absl::OutOfRangeError(
           "Object tile write range is outside the loaded ROM");
     }
+    if (std::any_of(validated_write_addresses.begin(),
+                    validated_write_addresses.end(), [&](int existing_address) {
+                      return WordRangesOverlap(existing_address, write.address);
+                    })) {
+      return absl::FailedPreconditionError(
+          "Object tile plan has overlapping write ranges");
+    }
+    validated_write_addresses.push_back(write.address);
     if (!write_addresses.insert(write.address).second) {
       return absl::FailedPreconditionError(
           "Object tile plan has duplicate write addresses");
@@ -748,7 +804,7 @@ absl::Status ObjectTileEditor::ApplyStandardWritePlan(
     const std::pair<uint32_t, uint32_t> expected_range = {
         static_cast<uint32_t>(write.address),
         static_cast<uint32_t>(write.address + 2)};
-    if (plan.write_ranges[write_index] != expected_range) {
+    if (plan.write_ranges_[write_index] != expected_range) {
       return absl::FailedPreconditionError(
           "Object tile write plan range does not match its write address");
     }
@@ -762,7 +818,7 @@ absl::Status ObjectTileEditor::ApplyStandardWritePlan(
 
   // Recheck every captured descriptor/source word immediately before the
   // transaction. This is the compare-and-swap boundary for a prepared plan.
-  for (const auto& precondition : plan.preconditions) {
+  for (const auto& precondition : plan.preconditions_) {
     auto current_word_or = rom_->ReadWord(precondition.address);
     if (!current_word_or.ok()) {
       return current_word_or.status();
@@ -772,7 +828,7 @@ absl::Status ObjectTileEditor::ApplyStandardWritePlan(
           "Object tile source changed after the write plan was built");
     }
   }
-  for (const auto& write : plan.writes) {
+  for (const auto& write : plan.writes_) {
     auto current_word_or = rom_->ReadWord(write.address);
     if (!current_word_or.ok()) {
       return current_word_or.status();
@@ -785,7 +841,7 @@ absl::Status ObjectTileEditor::ApplyStandardWritePlan(
 
   const bool was_dirty = rom_->dirty();
   Transaction transaction(*rom_);
-  for (const auto& write : plan.writes) {
+  for (const auto& write : plan.writes_) {
     transaction.WriteWord(write.address, write.word);
   }
   const absl::Status status = transaction.Commit();

--- a/src/zelda3/dungeon/object_tile_editor.cc
+++ b/src/zelda3/dungeon/object_tile_editor.cc
@@ -1,11 +1,13 @@
 #include "zelda3/dungeon/object_tile_editor.h"
 
 #include <algorithm>
+#include <array>
 #include <cstring>
 #include <filesystem>
 #include <fstream>
 #include <limits>
 #include <unordered_map>
+#include <unordered_set>
 
 #include "app/gfx/types/snes_tile.h"
 #include "core/features.h"
@@ -54,6 +56,21 @@ int ResolvePaletteIndex(const gfx::PaletteGroup& palette, int requested) {
     return requested;
   }
   return 0;
+}
+
+constexpr std::array<int16_t, 2> kEditableStandardObjectIds = {0x11F, 0x120};
+constexpr size_t kFixed2x2SourceWordCount = 4;
+
+absl::StatusOr<size_t> ResolveFixed2x2SourceWordIndex(
+    const ObjectTileLayout::Cell& cell) {
+  if (cell.rel_x < 0 || cell.rel_x > 1 || cell.rel_y < 0 || cell.rel_y > 1) {
+    return absl::FailedPreconditionError(
+        "Editable object cell is outside the audited 2x2 layout");
+  }
+
+  // RoomDraw_Single2x2 consumes its four source words in column-major order:
+  // visual grid [0 2; 1 3].
+  return static_cast<size_t>(cell.rel_x * 2 + cell.rel_y);
 }
 
 }  // namespace
@@ -263,10 +280,110 @@ absl::StatusOr<ObjectTileLayout> ObjectTileEditor::CaptureObjectLayout(
 
   // Build layout from traces
   ObjectTileLayout layout = ObjectTileLayout::FromTraces(traces);
-  layout.tile_data_address = obj.tile_data_ptr_;
+  // A draw trace proves visual placement, not ROM source ownership. Keep
+  // generic captures preview-only even when RoomObject happens to expose a
+  // legacy tile-data pointer.
+  layout.tile_data_address = -1;
+  layout.source_provenance.reset();
   layout.is_custom = is_custom;
   layout.custom_filename = custom_filename;
 
+  return layout;
+}
+
+bool ObjectTileEditor::IsEditableStandardObject(int16_t object_id) {
+  return std::find(kEditableStandardObjectIds.begin(),
+                   kEditableStandardObjectIds.end(),
+                   object_id) != kEditableStandardObjectIds.end();
+}
+
+absl::StatusOr<ObjectTileLayout> ObjectTileEditor::CaptureEditableObjectLayout(
+    int16_t object_id, const Room& room, const gfx::PaletteGroup& palette) {
+  if (!IsEditableStandardObject(object_id)) {
+    return absl::UnimplementedError(
+        "Standard object tile editing is not supported for this object");
+  }
+  if (rom_ == nullptr || !rom_->is_loaded()) {
+    return absl::FailedPreconditionError("ROM not loaded");
+  }
+
+  auto layout_or = CaptureObjectLayout(object_id, room, palette);
+  if (!layout_or.ok()) {
+    return layout_or.status();
+  }
+  ObjectTileLayout layout = std::move(*layout_or);
+  if (layout.is_custom) {
+    return absl::FailedPreconditionError(
+        "Custom objects do not use standard ROM source provenance");
+  }
+  if (layout.object_id != object_id ||
+      layout.cells.size() != kFixed2x2SourceWordCount ||
+      layout.bounds_width != 2 || layout.bounds_height != 2) {
+    return absl::FailedPreconditionError(
+        "Object draw does not match the audited fixed 2x2 layout");
+  }
+
+  const uint32_t descriptor_pc_address =
+      static_cast<uint32_t>(kRoomObjectSubtype2 + (object_id - 0x100) * 2);
+  auto descriptor_or = rom_->ReadWord(static_cast<int>(descriptor_pc_address));
+  if (!descriptor_or.ok()) {
+    return descriptor_or.status();
+  }
+  const uint16_t descriptor_word = *descriptor_or;
+  const int64_t source_address =
+      static_cast<int64_t>(kRoomObjectTileAddress) + descriptor_word;
+  if (source_address < 0 ||
+      source_address + static_cast<int64_t>(kFixed2x2SourceWordCount * 2) >
+          static_cast<int64_t>(rom_->size()) ||
+      source_address > std::numeric_limits<int>::max()) {
+    return absl::OutOfRangeError(
+        "Editable object tile source is outside the loaded ROM");
+  }
+
+  ObjectTileSourceSpan span;
+  span.pc_address = static_cast<uint32_t>(source_address);
+  span.expected_words.reserve(kFixed2x2SourceWordCount);
+  for (size_t word_index = 0; word_index < kFixed2x2SourceWordCount;
+       ++word_index) {
+    auto word_or =
+        rom_->ReadWord(static_cast<int>(span.pc_address + word_index * 2));
+    if (!word_or.ok()) {
+      return word_or.status();
+    }
+    span.expected_words.push_back(*word_or);
+  }
+
+  std::array<bool, kFixed2x2SourceWordCount> mapped_words{};
+  for (auto& cell : layout.cells) {
+    auto source_word_index_or = ResolveFixed2x2SourceWordIndex(cell);
+    if (!source_word_index_or.ok()) {
+      return source_word_index_or.status();
+    }
+    const size_t source_word_index = *source_word_index_or;
+    if (mapped_words[source_word_index]) {
+      return absl::FailedPreconditionError(
+          "Editable object layout maps multiple cells to one source word");
+    }
+    if (cell.original_word != span.expected_words[source_word_index]) {
+      return absl::FailedPreconditionError(
+          "Draw trace does not match the resolved ROM source word");
+    }
+    mapped_words[source_word_index] = true;
+    cell.source_ref = ObjectTileSourceRef{/*span_index=*/0, source_word_index};
+  }
+  if (std::find(mapped_words.begin(), mapped_words.end(), false) !=
+      mapped_words.end()) {
+    return absl::FailedPreconditionError(
+        "Editable object layout does not cover every source word");
+  }
+
+  ObjectTileSourceProvenance provenance;
+  provenance.object_id = object_id;
+  provenance.descriptor_pc_address = descriptor_pc_address;
+  provenance.expected_descriptor_word = descriptor_word;
+  provenance.spans.push_back(std::move(span));
+  layout.tile_data_address = static_cast<int>(source_address);
+  layout.source_provenance = std::move(provenance);
   return layout;
 }
 
@@ -425,41 +542,158 @@ absl::StatusOr<ObjectTileWritePlan> ObjectTileEditor::BuildStandardWritePlan(
   }
 
   ObjectTileWritePlan plan;
-  if (!layout.HasModifications()) {
-    return plan;
-  }
   if (rom_ == nullptr || !rom_->is_loaded()) {
     return absl::FailedPreconditionError("ROM not loaded");
   }
-  if (layout.tile_data_address < 0) {
+  if (!layout.source_provenance.has_value()) {
     return absl::FailedPreconditionError(
-        "No tile data address for ROM write-back");
+        "Standard object layout has no editable source provenance");
+  }
+  if (!IsEditableStandardObject(layout.object_id)) {
+    return absl::UnimplementedError(
+        "Standard object tile editing is not supported for this object");
+  }
+
+  const auto& provenance = *layout.source_provenance;
+  if (provenance.object_id != layout.object_id) {
+    return absl::FailedPreconditionError(
+        "Object tile source provenance does not match the layout object");
+  }
+  const uint32_t expected_descriptor_address = static_cast<uint32_t>(
+      kRoomObjectSubtype2 + (layout.object_id - 0x100) * 2);
+  if (provenance.descriptor_pc_address != expected_descriptor_address) {
+    return absl::FailedPreconditionError(
+        "Object tile source descriptor address does not match the object");
+  }
+  if (provenance.spans.size() != 1 ||
+      provenance.spans.front().expected_words.size() !=
+          kFixed2x2SourceWordCount) {
+    return absl::FailedPreconditionError(
+        "Object tile source provenance does not match the audited source map");
   }
 
   const int64_t rom_size = static_cast<int64_t>(rom_->size());
-  for (size_t i = 0; i < layout.cells.size(); ++i) {
-    const auto& cell = layout.cells[i];
-    if (!cell.modified)
-      continue;
+  if (provenance.descriptor_pc_address >
+          static_cast<uint32_t>(std::numeric_limits<int>::max()) ||
+      static_cast<int64_t>(provenance.descriptor_pc_address) + 2 > rom_size) {
+    return absl::OutOfRangeError(
+        "Object tile source descriptor is outside the loaded ROM");
+  }
+  auto current_descriptor_or =
+      rom_->ReadWord(static_cast<int>(provenance.descriptor_pc_address));
+  if (!current_descriptor_or.ok()) {
+    return current_descriptor_or.status();
+  }
+  if (*current_descriptor_or != provenance.expected_descriptor_word) {
+    return absl::FailedPreconditionError(
+        "Object tile source descriptor changed after capture");
+  }
 
-    if (cell.write_index < 0) {
+  const auto& span = provenance.spans.front();
+  const int64_t expected_span_address =
+      static_cast<int64_t>(kRoomObjectTileAddress) +
+      provenance.expected_descriptor_word;
+  if (span.pc_address != expected_span_address) {
+    return absl::FailedPreconditionError(
+        "Object tile source span does not match its descriptor");
+  }
+  if (span.pc_address >
+          static_cast<uint32_t>(std::numeric_limits<int>::max()) ||
+      static_cast<int64_t>(span.pc_address) +
+              static_cast<int64_t>(span.expected_words.size() * 2) >
+          rom_size) {
+    return absl::OutOfRangeError(
+        "Object tile source span is outside the loaded ROM");
+  }
+
+  std::unordered_set<int> precondition_addresses;
+  const int descriptor_address =
+      static_cast<int>(provenance.descriptor_pc_address);
+  precondition_addresses.insert(descriptor_address);
+  plan.preconditions.push_back(
+      {descriptor_address, provenance.expected_descriptor_word});
+  for (size_t word_index = 0; word_index < span.expected_words.size();
+       ++word_index) {
+    const int address = static_cast<int>(span.pc_address + word_index * 2);
+    if (!precondition_addresses.insert(address).second) {
       return absl::FailedPreconditionError(
-          "Object tile cell has no editable source index");
+          "Object tile descriptor and source preconditions alias");
     }
-    const int64_t write_index = static_cast<int64_t>(cell.write_index);
-    const int64_t address =
-        static_cast<int64_t>(layout.tile_data_address) + write_index * 2;
-    const int64_t end = address + 2;
-    if (address < 0 || end > rom_size ||
-        address > std::numeric_limits<int>::max()) {
+    auto current_word_or = rom_->ReadWord(address);
+    if (!current_word_or.ok()) {
+      return current_word_or.status();
+    }
+    if (*current_word_or != span.expected_words[word_index]) {
+      return absl::FailedPreconditionError(
+          "Object tile source word changed after capture");
+    }
+    plan.preconditions.push_back({address, span.expected_words[word_index]});
+  }
+
+  if (layout.cells.size() != kFixed2x2SourceWordCount ||
+      layout.bounds_width != 2 || layout.bounds_height != 2) {
+    return absl::FailedPreconditionError(
+        "Object tile layout does not match the audited fixed 2x2 shape");
+  }
+
+  std::unordered_set<int> resolved_addresses;
+  for (const auto& cell : layout.cells) {
+    if (!cell.source_ref.has_value()) {
+      return absl::FailedPreconditionError(
+          "Object tile cell has no editable source reference");
+    }
+    const auto& source_ref = *cell.source_ref;
+    if (source_ref.span_index >= provenance.spans.size()) {
+      return absl::FailedPreconditionError(
+          "Object tile source span reference is out of bounds");
+    }
+    const auto& referenced_span = provenance.spans[source_ref.span_index];
+    if (source_ref.word_index >= referenced_span.expected_words.size()) {
+      return absl::FailedPreconditionError(
+          "Object tile source word reference is out of bounds");
+    }
+
+    auto expected_source_index_or = ResolveFixed2x2SourceWordIndex(cell);
+    if (!expected_source_index_or.ok()) {
+      return expected_source_index_or.status();
+    }
+    if (source_ref.span_index != 0 ||
+        source_ref.word_index != *expected_source_index_or) {
+      return absl::FailedPreconditionError(
+          "Object tile cell source reference does not match the audited map");
+    }
+
+    const int64_t address64 = static_cast<int64_t>(referenced_span.pc_address) +
+                              static_cast<int64_t>(source_ref.word_index) * 2;
+    if (address64 < 0 || address64 + 2 > rom_size ||
+        address64 > std::numeric_limits<int>::max()) {
       return absl::OutOfRangeError(
           "Object tile write range is outside the loaded ROM");
     }
+    const int address = static_cast<int>(address64);
+    if (!resolved_addresses.insert(address).second) {
+      return absl::FailedPreconditionError(
+          "Object tile cells resolve to a duplicate ROM address");
+    }
 
-    plan.writes.push_back(
-        {static_cast<int>(address), gfx::TileInfoToWord(cell.tile_info)});
+    const uint16_t expected_word =
+        referenced_span.expected_words[source_ref.word_index];
+    if (cell.original_word != expected_word) {
+      return absl::FailedPreconditionError(
+          "Object tile cell original word does not match its source");
+    }
+    const uint16_t current_layout_word = gfx::TileInfoToWord(cell.tile_info);
+    if (!cell.modified && current_layout_word != cell.original_word) {
+      return absl::FailedPreconditionError(
+          "Object tile cell changed without being marked modified");
+    }
+    if (!cell.modified) {
+      continue;
+    }
+
+    plan.writes.push_back({address, expected_word, current_layout_word});
     plan.write_ranges.emplace_back(static_cast<uint32_t>(address),
-                                   static_cast<uint32_t>(end));
+                                   static_cast<uint32_t>(address + 2));
   }
 
   return plan;
@@ -470,16 +704,82 @@ absl::Status ObjectTileEditor::ApplyStandardWritePlan(
   if (plan.writes.empty()) {
     return absl::OkStatus();
   }
+  if (plan.write_ranges.size() != plan.writes.size()) {
+    return absl::FailedPreconditionError(
+        "Object tile write plan ranges do not match its writes");
+  }
+  if (plan.preconditions.empty()) {
+    return absl::FailedPreconditionError(
+        "Object tile write plan has no source provenance preconditions");
+  }
   if (rom_ == nullptr || !rom_->is_loaded()) {
     return absl::FailedPreconditionError("ROM not loaded");
   }
 
   const int64_t rom_size = static_cast<int64_t>(rom_->size());
-  for (const auto& write : plan.writes) {
+  std::unordered_map<int, uint16_t> precondition_words;
+  for (const auto& precondition : plan.preconditions) {
+    const int64_t address = static_cast<int64_t>(precondition.address);
+    if (address < 0 || address + 2 > rom_size) {
+      return absl::OutOfRangeError(
+          "Object tile precondition is outside the loaded ROM");
+    }
+    if (!precondition_words
+             .emplace(precondition.address, precondition.expected_word)
+             .second) {
+      return absl::FailedPreconditionError(
+          "Object tile plan has duplicate CAS preconditions");
+    }
+  }
+
+  std::unordered_set<int> write_addresses;
+  for (size_t write_index = 0; write_index < plan.writes.size();
+       ++write_index) {
+    const auto& write = plan.writes[write_index];
     const int64_t address = static_cast<int64_t>(write.address);
     if (address < 0 || address + 2 > rom_size) {
       return absl::OutOfRangeError(
           "Object tile write range is outside the loaded ROM");
+    }
+    if (!write_addresses.insert(write.address).second) {
+      return absl::FailedPreconditionError(
+          "Object tile plan has duplicate write addresses");
+    }
+    const std::pair<uint32_t, uint32_t> expected_range = {
+        static_cast<uint32_t>(write.address),
+        static_cast<uint32_t>(write.address + 2)};
+    if (plan.write_ranges[write_index] != expected_range) {
+      return absl::FailedPreconditionError(
+          "Object tile write plan range does not match its write address");
+    }
+    const auto precondition = precondition_words.find(write.address);
+    if (precondition == precondition_words.end() ||
+        precondition->second != write.expected_word) {
+      return absl::FailedPreconditionError(
+          "Object tile write has no matching source precondition");
+    }
+  }
+
+  // Recheck every captured descriptor/source word immediately before the
+  // transaction. This is the compare-and-swap boundary for a prepared plan.
+  for (const auto& precondition : plan.preconditions) {
+    auto current_word_or = rom_->ReadWord(precondition.address);
+    if (!current_word_or.ok()) {
+      return current_word_or.status();
+    }
+    if (*current_word_or != precondition.expected_word) {
+      return absl::FailedPreconditionError(
+          "Object tile source changed after the write plan was built");
+    }
+  }
+  for (const auto& write : plan.writes) {
+    auto current_word_or = rom_->ReadWord(write.address);
+    if (!current_word_or.ok()) {
+      return current_word_or.status();
+    }
+    if (*current_word_or != write.expected_word) {
+      return absl::FailedPreconditionError(
+          "Object tile write target changed after the plan was built");
     }
   }
 

--- a/src/zelda3/dungeon/object_tile_editor.h
+++ b/src/zelda3/dungeon/object_tile_editor.h
@@ -104,7 +104,8 @@ struct ObjectTileLayout {
  * The exact half-open PC ranges are derived from the same entries that are
  * applied, allowing callers to run Hack Manifest preflight before mutation.
  */
-struct ObjectTileWritePlan {
+class ObjectTileWritePlan {
+ public:
   struct Write {
     int address = -1;
     uint16_t expected_word = 0;
@@ -116,11 +117,29 @@ struct ObjectTileWritePlan {
     uint16_t expected_word = 0;
   };
 
-  std::vector<Write> writes;
+  ObjectTileWritePlan(const ObjectTileWritePlan&) = default;
+  ObjectTileWritePlan(ObjectTileWritePlan&&) noexcept = default;
+  ObjectTileWritePlan& operator=(const ObjectTileWritePlan&) = default;
+  ObjectTileWritePlan& operator=(ObjectTileWritePlan&&) noexcept = default;
+
+  const std::vector<Write>& writes() const { return writes_; }
+  const std::vector<WordPrecondition>& preconditions() const {
+    return preconditions_;
+  }
+  const std::vector<std::pair<uint32_t, uint32_t>>& write_ranges() const {
+    return write_ranges_;
+  }
+
+ private:
+  friend class ObjectTileEditor;
+
+  ObjectTileWritePlan() = default;
+
+  std::vector<Write> writes_;
   // Includes the pointer descriptor and every captured source word. Apply
   // rechecks these immediately before opening the transaction.
-  std::vector<WordPrecondition> preconditions;
-  std::vector<std::pair<uint32_t, uint32_t>> write_ranges;
+  std::vector<WordPrecondition> preconditions_;
+  std::vector<std::pair<uint32_t, uint32_t>> write_ranges_;
 };
 
 /**

--- a/src/zelda3/dungeon/object_tile_editor.h
+++ b/src/zelda3/dungeon/object_tile_editor.h
@@ -1,7 +1,9 @@
 #ifndef YAZE_ZELDA3_DUNGEON_OBJECT_TILE_EDITOR_H_
 #define YAZE_ZELDA3_DUNGEON_OBJECT_TILE_EDITOR_H_
 
+#include <cstddef>
 #include <cstdint>
+#include <optional>
 #include <string>
 #include <utility>
 #include <vector>
@@ -19,6 +21,35 @@ namespace yaze {
 namespace zelda3 {
 
 /**
+ * @brief One contiguous ROM-backed source span for an object's tile words.
+ */
+struct ObjectTileSourceSpan {
+  uint32_t pc_address = 0;
+  std::vector<uint16_t> expected_words;
+};
+
+/**
+ * @brief ROM descriptor and source snapshot authorizing an editable capture.
+ *
+ * Generic preview captures deliberately omit this structure. Only an
+ * object-specific resolver may attach provenance to a standard-object layout.
+ */
+struct ObjectTileSourceProvenance {
+  int16_t object_id = -1;
+  uint32_t descriptor_pc_address = 0;
+  uint16_t expected_descriptor_word = 0;
+  std::vector<ObjectTileSourceSpan> spans;
+};
+
+/**
+ * @brief A cell's exact word within an authorized source span.
+ */
+struct ObjectTileSourceRef {
+  size_t span_index = 0;
+  size_t word_index = 0;
+};
+
+/**
  * @brief Editable tile8 layout captured from an object's draw trace
  *
  * Built by running an object draw in trace_only mode and normalizing
@@ -34,8 +65,11 @@ struct ObjectTileLayout {
     int rel_y = 0;            // 0-based tile Y within bounding box
     gfx::TileInfo tile_info;  // Decomposed SNES tilemap word
     uint16_t original_word = 0;
-    // Original traced tile-data word index used for ROM write-back.
+    // Legacy name retained for preview/test compatibility. This is draw-trace
+    // order only and never authorizes a ROM write; draw order is not generally
+    // source order.
     int write_index = -1;
+    std::optional<ObjectTileSourceRef> source_ref;
     bool modified = false;
   };
 
@@ -43,7 +77,10 @@ struct ObjectTileLayout {
   int bounds_width = 0;   // Bounding box width in 8px tiles
   int bounds_height = 0;  // Bounding box height in 8px tiles
 
-  int tile_data_address = -1;  // ROM address for write-back
+  // Legacy display/shared-data metadata. Standard writes are authorized only
+  // by source_provenance + per-cell source_ref, never by this base address.
+  int tile_data_address = -1;
+  std::optional<ObjectTileSourceProvenance> source_provenance;
   bool is_custom = false;
   std::string custom_filename;
 
@@ -70,10 +107,19 @@ struct ObjectTileLayout {
 struct ObjectTileWritePlan {
   struct Write {
     int address = -1;
+    uint16_t expected_word = 0;
     uint16_t word = 0;
   };
 
+  struct WordPrecondition {
+    int address = -1;
+    uint16_t expected_word = 0;
+  };
+
   std::vector<Write> writes;
+  // Includes the pointer descriptor and every captured source word. Apply
+  // rechecks these immediately before opening the transaction.
+  std::vector<WordPrecondition> preconditions;
   std::vector<std::pair<uint32_t, uint32_t>> write_ranges;
 };
 
@@ -100,6 +146,14 @@ class ObjectTileEditor {
   absl::StatusOr<ObjectTileLayout> CaptureObjectLayout(
       int16_t object_id, const Room& room, const gfx::PaletteGroup& palette,
       uint8_t object_size);
+
+  // Capture a standard object with exact ROM source provenance. The initial
+  // fail-closed allowlist is intentionally limited to the two audited fixed
+  // 2x2 subtype-2 objects (0x11F and 0x120).
+  absl::StatusOr<ObjectTileLayout> CaptureEditableObjectLayout(
+      int16_t object_id, const Room& room, const gfx::PaletteGroup& palette);
+
+  static bool IsEditableStandardObject(int16_t object_id);
 
   // Render: draw layout to preview bitmap using room's gfx buffer
   absl::Status RenderLayoutToBitmap(const ObjectTileLayout& layout,

--- a/test/unit/editor/object_tile_editor_panel_test.cc
+++ b/test/unit/editor/object_tile_editor_panel_test.cc
@@ -235,11 +235,6 @@ struct ObjectTileEditorPanelTestAccess {
     return panel.current_layout_.cells.front().tile_info.palette_;
   }
 
-  static int FirstCellWriteIndex(const ObjectTileEditorPanel& panel) {
-    EXPECT_FALSE(panel.current_layout_.cells.empty());
-    return panel.current_layout_.cells.front().write_index;
-  }
-
   static int SharedTileDataUsageCount(const ObjectTileEditorPanel& panel) {
     return panel.GetSharedTileDataUsageCount();
   }

--- a/test/unit/editor/object_tile_editor_panel_test.cc
+++ b/test/unit/editor/object_tile_editor_panel_test.cc
@@ -2,6 +2,7 @@
 
 #include <chrono>
 #include <filesystem>
+#include <iterator>
 #include <optional>
 #include <string>
 #include <vector>
@@ -300,6 +301,52 @@ int ReadWordAt(const Rom& rom, int addr) {
   return static_cast<int>(low | (high << 8));
 }
 
+constexpr int16_t kEditableStandardObjectId = 0x11F;
+constexpr uint32_t kEditableDescriptorPcAddress = 0x842E;
+constexpr uint16_t kEditableDescriptorWord = 0x0E9A;
+constexpr uint32_t kEditableSourcePcAddress = 0x29EC;
+constexpr uint16_t kEditableSourceWords[] = {0x0DEE, 0x8DEE, 0x4DEE, 0xCDEE};
+
+void StoreWord(std::vector<uint8_t>& data, uint32_t address, uint16_t word) {
+  data[address] = static_cast<uint8_t>(word & 0xFF);
+  data[address + 1] = static_cast<uint8_t>(word >> 8);
+}
+
+std::vector<uint8_t> MakeEditableStandardObjectRomData() {
+  std::vector<uint8_t> data(0x200000, 0);
+  StoreWord(data, kEditableDescriptorPcAddress, kEditableDescriptorWord);
+  for (size_t index = 0; index < std::size(kEditableSourceWords); ++index) {
+    StoreWord(data, kEditableSourcePcAddress + index * 2,
+              kEditableSourceWords[index]);
+  }
+  return data;
+}
+
+absl::StatusOr<zelda3::ObjectTileLayout> CaptureEditableStandardLayout(
+    Rom& rom) {
+  zelda3::Room room(/*room_id=*/0, &rom, /*game_data=*/nullptr);
+  gfx::PaletteGroup palette;
+  zelda3::ObjectTileEditor editor(&rom);
+  return editor.CaptureEditableObjectLayout(kEditableStandardObjectId, room,
+                                            palette);
+}
+
+int FirstCellSourceAddress(const zelda3::ObjectTileLayout& layout) {
+  if (!layout.source_provenance.has_value() || layout.cells.empty() ||
+      !layout.cells.front().source_ref.has_value()) {
+    return -1;
+  }
+  const auto& provenance = *layout.source_provenance;
+  const auto& source_ref = *layout.cells.front().source_ref;
+  if (source_ref.span_index >= provenance.spans.size() ||
+      source_ref.word_index >=
+          provenance.spans[source_ref.span_index].expected_words.size()) {
+    return -1;
+  }
+  return static_cast<int>(provenance.spans[source_ref.span_index].pc_address +
+                          source_ref.word_index * 2);
+}
+
 std::string ManifestProtectingPcRange(uint32_t begin, uint32_t end) {
   return absl::StrFormat(
       R"json(
@@ -336,15 +383,12 @@ std::optional<int16_t> FindCapturableObjectId(Rom* rom, DungeonRoomStore* rooms,
 }
 
 void OpenInjectedSharedStandardObjectSession(ObjectTileEditorPanel& panel,
-                                             int16_t object_id) {
-  panel.OpenForObject(object_id, /*room_id=*/-1, nullptr);
+                                             Rom& rom) {
+  panel.OpenForObject(kEditableStandardObjectId, /*room_id=*/-1, nullptr);
 
-  auto layout = zelda3::ObjectTileLayout::CreateEmpty(
-      /*width=*/1, /*height=*/1, object_id, "shared.bin");
-  layout.is_custom = false;
-  layout.custom_filename.clear();
-  layout.tile_data_address = 0x1234;
-  ObjectTileEditorPanelTestAccess::SetLayout(panel, std::move(layout));
+  auto layout_or = CaptureEditableStandardLayout(rom);
+  ASSERT_TRUE(layout_or.ok()) << layout_or.status();
+  ObjectTileEditorPanelTestAccess::SetLayout(panel, std::move(*layout_or));
   ObjectTileEditorPanelTestAccess::SetSelectedCellIndex(panel, 0);
   ObjectTileEditorPanelTestAccess::SyncSourceSelectionFromSelectedCell(panel);
 }
@@ -598,30 +642,23 @@ TEST(ObjectTileEditorPanelTest,
 TEST(ObjectTileEditorPanelTest,
      ApplyChangesForSharedStandardObjectShowsConfirmationBeforeWriteback) {
   Rom rom;
-  ASSERT_TRUE(rom.LoadFromData(std::vector<uint8_t>(0x200000, 0)).ok());
+  ASSERT_TRUE(rom.LoadFromData(MakeEditableStandardObjectRomData()).ok());
 
   ObjectTileEditorPanel panel(nullptr, &rom);
-  auto layout = zelda3::ObjectTileLayout::CreateEmpty(
-      /*width=*/1, /*height=*/1, /*object_id=*/0x40, "shared.bin");
-  layout.is_custom = false;
-  layout.custom_filename.clear();
-  layout.tile_data_address = 0x1234;
-  ObjectTileEditorPanelTestAccess::SetLayout(panel, std::move(layout));
-  ObjectTileEditorPanelTestAccess::SetCurrentObjectId(panel,
-                                                      /*object_id=*/0x40);
+  auto layout_or = CaptureEditableStandardLayout(rom);
+  ASSERT_TRUE(layout_or.ok()) << layout_or.status();
+  ObjectTileEditorPanelTestAccess::SetLayout(panel, std::move(*layout_or));
+  ObjectTileEditorPanelTestAccess::SetCurrentObjectId(
+      panel, kEditableStandardObjectId);
   ObjectTileEditorPanelTestAccess::SetSharedTileDataUsageOverride(
       panel, /*shared_count=*/3);
 
   ASSERT_GT(ObjectTileEditorPanelTestAccess::SharedTileDataUsageCount(panel),
             1);
 
-  const int tile_data_address =
-      ObjectTileEditorPanelTestAccess::Layout(panel).tile_data_address;
-  const int write_index =
-      ObjectTileEditorPanelTestAccess::FirstCellWriteIndex(panel);
-  ASSERT_GE(tile_data_address, 0);
-  ASSERT_GE(write_index, -1);
-  const int write_addr = tile_data_address + write_index * 2;
+  const int write_addr =
+      FirstCellSourceAddress(ObjectTileEditorPanelTestAccess::Layout(panel));
+  ASSERT_GE(write_addr, 0);
   const int original_word = ReadWordAt(rom, write_addr);
 
   const uint16_t original_tile_id =
@@ -649,30 +686,23 @@ TEST(ObjectTileEditorPanelTest,
 TEST(ObjectTileEditorPanelTest,
      ApplyChangesWithoutConfirmationWritesSharedStandardObjectAndClearsModal) {
   Rom rom;
-  ASSERT_TRUE(rom.LoadFromData(std::vector<uint8_t>(0x200000, 0)).ok());
+  ASSERT_TRUE(rom.LoadFromData(MakeEditableStandardObjectRomData()).ok());
 
   ObjectTileEditorPanel panel(nullptr, &rom);
-  auto layout = zelda3::ObjectTileLayout::CreateEmpty(
-      /*width=*/1, /*height=*/1, /*object_id=*/0x40, "shared.bin");
-  layout.is_custom = false;
-  layout.custom_filename.clear();
-  layout.tile_data_address = 0x1234;
-  ObjectTileEditorPanelTestAccess::SetLayout(panel, std::move(layout));
-  ObjectTileEditorPanelTestAccess::SetCurrentObjectId(panel,
-                                                      /*object_id=*/0x40);
+  auto layout_or = CaptureEditableStandardLayout(rom);
+  ASSERT_TRUE(layout_or.ok()) << layout_or.status();
+  ObjectTileEditorPanelTestAccess::SetLayout(panel, std::move(*layout_or));
+  ObjectTileEditorPanelTestAccess::SetCurrentObjectId(
+      panel, kEditableStandardObjectId);
   ObjectTileEditorPanelTestAccess::SetSharedTileDataUsageOverride(
       panel, /*shared_count=*/3);
 
   ASSERT_GT(ObjectTileEditorPanelTestAccess::SharedTileDataUsageCount(panel),
             1);
 
-  const int tile_data_address =
-      ObjectTileEditorPanelTestAccess::Layout(panel).tile_data_address;
-  const int write_index =
-      ObjectTileEditorPanelTestAccess::FirstCellWriteIndex(panel);
-  ASSERT_GE(tile_data_address, 0);
-  ASSERT_GE(write_index, -1);
-  const int write_addr = tile_data_address + write_index * 2;
+  const int write_addr =
+      FirstCellSourceAddress(ObjectTileEditorPanelTestAccess::Layout(panel));
+  ASSERT_GE(write_addr, 0);
   const int original_word = ReadWordAt(rom, write_addr);
 
   const uint16_t original_tile_id =
@@ -713,19 +743,15 @@ TEST(ObjectTileEditorPanelTest,
 
 TEST(ObjectTileEditorPanelTest,
      ManifestBlockedApplyPreservesRomAndModifiedRetryState) {
-  constexpr uint32_t kTileDataAddress = 0x1234;
   Rom rom;
-  ASSERT_TRUE(rom.LoadFromData(std::vector<uint8_t>(0x200000, 0)).ok());
+  ASSERT_TRUE(rom.LoadFromData(MakeEditableStandardObjectRomData()).ok());
 
   ObjectTileEditorPanel panel(nullptr, &rom);
-  auto layout = zelda3::ObjectTileLayout::CreateEmpty(
-      /*width=*/1, /*height=*/1, /*object_id=*/0x40, "standard.bin");
-  layout.is_custom = false;
-  layout.custom_filename.clear();
-  layout.tile_data_address = kTileDataAddress;
-  ObjectTileEditorPanelTestAccess::SetLayout(panel, std::move(layout));
-  ObjectTileEditorPanelTestAccess::SetCurrentObjectId(panel,
-                                                      /*object_id=*/0x40);
+  auto layout_or = CaptureEditableStandardLayout(rom);
+  ASSERT_TRUE(layout_or.ok()) << layout_or.status();
+  ObjectTileEditorPanelTestAccess::SetLayout(panel, std::move(*layout_or));
+  ObjectTileEditorPanelTestAccess::SetCurrentObjectId(
+      panel, kEditableStandardObjectId);
   ObjectTileEditorPanelTestAccess::SetSharedTileDataUsageOverride(
       panel, /*shared_count=*/1);
   ObjectTileEditorPanelTestAccess::SetFirstCellTileAndPalette(
@@ -734,7 +760,7 @@ TEST(ObjectTileEditorPanelTest,
   project::YazeProject project;
   ASSERT_TRUE(project.hack_manifest
                   .LoadFromString(ManifestProtectingPcRange(
-                      kTileDataAddress, kTileDataAddress + 2))
+                      kEditableSourcePcAddress, kEditableSourcePcAddress + 2))
                   .ok());
   project.rom_metadata.write_policy = project::RomWritePolicy::kBlock;
 
@@ -756,8 +782,9 @@ TEST(ObjectTileEditorPanelTest,
                                                 /*confirm_shared=*/false);
 
   EXPECT_EQ(preflight_count, 1);
-  EXPECT_EQ(observed_ranges, (std::vector<std::pair<uint32_t, uint32_t>>{
-                                 {kTileDataAddress, kTileDataAddress + 2}}));
+  EXPECT_EQ(observed_ranges,
+            (std::vector<std::pair<uint32_t, uint32_t>>{
+                {kEditableSourcePcAddress, kEditableSourcePcAddress + 2}}));
   EXPECT_EQ(rom.vector(), original);
   EXPECT_EQ(rom.dirty(), original_dirty);
   EXPECT_TRUE(ObjectTileEditorPanelTestAccess::HasModifications(panel));
@@ -778,19 +805,15 @@ TEST(ObjectTileEditorPanelTest,
 }
 
 TEST(ObjectTileEditorPanelTest, UnrelatedManifestRangeAllowsStandardApply) {
-  constexpr uint32_t kTileDataAddress = 0x1234;
   Rom rom;
-  ASSERT_TRUE(rom.LoadFromData(std::vector<uint8_t>(0x200000, 0)).ok());
+  ASSERT_TRUE(rom.LoadFromData(MakeEditableStandardObjectRomData()).ok());
 
   ObjectTileEditorPanel panel(nullptr, &rom);
-  auto layout = zelda3::ObjectTileLayout::CreateEmpty(
-      /*width=*/1, /*height=*/1, /*object_id=*/0x40, "standard.bin");
-  layout.is_custom = false;
-  layout.custom_filename.clear();
-  layout.tile_data_address = kTileDataAddress;
-  ObjectTileEditorPanelTestAccess::SetLayout(panel, std::move(layout));
-  ObjectTileEditorPanelTestAccess::SetCurrentObjectId(panel,
-                                                      /*object_id=*/0x40);
+  auto layout_or = CaptureEditableStandardLayout(rom);
+  ASSERT_TRUE(layout_or.ok()) << layout_or.status();
+  ObjectTileEditorPanelTestAccess::SetLayout(panel, std::move(*layout_or));
+  ObjectTileEditorPanelTestAccess::SetCurrentObjectId(
+      panel, kEditableStandardObjectId);
   ObjectTileEditorPanelTestAccess::SetSharedTileDataUsageOverride(
       panel, /*shared_count=*/1);
   ObjectTileEditorPanelTestAccess::SetFirstCellTileAndPalette(
@@ -812,32 +835,31 @@ TEST(ObjectTileEditorPanelTest, UnrelatedManifestRangeAllowsStandardApply) {
             /*toast_manager=*/nullptr);
       });
 
-  const int original_word = ReadWordAt(rom, kTileDataAddress);
+  const int original_word = ReadWordAt(rom, kEditableSourcePcAddress);
   ObjectTileEditorPanelTestAccess::ApplyChanges(panel,
                                                 /*confirm_shared=*/false);
 
   EXPECT_EQ(preflight_count, 1);
   EXPECT_FALSE(ObjectTileEditorPanelTestAccess::HasModifications(panel));
-  EXPECT_NE(ReadWordAt(rom, kTileDataAddress), original_word);
+  EXPECT_NE(ReadWordAt(rom, kEditableSourcePcAddress), original_word);
   EXPECT_FALSE(ObjectTileEditorPanelTestAccess::ActionStatusIsError(panel));
 }
 
 TEST(ObjectTileEditorPanelTest,
      SharedGuardedApplyCanWarnAgainAfterCloseAndReopen) {
   Rom rom;
-  ASSERT_TRUE(rom.LoadFromData(std::vector<uint8_t>(0x200000, 0)).ok());
+  ASSERT_TRUE(rom.LoadFromData(MakeEditableStandardObjectRomData()).ok());
 
   ObjectTileEditorPanel panel(nullptr, &rom);
-  OpenInjectedSharedStandardObjectSession(panel, /*object_id=*/0x40);
+  OpenInjectedSharedStandardObjectSession(panel, rom);
   ASSERT_TRUE(panel.IsOpen());
   ASSERT_TRUE(ObjectTileEditorPanelTestAccess::HasLayout(panel));
 
   ObjectTileEditorPanelTestAccess::SetSharedTileDataUsageOverride(
       panel, /*shared_count=*/3);
   const auto first_layout = ObjectTileEditorPanelTestAccess::Layout(panel);
-  const int first_write_addr =
-      first_layout.tile_data_address +
-      ObjectTileEditorPanelTestAccess::FirstCellWriteIndex(panel) * 2;
+  const int first_write_addr = FirstCellSourceAddress(first_layout);
+  ASSERT_GE(first_write_addr, 0);
   const int first_original_word = ReadWordAt(rom, first_write_addr);
   const uint16_t first_tile_id =
       ObjectTileEditorPanelTestAccess::FirstCellTileId(panel);
@@ -860,7 +882,7 @@ TEST(ObjectTileEditorPanelTest,
   EXPECT_FALSE(ObjectTileEditorPanelTestAccess::ShowSharedConfirm(panel));
   EXPECT_FALSE(ObjectTileEditorPanelTestAccess::HasActionStatus(panel));
 
-  OpenInjectedSharedStandardObjectSession(panel, /*object_id=*/0x40);
+  OpenInjectedSharedStandardObjectSession(panel, rom);
   ASSERT_TRUE(panel.IsOpen());
   ASSERT_TRUE(ObjectTileEditorPanelTestAccess::HasLayout(panel));
   EXPECT_EQ(ObjectTileEditorPanelTestAccess::SelectedCellIndex(panel), 0);
@@ -874,9 +896,8 @@ TEST(ObjectTileEditorPanelTest,
   ObjectTileEditorPanelTestAccess::SetSharedTileDataUsageOverride(
       panel, /*shared_count=*/3);
   const auto reopened_layout = ObjectTileEditorPanelTestAccess::Layout(panel);
-  const int reopened_write_addr =
-      reopened_layout.tile_data_address +
-      ObjectTileEditorPanelTestAccess::FirstCellWriteIndex(panel) * 2;
+  const int reopened_write_addr = FirstCellSourceAddress(reopened_layout);
+  ASSERT_GE(reopened_write_addr, 0);
   const int reopened_original_word = ReadWordAt(rom, reopened_write_addr);
   const uint16_t reopened_tile_id =
       ObjectTileEditorPanelTestAccess::FirstCellTileId(panel);

--- a/test/unit/zelda3/dungeon/object_tile_editor_test.cc
+++ b/test/unit/zelda3/dungeon/object_tile_editor_test.cc
@@ -5,6 +5,7 @@
 #include <filesystem>
 #include <fstream>
 #include <string>
+#include <type_traits>
 #include <vector>
 
 #include <gtest/gtest.h>
@@ -401,6 +402,39 @@ TEST(ObjectTileEditorTest, EditableCaptureRejectsUnsupportedStandardObject) {
 }
 
 TEST(ObjectTileEditorTest,
+     EditableCaptureRejectsSourcesOverlappingObjectMetadata) {
+  ScopedCustomObjectsDisabled disable_custom_objects;
+
+  for (const uint32_t source_address :
+       {static_cast<uint32_t>(0x7FF9), static_cast<uint32_t>(0x8000),
+        static_cast<uint32_t>(0x842F), static_cast<uint32_t>(0x8432),
+        static_cast<uint32_t>(0x8470), static_cast<uint32_t>(0x84F0),
+        static_cast<uint32_t>(0x86EF)}) {
+    SCOPED_TRACE(::testing::Message()
+                 << "source_address=0x" << std::hex << source_address);
+    Rom rom;
+    auto data = MakeEditableObjectRomData();
+    StoreWord(data, /*address=*/0x842E,
+              static_cast<uint16_t>(source_address - 0x1B52));
+    ASSERT_TRUE(rom.LoadFromData(data).ok());
+
+    Room room(/*room_id=*/0, &rom, /*game_data=*/nullptr);
+    gfx::PaletteGroup palette;
+    ObjectTileEditor editor(&rom);
+    const auto original = rom.vector();
+    const bool original_dirty = rom.dirty();
+
+    const auto layout_or =
+        editor.CaptureEditableObjectLayout(0x11F, room, palette);
+    EXPECT_TRUE(absl::IsFailedPrecondition(layout_or.status()));
+    EXPECT_NE(std::string(layout_or.status().message()).find("overlaps"),
+              std::string::npos);
+    EXPECT_EQ(rom.vector(), original);
+    EXPECT_EQ(rom.dirty(), original_dirty);
+  }
+}
+
+TEST(ObjectTileEditorTest,
      EditableCapturePinsDescriptorsSpansAndColumnMajorSourceMap) {
   ScopedCustomObjectsDisabled disable_custom_objects;
   Rom rom;
@@ -546,49 +580,54 @@ TEST(ObjectTileEditorTest,
 
   const auto plan_or = editor.BuildStandardWritePlan(*layout_or);
   ASSERT_TRUE(absl::IsFailedPrecondition(plan_or.status()));
-  EXPECT_NE(std::string(plan_or.status().message()).find("alias"),
+  EXPECT_NE(std::string(plan_or.status().message()).find("overlap"),
             std::string::npos);
 }
 
 TEST(ObjectTileEditorTest,
-     ApplyStandardWritePlanRejectsForgedRangesAndCASBeforeMutation) {
-  Rom rom;
-  ASSERT_TRUE(rom.LoadFromData(std::vector<uint8_t>(0x200000, 0)).ok());
-  ObjectTileEditor editor(&rom);
+     BuildStandardWritePlanRejectsSourcesOverlappingObjectMetadata) {
+  ScopedCustomObjectsDisabled disable_custom_objects;
 
-  ObjectTileWritePlan plan;
-  plan.writes.push_back(
-      {/*address=*/0x1000, /*expected_word=*/0, /*word=*/0x1234});
-  plan.write_ranges.push_back({0x1002, 0x1004});
-  plan.preconditions.push_back({/*address=*/0x1000, /*expected_word=*/0});
-  const auto original = rom.vector();
-  const bool original_dirty = rom.dirty();
+  for (const uint32_t source_address :
+       {static_cast<uint32_t>(0x7FF9), static_cast<uint32_t>(0x8000),
+        static_cast<uint32_t>(0x842F), static_cast<uint32_t>(0x8432),
+        static_cast<uint32_t>(0x8470), static_cast<uint32_t>(0x84F0),
+        static_cast<uint32_t>(0x86EF)}) {
+    SCOPED_TRACE(::testing::Message()
+                 << "source_address=0x" << std::hex << source_address);
+    Rom rom;
+    ASSERT_TRUE(rom.LoadFromData(MakeEditableObjectRomData()).ok());
+    Room room(/*room_id=*/0, &rom, /*game_data=*/nullptr);
+    gfx::PaletteGroup palette;
+    ObjectTileEditor editor(&rom);
+    auto layout_or = editor.CaptureEditableObjectLayout(0x11F, room, palette);
+    ASSERT_TRUE(layout_or.ok()) << layout_or.status();
+    ASSERT_TRUE(layout_or->source_provenance.has_value());
 
-  EXPECT_TRUE(absl::IsFailedPrecondition(editor.ApplyStandardWritePlan(plan)));
-  EXPECT_EQ(rom.vector(), original);
-  EXPECT_EQ(rom.dirty(), original_dirty);
+    const uint16_t descriptor_word =
+        static_cast<uint16_t>(source_address - 0x1B52);
+    auto& provenance = *layout_or->source_provenance;
+    provenance.expected_descriptor_word = descriptor_word;
+    ASSERT_EQ(provenance.spans.size(), 1u);
+    provenance.spans[0].pc_address = source_address;
+    StoreWordWithoutDirtying(rom, provenance.descriptor_pc_address,
+                             descriptor_word);
+    const auto original = rom.vector();
+    const bool original_dirty = rom.dirty();
 
-  plan.write_ranges[0] = {0x1000, 0x1002};
-  plan.preconditions.clear();
-  EXPECT_TRUE(absl::IsFailedPrecondition(editor.ApplyStandardWritePlan(plan)));
-  EXPECT_EQ(rom.vector(), original);
-  EXPECT_EQ(rom.dirty(), original_dirty);
+    const auto plan_or = editor.BuildStandardWritePlan(*layout_or);
+    EXPECT_TRUE(absl::IsFailedPrecondition(plan_or.status()));
+    EXPECT_NE(std::string(plan_or.status().message()).find("overlaps"),
+              std::string::npos);
+    EXPECT_EQ(rom.vector(), original);
+    EXPECT_EQ(rom.dirty(), original_dirty);
+  }
+}
 
-  plan.preconditions.push_back({/*address=*/0x1002, /*expected_word=*/0});
-  EXPECT_TRUE(absl::IsFailedPrecondition(editor.ApplyStandardWritePlan(plan)));
-  EXPECT_EQ(rom.vector(), original);
-  EXPECT_EQ(rom.dirty(), original_dirty);
-
-  plan.preconditions = {{/*address=*/0x1000, /*expected_word=*/0},
-                        {/*address=*/0x1000, /*expected_word=*/0}};
-  EXPECT_TRUE(absl::IsFailedPrecondition(editor.ApplyStandardWritePlan(plan)));
-  EXPECT_EQ(rom.vector(), original);
-  EXPECT_EQ(rom.dirty(), original_dirty);
-
-  plan.preconditions = {{/*address=*/0x1000, /*expected_word=*/1}};
-  EXPECT_TRUE(absl::IsFailedPrecondition(editor.ApplyStandardWritePlan(plan)));
-  EXPECT_EQ(rom.vector(), original);
-  EXPECT_EQ(rom.dirty(), original_dirty);
+TEST(ObjectTileEditorTest, StandardWritePlansAreOpaqueAndBuilderOwned) {
+  static_assert(!std::is_aggregate_v<ObjectTileWritePlan>);
+  static_assert(!std::is_default_constructible_v<ObjectTileWritePlan>);
+  SUCCEED();
 }
 
 TEST(ObjectTileEditorTest,
@@ -650,20 +689,20 @@ TEST(ObjectTileEditorTest, StandardWritePlanUsesExactWritesAndReadback) {
 
   auto plan_or = editor.BuildStandardWritePlan(*layout_or);
   ASSERT_TRUE(plan_or.ok()) << plan_or.status();
-  ASSERT_EQ(plan_or->preconditions.size(), 5u);
-  EXPECT_EQ(plan_or->preconditions[0].address, 0x842E);
-  EXPECT_EQ(plan_or->preconditions[0].expected_word, 0x0E9A);
-  ASSERT_EQ(plan_or->writes.size(), 2u);
-  ASSERT_EQ(plan_or->write_ranges.size(), 2u);
-  EXPECT_EQ(plan_or->writes[0].address, 0x29EC);
-  EXPECT_EQ(plan_or->writes[0].expected_word, 0x0DEE);
-  EXPECT_EQ(plan_or->writes[0].word, top_left_word);
-  EXPECT_EQ(plan_or->write_ranges[0],
+  ASSERT_EQ(plan_or->preconditions().size(), 5u);
+  EXPECT_EQ(plan_or->preconditions()[0].address, 0x842E);
+  EXPECT_EQ(plan_or->preconditions()[0].expected_word, 0x0E9A);
+  ASSERT_EQ(plan_or->writes().size(), 2u);
+  ASSERT_EQ(plan_or->write_ranges().size(), 2u);
+  EXPECT_EQ(plan_or->writes()[0].address, 0x29EC);
+  EXPECT_EQ(plan_or->writes()[0].expected_word, 0x0DEE);
+  EXPECT_EQ(plan_or->writes()[0].word, top_left_word);
+  EXPECT_EQ(plan_or->write_ranges()[0],
             (std::pair<uint32_t, uint32_t>{0x29EC, 0x29EE}));
-  EXPECT_EQ(plan_or->writes[1].address, 0x29F2);
-  EXPECT_EQ(plan_or->writes[1].expected_word, 0xCDEE);
-  EXPECT_EQ(plan_or->writes[1].word, bottom_right_word);
-  EXPECT_EQ(plan_or->write_ranges[1],
+  EXPECT_EQ(plan_or->writes()[1].address, 0x29F2);
+  EXPECT_EQ(plan_or->writes()[1].expected_word, 0xCDEE);
+  EXPECT_EQ(plan_or->writes()[1].word, bottom_right_word);
+  EXPECT_EQ(plan_or->write_ranges()[1],
             (std::pair<uint32_t, uint32_t>{0x29F2, 0x29F4}));
 
   auto expected_rom = rom.vector();
@@ -746,7 +785,7 @@ TEST(ObjectTileEditorTest, ApplyStandardWritePlanRollsBackAndPreservesDirty) {
 
   auto plan_or = editor.BuildStandardWritePlan(*layout_or);
   ASSERT_TRUE(plan_or.ok()) << plan_or.status();
-  ASSERT_EQ(plan_or->writes.size(), 2u);
+  ASSERT_EQ(plan_or->writes().size(), 2u);
 
   rom::WriteFence fence;
   ASSERT_TRUE(fence.Allow(0x29EC, 0x29EE, "first object tile word").ok());

--- a/test/unit/zelda3/dungeon/object_tile_editor_test.cc
+++ b/test/unit/zelda3/dungeon/object_tile_editor_test.cc
@@ -1,8 +1,10 @@
 #include "zelda3/dungeon/object_tile_editor.h"
 
+#include <array>
 #include <chrono>
 #include <filesystem>
 #include <fstream>
+#include <string>
 #include <vector>
 
 #include <gtest/gtest.h>
@@ -39,6 +41,63 @@ gfx::PaletteGroup MakeTestPaletteGroup() {
 
   return group;
 }
+
+struct EditableObjectFixture {
+  int16_t object_id;
+  uint32_t descriptor_pc_address;
+  uint16_t descriptor_word;
+  uint32_t source_pc_address;
+  std::array<uint16_t, 4> source_words;
+};
+
+constexpr std::array<EditableObjectFixture, 2> kEditableObjectFixtures = {{
+    {/*object_id=*/0x11F,
+     /*descriptor_pc_address=*/0x842E,
+     /*descriptor_word=*/0x0E9A,
+     /*source_pc_address=*/0x29EC,
+     /*source_words=*/{0x0DEE, 0x8DEE, 0x4DEE, 0xCDEE}},
+    {/*object_id=*/0x120,
+     /*descriptor_pc_address=*/0x8430,
+     /*descriptor_word=*/0x0ECA,
+     /*source_pc_address=*/0x2A1C,
+     /*source_words=*/{0x0DC0, 0x0DC1, 0x4DC0, 0x4DC1}},
+}};
+
+void StoreWord(std::vector<uint8_t>& data, uint32_t address, uint16_t word) {
+  data[address] = static_cast<uint8_t>(word & 0xFF);
+  data[address + 1] = static_cast<uint8_t>(word >> 8);
+}
+
+std::vector<uint8_t> MakeEditableObjectRomData() {
+  std::vector<uint8_t> data(0x200000, 0);
+  for (const auto& fixture : kEditableObjectFixtures) {
+    StoreWord(data, fixture.descriptor_pc_address, fixture.descriptor_word);
+    for (size_t index = 0; index < fixture.source_words.size(); ++index) {
+      StoreWord(data, fixture.source_pc_address + index * 2,
+                fixture.source_words[index]);
+    }
+  }
+  return data;
+}
+
+void StoreWordWithoutDirtying(Rom& rom, uint32_t address, uint16_t word) {
+  StoreWord(rom.mutable_vector(), address, word);
+}
+
+class ScopedCustomObjectsDisabled {
+ public:
+  ScopedCustomObjectsDisabled()
+      : previous_(core::FeatureFlags::get().kEnableCustomObjects) {
+    core::FeatureFlags::get().kEnableCustomObjects = false;
+  }
+
+  ~ScopedCustomObjectsDisabled() {
+    core::FeatureFlags::get().kEnableCustomObjects = previous_;
+  }
+
+ private:
+  bool previous_;
+};
 
 // Pins ObjectTileEditor::CaptureObjectLayout against the canonical
 // ObjectGeometry bounds for routines that draw upward or leftward. The
@@ -293,180 +352,404 @@ TEST(ObjectTileLayoutTest, CreateEmptyBuildsCustomModifiedGrid) {
   EXPECT_EQ(layout.FindCell(1, 2)->rel_y, 2);
 }
 
-TEST(ObjectTileEditorTest, StandardObjectWriteBackRoundtrip) {
-  Rom rom;
-  ASSERT_TRUE(rom.LoadFromData(std::vector<uint8_t>(0x200000, 0)).ok());
-
-  ObjectTileEditor editor(&rom);
-  ObjectTileLayout layout;
-  layout.tile_data_address = 0x1000;
-  layout.is_custom = false;
-
-  ObjectTileLayout::Cell cell;
-  cell.tile_info = gfx::TileInfo(0x123, 3, true, false, true);
-  cell.original_word = 0;
-  cell.write_index = 0;
-  cell.modified = true;
-  layout.cells.push_back(cell);
-
-  ASSERT_TRUE(editor.WriteBack(layout).ok());
-
-  uint8_t low = rom.ReadByte(0x1000).value();
-  uint8_t high = rom.ReadByte(0x1001).value();
-  uint16_t word = static_cast<uint16_t>(low | (high << 8));
-
-  EXPECT_EQ(word, gfx::TileInfoToWord(cell.tile_info));
-}
-
 TEST(ObjectTileEditorTest,
-     StandardObjectWriteBackRejectsMissingEditableSourceIndex) {
+     GenericCaptureIsPreviewOnlyAndCannotAuthorizeStandardWrites) {
+  ScopedCustomObjectsDisabled disable_custom_objects;
   Rom rom;
-  ASSERT_TRUE(rom.LoadFromData(std::vector<uint8_t>(0x200000, 0)).ok());
+  ASSERT_TRUE(rom.LoadFromData(MakeEditableObjectRomData()).ok());
 
+  Room room(/*room_id=*/0, &rom, /*game_data=*/nullptr);
+  gfx::PaletteGroup palette;
   ObjectTileEditor editor(&rom);
-  ObjectTileLayout layout;
-  layout.tile_data_address = 0x1000;
-  layout.is_custom = false;
-
-  ObjectTileLayout::Cell cell;
-  cell.tile_info = gfx::TileInfo(0x123, 3, true, false, true);
-  cell.modified = true;
-  ASSERT_EQ(cell.write_index, -1);
-  layout.cells.push_back(cell);
-
-  const auto original = rom.vector();
-  const bool original_dirty = rom.dirty();
-  const absl::Status status = editor.WriteBack(layout);
-
-  EXPECT_TRUE(absl::IsFailedPrecondition(status));
-  EXPECT_EQ(rom.vector(), original);
-  EXPECT_EQ(rom.dirty(), original_dirty);
-}
-
-TEST(ObjectTileEditorTest, StandardObjectWriteBackUsesCellWriteIndex) {
-  Rom rom;
-  ASSERT_TRUE(rom.LoadFromData(std::vector<uint8_t>(0x200000, 0)).ok());
-
-  ObjectTileEditor editor(&rom);
-  ObjectTileLayout layout;
-  layout.tile_data_address = 0x1000;
-  layout.is_custom = false;
-
-  ObjectTileLayout::Cell cell;
-  cell.tile_info = gfx::TileInfo(0x234, 4, false, true, false);
-  cell.original_word = 0;
-  cell.write_index = 1;
-  cell.modified = true;
-  layout.cells.push_back(cell);
-
-  ASSERT_TRUE(editor.WriteBack(layout).ok());
-
-  EXPECT_EQ(rom.ReadByte(0x1000).value(), 0x00);
-  EXPECT_EQ(rom.ReadByte(0x1001).value(), 0x00);
-
-  uint8_t low = rom.ReadByte(0x1002).value();
-  uint8_t high = rom.ReadByte(0x1003).value();
-  uint16_t word = static_cast<uint16_t>(low | (high << 8));
-  EXPECT_EQ(word, gfx::TileInfoToWord(cell.tile_info));
-}
-
-TEST(ObjectTileEditorTest,
-     BuildStandardWritePlanUsesSparseWriteIndicesAndExactRanges) {
-  Rom rom;
-  ASSERT_TRUE(rom.LoadFromData(std::vector<uint8_t>(0x2000, 0)).ok());
-
-  ObjectTileEditor editor(&rom);
-  ObjectTileLayout layout;
-  layout.tile_data_address = 0x1000;
-  layout.is_custom = false;
-
-  ObjectTileLayout::Cell first;
-  first.tile_info = gfx::TileInfo(0x123, 3, true, false, true);
-  first.write_index = 3;
-  first.modified = true;
-  layout.cells.push_back(first);
-
-  ObjectTileLayout::Cell unmodified;
-  unmodified.tile_info = gfx::TileInfo(0x111, 1, false, false, false);
-  unmodified.write_index = 1;
-  unmodified.modified = false;
-  layout.cells.push_back(unmodified);
-
-  ObjectTileLayout::Cell second;
-  second.tile_info = gfx::TileInfo(0x234, 4, false, true, false);
-  second.write_index = 0;
-  second.modified = true;
-  layout.cells.push_back(second);
-
-  auto plan_or = editor.BuildStandardWritePlan(layout);
-  ASSERT_TRUE(plan_or.ok()) << plan_or.status();
-  const auto& plan = *plan_or;
-  ASSERT_EQ(plan.writes.size(), 2u);
-  ASSERT_EQ(plan.write_ranges.size(), 2u);
-
-  EXPECT_EQ(plan.writes[0].address, 0x1006);
-  EXPECT_EQ(plan.writes[0].word, gfx::TileInfoToWord(first.tile_info));
-  EXPECT_EQ(plan.write_ranges[0],
-            (std::pair<uint32_t, uint32_t>{0x1006, 0x1008}));
-  EXPECT_EQ(plan.writes[1].address, 0x1000);
-  EXPECT_EQ(plan.writes[1].word, gfx::TileInfoToWord(second.tile_info));
-  EXPECT_EQ(plan.write_ranges[1],
-            (std::pair<uint32_t, uint32_t>{0x1000, 0x1002}));
-}
-
-TEST(ObjectTileEditorTest,
-     StandardObjectWriteBackRejectsAllInvalidRangesBeforeMutation) {
-  Rom rom;
-  ASSERT_TRUE(rom.LoadFromData(std::vector<uint8_t>(0x20, 0x5A)).ok());
-
-  ObjectTileEditor editor(&rom);
-  ObjectTileLayout layout;
-  layout.tile_data_address = 0x10;
-  layout.is_custom = false;
-
-  ObjectTileLayout::Cell valid;
-  valid.tile_info = gfx::TileInfo(0x123, 3, true, false, true);
-  valid.write_index = 0;
-  valid.modified = true;
-  layout.cells.push_back(valid);
-
-  ObjectTileLayout::Cell invalid;
-  invalid.tile_info = gfx::TileInfo(0x234, 4, false, true, false);
-  invalid.write_index = 8;
-  invalid.modified = true;
-  layout.cells.push_back(invalid);
-
-  const auto original = rom.vector();
-  const bool original_dirty = rom.dirty();
-  const absl::Status status = editor.WriteBack(layout);
-
-  EXPECT_TRUE(absl::IsOutOfRange(status));
-  EXPECT_EQ(rom.vector(), original);
-  EXPECT_EQ(rom.dirty(), original_dirty);
-}
-
-TEST(ObjectTileEditorTest, ApplyStandardWritePlanRollsBackWhenLaterWriteFails) {
-  Rom rom;
-  ASSERT_TRUE(rom.LoadFromData(std::vector<uint8_t>(0x40, 0x5A)).ok());
-
-  ObjectTileEditor editor(&rom);
-  ObjectTileLayout layout;
-  layout.tile_data_address = 0x10;
-  layout.is_custom = false;
-  for (int index = 0; index < 2; ++index) {
-    ObjectTileLayout::Cell cell;
-    cell.tile_info = gfx::TileInfo(static_cast<uint16_t>(0x120 + index), 3,
-                                   false, false, false);
-    cell.write_index = index;
-    cell.modified = true;
-    layout.cells.push_back(cell);
+  auto layout_or =
+      editor.CaptureObjectLayout(/*object_id=*/0x11F, room, palette);
+  ASSERT_TRUE(layout_or.ok()) << layout_or.status();
+  EXPECT_EQ(layout_or->tile_data_address, -1);
+  EXPECT_FALSE(layout_or->source_provenance.has_value());
+  for (const auto& cell : layout_or->cells) {
+    EXPECT_FALSE(cell.source_ref.has_value());
   }
 
-  auto plan_or = editor.BuildStandardWritePlan(layout);
+  auto* cell = layout_or->FindCell(0, 0);
+  ASSERT_NE(cell, nullptr);
+  cell->tile_info.id_ ^= 1;
+  cell->modified = true;
+
+  const auto original = rom.vector();
+  const bool original_dirty = rom.dirty();
+  const auto plan_or = editor.BuildStandardWritePlan(*layout_or);
+  EXPECT_TRUE(absl::IsFailedPrecondition(plan_or.status()));
+  EXPECT_EQ(rom.vector(), original);
+  EXPECT_EQ(rom.dirty(), original_dirty);
+}
+
+TEST(ObjectTileEditorTest, EditableCaptureRejectsUnsupportedStandardObject) {
+  ScopedCustomObjectsDisabled disable_custom_objects;
+  Rom rom;
+  ASSERT_TRUE(rom.LoadFromData(MakeEditableObjectRomData()).ok());
+
+  Room room(/*room_id=*/0, &rom, /*game_data=*/nullptr);
+  gfx::PaletteGroup palette;
+  ObjectTileEditor editor(&rom);
+
+  EXPECT_TRUE(ObjectTileEditor::IsEditableStandardObject(0x11F));
+  EXPECT_TRUE(ObjectTileEditor::IsEditableStandardObject(0x120));
+  EXPECT_FALSE(ObjectTileEditor::IsEditableStandardObject(0x11E));
+  const auto layout_or = editor.CaptureEditableObjectLayout(
+      /*object_id=*/0x11E, room, palette);
+  EXPECT_TRUE(absl::IsUnimplemented(layout_or.status()));
+}
+
+TEST(ObjectTileEditorTest,
+     EditableCapturePinsDescriptorsSpansAndColumnMajorSourceMap) {
+  ScopedCustomObjectsDisabled disable_custom_objects;
+  Rom rom;
+  ASSERT_TRUE(rom.LoadFromData(MakeEditableObjectRomData()).ok());
+
+  Room room(/*room_id=*/0, &rom, /*game_data=*/nullptr);
+  gfx::PaletteGroup palette;
+  ObjectTileEditor editor(&rom);
+
+  struct VisualCell {
+    int rel_x;
+    int rel_y;
+    size_t source_word_index;
+  };
+  // Explicit visual/source map: [0 2; 1 3].
+  constexpr std::array<VisualCell, 4> kVisualCells = {{
+      {0, 0, 0},
+      {1, 0, 2},
+      {0, 1, 1},
+      {1, 1, 3},
+  }};
+
+  for (const auto& fixture : kEditableObjectFixtures) {
+    SCOPED_TRACE(::testing::Message()
+                 << "object_id=0x" << std::hex << fixture.object_id);
+    auto layout_or =
+        editor.CaptureEditableObjectLayout(fixture.object_id, room, palette);
+    ASSERT_TRUE(layout_or.ok()) << layout_or.status();
+    const auto& layout = *layout_or;
+
+    EXPECT_EQ(layout.object_id, fixture.object_id);
+    EXPECT_EQ(layout.bounds_width, 2);
+    EXPECT_EQ(layout.bounds_height, 2);
+    EXPECT_EQ(layout.tile_data_address,
+              static_cast<int>(fixture.source_pc_address));
+    ASSERT_TRUE(layout.source_provenance.has_value());
+    const auto& provenance = *layout.source_provenance;
+    EXPECT_EQ(provenance.object_id, fixture.object_id);
+    EXPECT_EQ(provenance.descriptor_pc_address, fixture.descriptor_pc_address);
+    EXPECT_EQ(provenance.expected_descriptor_word, fixture.descriptor_word);
+    ASSERT_EQ(provenance.spans.size(), 1u);
+    EXPECT_EQ(provenance.spans[0].pc_address, fixture.source_pc_address);
+    EXPECT_EQ(provenance.spans[0].expected_words,
+              std::vector<uint16_t>(fixture.source_words.begin(),
+                                    fixture.source_words.end()));
+
+    for (const auto& visual_cell : kVisualCells) {
+      const auto* cell = layout.FindCell(visual_cell.rel_x, visual_cell.rel_y);
+      ASSERT_NE(cell, nullptr);
+      ASSERT_TRUE(cell->source_ref.has_value());
+      EXPECT_EQ(cell->source_ref->span_index, 0u);
+      EXPECT_EQ(cell->source_ref->word_index, visual_cell.source_word_index);
+      EXPECT_EQ(cell->original_word,
+                fixture.source_words[visual_cell.source_word_index]);
+      EXPECT_EQ(gfx::TileInfoToWord(cell->tile_info), cell->original_word);
+    }
+  }
+}
+
+TEST(ObjectTileEditorTest, BuildStandardWritePlanRejectsObjectMismatch) {
+  ScopedCustomObjectsDisabled disable_custom_objects;
+  Rom rom;
+  ASSERT_TRUE(rom.LoadFromData(MakeEditableObjectRomData()).ok());
+
+  Room room(/*room_id=*/0, &rom, /*game_data=*/nullptr);
+  gfx::PaletteGroup palette;
+  ObjectTileEditor editor(&rom);
+  auto layout_or = editor.CaptureEditableObjectLayout(0x11F, room, palette);
+  ASSERT_TRUE(layout_or.ok()) << layout_or.status();
+  layout_or->object_id = 0x120;
+
+  const auto plan_or = editor.BuildStandardWritePlan(*layout_or);
+  EXPECT_TRUE(absl::IsFailedPrecondition(plan_or.status()));
+}
+
+TEST(ObjectTileEditorTest,
+     BuildStandardWritePlanRejectsOutOfBoundsSourceReferences) {
+  ScopedCustomObjectsDisabled disable_custom_objects;
+  Rom rom;
+  ASSERT_TRUE(rom.LoadFromData(MakeEditableObjectRomData()).ok());
+
+  Room room(/*room_id=*/0, &rom, /*game_data=*/nullptr);
+  gfx::PaletteGroup palette;
+  ObjectTileEditor editor(&rom);
+  auto layout_or = editor.CaptureEditableObjectLayout(0x11F, room, palette);
+  ASSERT_TRUE(layout_or.ok()) << layout_or.status();
+
+  ObjectTileLayout bad_span = *layout_or;
+  ASSERT_TRUE(bad_span.cells[0].source_ref.has_value());
+  bad_span.cells[0].source_ref->span_index = 1;
+  EXPECT_TRUE(absl::IsFailedPrecondition(
+      editor.BuildStandardWritePlan(bad_span).status()));
+
+  ObjectTileLayout bad_word = *layout_or;
+  ASSERT_TRUE(bad_word.cells[0].source_ref.has_value());
+  bad_word.cells[0].source_ref->word_index = 4;
+  EXPECT_TRUE(absl::IsFailedPrecondition(
+      editor.BuildStandardWritePlan(bad_word).status()));
+}
+
+TEST(ObjectTileEditorTest,
+     BuildStandardWritePlanRejectsDuplicateResolvedAddresses) {
+  ScopedCustomObjectsDisabled disable_custom_objects;
+  Rom rom;
+  ASSERT_TRUE(rom.LoadFromData(MakeEditableObjectRomData()).ok());
+
+  Room room(/*room_id=*/0, &rom, /*game_data=*/nullptr);
+  gfx::PaletteGroup palette;
+  ObjectTileEditor editor(&rom);
+  auto layout_or = editor.CaptureEditableObjectLayout(0x11F, room, palette);
+  ASSERT_TRUE(layout_or.ok()) << layout_or.status();
+
+  auto* duplicate = layout_or->FindCell(0, 1);
+  ASSERT_NE(duplicate, nullptr);
+  duplicate->rel_y = 0;
+  duplicate->source_ref = ObjectTileSourceRef{/*span_index=*/0,
+                                              /*word_index=*/0};
+  const auto plan_or = editor.BuildStandardWritePlan(*layout_or);
+  ASSERT_TRUE(absl::IsFailedPrecondition(plan_or.status()));
+  EXPECT_NE(std::string(plan_or.status().message()).find("duplicate"),
+            std::string::npos);
+}
+
+TEST(ObjectTileEditorTest,
+     BuildStandardWritePlanRejectsDescriptorSourcePreconditionAlias) {
+  ScopedCustomObjectsDisabled disable_custom_objects;
+  Rom rom;
+  ASSERT_TRUE(rom.LoadFromData(MakeEditableObjectRomData()).ok());
+
+  Room room(/*room_id=*/0, &rom, /*game_data=*/nullptr);
+  gfx::PaletteGroup palette;
+  ObjectTileEditor editor(&rom);
+  auto layout_or = editor.CaptureEditableObjectLayout(0x11F, room, palette);
+  ASSERT_TRUE(layout_or.ok()) << layout_or.status();
+  ASSERT_TRUE(layout_or->source_provenance.has_value());
+
+  auto& provenance = *layout_or->source_provenance;
+  provenance.expected_descriptor_word = 0x68DC;
+  ASSERT_EQ(provenance.spans.size(), 1u);
+  provenance.spans[0].pc_address = provenance.descriptor_pc_address;
+  StoreWordWithoutDirtying(rom, provenance.descriptor_pc_address,
+                           provenance.expected_descriptor_word);
+
+  const auto plan_or = editor.BuildStandardWritePlan(*layout_or);
+  ASSERT_TRUE(absl::IsFailedPrecondition(plan_or.status()));
+  EXPECT_NE(std::string(plan_or.status().message()).find("alias"),
+            std::string::npos);
+}
+
+TEST(ObjectTileEditorTest,
+     ApplyStandardWritePlanRejectsForgedRangesAndCASBeforeMutation) {
+  Rom rom;
+  ASSERT_TRUE(rom.LoadFromData(std::vector<uint8_t>(0x200000, 0)).ok());
+  ObjectTileEditor editor(&rom);
+
+  ObjectTileWritePlan plan;
+  plan.writes.push_back(
+      {/*address=*/0x1000, /*expected_word=*/0, /*word=*/0x1234});
+  plan.write_ranges.push_back({0x1002, 0x1004});
+  plan.preconditions.push_back({/*address=*/0x1000, /*expected_word=*/0});
+  const auto original = rom.vector();
+  const bool original_dirty = rom.dirty();
+
+  EXPECT_TRUE(absl::IsFailedPrecondition(editor.ApplyStandardWritePlan(plan)));
+  EXPECT_EQ(rom.vector(), original);
+  EXPECT_EQ(rom.dirty(), original_dirty);
+
+  plan.write_ranges[0] = {0x1000, 0x1002};
+  plan.preconditions.clear();
+  EXPECT_TRUE(absl::IsFailedPrecondition(editor.ApplyStandardWritePlan(plan)));
+  EXPECT_EQ(rom.vector(), original);
+  EXPECT_EQ(rom.dirty(), original_dirty);
+
+  plan.preconditions.push_back({/*address=*/0x1002, /*expected_word=*/0});
+  EXPECT_TRUE(absl::IsFailedPrecondition(editor.ApplyStandardWritePlan(plan)));
+  EXPECT_EQ(rom.vector(), original);
+  EXPECT_EQ(rom.dirty(), original_dirty);
+
+  plan.preconditions = {{/*address=*/0x1000, /*expected_word=*/0},
+                        {/*address=*/0x1000, /*expected_word=*/0}};
+  EXPECT_TRUE(absl::IsFailedPrecondition(editor.ApplyStandardWritePlan(plan)));
+  EXPECT_EQ(rom.vector(), original);
+  EXPECT_EQ(rom.dirty(), original_dirty);
+
+  plan.preconditions = {{/*address=*/0x1000, /*expected_word=*/1}};
+  EXPECT_TRUE(absl::IsFailedPrecondition(editor.ApplyStandardWritePlan(plan)));
+  EXPECT_EQ(rom.vector(), original);
+  EXPECT_EQ(rom.dirty(), original_dirty);
+}
+
+TEST(ObjectTileEditorTest,
+     BuildStandardWritePlanRejectsStaleDescriptorAndSource) {
+  ScopedCustomObjectsDisabled disable_custom_objects;
+
+  for (bool stale_descriptor : {true, false}) {
+    SCOPED_TRACE(stale_descriptor ? "stale descriptor" : "stale source");
+    Rom rom;
+    ASSERT_TRUE(rom.LoadFromData(MakeEditableObjectRomData()).ok());
+    Room room(/*room_id=*/0, &rom, /*game_data=*/nullptr);
+    gfx::PaletteGroup palette;
+    ObjectTileEditor editor(&rom);
+    auto layout_or = editor.CaptureEditableObjectLayout(0x11F, room, palette);
+    ASSERT_TRUE(layout_or.ok()) << layout_or.status();
+
+    if (stale_descriptor) {
+      StoreWordWithoutDirtying(rom,
+                               kEditableObjectFixtures[0].descriptor_pc_address,
+                               kEditableObjectFixtures[0].descriptor_word ^ 1);
+    } else {
+      StoreWordWithoutDirtying(rom,
+                               kEditableObjectFixtures[0].source_pc_address + 4,
+                               kEditableObjectFixtures[0].source_words[2] ^ 1);
+    }
+    rom.set_dirty(stale_descriptor);
+    const auto before = rom.vector();
+    const bool was_dirty = rom.dirty();
+
+    const auto plan_or = editor.BuildStandardWritePlan(*layout_or);
+    EXPECT_TRUE(absl::IsFailedPrecondition(plan_or.status()));
+    EXPECT_EQ(rom.vector(), before);
+    EXPECT_EQ(rom.dirty(), was_dirty);
+  }
+}
+
+TEST(ObjectTileEditorTest, StandardWritePlanUsesExactWritesAndReadback) {
+  ScopedCustomObjectsDisabled disable_custom_objects;
+  Rom rom;
+  ASSERT_TRUE(rom.LoadFromData(MakeEditableObjectRomData()).ok());
+
+  Room room(/*room_id=*/0, &rom, /*game_data=*/nullptr);
+  gfx::PaletteGroup palette;
+  ObjectTileEditor editor(&rom);
+  auto layout_or = editor.CaptureEditableObjectLayout(0x11F, room, palette);
+  ASSERT_TRUE(layout_or.ok()) << layout_or.status();
+
+  auto* top_left = layout_or->FindCell(0, 0);
+  auto* bottom_right = layout_or->FindCell(1, 1);
+  ASSERT_NE(top_left, nullptr);
+  ASSERT_NE(bottom_right, nullptr);
+  top_left->tile_info.id_ ^= 1;
+  top_left->modified = true;
+  bottom_right->tile_info.id_ ^= 1;
+  bottom_right->modified = true;
+  const uint16_t top_left_word = gfx::TileInfoToWord(top_left->tile_info);
+  const uint16_t bottom_right_word =
+      gfx::TileInfoToWord(bottom_right->tile_info);
+
+  auto plan_or = editor.BuildStandardWritePlan(*layout_or);
   ASSERT_TRUE(plan_or.ok()) << plan_or.status();
+  ASSERT_EQ(plan_or->preconditions.size(), 5u);
+  EXPECT_EQ(plan_or->preconditions[0].address, 0x842E);
+  EXPECT_EQ(plan_or->preconditions[0].expected_word, 0x0E9A);
+  ASSERT_EQ(plan_or->writes.size(), 2u);
+  ASSERT_EQ(plan_or->write_ranges.size(), 2u);
+  EXPECT_EQ(plan_or->writes[0].address, 0x29EC);
+  EXPECT_EQ(plan_or->writes[0].expected_word, 0x0DEE);
+  EXPECT_EQ(plan_or->writes[0].word, top_left_word);
+  EXPECT_EQ(plan_or->write_ranges[0],
+            (std::pair<uint32_t, uint32_t>{0x29EC, 0x29EE}));
+  EXPECT_EQ(plan_or->writes[1].address, 0x29F2);
+  EXPECT_EQ(plan_or->writes[1].expected_word, 0xCDEE);
+  EXPECT_EQ(plan_or->writes[1].word, bottom_right_word);
+  EXPECT_EQ(plan_or->write_ranges[1],
+            (std::pair<uint32_t, uint32_t>{0x29F2, 0x29F4}));
+
+  auto expected_rom = rom.vector();
+  StoreWord(expected_rom, 0x29EC, top_left_word);
+  StoreWord(expected_rom, 0x29F2, bottom_right_word);
+  ASSERT_TRUE(editor.ApplyStandardWritePlan(*plan_or).ok());
+  EXPECT_EQ(rom.vector(), expected_rom);
+  EXPECT_TRUE(rom.dirty());
+
+  Rom reopened;
+  ASSERT_TRUE(reopened.LoadFromData(rom.vector()).ok());
+  Room reopened_room(/*room_id=*/0, &reopened, /*game_data=*/nullptr);
+  ObjectTileEditor reopened_editor(&reopened);
+  auto readback_or = reopened_editor.CaptureEditableObjectLayout(
+      0x11F, reopened_room, palette);
+  ASSERT_TRUE(readback_or.ok()) << readback_or.status();
+  EXPECT_EQ(readback_or->FindCell(0, 0)->original_word, top_left_word);
+  EXPECT_EQ(readback_or->FindCell(1, 1)->original_word, bottom_right_word);
+}
+
+TEST(ObjectTileEditorTest,
+     ApplyStandardWritePlanRejectsDescriptorAndSourceCASStaleness) {
+  ScopedCustomObjectsDisabled disable_custom_objects;
+
+  for (bool stale_descriptor : {true, false}) {
+    SCOPED_TRACE(stale_descriptor ? "stale descriptor" : "stale source");
+    Rom rom;
+    ASSERT_TRUE(rom.LoadFromData(MakeEditableObjectRomData()).ok());
+    Room room(/*room_id=*/0, &rom, /*game_data=*/nullptr);
+    gfx::PaletteGroup palette;
+    ObjectTileEditor editor(&rom);
+    auto layout_or = editor.CaptureEditableObjectLayout(0x11F, room, palette);
+    ASSERT_TRUE(layout_or.ok()) << layout_or.status();
+    auto* cell = layout_or->FindCell(0, 0);
+    ASSERT_NE(cell, nullptr);
+    cell->tile_info.id_ ^= 1;
+    cell->modified = true;
+    auto plan_or = editor.BuildStandardWritePlan(*layout_or);
+    ASSERT_TRUE(plan_or.ok()) << plan_or.status();
+
+    if (stale_descriptor) {
+      StoreWordWithoutDirtying(rom,
+                               kEditableObjectFixtures[0].descriptor_pc_address,
+                               kEditableObjectFixtures[0].descriptor_word ^ 1);
+    } else {
+      // Change an unmodified source word to prove Apply rechecks the complete
+      // captured source, not only the target write address.
+      StoreWordWithoutDirtying(rom,
+                               kEditableObjectFixtures[0].source_pc_address + 4,
+                               kEditableObjectFixtures[0].source_words[2] ^ 1);
+    }
+    rom.set_dirty(stale_descriptor);
+    const auto before = rom.vector();
+    const bool was_dirty = rom.dirty();
+
+    const absl::Status status = editor.ApplyStandardWritePlan(*plan_or);
+    EXPECT_TRUE(absl::IsFailedPrecondition(status));
+    EXPECT_EQ(rom.vector(), before);
+    EXPECT_EQ(rom.dirty(), was_dirty);
+  }
+}
+
+TEST(ObjectTileEditorTest, ApplyStandardWritePlanRollsBackAndPreservesDirty) {
+  ScopedCustomObjectsDisabled disable_custom_objects;
+  Rom rom;
+  ASSERT_TRUE(rom.LoadFromData(MakeEditableObjectRomData()).ok());
+
+  Room room(/*room_id=*/0, &rom, /*game_data=*/nullptr);
+  gfx::PaletteGroup palette;
+  ObjectTileEditor editor(&rom);
+  auto layout_or = editor.CaptureEditableObjectLayout(0x11F, room, palette);
+  ASSERT_TRUE(layout_or.ok()) << layout_or.status();
+  for (const auto& coordinate :
+       std::array<std::pair<int, int>, 2>{{{0, 0}, {0, 1}}}) {
+    auto* cell = layout_or->FindCell(coordinate.first, coordinate.second);
+    ASSERT_NE(cell, nullptr);
+    cell->tile_info.id_ ^= 1;
+    cell->modified = true;
+  }
+
+  auto plan_or = editor.BuildStandardWritePlan(*layout_or);
+  ASSERT_TRUE(plan_or.ok()) << plan_or.status();
+  ASSERT_EQ(plan_or->writes.size(), 2u);
 
   rom::WriteFence fence;
-  ASSERT_TRUE(fence.Allow(0x10, 0x12, "first object tile word").ok());
+  ASSERT_TRUE(fence.Allow(0x29EC, 0x29EE, "first object tile word").ok());
   rom::ScopedWriteFence fence_scope(&rom, &fence);
 
   const auto original = rom.vector();


### PR DESCRIPTION
## Summary
- keep generic dungeon-object draw traces preview-only so trace order can never authorize a ROM write
- add an explicit editable capture for audited fixed 2x2 objects `0x11F` and `0x120`
- bind each visible cell to its exact column-major source word (`[0 2; 1 3]`) plus the Type-2 descriptor and captured source snapshot
- require descriptor/source compare-and-swap checks at plan build and immediately before transaction apply
- make write plans builder-owned and read-only so callers cannot forge self-consistent arbitrary-address writes
- reject partial-byte overlap with all known Type-1/2/3 descriptor and routine metadata, plus overlapping CAS/write word ranges
- preserve the custom `.bin` serialization path unchanged

## Verification
- retargeted to `master` after #182 merged as `c54f26e9742ad11efe08c53af2c6fa34a43df047`
- exact head `09a56cd8f4ebe9848082893fd3c0064e86113a16`; topic patch-id remained `220df8cfb146ede3d030cf8d01d4a20e24f3a31f` across the merge
- `cmake --build build/presets/mac-ai --target yaze_test_unit --parallel 8`
- `yaze_test_unit --gtest_filter='ObjectTileEditorTest.*:ObjectTileLayoutTest.*:ObjectTileEditorPanelTest.*' --gtest_brief=1` (48/48)
- `scripts/pre-push.sh --build-dir build/presets/mac-ai` (build, 13/13 smoke tests, formatting; change-aware UI step reported no panel/workflow match and skipped)
- `git diff --check`
- `clang-format --dry-run --Werror` on the five topic files
- two independent findings-first re-reviews found no remaining blocker after the opacity and full metadata-overlap remediation

## Scope / follow-up gate
Backend provenance only. This intentionally does **not** expose a standard-object `Edit Tiles` action yet. Before UI reachability, the next slice must add complete overlap/shared-source detection, a ROM object-tile cache revision for copied `RoomObject`s, selector/layout cache invalidation, materialized-room redraw invalidation, and active placement-ghost cancellation.

Retargeted to `master`; full exact-head hosted CI is the remaining merge gate.

