### PR TITLE
Invalidate dungeon object tile caches after writes

### DIFF
--- a/src/rom/rom.cc
+++ b/src/rom/rom.cc
@@ -224,6 +224,19 @@ void BestEffortFsyncParentDir(const std::filesystem::path& file_path) {
 
 }  // namespace
 
+Rom::Rom(const Rom& other)
+    : size_(other.size_),
+      title_(other.title_),
+      filename_(other.filename_),
+      short_name_(other.short_name_),
+      rom_data_(other.rom_data_),
+      resource_label_manager_(other.resource_label_manager_),
+      dirty_(other.dirty_),
+      object_tile_revision_(other.object_tile_revision_) {
+  // Write fences are non-owning, instance-local transaction state. A new Rom
+  // must never inherit pointers owned by active scopes on `other`.
+}
+
 Rom& Rom::operator=(const Rom& other) {
   if (this == &other) {
     return *this;

--- a/src/rom/rom.cc
+++ b/src/rom/rom.cc
@@ -237,7 +237,9 @@ Rom& Rom::operator=(const Rom& other) {
   rom_data_ = other.rom_data_;
   resource_label_manager_ = other.resource_label_manager_;
   dirty_ = other.dirty_;
-  write_fence_stack_ = other.write_fence_stack_;
+
+  // Write fences are non-owning, instance-local transaction state. Preserve
+  // this Rom's active scopes rather than importing pointers owned by `other`.
 
   object_tile_revision_ =
       std::max(previous_revision, other.object_tile_revision_);

--- a/src/rom/rom.cc
+++ b/src/rom/rom.cc
@@ -224,6 +224,34 @@ void BestEffortFsyncParentDir(const std::filesystem::path& file_path) {
 
 }  // namespace
 
+Rom& Rom::operator=(const Rom& other) {
+  if (this == &other) {
+    return *this;
+  }
+
+  const uint64_t previous_revision = object_tile_revision_;
+  size_ = other.size_;
+  title_ = other.title_;
+  filename_ = other.filename_;
+  short_name_ = other.short_name_;
+  rom_data_ = other.rom_data_;
+  resource_label_manager_ = other.resource_label_manager_;
+  dirty_ = other.dirty_;
+  write_fence_stack_ = other.write_fence_stack_;
+
+  object_tile_revision_ =
+      std::max(previous_revision, other.object_tile_revision_);
+  AdvanceObjectTileRevision();
+  return *this;
+}
+
+Rom& Rom::operator=(Rom&& other) {
+  // Rom historically has copy-on-rvalue assignment semantics. Keep the source
+  // intact while ensuring in-place session replacement uses the same strictly
+  // monotonic destination generation as lvalue assignment.
+  return operator=(static_cast<const Rom&>(other));
+}
+
 absl::Status Rom::LoadFromFile(const std::string& filename,
                                const LoadOptions& options) {
   if (filename.empty()) {
@@ -329,6 +357,7 @@ absl::Status Rom::LoadFromFile(const std::string& filename,
     }
   }
 
+  AdvanceObjectTileRevision();
   return absl::OkStatus();
 }
 
@@ -365,6 +394,7 @@ absl::Status Rom::LoadFromData(const std::vector<uint8_t>& data,
     }
   }
 
+  AdvanceObjectTileRevision();
   return absl::OkStatus();
 }
 

--- a/src/rom/rom.h
+++ b/src/rom/rom.h
@@ -46,7 +46,7 @@ class Rom {
   };
 
   Rom() = default;
-  Rom(const Rom&) = default;
+  Rom(const Rom& other);
   Rom& operator=(const Rom& other);
   Rom& operator=(Rom&& other);
   ~Rom() = default;

--- a/src/rom/rom.h
+++ b/src/rom/rom.h
@@ -46,6 +46,9 @@ class Rom {
   };
 
   Rom() = default;
+  Rom(const Rom&) = default;
+  Rom& operator=(const Rom& other);
+  Rom& operator=(Rom&& other);
   ~Rom() = default;
 
   absl::Status LoadFromFile(
@@ -58,13 +61,21 @@ class Rom {
   absl::Status SaveToFile(const SaveSettings& settings);
 
   void Expand(int size) {
+    const bool size_changed = rom_data_.size() != static_cast<size_t>(size);
     rom_data_.resize(size);
     size_ = size;
+    if (size_changed) {
+      AdvanceObjectTileRevision();
+    }
   }
 
   void Close() {
+    const bool had_data = !rom_data_.empty();
     rom_data_.clear();
     size_ = 0;
+    if (had_data) {
+      AdvanceObjectTileRevision();
+    }
   }
 
   // Raw access
@@ -146,6 +157,13 @@ class Rom {
   void set_dirty(bool dirty) { dirty_ = dirty; }
   void ClearDirty() { dirty_ = false; }
 
+  // Monotonic generation for RoomObject caches derived from ROM tile tables.
+  // Successful loads, content replacement, a real Close, and real size changes
+  // advance it automatically. Writers that mutate object tile sources must
+  // advance it only after their transaction commits successfully.
+  uint64_t object_tile_revision() const { return object_tile_revision_; }
+  void AdvanceObjectTileRevision() { ++object_tile_revision_; }
+
   auto title() const { return title_; }
   auto size() const { return size_; }
   auto data() const { return rom_data_.data(); }
@@ -193,6 +211,9 @@ class Rom {
 
   // True if there are unsaved changes
   bool dirty_ = false;
+
+  // Generation of object-tile data visible to RoomObject parser caches.
+  uint64_t object_tile_revision_ = 0;
 
   // Active write fences (not owned).
   std::vector<rom::WriteFence*> write_fence_stack_;

--- a/src/zelda3/dungeon/object_tile_editor.cc
+++ b/src/zelda3/dungeon/object_tile_editor.cc
@@ -847,8 +847,10 @@ absl::Status ObjectTileEditor::ApplyStandardWritePlan(
   const absl::Status status = transaction.Commit();
   if (!status.ok()) {
     rom_->set_dirty(was_dirty);
+    return status;
   }
-  return status;
+  rom_->AdvanceObjectTileRevision();
+  return absl::OkStatus();
 }
 
 int ObjectTileEditor::CountObjectsSharingTileData(int16_t object_id) const {

--- a/src/zelda3/dungeon/room_object.cc
+++ b/src/zelda3/dungeon/room_object.cc
@@ -83,6 +83,9 @@ ObjectOption operator~(ObjectOption option) {
 // bitmaps.
 
 void RoomObject::EnsureTilesLoaded() {
+  if (tiles_loaded_ && !IsTrackedTileCacheCurrent()) {
+    InvalidateTileCache();
+  }
   if (tiles_loaded_) {
     return;
   }
@@ -101,6 +104,7 @@ void RoomObject::EnsureTilesLoaded() {
   auto parser_status = LoadTilesWithParser();
   if (parser_status.ok()) {
     tiles_loaded_ = true;
+    MarkTileCacheCurrent();
     // DEBUG: Log wall/corner objects
     if (id_ == 0x001 || id_ == 0x002 || id_ == 0x061 || id_ == 0x062 ||
         (id_ >= 0x100 && id_ <= 0x103)) {
@@ -134,6 +138,7 @@ void RoomObject::EnsureTilesLoaded() {
     LOG_DEBUG("RoomObject", "Tile pointer out of bounds for object %04X", id_);
     tiles_.clear();
     tiles_loaded_ = true;  // Mark as loaded (empty) to prevent retry
+    MarkTileCacheCurrent();
     return;
   }
 
@@ -148,6 +153,7 @@ void RoomObject::EnsureTilesLoaded() {
               id_);
     tiles_.clear();
     tiles_loaded_ = true;  // Mark as loaded (empty) to prevent retry
+    MarkTileCacheCurrent();
     return;
   }
 
@@ -164,6 +170,7 @@ void RoomObject::EnsureTilesLoaded() {
   tiles_.push_back(gfx::WordToTileInfo(w3));
   tile_count_ = 1;
   tiles_loaded_ = true;
+  MarkTileCacheCurrent();
 }
 
 void RoomObject::InvalidateTileCache() {
@@ -171,6 +178,25 @@ void RoomObject::InvalidateTileCache() {
   tiles_loaded_ = false;
   tile_count_ = 0;
   tile_data_ptr_ = -1;
+  MarkTileCacheUntracked();
+}
+
+bool RoomObject::IsTrackedTileCacheCurrent() const {
+  return !tile_cache_tracked_ ||
+         (rom_ != nullptr && tile_cache_rom_identity_ == rom_ &&
+          tile_cache_revision_ == rom_->object_tile_revision());
+}
+
+void RoomObject::MarkTileCacheCurrent() {
+  tile_cache_rom_identity_ = rom_;
+  tile_cache_revision_ = rom_->object_tile_revision();
+  tile_cache_tracked_ = true;
+}
+
+void RoomObject::MarkTileCacheUntracked() {
+  tile_cache_rom_identity_ = nullptr;
+  tile_cache_revision_ = 0;
+  tile_cache_tracked_ = false;
 }
 
 void RoomObject::RefreshDerivedFlagsFromId() {
@@ -203,9 +229,7 @@ absl::Status RoomObject::LoadTilesWithParser() {
 }
 
 absl::StatusOr<std::span<const gfx::TileInfo>> RoomObject::GetTiles() const {
-  if (!tiles_loaded_) {
-    const_cast<RoomObject*>(this)->EnsureTilesLoaded();
-  }
+  const_cast<RoomObject*>(this)->EnsureTilesLoaded();
 
   if (tiles_.empty()) {
     return absl::FailedPreconditionError("No tiles loaded for object");
@@ -215,9 +239,7 @@ absl::StatusOr<std::span<const gfx::TileInfo>> RoomObject::GetTiles() const {
 }
 
 absl::StatusOr<const gfx::TileInfo*> RoomObject::GetTile(int index) const {
-  if (!tiles_loaded_) {
-    const_cast<RoomObject*>(this)->EnsureTilesLoaded();
-  }
+  const_cast<RoomObject*>(this)->EnsureTilesLoaded();
 
   if (index < 0 || index >= static_cast<int>(tiles_.size())) {
     return absl::OutOfRangeError(absl::StrFormat(
@@ -228,9 +250,7 @@ absl::StatusOr<const gfx::TileInfo*> RoomObject::GetTile(int index) const {
 }
 
 int RoomObject::GetTileCount() const {
-  if (!tiles_loaded_) {
-    const_cast<RoomObject*>(this)->EnsureTilesLoaded();
-  }
+  const_cast<RoomObject*>(this)->EnsureTilesLoaded();
 
   return tile_count_;
 }

--- a/src/zelda3/dungeon/room_object.h
+++ b/src/zelda3/dungeon/room_object.h
@@ -98,8 +98,14 @@ class RoomObject {
   absl::Status LoadTilesWithParser();
 
   // Getter for tiles
-  const std::vector<gfx::TileInfo>& tiles() const { return tiles_; }
-  std::vector<gfx::TileInfo>& mutable_tiles() { return tiles_; }
+  const std::vector<gfx::TileInfo>& tiles() const {
+    const_cast<RoomObject*>(this)->EnsureTilesLoaded();
+    return tiles_;
+  }
+  std::vector<gfx::TileInfo>& mutable_tiles() {
+    MarkTileCacheUntracked();
+    return tiles_;
+  }
 
   // Get tile data through Arena system - returns references, not copies
   absl::StatusOr<std::span<const gfx::TileInfo>> GetTiles() const;
@@ -239,6 +245,16 @@ class RoomObject {
  private:
   void RefreshDerivedFlagsFromId();
   void InvalidateTileCache();
+  bool IsTrackedTileCacheCurrent() const;
+  void MarkTileCacheCurrent();
+  void MarkTileCacheUntracked();
+
+  // Only parser-populated caches are tracked. Tests, custom previews, and
+  // other callers that inject tiles directly retain their cache across ROM
+  // revisions because no ROM provenance was claimed for those tiles.
+  mutable const Rom* tile_cache_rom_identity_ = nullptr;
+  mutable uint64_t tile_cache_revision_ = 0;
+  mutable bool tile_cache_tracked_ = false;
 };
 
 // Room-object size is persisted only for Type 1 objects. Type 2 has no size

--- a/test/unit/rom/rom_test.cc
+++ b/test/unit/rom/rom_test.cc
@@ -132,6 +132,53 @@ TEST_F(RomTest, LoadFromFileEmpty) {
               StatusIs(absl::StatusCode::kInvalidArgument));
 }
 
+TEST_F(RomTest, ObjectTileRevisionTracksSuccessfulLifecycleTransitions) {
+  EXPECT_EQ(rom_.object_tile_revision(), 0u);
+
+  EXPECT_THAT(rom_.LoadFromData({}),
+              StatusIs(absl::StatusCode::kInvalidArgument));
+  EXPECT_EQ(rom_.object_tile_revision(), 0u);
+
+  EXPECT_OK(rom_.LoadFromData(kMockRomData));
+  EXPECT_EQ(rom_.object_tile_revision(), 1u);
+
+  EXPECT_THAT(rom_.LoadFromFile("missing-object-tile-revision-test.sfc"),
+              StatusIs(absl::StatusCode::kNotFound));
+  EXPECT_EQ(rom_.object_tile_revision(), 1u);
+
+  ScopedTempDirectory temp_dir;
+  const auto rom_path = temp_dir.path() / "reload.sfc";
+  WriteFileBytes(rom_path, std::vector<uint8_t>(32768, 0));
+  EXPECT_OK(rom_.LoadFromFile(rom_path.string()));
+  EXPECT_EQ(rom_.object_tile_revision(), 2u);
+
+  rom_.Close();
+  EXPECT_EQ(rom_.object_tile_revision(), 3u);
+  rom_.Close();
+  EXPECT_EQ(rom_.object_tile_revision(), 3u);
+
+  rom_.AdvanceObjectTileRevision();
+  EXPECT_EQ(rom_.object_tile_revision(), 4u);
+}
+
+TEST_F(RomTest, ObjectTileRevisionAdvancesAcrossResizeAndAssignment) {
+  EXPECT_OK(rom_.LoadFromData(kMockRomData));
+  const uint64_t loaded_revision = rom_.object_tile_revision();
+
+  rom_.Expand(static_cast<int>(rom_.size()));
+  EXPECT_EQ(rom_.object_tile_revision(), loaded_revision);
+  rom_.Expand(static_cast<int>(rom_.size() + 1));
+  EXPECT_EQ(rom_.object_tile_revision(), loaded_revision + 1);
+
+  Rom replacement;
+  EXPECT_OK(replacement.LoadFromData(std::vector<uint8_t>(64, 0xA5)));
+  const uint64_t before_assignment = rom_.object_tile_revision();
+  rom_ = replacement;
+  EXPECT_GT(rom_.object_tile_revision(), before_assignment);
+  EXPECT_GT(rom_.object_tile_revision(), replacement.object_tile_revision());
+  EXPECT_EQ(rom_.vector(), replacement.vector());
+}
+
 TEST_F(RomTest, LoadFromFileTooLarge) {
 #if defined(__linux__)
   GTEST_SKIP() << "File tests skipped on Linux CI (filesystem access)";

--- a/test/unit/rom/write_fence_test.cc
+++ b/test/unit/rom/write_fence_test.cc
@@ -37,7 +37,8 @@ TEST(WriteFenceTest, BlocksWritesOutsideAllowedRanges) {
     EXPECT_FALSE(denied.ok());
     EXPECT_EQ(denied.code(), absl::StatusCode::kPermissionDenied);
 
-    auto denied_vec = rom.WriteVector(/*addr=*/145, std::vector<uint8_t>(10, 0));
+    auto denied_vec =
+        rom.WriteVector(/*addr=*/145, std::vector<uint8_t>(10, 0));
     EXPECT_FALSE(denied_vec.ok());
     EXPECT_EQ(denied_vec.code(), absl::StatusCode::kPermissionDenied);
   }
@@ -72,6 +73,37 @@ TEST(WriteFenceTest, NestedFencesRestrictByIntersection) {
   }
 }
 
+TEST(WriteFenceTest, AssignmentPreservesDestinationFenceOwnership) {
+  Rom destination = MakeRom(256);
+  Rom source = MakeRom(256);
+
+  WriteFence destination_fence;
+  ASSERT_TRUE(
+      destination_fence.Allow(/*start=*/0, /*end=*/16, "destination").ok());
+  WriteFence source_fence;
+  ASSERT_TRUE(source_fence.Allow(/*start=*/100, /*end=*/116, "source").ok());
+
+  {
+    ScopedWriteFence destination_scope(&destination, &destination_fence);
+    {
+      ScopedWriteFence source_scope(&source, &source_fence);
+      destination = std::move(source);
+
+      EXPECT_EQ(destination.write_fence_depth(), 1u);
+      EXPECT_EQ(source.write_fence_depth(), 1u);
+      EXPECT_TRUE(destination.WriteByte(/*addr=*/4, /*value=*/0xAA).ok());
+      EXPECT_TRUE(absl::IsPermissionDenied(
+          destination.WriteByte(/*addr=*/104, /*value=*/0xBB)));
+    }
+
+    EXPECT_EQ(source.write_fence_depth(), 0u);
+    EXPECT_EQ(destination.write_fence_depth(), 1u);
+    EXPECT_TRUE(destination.WriteByte(/*addr=*/5, /*value=*/0xCC).ok());
+  }
+
+  EXPECT_EQ(destination.write_fence_depth(), 0u);
+}
+
 TEST(WriteFenceTest, RejectsOverlappingAllowedRanges) {
   WriteFence fence;
   ASSERT_TRUE(fence.Allow(/*start=*/10, /*end=*/20, "a").ok());
@@ -81,4 +113,3 @@ TEST(WriteFenceTest, RejectsOverlappingAllowedRanges) {
 }
 
 }  // namespace yaze::rom
-

--- a/test/unit/rom/write_fence_test.cc
+++ b/test/unit/rom/write_fence_test.cc
@@ -104,6 +104,23 @@ TEST(WriteFenceTest, AssignmentPreservesDestinationFenceOwnership) {
   EXPECT_EQ(destination.write_fence_depth(), 0u);
 }
 
+TEST(WriteFenceTest, CopyConstructionDoesNotImportSourceFence) {
+  Rom source = MakeRom(256);
+  WriteFence source_fence;
+  ASSERT_TRUE(source_fence.Allow(/*start=*/0, /*end=*/16, "source").ok());
+
+  {
+    ScopedWriteFence source_scope(&source, &source_fence);
+    Rom copy(source);
+
+    EXPECT_EQ(source.write_fence_depth(), 1u);
+    EXPECT_EQ(copy.write_fence_depth(), 0u);
+    EXPECT_TRUE(copy.WriteByte(/*addr=*/104, /*value=*/0xAA).ok());
+  }
+
+  EXPECT_EQ(source.write_fence_depth(), 0u);
+}
+
 TEST(WriteFenceTest, RejectsOverlappingAllowedRanges) {
   WriteFence fence;
   ASSERT_TRUE(fence.Allow(/*start=*/10, /*end=*/20, "a").ok());

--- a/test/unit/zelda3/dungeon/object_tile_editor_test.cc
+++ b/test/unit/zelda3/dungeon/object_tile_editor_test.cc
@@ -504,6 +504,7 @@ TEST(ObjectTileEditorTest, BuildStandardWritePlanRejectsObjectMismatch) {
   ObjectTileEditor editor(&rom);
   auto layout_or = editor.CaptureEditableObjectLayout(0x11F, room, palette);
   ASSERT_TRUE(layout_or.ok()) << layout_or.status();
+
   layout_or->object_id = 0x120;
 
   const auto plan_or = editor.BuildStandardWritePlan(*layout_or);
@@ -675,6 +676,14 @@ TEST(ObjectTileEditorTest, StandardWritePlanUsesExactWritesAndReadback) {
   auto layout_or = editor.CaptureEditableObjectLayout(0x11F, room, palette);
   ASSERT_TRUE(layout_or.ok()) << layout_or.status();
 
+  RoomObject cached_object(/*id=*/0x11F, /*x=*/0, /*y=*/0, /*size=*/0,
+                           /*layer=*/0);
+  cached_object.SetRom(&rom);
+  auto cached_tile_or = cached_object.GetTile(/*index=*/0);
+  ASSERT_TRUE(cached_tile_or.ok()) << cached_tile_or.status();
+  const int original_cached_tile_id = (*cached_tile_or)->id_;
+  RoomObject copied_cached_object = cached_object;
+
   auto* top_left = layout_or->FindCell(0, 0);
   auto* bottom_right = layout_or->FindCell(1, 1);
   ASSERT_NE(top_left, nullptr);
@@ -708,9 +717,16 @@ TEST(ObjectTileEditorTest, StandardWritePlanUsesExactWritesAndReadback) {
   auto expected_rom = rom.vector();
   StoreWord(expected_rom, 0x29EC, top_left_word);
   StoreWord(expected_rom, 0x29F2, bottom_right_word);
+  const uint64_t revision_before_apply = rom.object_tile_revision();
   ASSERT_TRUE(editor.ApplyStandardWritePlan(*plan_or).ok());
   EXPECT_EQ(rom.vector(), expected_rom);
   EXPECT_TRUE(rom.dirty());
+  EXPECT_EQ(rom.object_tile_revision(), revision_before_apply + 1);
+  auto refreshed_cached_tile_or = copied_cached_object.GetTile(/*index=*/0);
+  ASSERT_TRUE(refreshed_cached_tile_or.ok())
+      << refreshed_cached_tile_or.status();
+  EXPECT_EQ((*refreshed_cached_tile_or)->id_, top_left->tile_info.id_);
+  EXPECT_NE((*refreshed_cached_tile_or)->id_, original_cached_tile_id);
 
   Rom reopened;
   ASSERT_TRUE(reopened.LoadFromData(rom.vector()).ok());
@@ -721,6 +737,26 @@ TEST(ObjectTileEditorTest, StandardWritePlanUsesExactWritesAndReadback) {
   ASSERT_TRUE(readback_or.ok()) << readback_or.status();
   EXPECT_EQ(readback_or->FindCell(0, 0)->original_word, top_left_word);
   EXPECT_EQ(readback_or->FindCell(1, 1)->original_word, bottom_right_word);
+}
+
+TEST(ObjectTileEditorTest,
+     EmptyStandardWritePlanDoesNotAdvanceObjectTileRevision) {
+  ScopedCustomObjectsDisabled disable_custom_objects;
+  Rom rom;
+  ASSERT_TRUE(rom.LoadFromData(MakeEditableObjectRomData()).ok());
+
+  Room room(/*room_id=*/0, &rom, /*game_data=*/nullptr);
+  gfx::PaletteGroup palette;
+  ObjectTileEditor editor(&rom);
+  auto layout_or = editor.CaptureEditableObjectLayout(0x11F, room, palette);
+  ASSERT_TRUE(layout_or.ok()) << layout_or.status();
+  auto plan_or = editor.BuildStandardWritePlan(*layout_or);
+  ASSERT_TRUE(plan_or.ok()) << plan_or.status();
+  ASSERT_TRUE(plan_or->writes().empty());
+
+  const uint64_t revision_before_apply = rom.object_tile_revision();
+  EXPECT_TRUE(editor.ApplyStandardWritePlan(*plan_or).ok());
+  EXPECT_EQ(rom.object_tile_revision(), revision_before_apply);
 }
 
 TEST(ObjectTileEditorTest,
@@ -757,11 +793,13 @@ TEST(ObjectTileEditorTest,
     rom.set_dirty(stale_descriptor);
     const auto before = rom.vector();
     const bool was_dirty = rom.dirty();
+    const uint64_t revision_before_apply = rom.object_tile_revision();
 
     const absl::Status status = editor.ApplyStandardWritePlan(*plan_or);
     EXPECT_TRUE(absl::IsFailedPrecondition(status));
     EXPECT_EQ(rom.vector(), before);
     EXPECT_EQ(rom.dirty(), was_dirty);
+    EXPECT_EQ(rom.object_tile_revision(), revision_before_apply);
   }
 }
 
@@ -787,17 +825,31 @@ TEST(ObjectTileEditorTest, ApplyStandardWritePlanRollsBackAndPreservesDirty) {
   ASSERT_TRUE(plan_or.ok()) << plan_or.status();
   ASSERT_EQ(plan_or->writes().size(), 2u);
 
+  RoomObject cached_object(/*id=*/0x11F, /*x=*/0, /*y=*/0, /*size=*/0,
+                           /*layer=*/0);
+  cached_object.SetRom(&rom);
+  auto cached_tile_or = cached_object.GetTile(/*index=*/0);
+  ASSERT_TRUE(cached_tile_or.ok()) << cached_tile_or.status();
+  const int original_cached_tile_id = (*cached_tile_or)->id_;
+  RoomObject copied_cached_object = cached_object;
+
   rom::WriteFence fence;
   ASSERT_TRUE(fence.Allow(0x29EC, 0x29EE, "first object tile word").ok());
   rom::ScopedWriteFence fence_scope(&rom, &fence);
 
   const auto original = rom.vector();
   const bool original_dirty = rom.dirty();
+  const uint64_t revision_before_apply = rom.object_tile_revision();
   const absl::Status status = editor.ApplyStandardWritePlan(*plan_or);
 
   EXPECT_TRUE(absl::IsPermissionDenied(status));
   EXPECT_EQ(rom.vector(), original);
   EXPECT_EQ(rom.dirty(), original_dirty);
+  EXPECT_EQ(rom.object_tile_revision(), revision_before_apply);
+  auto preserved_cached_tile_or = copied_cached_object.GetTile(/*index=*/0);
+  ASSERT_TRUE(preserved_cached_tile_or.ok())
+      << preserved_cached_tile_or.status();
+  EXPECT_EQ((*preserved_cached_tile_or)->id_, original_cached_tile_id);
 }
 
 TEST(ObjectTileEditorTest, RenderLayoutToBitmapUsesThirdPaletteWhenAvailable) {

--- a/test/unit/zelda3/dungeon/room_object_set_id_test.cc
+++ b/test/unit/zelda3/dungeon/room_object_set_id_test.cc
@@ -1,9 +1,33 @@
 #include "gtest/gtest.h"
 
+#include <utility>
+
 #include "zelda3/dungeon/room_object.h"
 
 namespace yaze {
 namespace zelda3 {
+namespace {
+
+constexpr uint32_t kObject11fDescriptorAddress = 0x842E;
+constexpr uint16_t kObject11fDescriptorWord = 0x0E9A;
+constexpr uint32_t kObject11fSourceAddress = 0x29EC;
+
+void StoreWord(std::vector<uint8_t>& data, uint32_t address, uint16_t word) {
+  data[address] = static_cast<uint8_t>(word & 0xFF);
+  data[address + 1] = static_cast<uint8_t>(word >> 8);
+}
+
+std::vector<uint8_t> MakeObjectTileRomData(uint16_t first_word) {
+  std::vector<uint8_t> data(0x200000, 0);
+  StoreWord(data, kObject11fDescriptorAddress, kObject11fDescriptorWord);
+  for (size_t index = 0; index < 4; ++index) {
+    StoreWord(data, kObject11fSourceAddress + index * 2,
+              static_cast<uint16_t>(first_word + index));
+  }
+  return data;
+}
+
+}  // namespace
 
 TEST(RoomObjectSetIdTest, RecomputesAllBgsAndInvalidatesTileCache) {
   RoomObject obj(/*id=*/0x21, /*x=*/0, /*y=*/0, /*size=*/0, /*layer=*/0);
@@ -44,6 +68,125 @@ TEST(RoomObjectSetIdTest, NoOpWhenIdUnchanged) {
   EXPECT_TRUE(obj.all_bgs_);
 }
 
+TEST(RoomObjectTileCacheTest, EveryAccessorRefreshesTrackedCacheRevision) {
+  Rom rom;
+  ASSERT_TRUE(rom.LoadFromData(MakeObjectTileRomData(/*first_word=*/1)).ok());
+  RoomObject object(/*id=*/0x11F, /*x=*/0, /*y=*/0, /*size=*/0, /*layer=*/0);
+  object.SetRom(&rom);
+
+  auto initial_tiles_or = object.GetTiles();
+  ASSERT_TRUE(initial_tiles_or.ok()) << initial_tiles_or.status();
+  ASSERT_FALSE(initial_tiles_or->empty());
+  EXPECT_EQ((*initial_tiles_or)[0].id_, 1);
+
+  StoreWord(rom.mutable_vector(), kObject11fSourceAddress, /*word=*/2);
+  rom.AdvanceObjectTileRevision();
+  auto refreshed_tiles_or = object.GetTiles();
+  ASSERT_TRUE(refreshed_tiles_or.ok()) << refreshed_tiles_or.status();
+  EXPECT_EQ((*refreshed_tiles_or)[0].id_, 2);
+
+  StoreWord(rom.mutable_vector(), kObject11fSourceAddress, /*word=*/3);
+  rom.AdvanceObjectTileRevision();
+  auto refreshed_tile_or = object.GetTile(/*index=*/0);
+  ASSERT_TRUE(refreshed_tile_or.ok()) << refreshed_tile_or.status();
+  EXPECT_EQ((*refreshed_tile_or)->id_, 3);
+
+  StoreWord(rom.mutable_vector(), kObject11fSourceAddress, /*word=*/4);
+  rom.AdvanceObjectTileRevision();
+  ASSERT_FALSE(object.tiles().empty());
+  EXPECT_EQ(object.tiles()[0].id_, 4);
+
+  object.tile_count_ = 999;
+  rom.AdvanceObjectTileRevision();
+  EXPECT_EQ(object.GetTileCount(), 4);
+}
+
+TEST(RoomObjectTileCacheTest,
+     InPlaceRomReplacementCannotReuseEqualRevisionCache) {
+  Rom active_rom;
+  Rom replacement;
+  ASSERT_TRUE(
+      active_rom.LoadFromData(MakeObjectTileRomData(/*first_word=*/1)).ok());
+  ASSERT_TRUE(
+      replacement.LoadFromData(MakeObjectTileRomData(/*first_word=*/9)).ok());
+  ASSERT_EQ(active_rom.object_tile_revision(),
+            replacement.object_tile_revision());
+
+  RoomObject object(/*id=*/0x11F, /*x=*/0, /*y=*/0, /*size=*/0, /*layer=*/0);
+  object.SetRom(&active_rom);
+  auto initial_tile_or = object.GetTile(/*index=*/0);
+  ASSERT_TRUE(initial_tile_or.ok()) << initial_tile_or.status();
+  EXPECT_EQ((*initial_tile_or)->id_, 1);
+
+  active_rom = std::move(replacement);
+  auto replaced_tile_or = object.GetTile(/*index=*/0);
+  ASSERT_TRUE(replaced_tile_or.ok()) << replaced_tile_or.status();
+  EXPECT_EQ((*replaced_tile_or)->id_, 9);
+}
+
+TEST(RoomObjectTileCacheTest, CopiedTrackedCachesCheckRevisionAndRomIdentity) {
+  Rom first_rom;
+  Rom second_rom;
+  ASSERT_TRUE(
+      first_rom.LoadFromData(MakeObjectTileRomData(/*first_word=*/1)).ok());
+  ASSERT_TRUE(
+      second_rom.LoadFromData(MakeObjectTileRomData(/*first_word=*/9)).ok());
+  ASSERT_EQ(first_rom.object_tile_revision(),
+            second_rom.object_tile_revision());
+
+  RoomObject source(/*id=*/0x11F, /*x=*/0, /*y=*/0, /*size=*/0, /*layer=*/0);
+  source.SetRom(&first_rom);
+  auto source_tile_or = source.GetTile(/*index=*/0);
+  ASSERT_TRUE(source_tile_or.ok()) << source_tile_or.status();
+  EXPECT_EQ((*source_tile_or)->id_, 1);
+
+  RoomObject same_rom_copy = source;
+  StoreWord(first_rom.mutable_vector(), kObject11fSourceAddress, /*word=*/2);
+  first_rom.AdvanceObjectTileRevision();
+  auto refreshed_copy_tile_or = same_rom_copy.GetTile(/*index=*/0);
+  ASSERT_TRUE(refreshed_copy_tile_or.ok()) << refreshed_copy_tile_or.status();
+  EXPECT_EQ((*refreshed_copy_tile_or)->id_, 2);
+
+  // Equal revision numbers are insufficient: a copied cache moved to another
+  // ROM must reload from that ROM rather than reuse the source object's tiles.
+  RoomObject other_rom_copy = source;
+  other_rom_copy.SetRom(&second_rom);
+  auto other_tile_or = other_rom_copy.GetTile(/*index=*/0);
+  ASSERT_TRUE(other_tile_or.ok()) << other_tile_or.status();
+  EXPECT_EQ((*other_tile_or)->id_, 9);
+}
+
+TEST(RoomObjectTileCacheTest,
+     CopiedInjectedCacheRemainsUntrackedAcrossRomChanges) {
+  Rom first_rom;
+  Rom second_rom;
+  ASSERT_TRUE(
+      first_rom.LoadFromData(MakeObjectTileRomData(/*first_word=*/1)).ok());
+  ASSERT_TRUE(
+      second_rom.LoadFromData(MakeObjectTileRomData(/*first_word=*/9)).ok());
+
+  RoomObject injected(/*id=*/0x11F, /*x=*/0, /*y=*/0, /*size=*/0, /*layer=*/0);
+  injected.SetRom(&first_rom);
+  ASSERT_TRUE(injected.GetTile(/*index=*/0).ok());
+  injected.mutable_tiles().assign(
+      1, gfx::TileInfo(/*id=*/777, /*palette=*/0, /*v=*/false, /*h=*/false,
+                       /*o=*/false));
+  injected.tiles_loaded_ = true;
+  injected.tile_count_ = 1;
+
+  RoomObject copied = injected;
+  copied.SetRom(&second_rom);
+  second_rom.AdvanceObjectTileRevision();
+
+  auto tiles_or = copied.GetTiles();
+  ASSERT_TRUE(tiles_or.ok()) << tiles_or.status();
+  ASSERT_EQ(tiles_or->size(), 1u);
+  EXPECT_EQ((*tiles_or)[0].id_, 777);
+  auto tile_or = copied.GetTile(/*index=*/0);
+  ASSERT_TRUE(tile_or.ok()) << tile_or.status();
+  EXPECT_EQ((*tile_or)->id_, 777);
+  EXPECT_EQ(copied.GetTileCount(), 1);
+}
+
 }  // namespace zelda3
 }  // namespace yaze
-


### PR DESCRIPTION
## Summary

- add a monotonic object-tile revision to `Rom` across successful loads, replacement, resize, close, and committed object-tile transactions
- make parser-derived `RoomObject` caches validate both ROM identity and revision before every tile accessor
- preserve intentionally injected/untracked tile caches
- cover successful write/readback, copied-cache refresh, failure/rollback preservation, in-place ROM replacement, and lifecycle transitions

## Why

The guarded Object Tile Editor backend can now commit standard object tile writes, but already-materialized room objects could continue rendering stale cached tiles. This stack makes the cache contract explicit and invalidates parser-derived caches only after a real committed change.

## Stack

Retargeted to `master` after prerequisite PR #183 merged.

Exact head `c85213f2420e463cdbc922c9095ac4cb632fa38a`; aggregate topic patch-id `7790e8ef4f0bb19cc871d0f196c1df728dae56c8` remained unchanged across the retarget merge. The pre/post-retarget trees are identical.

This PR does not expose the Object Tile Editor write action in the UI. Shared-source editing, selector/layout redraw, materialized-room redraw, and placement-ghost cancellation remain separate gates.

## Verification

- `cmake --build build/presets/mac-ai --target yaze_test_unit -j8`
- 36/36 focused ROM revision, copy/assignment fence ownership, room-object cache, set-id, and object-tile transaction tests passed from an exact-head rebuild
- `scripts/pre-push.sh --build-dir build/presets/mac-ai`: build passed, 13/13 smoke tests passed; UI regression skipped because no panel/workflow files changed
- `git range-diff` and an independent strict read-only review confirmed the three topic commits are byte-identical after retargeting
- Claude fence-ownership reviews addressed in `b2bedabb1` and `f93c8d2e0`: assignment preserves destination-local active fences, and copy construction starts with no imported source pointers
