### PR TITLE
Detect shared dungeon object tile sources

### DIFF
--- a/src/app/editor/dungeon/ui/window/object_tile_editor_panel.cc
+++ b/src/app/editor/dungeon/ui/window/object_tile_editor_panel.cc
@@ -130,21 +130,38 @@ void ObjectTileEditorPanel::SelectFirstCellIfAvailable() {
   SyncSourceSelectionFromSelectedCell();
 }
 
-int ObjectTileEditorPanel::GetSharedTileDataUsageCount() const {
+absl::StatusOr<int> ObjectTileEditorPanel::GetSharedTileDataUsageCount() const {
   if (shared_tile_data_usage_override_ >= 0) {
     return shared_tile_data_usage_override_;
   }
 
-  if (current_layout_.is_custom || current_layout_.tile_data_address < 0 ||
-      current_object_id_ < 0 || rom_ == nullptr || !rom_->is_loaded()) {
+  if (current_layout_.is_custom) {
     return 0;
   }
+  if (current_object_id_ < 0 ||
+      current_layout_.object_id != current_object_id_) {
+    return absl::FailedPreconditionError(
+        "No matching standard object is selected for source-impact analysis");
+  }
+  if (rom_ == nullptr || !rom_->is_loaded()) {
+    return absl::FailedPreconditionError(
+        "A loaded ROM is required for source-impact analysis");
+  }
 
-  return tile_editor_->CountObjectsSharingTileData(current_object_id_);
+  auto impact_or =
+      tile_editor_->AnalyzeStandardTileSourceImpact(current_layout_);
+  if (!impact_or.ok()) {
+    return impact_or.status();
+  }
+  return static_cast<int>(impact_or->consumer_count());
 }
 
-bool ObjectTileEditorPanel::HasSharedTileDataConflict() const {
-  return GetSharedTileDataUsageCount() > 1;
+absl::StatusOr<bool> ObjectTileEditorPanel::HasSharedTileDataConflict() const {
+  auto usage_count_or = GetSharedTileDataUsageCount();
+  if (!usage_count_or.ok()) {
+    return usage_count_or.status();
+  }
+  return *usage_count_or > 1;
 }
 
 bool ObjectTileEditorPanel::HasRenderableRoomContext() const {
@@ -215,7 +232,7 @@ void ObjectTileEditorPanel::Draw(bool* p_open) {
   }
   if (ImGui::BeginPopupModal("Shared Tile Data", nullptr,
                              ImGuiWindowFlags_AlwaysAutoResize)) {
-    ImGui::Text(tr("This tile data is shared by %d objects."),
+    ImGui::Text(tr("This tile data is shared by %d consumers."),
                 shared_object_count_);
     ImGui::Text(tr("Changes will affect all of them."));
     ImGui::Spacing();
@@ -544,15 +561,31 @@ absl::Status ObjectTileEditorPanel::WriteBackCurrentLayout() {
 }
 
 void ObjectTileEditorPanel::ApplyChanges(bool confirm_shared) {
-  // Check for shared tile data and ask for confirmation
-  const int shared_count = GetSharedTileDataUsageCount();
+  // Resolve the complete source impact before every standard write, including
+  // the second call after the user accepts the shared-data confirmation. A
+  // malformed or unresolved object family must block the write rather than be
+  // interpreted as an unshared source.
+  const auto shared_count_or = GetSharedTileDataUsageCount();
+  if (!shared_count_or.ok()) {
+    show_shared_confirm_ = false;
+    shared_object_count_ = 0;
+    SetActionStatus(
+        ActionStatusTone::kError,
+        absl::StrFormat(ICON_MD_ERROR
+                        " Apply blocked: source impact could not be resolved: "
+                        "%s",
+                        shared_count_or.status().message()));
+    return;
+  }
+  const int shared_count = *shared_count_or;
   if (confirm_shared && shared_count > 1) {
     shared_object_count_ = shared_count;
     show_shared_confirm_ = true;
     SetActionStatus(
         ActionStatusTone::kWarning,
         absl::StrFormat(ICON_MD_WARNING
-                        " Confirm shared apply: %d objects use this tile data.",
+                        " Confirm shared apply: %d consumers use this tile "
+                        "data.",
                         shared_count));
     return;
   }
@@ -569,10 +602,26 @@ void ObjectTileEditorPanel::ApplyChanges(bool confirm_shared) {
       room.RenderRoomGraphics();
     }
 
-    // Update original words to match current state
+    // Update both the cells and the authoritative source snapshot only after
+    // the write succeeds. The next impact analysis reuses BuildStandardWritePlan
+    // as its CAS gate, so leaving expected_words stale here would make every
+    // later apply fail until the panel was reopened.
     for (auto& cell : current_layout_.cells) {
       if (cell.modified) {
-        cell.original_word = gfx::TileInfoToWord(cell.tile_info);
+        const uint16_t applied_word = gfx::TileInfoToWord(cell.tile_info);
+        cell.original_word = applied_word;
+        if (!current_layout_.is_custom &&
+            current_layout_.source_provenance.has_value() &&
+            cell.source_ref.has_value()) {
+          const auto& source_ref = *cell.source_ref;
+          auto& spans = current_layout_.source_provenance->spans;
+          if (source_ref.span_index < spans.size() &&
+              source_ref.word_index <
+                  spans[source_ref.span_index].expected_words.size()) {
+            spans[source_ref.span_index].expected_words[source_ref.word_index] =
+                applied_word;
+          }
+        }
         cell.modified = false;
       }
     }
@@ -593,7 +642,7 @@ void ObjectTileEditorPanel::ApplyChanges(bool confirm_shared) {
           ActionStatusTone::kSuccess,
           absl::StrFormat(
               ICON_MD_CHECK_CIRCLE
-              " Applied changes to shared tile data used by %d objects.",
+              " Applied changes to shared tile data used by %d consumers.",
               shared_count));
     } else {
       ClearActionStatus();
@@ -621,15 +670,27 @@ void ObjectTileEditorPanel::DrawActionBar() {
     ImGui::SameLine();
   }
 
-  // Shared tile data warning
-  const int shared_count = GetSharedTileDataUsageCount();
-  if (shared_count > 1) {
+  // Shared tile data warning. Keep analysis errors visible here, but enforce
+  // fail-closed behavior in ApplyChanges so the disabled-by-default standard
+  // editor cannot silently turn an unknown impact into a write.
+  const auto shared_count_or = GetSharedTileDataUsageCount();
+  if (!shared_count_or.ok()) {
+    ImGui::TextColored(gui::ConvertColorToImVec4(theme.error),
+                       ICON_MD_ERROR " Source impact unavailable");
+    if (ImGui::IsItemHovered()) {
+      ImGui::SetItemTooltip("%s", shared_count_or.status().message().data());
+    }
+    ImGui::SameLine();
+  } else if (*shared_count_or > 1) {
+    const int shared_count = *shared_count_or;
     ImGui::TextColored(gui::ConvertColorToImVec4(theme.warning),
-                       ICON_MD_WARNING " Shared by %d objects", shared_count);
+                       ICON_MD_WARNING " Shared by %d consumers", shared_count);
     if (ImGui::IsItemHovered()) {
       ImGui::SetItemTooltip(
-          tr("This object reuses tile data with %d objects.\nApplying changes "
-             "will update every object in that shared data group."),
+          tr("This object reuses tile data with %d consumers.\nApplying "
+             "changes "
+             "will update every object or runtime consumer in that shared "
+             "data group."),
           shared_count);
     }
     ImGui::SameLine();

--- a/src/app/editor/dungeon/ui/window/object_tile_editor_panel.h
+++ b/src/app/editor/dungeon/ui/window/object_tile_editor_panel.h
@@ -86,8 +86,8 @@ class ObjectTileEditorPanel : public WindowContent {
   void ResetTransientState();
   std::string BuildWindowTitle() const;
   void SelectFirstCellIfAvailable();
-  int GetSharedTileDataUsageCount() const;
-  bool HasSharedTileDataConflict() const;
+  absl::StatusOr<int> GetSharedTileDataUsageCount() const;
+  absl::StatusOr<bool> HasSharedTileDataConflict() const;
   bool HasRenderableRoomContext() const;
   void RefreshRenderedViewsFromCurrentRoom();
 

--- a/src/zelda3/dungeon/object_parser.cc
+++ b/src/zelda3/dungeon/object_parser.cc
@@ -1,6 +1,8 @@
 #include "object_parser.h"
 
+#include <algorithm>
 #include <cstring>
+#include <tuple>
 
 #include "absl/strings/str_format.h"
 #include "util/log.h"
@@ -118,6 +120,30 @@ absl::StatusOr<std::vector<gfx::TileInfo>> ObjectParser::ParseObject(
       return absl::InvalidArgumentError(
           absl::StrFormat("Invalid object subtype for ID: %#04x", object_id));
   }
+}
+
+absl::StatusOr<std::vector<ObjectTileReadRange>>
+ObjectParser::ResolveTileReadRanges(int16_t object_id) {
+  if (tile_read_range_collector_ != nullptr) {
+    return absl::FailedPreconditionError(
+        "Object tile source resolution is already active");
+  }
+
+  std::vector<ObjectTileReadRange> ranges;
+  tile_read_range_collector_ = &ranges;
+  const auto parsed_or = ParseObject(object_id);
+  tile_read_range_collector_ = nullptr;
+  if (!parsed_or.ok()) {
+    return parsed_or.status();
+  }
+
+  std::sort(ranges.begin(), ranges.end(),
+            [](const ObjectTileReadRange& lhs, const ObjectTileReadRange& rhs) {
+              return std::tie(lhs.begin, lhs.end) <
+                     std::tie(rhs.begin, rhs.end);
+            });
+  ranges.erase(std::unique(ranges.begin(), ranges.end()), ranges.end());
+  return ranges;
 }
 
 absl::StatusOr<ObjectRoutineInfo> ObjectParser::ParseObjectRoutine(
@@ -332,6 +358,8 @@ absl::StatusOr<std::vector<gfx::TileInfo>> ObjectParser::ParseSubtype3(
   constexpr int kBombableFloorStateTileCount = 16;
   constexpr int kPrisonCellTileOffset = 0x1488;
   constexpr int kPrisonCellTileCount = 6;
+  constexpr int kRupeeFloorTileOffset = 0x1DD6;
+  constexpr int kRupeeFloorTileCount = 2;
   constexpr int kBigKeyLockTileOffset = 0x1494;
   constexpr int kClosedChestTileOffset = 0x149C;
   constexpr int kOpenChestTileOffset = 0x14A4;
@@ -393,6 +421,15 @@ absl::StatusOr<std::vector<gfx::TileInfo>> ObjectParser::ParseSubtype3(
   if (object_id == 0xF8D || object_id == 0xF97) {
     return ReadTileData(kRoomObjectTileAddress + kPrisonCellTileOffset,
                         kPrisonCellTileCount);
+  }
+
+  // RupeeFloor replaces the table-derived pointer with literal obj1DD6 and
+  // repeats those two words across its fixed footprint. Following the table
+  // here would hide a real shared-source overlap from both rendering and the
+  // source-impact resolver.
+  if (object_id == 0xF92) {
+    return ReadTileData(kRoomObjectTileAddress + kRupeeFloorTileOffset,
+                        kRupeeFloorTileCount);
   }
 
   // BigKeyLock overwrites the table-derived X register with obj1494 before
@@ -488,6 +525,12 @@ absl::StatusOr<std::vector<gfx::TileInfo>> ObjectParser::ReadTileData(
   if (address < 0 || address + (tile_count * 2) >= (int)rom_->size()) {
     return absl::OutOfRangeError(
         absl::StrFormat("Tile data address out of range: %#06x", address));
+  }
+
+  if (tile_read_range_collector_ != nullptr) {
+    tile_read_range_collector_->push_back(
+        {static_cast<uint32_t>(address),
+         static_cast<uint32_t>(address + tile_count * 2)});
   }
 
   std::vector<gfx::TileInfo> tiles;

--- a/src/zelda3/dungeon/object_parser.h
+++ b/src/zelda3/dungeon/object_parser.h
@@ -82,6 +82,20 @@ struct ObjectDrawInfo {
 };
 
 /**
+ * @brief One half-open PC range consumed while parsing an object's tile data.
+ *
+ * Keeping this trace inside ObjectParser makes split and literal sources use
+ * the exact same control flow as rendering instead of inferring one contiguous
+ * range from a descriptor and a total tile count.
+ */
+struct ObjectTileReadRange {
+  uint32_t begin = 0;
+  uint32_t end = 0;
+
+  bool operator==(const ObjectTileReadRange&) const = default;
+};
+
+/**
  * @brief Direct ROM parser for dungeon objects
  *
  * This class replaces the SNES emulation approach with direct ROM parsing,
@@ -98,6 +112,16 @@ class ObjectParser {
    * @return StatusOr containing the parsed tile data
    */
   absl::StatusOr<std::vector<gfx::TileInfo>> ParseObject(int16_t object_id);
+
+  /**
+   * @brief Resolve every tile-data range consumed by ParseObject.
+   *
+   * This deliberately executes the parser's normal read path and therefore
+   * fails if any source is malformed or outside the loaded ROM. Callers must
+   * not turn a resolution error into an empty impact set.
+   */
+  absl::StatusOr<std::vector<ObjectTileReadRange>> ResolveTileReadRanges(
+      int16_t object_id);
 
   /**
    * @brief Parse object routine data
@@ -181,6 +205,7 @@ class ObjectParser {
    *
    * Different subtype 3 objects have different tile counts:
    * - PrisonCell aliases (0xF8D/0xF97): 6 tiles from literal obj1488
+   * - RupeeFloor (0xF92): 2 tiles from literal obj1DD6
    * - BigKeyLock (0xF98): 4 tiles (one closed 2x2 block)
    * - BombableFloor (0xFC7): 32 tiles (two non-contiguous 4x4 states)
    * - Chest/OpenChest (0xF99/0xF9A): 8/4 tiles (stateful/fixed 2x2)
@@ -199,6 +224,7 @@ class ObjectParser {
   int ResolveTileCountForObject(int16_t object_id) const;
 
   Rom* rom_;
+  std::vector<ObjectTileReadRange>* tile_read_range_collector_ = nullptr;
 };
 
 }  // namespace zelda3

--- a/src/zelda3/dungeon/object_tile_editor.cc
+++ b/src/zelda3/dungeon/object_tile_editor.cc
@@ -9,6 +9,7 @@
 #include <unordered_map>
 #include <unordered_set>
 
+#include "absl/strings/str_format.h"
 #include "app/gfx/types/snes_tile.h"
 #include "core/features.h"
 #include "rom/transaction.h"
@@ -853,30 +854,133 @@ absl::Status ObjectTileEditor::ApplyStandardWritePlan(
   return absl::OkStatus();
 }
 
-int ObjectTileEditor::CountObjectsSharingTileData(int16_t object_id) const {
-  if (!rom_ || !rom_->is_loaded())
-    return 0;
+absl::StatusOr<ObjectTileSourceImpact>
+ObjectTileEditor::AnalyzeStandardTileSourceImpact(
+    const ObjectTileLayout& layout) const {
+  if (rom_ == nullptr || !rom_->is_loaded()) {
+    return absl::FailedPreconditionError("ROM not loaded");
+  }
+  if (layout.is_custom) {
+    return absl::InvalidArgumentError(
+        "Custom objects do not use standard ROM tile sources");
+  }
+  if (!layout.source_provenance.has_value()) {
+    return absl::FailedPreconditionError(
+        "Standard object layout has no editable source provenance");
+  }
 
-  // Create temporary object to get its tile_data_ptr_
-  RoomObject test_obj(object_id, 0, 0, 0, 0);
-  test_obj.SetRom(rom_);
-  test_obj.EnsureTilesLoaded();
-  int target_ptr = test_obj.tile_data_ptr_;
-  if (target_ptr < 0)
-    return 0;
+  // Reuse the write-plan validator as the provenance/CAS gate. This validates
+  // the audited object ID, descriptor, complete source snapshot, and cell map
+  // without mutating the ROM, regardless of whether the layout has edits.
+  const auto plan_or = BuildStandardWritePlan(layout);
+  if (!plan_or.ok()) {
+    return plan_or.status();
+  }
 
-  // Scan type 1 objects (0x00-0xFF) for shared pointers
-  int count = 0;
-  for (int id = 0; id < 0x100; ++id) {
-    RoomObject scan_obj(static_cast<int16_t>(id), 0, 0, 0, 0);
-    scan_obj.SetRom(rom_);
-    scan_obj.EnsureTilesLoaded();
-    if (scan_obj.tile_data_ptr_ == target_ptr) {
-      ++count;
+  std::vector<ObjectTileReadRange> target_ranges;
+  for (const auto& span : layout.source_provenance->spans) {
+    if (span.expected_words.empty()) {
+      return absl::FailedPreconditionError(
+          "Editable object tile source span is empty");
+    }
+    const uint64_t end = static_cast<uint64_t>(span.pc_address) +
+                         static_cast<uint64_t>(span.expected_words.size()) * 2;
+    if (end > rom_->size() || end > std::numeric_limits<uint32_t>::max()) {
+      return absl::OutOfRangeError(
+          "Editable object tile source span is outside the loaded ROM");
+    }
+    target_ranges.push_back({span.pc_address, static_cast<uint32_t>(end)});
+  }
+
+  const auto overlaps_target =
+      [&target_ranges](const ObjectTileReadRange& candidate) {
+        return std::any_of(target_ranges.begin(), target_ranges.end(),
+                           [&candidate](const ObjectTileReadRange& target) {
+                             return candidate.begin < target.end &&
+                                    target.begin < candidate.end;
+                           });
+      };
+
+  ObjectParser parser(rom_);
+  ObjectTileSourceImpact impact;
+  const auto inspect_object = [&](int object_id) -> absl::Status {
+    auto ranges_or =
+        parser.ResolveTileReadRanges(static_cast<int16_t>(object_id));
+    if (!ranges_or.ok()) {
+      return absl::FailedPreconditionError(absl::StrFormat(
+          "Unable to resolve tile sources for object 0x%03X: %s", object_id,
+          ranges_or.status().message()));
+    }
+
+    ObjectTileSourceImpactEntry entry;
+    entry.object_id = static_cast<int16_t>(object_id);
+    for (const auto& range : *ranges_or) {
+      if (overlaps_target(range)) {
+        entry.overlapping_ranges.push_back(range);
+      }
+    }
+    if (!entry.overlapping_ranges.empty()) {
+      impact.affected_objects.push_back(std::move(entry));
+    }
+    return absl::OkStatus();
+  };
+
+  // Only IDs representable in the dungeon object stream are relevant. Keep the
+  // three families explicit so invalid aliases (Type 1 0xF8..0xFF and Type 2
+  // 0x140..0x1FF) cannot silently inflate or hide the impact set.
+  for (int object_id = 0x000; object_id <= 0x0F7; ++object_id) {
+    const absl::Status status = inspect_object(object_id);
+    if (!status.ok()) {
+      return status;
+    }
+  }
+  for (int object_id = 0x100; object_id <= 0x13F; ++object_id) {
+    const absl::Status status = inspect_object(object_id);
+    if (!status.ok()) {
+      return status;
+    }
+  }
+  for (int object_id = 0xF80; object_id <= 0xFFF; ++object_id) {
+    const absl::Status status = inspect_object(object_id);
+    if (!status.ok()) {
+      return status;
     }
   }
 
-  return count;
+  // Room::RenderObjectsToBackground synthesizes lightable torches as global
+  // object 0x150, outside the persisted stream-ID families above. Both room
+  // rendering and the in-game lighting-change path read these literal blocks.
+  // In particular, the lit block aliases editable object 0x120 exactly.
+  constexpr int kLightableTorchTileCount = 4;
+  constexpr ObjectTileReadRange kLightableTorchSources[] = {
+      {kRoomObjectTileAddress + 0x0EC2,
+       kRoomObjectTileAddress + 0x0EC2 + kLightableTorchTileCount * 2},
+      {kRoomObjectTileAddress + 0x0ECA,
+       kRoomObjectTileAddress + 0x0ECA + kLightableTorchTileCount * 2},
+  };
+  for (const auto consumer :
+       {ObjectTileRuntimeConsumer::kLightableTorchDraw,
+        ObjectTileRuntimeConsumer::kTorchLightingChange}) {
+    ObjectTileRuntimeConsumerImpactEntry torch_impact{consumer, {}};
+    for (const auto& range : kLightableTorchSources) {
+      if (overlaps_target(range)) {
+        torch_impact.overlapping_ranges.push_back(range);
+      }
+    }
+    if (!torch_impact.overlapping_ranges.empty()) {
+      impact.runtime_consumers.push_back(std::move(torch_impact));
+    }
+  }
+
+  const bool includes_edited_object = std::any_of(
+      impact.affected_objects.begin(), impact.affected_objects.end(),
+      [&](const auto& entry) { return entry.object_id == layout.object_id; });
+  if (!includes_edited_object) {
+    return absl::FailedPreconditionError(
+        "Edited object is missing from its tile source impact inventory");
+  }
+
+  return impact;
 }
 
 }  // namespace zelda3

--- a/src/zelda3/dungeon/object_tile_editor.h
+++ b/src/zelda3/dungeon/object_tile_editor.h
@@ -15,6 +15,7 @@
 #include "app/gfx/types/snes_tile.h"
 #include "rom/rom.h"
 #include "zelda3/dungeon/object_drawer.h"
+#include "zelda3/dungeon/object_parser.h"
 #include "zelda3/dungeon/room.h"
 
 namespace yaze {
@@ -47,6 +48,47 @@ struct ObjectTileSourceProvenance {
 struct ObjectTileSourceRef {
   size_t span_index = 0;
   size_t word_index = 0;
+};
+
+/**
+ * @brief One standard object whose parser-visible tile sources overlap an
+ * editable layout's authorized source spans.
+ */
+struct ObjectTileSourceImpactEntry {
+  int16_t object_id = -1;
+  std::vector<ObjectTileReadRange> overlapping_ranges;
+};
+
+enum class ObjectTileRuntimeConsumer {
+  // Synthesized room object 0x150 reads the unlit/lit torch blocks directly
+  // during initial room drawing; it is not representable in the persisted
+  // dungeon object stream.
+  kLightableTorchDraw,
+  // Underworld light/extinguish updates read the same literal blocks again
+  // when replacing the torch tiles at runtime.
+  kTorchLightingChange,
+};
+
+struct ObjectTileRuntimeConsumerImpactEntry {
+  ObjectTileRuntimeConsumer consumer;
+  std::vector<ObjectTileReadRange> overlapping_ranges;
+};
+
+/**
+ * @brief Fail-closed impact inventory within ObjectParser's source model plus
+ * explicitly modeled runtime consumers.
+ *
+ * This is not proof that every SNES runtime routine has already been audited
+ * for hidden pointer substitution. Known consumers outside the persisted
+ * object-ID space must be represented explicitly in runtime_consumers.
+ */
+struct ObjectTileSourceImpact {
+  std::vector<ObjectTileSourceImpactEntry> affected_objects;
+  std::vector<ObjectTileRuntimeConsumerImpactEntry> runtime_consumers;
+
+  size_t consumer_count() const {
+    return affected_objects.size() + runtime_consumers.size();
+  }
 };
 
 /**
@@ -196,8 +238,13 @@ class ObjectTileEditor {
   // Atomically apply a previously validated standard-object write plan.
   absl::Status ApplyStandardWritePlan(const ObjectTileWritePlan& plan);
 
-  // Check how many objects share the same tile data pointer
-  int CountObjectsSharingTileData(int16_t object_id) const;
+  // Enumerate every representable standard object whose parser-visible source
+  // ranges overlap this editable layout, plus the explicit runtime consumers
+  // modeled by this backend. Resolution errors are returned to the caller and
+  // must block writes rather than being interpreted as no sharing. Other
+  // runtime-only behavior remains a separate parity-audit concern.
+  absl::StatusOr<ObjectTileSourceImpact> AnalyzeStandardTileSourceImpact(
+      const ObjectTileLayout& layout) const;
 
  private:
   Rom* rom_;

--- a/test/unit/editor/object_tile_editor_panel_test.cc
+++ b/test/unit/editor/object_tile_editor_panel_test.cc
@@ -235,11 +235,13 @@ struct ObjectTileEditorPanelTestAccess {
     return panel.current_layout_.cells.front().tile_info.palette_;
   }
 
-  static int SharedTileDataUsageCount(const ObjectTileEditorPanel& panel) {
+  static absl::StatusOr<int> SharedTileDataUsageCount(
+      const ObjectTileEditorPanel& panel) {
     return panel.GetSharedTileDataUsageCount();
   }
 
-  static bool HasSharedTileDataConflict(const ObjectTileEditorPanel& panel) {
+  static absl::StatusOr<bool> HasSharedTileDataConflict(
+      const ObjectTileEditorPanel& panel) {
     return panel.HasSharedTileDataConflict();
   }
 };
@@ -301,6 +303,11 @@ constexpr uint32_t kEditableDescriptorPcAddress = 0x842E;
 constexpr uint16_t kEditableDescriptorWord = 0x0E9A;
 constexpr uint32_t kEditableSourcePcAddress = 0x29EC;
 constexpr uint16_t kEditableSourceWords[] = {0x0DEE, 0x8DEE, 0x4DEE, 0xCDEE};
+constexpr int16_t kTorchAliasObjectId = 0x120;
+constexpr uint32_t kTorchAliasDescriptorPcAddress = 0x8430;
+constexpr uint16_t kTorchAliasDescriptorWord = 0x0ECA;
+constexpr uint32_t kTorchAliasSourcePcAddress = 0x2A1C;
+constexpr uint16_t kTorchAliasSourceWords[] = {0x0DC0, 0x0DC1, 0x4DC0, 0x4DC1};
 
 void StoreWord(std::vector<uint8_t>& data, uint32_t address, uint16_t word) {
   data[address] = static_cast<uint8_t>(word & 0xFF);
@@ -314,16 +321,20 @@ std::vector<uint8_t> MakeEditableStandardObjectRomData() {
     StoreWord(data, kEditableSourcePcAddress + index * 2,
               kEditableSourceWords[index]);
   }
+  StoreWord(data, kTorchAliasDescriptorPcAddress, kTorchAliasDescriptorWord);
+  for (size_t index = 0; index < std::size(kTorchAliasSourceWords); ++index) {
+    StoreWord(data, kTorchAliasSourcePcAddress + index * 2,
+              kTorchAliasSourceWords[index]);
+  }
   return data;
 }
 
 absl::StatusOr<zelda3::ObjectTileLayout> CaptureEditableStandardLayout(
-    Rom& rom) {
+    Rom& rom, int16_t object_id = kEditableStandardObjectId) {
   zelda3::Room room(/*room_id=*/0, &rom, /*game_data=*/nullptr);
   gfx::PaletteGroup palette;
   zelda3::ObjectTileEditor editor(&rom);
-  return editor.CaptureEditableObjectLayout(kEditableStandardObjectId, room,
-                                            palette);
+  return editor.CaptureEditableObjectLayout(object_id, room, palette);
 }
 
 int FirstCellSourceAddress(const zelda3::ObjectTileLayout& layout) {
@@ -543,14 +554,18 @@ TEST(ObjectTileEditorPanelTest,
   layout.tile_data_address = 0x1234;
   ObjectTileEditorPanelTestAccess::SetLayout(panel, std::move(layout));
 
-  EXPECT_EQ(ObjectTileEditorPanelTestAccess::SharedTileDataUsageCount(panel),
-            0);
-  EXPECT_FALSE(
-      ObjectTileEditorPanelTestAccess::HasSharedTileDataConflict(panel));
+  auto usage_count_or =
+      ObjectTileEditorPanelTestAccess::SharedTileDataUsageCount(panel);
+  ASSERT_TRUE(usage_count_or.ok()) << usage_count_or.status();
+  EXPECT_EQ(*usage_count_or, 0);
+  auto conflict_or =
+      ObjectTileEditorPanelTestAccess::HasSharedTileDataConflict(panel);
+  ASSERT_TRUE(conflict_or.ok()) << conflict_or.status();
+  EXPECT_FALSE(*conflict_or);
 }
 
 TEST(ObjectTileEditorPanelTest,
-     SharedTileDataUsageCountIgnoresStandardLayoutsWithoutTileDataAddress) {
+     SharedTileDataUsageCountRejectsStandardLayoutsWithoutProvenance) {
   Rom rom;
   ASSERT_TRUE(rom.LoadFromData(std::vector<uint8_t>(0x200000, 0)).ok());
 
@@ -562,10 +577,13 @@ TEST(ObjectTileEditorPanelTest,
   layout.tile_data_address = -1;
   ObjectTileEditorPanelTestAccess::SetLayout(panel, std::move(layout));
 
-  EXPECT_EQ(ObjectTileEditorPanelTestAccess::SharedTileDataUsageCount(panel),
-            0);
-  EXPECT_FALSE(
-      ObjectTileEditorPanelTestAccess::HasSharedTileDataConflict(panel));
+  ObjectTileEditorPanelTestAccess::SetCurrentObjectId(panel, 0x40);
+  auto usage_count_or =
+      ObjectTileEditorPanelTestAccess::SharedTileDataUsageCount(panel);
+  EXPECT_TRUE(absl::IsFailedPrecondition(usage_count_or.status()));
+  auto conflict_or =
+      ObjectTileEditorPanelTestAccess::HasSharedTileDataConflict(panel);
+  EXPECT_TRUE(absl::IsFailedPrecondition(conflict_or.status()));
 }
 
 TEST(ObjectTileEditorPanelTest, RenderWithoutRoomContextClearsStaleBitmaps) {
@@ -648,8 +666,10 @@ TEST(ObjectTileEditorPanelTest,
   ObjectTileEditorPanelTestAccess::SetSharedTileDataUsageOverride(
       panel, /*shared_count=*/3);
 
-  ASSERT_GT(ObjectTileEditorPanelTestAccess::SharedTileDataUsageCount(panel),
-            1);
+  auto shared_count_or =
+      ObjectTileEditorPanelTestAccess::SharedTileDataUsageCount(panel);
+  ASSERT_TRUE(shared_count_or.ok()) << shared_count_or.status();
+  ASSERT_GT(*shared_count_or, 1);
 
   const int write_addr =
       FirstCellSourceAddress(ObjectTileEditorPanelTestAccess::Layout(panel));
@@ -679,6 +699,126 @@ TEST(ObjectTileEditorPanelTest,
 }
 
 TEST(ObjectTileEditorPanelTest,
+     ApplyChangesUsesRealPartialOverlapImpactBeforeWriteback) {
+  auto data = MakeEditableStandardObjectRomData();
+  // Type 1 object 0 consumes [0x29E8, 0x29F0), partially overlapping the
+  // editable object's [0x29EC, 0x29F4) source.
+  StoreWord(data, /*Type 1 object 0 descriptor=*/0x8000, 0x0E96);
+  Rom rom;
+  ASSERT_TRUE(rom.LoadFromData(data).ok());
+
+  ObjectTileEditorPanel panel(nullptr, &rom);
+  OpenInjectedSharedStandardObjectSession(panel, rom);
+  auto shared_count_or =
+      ObjectTileEditorPanelTestAccess::SharedTileDataUsageCount(panel);
+  ASSERT_TRUE(shared_count_or.ok()) << shared_count_or.status();
+  ASSERT_EQ(*shared_count_or, 2);
+
+  const int write_addr =
+      FirstCellSourceAddress(ObjectTileEditorPanelTestAccess::Layout(panel));
+  ASSERT_GE(write_addr, 0);
+  const int original_word = ReadWordAt(rom, write_addr);
+  ObjectTileEditorPanelTestAccess::SetFirstCellTileAndPalette(
+      panel, /*tile_id=*/0x123, /*palette=*/3);
+
+  ObjectTileEditorPanelTestAccess::ApplyChanges(panel,
+                                                /*confirm_shared=*/true);
+
+  EXPECT_TRUE(ObjectTileEditorPanelTestAccess::ShowSharedConfirm(panel));
+  EXPECT_EQ(ObjectTileEditorPanelTestAccess::SharedObjectCount(panel), 2);
+  EXPECT_TRUE(ObjectTileEditorPanelTestAccess::ActionStatusIsWarning(panel));
+  EXPECT_TRUE(ObjectTileEditorPanelTestAccess::HasModifications(panel));
+  EXPECT_EQ(ReadWordAt(rom, write_addr), original_word);
+
+  ObjectTileEditorPanelTestAccess::ApplyChanges(panel,
+                                                /*confirm_shared=*/false);
+  ASSERT_FALSE(ObjectTileEditorPanelTestAccess::HasModifications(panel));
+  ASSERT_NE(ReadWordAt(rom, write_addr), original_word);
+
+  // The successful apply must refresh provenance.expected_words. A second
+  // edit in the same session should pass the real analyzer and warn again,
+  // not fail its write-plan CAS check against the first applied value.
+  const int first_applied_word = ReadWordAt(rom, write_addr);
+  ObjectTileEditorPanelTestAccess::SetFirstCellTileAndPalette(
+      panel, /*tile_id=*/0x234, /*palette=*/4);
+  ObjectTileEditorPanelTestAccess::ApplyChanges(panel,
+                                                /*confirm_shared=*/true);
+
+  EXPECT_TRUE(ObjectTileEditorPanelTestAccess::ShowSharedConfirm(panel));
+  EXPECT_EQ(ObjectTileEditorPanelTestAccess::SharedObjectCount(panel), 2);
+  EXPECT_TRUE(ObjectTileEditorPanelTestAccess::ActionStatusIsWarning(panel));
+  EXPECT_FALSE(ObjectTileEditorPanelTestAccess::ActionStatusIsError(panel));
+  EXPECT_TRUE(ObjectTileEditorPanelTestAccess::HasModifications(panel));
+  EXPECT_EQ(ReadWordAt(rom, write_addr), first_applied_word);
+}
+
+TEST(ObjectTileEditorPanelTest,
+     ApplyChangesWarnsForGlobalTorchConsumersOfObject120) {
+  Rom rom;
+  ASSERT_TRUE(rom.LoadFromData(MakeEditableStandardObjectRomData()).ok());
+
+  ObjectTileEditorPanel panel(nullptr, &rom);
+  panel.OpenForObject(kTorchAliasObjectId, /*room_id=*/-1, nullptr);
+  auto layout_or = CaptureEditableStandardLayout(rom, kTorchAliasObjectId);
+  ASSERT_TRUE(layout_or.ok()) << layout_or.status();
+  ObjectTileEditorPanelTestAccess::SetLayout(panel, std::move(*layout_or));
+  ObjectTileEditorPanelTestAccess::SetFirstCellTileAndPalette(
+      panel, /*tile_id=*/0x123, /*palette=*/3);
+
+  auto shared_count_or =
+      ObjectTileEditorPanelTestAccess::SharedTileDataUsageCount(panel);
+  ASSERT_TRUE(shared_count_or.ok()) << shared_count_or.status();
+  // Object 0x120 plus initial torch drawing and live lighting-change paths.
+  ASSERT_EQ(*shared_count_or, 3);
+
+  const int original_word = ReadWordAt(rom, kTorchAliasSourcePcAddress);
+  ObjectTileEditorPanelTestAccess::ApplyChanges(panel,
+                                                /*confirm_shared=*/true);
+
+  EXPECT_TRUE(ObjectTileEditorPanelTestAccess::ShowSharedConfirm(panel));
+  EXPECT_EQ(ObjectTileEditorPanelTestAccess::SharedObjectCount(panel), 3);
+  EXPECT_TRUE(ObjectTileEditorPanelTestAccess::ActionStatusIsWarning(panel));
+  EXPECT_NE(ObjectTileEditorPanelTestAccess::ActionStatusMessage(panel).find(
+                "3 consumers"),
+            std::string::npos);
+  EXPECT_TRUE(ObjectTileEditorPanelTestAccess::HasModifications(panel));
+  EXPECT_EQ(ReadWordAt(rom, kTorchAliasSourcePcAddress), original_word);
+}
+
+TEST(ObjectTileEditorPanelTest,
+     ApplyChangesFailsClosedWhenAnySourceImpactIsMalformed) {
+  Rom rom;
+  ASSERT_TRUE(rom.LoadFromData(MakeEditableStandardObjectRomData()).ok());
+
+  ObjectTileEditorPanel panel(nullptr, &rom);
+  OpenInjectedSharedStandardObjectSession(panel, rom);
+  StoreWord(rom.mutable_vector(), /*Type 1 object 1 descriptor=*/0x8002,
+            0x8000);
+
+  const int write_addr =
+      FirstCellSourceAddress(ObjectTileEditorPanelTestAccess::Layout(panel));
+  ASSERT_GE(write_addr, 0);
+  const int original_word = ReadWordAt(rom, write_addr);
+  ObjectTileEditorPanelTestAccess::SetFirstCellTileAndPalette(
+      panel, /*tile_id=*/0x123, /*palette=*/3);
+
+  ObjectTileEditorPanelTestAccess::ApplyChanges(panel,
+                                                /*confirm_shared=*/true);
+
+  EXPECT_FALSE(ObjectTileEditorPanelTestAccess::ShowSharedConfirm(panel));
+  EXPECT_EQ(ObjectTileEditorPanelTestAccess::SharedObjectCount(panel), 0);
+  EXPECT_TRUE(ObjectTileEditorPanelTestAccess::ActionStatusIsError(panel));
+  EXPECT_NE(ObjectTileEditorPanelTestAccess::ActionStatusMessage(panel).find(
+                "source impact could not be resolved"),
+            std::string::npos);
+  EXPECT_NE(ObjectTileEditorPanelTestAccess::ActionStatusMessage(panel).find(
+                "object 0x001"),
+            std::string::npos);
+  EXPECT_TRUE(ObjectTileEditorPanelTestAccess::HasModifications(panel));
+  EXPECT_EQ(ReadWordAt(rom, write_addr), original_word);
+}
+
+TEST(ObjectTileEditorPanelTest,
      ApplyChangesWithoutConfirmationWritesSharedStandardObjectAndClearsModal) {
   Rom rom;
   ASSERT_TRUE(rom.LoadFromData(MakeEditableStandardObjectRomData()).ok());
@@ -692,8 +832,10 @@ TEST(ObjectTileEditorPanelTest,
   ObjectTileEditorPanelTestAccess::SetSharedTileDataUsageOverride(
       panel, /*shared_count=*/3);
 
-  ASSERT_GT(ObjectTileEditorPanelTestAccess::SharedTileDataUsageCount(panel),
-            1);
+  auto shared_count_or =
+      ObjectTileEditorPanelTestAccess::SharedTileDataUsageCount(panel);
+  ASSERT_TRUE(shared_count_or.ok()) << shared_count_or.status();
+  ASSERT_GT(*shared_count_or, 1);
 
   const int write_addr =
       FirstCellSourceAddress(ObjectTileEditorPanelTestAccess::Layout(panel));

--- a/test/unit/zelda3/dungeon/object_tile_editor_test.cc
+++ b/test/unit/zelda3/dungeon/object_tile_editor_test.cc
@@ -8,6 +8,7 @@
 #include <type_traits>
 #include <vector>
 
+#include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
 #include "core/features.h"
@@ -492,6 +493,121 @@ TEST(ObjectTileEditorTest,
       EXPECT_EQ(gfx::TileInfoToWord(cell->tile_info), cell->original_word);
     }
   }
+}
+
+TEST(ObjectTileEditorTest,
+     StandardTileSourceImpactIncludesAliasesAcrossObjectFamilies) {
+  ScopedCustomObjectsDisabled disable_custom_objects;
+  auto data = MakeEditableObjectRomData();
+  // Type 1 object 0 and Type 3 object F96 both consume the same exact four
+  // words as editable Type 2 object 11F.
+  StoreWord(data, /*Type 1 object 0 descriptor=*/0x8000, 0x0E9A);
+  StoreWord(data, /*Type 3 object F96 descriptor=*/0x851C, 0x0E9A);
+
+  Rom rom;
+  ASSERT_TRUE(rom.LoadFromData(data).ok());
+  Room room(/*room_id=*/0, &rom, /*game_data=*/nullptr);
+  gfx::PaletteGroup palette;
+  ObjectTileEditor editor(&rom);
+  auto layout_or = editor.CaptureEditableObjectLayout(0x11F, room, palette);
+  ASSERT_TRUE(layout_or.ok()) << layout_or.status();
+
+  auto impact_or = editor.AnalyzeStandardTileSourceImpact(*layout_or);
+  ASSERT_TRUE(impact_or.ok()) << impact_or.status();
+  ASSERT_EQ(impact_or->consumer_count(), 3u);
+  EXPECT_TRUE(impact_or->runtime_consumers.empty());
+  EXPECT_EQ(impact_or->affected_objects[0].object_id, 0x000);
+  EXPECT_EQ(impact_or->affected_objects[1].object_id, 0x11F);
+  EXPECT_EQ(impact_or->affected_objects[2].object_id, 0xF96);
+  for (const auto& entry : impact_or->affected_objects) {
+    EXPECT_THAT(entry.overlapping_ranges,
+                ::testing::ElementsAre(ObjectTileReadRange{0x29EC, 0x29F4}));
+  }
+}
+
+TEST(ObjectTileEditorTest,
+     StandardTileSourceImpactIncludesGlobalLightableTorchConsumer) {
+  ScopedCustomObjectsDisabled disable_custom_objects;
+  Rom rom;
+  ASSERT_TRUE(rom.LoadFromData(MakeEditableObjectRomData()).ok());
+  Room room(/*room_id=*/0, &rom, /*game_data=*/nullptr);
+  gfx::PaletteGroup palette;
+  ObjectTileEditor editor(&rom);
+  auto layout_or = editor.CaptureEditableObjectLayout(0x120, room, palette);
+  ASSERT_TRUE(layout_or.ok()) << layout_or.status();
+
+  auto impact_or = editor.AnalyzeStandardTileSourceImpact(*layout_or);
+  ASSERT_TRUE(impact_or.ok()) << impact_or.status();
+  ASSERT_EQ(impact_or->affected_objects.size(), 1u);
+  EXPECT_EQ(impact_or->affected_objects[0].object_id, 0x120);
+  ASSERT_EQ(impact_or->runtime_consumers.size(), 2u);
+  EXPECT_EQ(impact_or->runtime_consumers[0].consumer,
+            ObjectTileRuntimeConsumer::kLightableTorchDraw);
+  EXPECT_THAT(impact_or->runtime_consumers[0].overlapping_ranges,
+              ::testing::ElementsAre(ObjectTileReadRange{0x2A1C, 0x2A24}));
+  EXPECT_EQ(impact_or->runtime_consumers[1].consumer,
+            ObjectTileRuntimeConsumer::kTorchLightingChange);
+  EXPECT_THAT(impact_or->runtime_consumers[1].overlapping_ranges,
+              ::testing::ElementsAre(ObjectTileReadRange{0x2A1C, 0x2A24}));
+  EXPECT_EQ(impact_or->consumer_count(), 3u);
+}
+
+TEST(ObjectTileEditorTest,
+     StandardTileSourceImpactDetectsPartialButNotAdjacentRanges) {
+  ScopedCustomObjectsDisabled disable_custom_objects;
+  auto data = MakeEditableObjectRomData();
+  // Editable source: [0x29EC, 0x29F4).
+  StoreWord(data, /*Type 1 object 0 descriptor=*/0x8000,
+            /*source 0x29E8=*/0x0E96);
+  StoreWord(data, /*Type 1 object 7 descriptor=*/0x800E,
+            /*source 0x29F0=*/0x0E9E);
+  StoreWord(data, /*Type 1 object 8 descriptor=*/0x8010,
+            /*source 0x29F4=*/0x0EA2);
+
+  Rom rom;
+  ASSERT_TRUE(rom.LoadFromData(data).ok());
+  Room room(/*room_id=*/0, &rom, /*game_data=*/nullptr);
+  gfx::PaletteGroup palette;
+  ObjectTileEditor editor(&rom);
+  auto layout_or = editor.CaptureEditableObjectLayout(0x11F, room, palette);
+  ASSERT_TRUE(layout_or.ok()) << layout_or.status();
+
+  auto impact_or = editor.AnalyzeStandardTileSourceImpact(*layout_or);
+  ASSERT_TRUE(impact_or.ok()) << impact_or.status();
+  ASSERT_EQ(impact_or->consumer_count(), 3u);
+  EXPECT_EQ(impact_or->affected_objects[0].object_id, 0x000);
+  EXPECT_THAT(impact_or->affected_objects[0].overlapping_ranges,
+              ::testing::ElementsAre(ObjectTileReadRange{0x29E8, 0x29F0}));
+  EXPECT_EQ(impact_or->affected_objects[1].object_id, 0x007);
+  EXPECT_THAT(impact_or->affected_objects[1].overlapping_ranges,
+              ::testing::ElementsAre(ObjectTileReadRange{0x29F0, 0x29F8}));
+  EXPECT_EQ(impact_or->affected_objects[2].object_id, 0x11F);
+}
+
+TEST(ObjectTileEditorTest,
+     StandardTileSourceImpactFailsClosedOnMalformedUnrelatedObject) {
+  ScopedCustomObjectsDisabled disable_custom_objects;
+  Rom rom;
+  ASSERT_TRUE(rom.LoadFromData(MakeEditableObjectRomData()).ok());
+  Room room(/*room_id=*/0, &rom, /*game_data=*/nullptr);
+  gfx::PaletteGroup palette;
+  ObjectTileEditor editor(&rom);
+  auto layout_or = editor.CaptureEditableObjectLayout(0x11F, room, palette);
+  ASSERT_TRUE(layout_or.ok()) << layout_or.status();
+
+  // Type 1 offsets are signed. 0x8000 resolves before the start of this ROM
+  // and must invalidate the complete impact inventory instead of being
+  // silently ignored as a non-overlap.
+  StoreWordWithoutDirtying(rom, /*Type 1 object 1 descriptor=*/0x8002, 0x8000);
+  const auto original = rom.vector();
+  const bool original_dirty = rom.dirty();
+
+  auto impact_or = editor.AnalyzeStandardTileSourceImpact(*layout_or);
+  EXPECT_TRUE(absl::IsFailedPrecondition(impact_or.status()));
+  EXPECT_NE(std::string(impact_or.status().message()).find("object 0x001"),
+            std::string::npos);
+  EXPECT_EQ(rom.vector(), original);
+  EXPECT_EQ(rom.dirty(), original_dirty);
 }
 
 TEST(ObjectTileEditorTest, BuildStandardWritePlanRejectsObjectMismatch) {

--- a/test/unit/zelda3/object_parser_test.cc
+++ b/test/unit/zelda3/object_parser_test.cc
@@ -126,6 +126,76 @@ TEST_F(ObjectParserTest, RupeeFloorLoadsExactTwoWordPayload) {
   EXPECT_EQ(draw_info.tile_count, 2);
 }
 
+TEST_F(ObjectParserTest, ResolveTileReadRangesPreservesSplitSources) {
+  auto* data = mock_rom_->mutable_data();
+  auto write_pointer = [&](int table_address, uint16_t offset) {
+    data[table_address] = static_cast<uint8_t>(offset & 0xFF);
+    data[table_address + 1] = static_cast<uint8_t>(offset >> 8);
+  };
+
+  constexpr uint16_t kFloodGateOffset = 0x0300;
+  write_pointer(zelda3::kRoomObjectSubtype2 + (0x137 - 0x100) * 2,
+                kFloodGateOffset);
+  auto flood_gate_ranges = parser_->ResolveTileReadRanges(0x137);
+  ASSERT_TRUE(flood_gate_ranges.ok()) << flood_gate_ranges.status();
+  EXPECT_THAT(
+      *flood_gate_ranges,
+      ::testing::ElementsAre(
+          zelda3::ObjectTileReadRange{
+              zelda3::kRoomObjectTileAddress + kFloodGateOffset,
+              zelda3::kRoomObjectTileAddress + kFloodGateOffset + 40 * 2},
+          zelda3::ObjectTileReadRange{
+              zelda3::kRoomObjectTileAddress + 0x13E8,
+              zelda3::kRoomObjectTileAddress + 0x13E8 + 40 * 2}));
+
+  constexpr uint16_t kBombableFloorOffset = 0x0400;
+  write_pointer(zelda3::kRoomObjectSubtype3 + (0xFC7 - 0xF80) * 2,
+                kBombableFloorOffset);
+  auto bombable_floor_ranges = parser_->ResolveTileReadRanges(0xFC7);
+  ASSERT_TRUE(bombable_floor_ranges.ok()) << bombable_floor_ranges.status();
+  EXPECT_THAT(
+      *bombable_floor_ranges,
+      ::testing::ElementsAre(
+          zelda3::ObjectTileReadRange{
+              zelda3::kRoomObjectTileAddress + kBombableFloorOffset,
+              zelda3::kRoomObjectTileAddress + kBombableFloorOffset + 16 * 2},
+          zelda3::ObjectTileReadRange{
+              zelda3::kRoomObjectTileAddress + 0x05BA,
+              zelda3::kRoomObjectTileAddress + 0x05BA + 16 * 2}));
+}
+
+TEST_F(ObjectParserTest, ResolveTileReadRangesPreservesRuntimeLiterals) {
+  auto chest_ranges = parser_->ResolveTileReadRanges(0xF99);
+  ASSERT_TRUE(chest_ranges.ok()) << chest_ranges.status();
+  EXPECT_THAT(*chest_ranges,
+              ::testing::ElementsAre(
+                  zelda3::ObjectTileReadRange{
+                      zelda3::kRoomObjectTileAddress + 0x149C,
+                      zelda3::kRoomObjectTileAddress + 0x149C + 4 * 2},
+                  zelda3::ObjectTileReadRange{
+                      zelda3::kRoomObjectTileAddress + 0x14A4,
+                      zelda3::kRoomObjectTileAddress + 0x14A4 + 4 * 2}));
+
+  auto rupee_floor_ranges = parser_->ResolveTileReadRanges(0xF92);
+  ASSERT_TRUE(rupee_floor_ranges.ok()) << rupee_floor_ranges.status();
+  EXPECT_THAT(*rupee_floor_ranges,
+              ::testing::ElementsAre(zelda3::ObjectTileReadRange{
+                  zelda3::kRoomObjectTileAddress + 0x1DD6,
+                  zelda3::kRoomObjectTileAddress + 0x1DD6 + 2 * 2}));
+}
+
+TEST_F(ObjectParserTest, ResolveTileReadRangesPropagatesMalformedSource) {
+  auto* data = mock_rom_->mutable_data();
+  data[zelda3::kRoomObjectSubtype1] = 0x00;
+  data[zelda3::kRoomObjectSubtype1 + 1] = 0x80;
+
+  auto malformed_ranges = parser_->ResolveTileReadRanges(0x000);
+  EXPECT_TRUE(absl::IsOutOfRange(malformed_ranges.status()));
+
+  // A failed trace must release the collector so later resolutions still run.
+  EXPECT_TRUE(parser_->ResolveTileReadRanges(0x001).ok());
+}
+
 TEST_F(ObjectParserTest, BigKeyLockLoadsExactClosedTwoByTwoPayload) {
   auto result = parser_->ParseObject(0xF98);
   ASSERT_TRUE(result.ok());


### PR DESCRIPTION
## Summary

- trace the exact half-open ROM tile-source ranges consumed by `ObjectParser`, including split and runtime-literal payloads
- fail closed when any representable standard object's source cannot be resolved, and detect exact aliases plus partial overlaps across Type 1, Type 2, and Type 3 IDs
- model the global lightable-torch draw and live lighting-change paths that also consume object `0x120`'s `obj0ECA` payload
- require shared-source confirmation before standard tile writes, preserve retry state on analysis failure, and refresh provenance after a successful same-session write
- correct Rupee Floor (`0xF92`) parsing to the runtime literal `obj1DD6`

## Why

The previous warning compared a single legacy tile pointer, scanned only Type 1 objects, and treated unresolved state as unshared. That could miss cross-family aliases, partial overlaps, split sources, and runtime-only consumers before a ROM mutation.

This keeps the editor backend fail-closed before standard Object Tile Editor UI reachability is enabled. The production `OpenForObject` path remains preview-only in this PR; lifecycle wiring, cached display analysis, and the explicit `Edit Object Tiles...` action are follow-up work.

## Verification

- `cmake --build build/presets/mac-ai --target yaze_test_unit -j8` — passed
- focused parser/editor/panel run — 90/90 passed before stack sync
- focused source-impact + cache/fence run — 101/101 passed after syncing exact parent head `c85213f2420e463cdbc922c9095ac4cb632fa38a`
- `scripts/pre-push.sh --build-dir build/presets/mac-ai` — passed (13/13 smoke; UI step skipped by change-aware gate)
- `git diff --check` — passed
- `clang-format --dry-run --Werror` on all 9 topic files — passed

## Stack

Depends on #184 (`codex/object-tile-cache-revision`). Retarget to `master` after the parent lands.

Exact head `7e157c9c9e5a6e12b3e5af6c6294ab4e168b3980`; topic patch-id `de124322cb0ddb847b24ce669380ccb19a87450a` and tree `1fa2a60342acfeafd0edf59cb69d2725ad2c5c3a` remained unchanged across the parent sync.
