### PR TITLE
Expose guarded dungeon object tile editing

### DIFF
--- a/src/app/editor/dungeon/dungeon_canvas_context_menu.cc
+++ b/src/app/editor/dungeon/dungeon_canvas_context_menu.cc
@@ -11,6 +11,7 @@
 #include "imgui/imgui.h"
 #include "util/log.h"
 #include "zelda3/dungeon/object_layer_semantics.h"
+#include "zelda3/dungeon/object_tile_editor.h"
 #include "zelda3/resource_labels.h"
 #include "zelda3/sprite/sprite.h"
 
@@ -162,7 +163,9 @@ DungeonCanvasViewer::BuildSelectionContextMenuItems(int room_id) {
 
   bool can_edit_selected_graphics = false;
   std::function<void()> edit_selected_graphics;
-  if (single_selection && rooms_) {
+  bool can_edit_selected_tiles = false;
+  std::function<void()> edit_selected_tiles;
+  if (single_selection && valid_room) {
     auto& room = (*rooms_)[room_id];
     const auto& objects = room.GetTileObjects();
     if (selected[0] < objects.size()) {
@@ -174,6 +177,14 @@ DungeonCanvasViewer::BuildSelectionContextMenuItems(int room_id) {
           edit_graphics_callback_(room_id, object);
         } else if (show_room_graphics_callback_) {
           show_room_graphics_callback_();
+        }
+      };
+      can_edit_selected_tiles =
+          edit_object_tiles_callback_ != nullptr &&
+          zelda3::ObjectTileEditor::IsEditableStandardObject(object.id_);
+      edit_selected_tiles = [this, room_id, object]() {
+        if (edit_object_tiles_callback_) {
+          edit_object_tiles_callback_(room_id, object);
         }
       };
     }
@@ -291,6 +302,10 @@ DungeonCanvasViewer::BuildSelectionContextMenuItems(int room_id) {
   if (can_edit_selected_graphics) {
     items.emplace_back("Edit Graphics...", ICON_MD_IMAGE,
                        std::move(edit_selected_graphics));
+  }
+  if (can_edit_selected_tiles) {
+    items.emplace_back("Edit Object Tiles...", ICON_MD_GRID_ON,
+                       std::move(edit_selected_tiles));
   }
 
   const bool has_entity_selection = interaction.HasEntitySelection();

--- a/src/app/editor/dungeon/dungeon_canvas_viewer.h
+++ b/src/app/editor/dungeon/dungeon_canvas_viewer.h
@@ -488,6 +488,10 @@ class DungeonCanvasViewer {
       std::function<void(int, const zelda3::RoomObject&)> callback) {
     edit_graphics_callback_ = std::move(callback);
   }
+  void SetEditObjectTilesCallback(
+      std::function<void(int, const zelda3::RoomObject&)> callback) {
+    edit_object_tiles_callback_ = std::move(callback);
+  }
   void SetMinecartTrackPanel(MinecartTrackEditorPanel* panel) {
     minecart_track_panel_ = panel;
   }
@@ -1003,6 +1007,8 @@ class DungeonCanvasViewer {
   int canvas_capture_height_ = 0;
   std::vector<ChangePingRect> change_ping_rects_;
   double change_ping_start_time_ = -1.0;
+  std::function<void(int, const zelda3::RoomObject&)>
+      edit_object_tiles_callback_;
 };
 
 }  // namespace editor

--- a/src/app/editor/dungeon/dungeon_editor_v2.cc
+++ b/src/app/editor/dungeon/dungeon_editor_v2.cc
@@ -860,6 +860,11 @@ absl::Status DungeonEditorV2::Load() {
                 "dungeon object tile data", "ObjectTileEditorPanel",
                 dependencies_.toast_manager);
           });
+      tile_editor_panel->SetStandardTilesAppliedCallback([this]() {
+        if (object_selector_panel_) {
+          object_selector_panel_->object_selector().InvalidatePreviewCache();
+        }
+      });
 
       // Wire creation callback: when a new custom object is saved,
       // register it with the manager, persist to project, and refresh UI.
@@ -887,6 +892,13 @@ absl::Status DungeonEditorV2::Load() {
     if (object_selector_panel_) {
       object_selector_panel_->object_selector().SetTileEditorPanel(
           object_tile_editor_panel_);
+      object_selector_panel_->object_selector().SetOpenTileEditorWindowCallback(
+          [this]() {
+            return dependencies_.window_manager != nullptr &&
+                   object_tile_editor_panel_ != nullptr &&
+                   dependencies_.window_manager->OpenWindow(
+                       object_tile_editor_panel_->GetId());
+          });
       if (dependencies_.project) {
         object_selector_panel_->object_selector().SetProject(
             dependencies_.project);
@@ -1046,8 +1058,8 @@ void DungeonEditorV2::HandleDungeonPaletteChanged(
           room_graphics_panel_->SetCurrentPaletteGroup(current_palette_group_);
         }
         if (object_tile_editor_panel_) {
-          object_tile_editor_panel_->SetCurrentPaletteGroup(
-              current_palette_group_);
+          object_tile_editor_panel_->SetCurrentPaletteGroupForRoom(
+              current_room_id_, current_palette_group_);
         }
       }
     }
@@ -1688,6 +1700,10 @@ void DungeonEditorV2::OnRoomSelected(int room_id, bool request_focus) {
                 room_graphics_panel_->SetCurrentPaletteGroup(
                     current_palette_group_);
               }
+              if (object_tile_editor_panel_) {
+                object_tile_editor_panel_->SetCurrentPaletteGroupForRoom(
+                    room_id, current_palette_group_);
+              }
             }
           }
         }
@@ -1932,6 +1948,71 @@ void DungeonEditorV2::OpenGraphicsEditorForObject(
   }
 }
 
+absl::Status DungeonEditorV2::OpenObjectTileEditorForObject(
+    int room_id, const zelda3::RoomObject& object) {
+  if (object_tile_editor_panel_ == nullptr) {
+    return absl::FailedPreconditionError(
+        "Object Tile Editor panel is unavailable");
+  }
+  if (dependencies_.window_manager == nullptr) {
+    return absl::FailedPreconditionError(
+        "Workspace window manager is unavailable");
+  }
+  if (rom_ == nullptr || !rom_->is_loaded()) {
+    return absl::FailedPreconditionError("ROM not loaded");
+  }
+  if (room_id < 0 || room_id >= static_cast<int>(rooms_.size())) {
+    return absl::OutOfRangeError("Dungeon room id is outside the room store");
+  }
+  if (!zelda3::ObjectTileEditor::IsEditableStandardObject(object.id_)) {
+    return absl::UnimplementedError(
+        "Object tile editing is supported only for audited objects 0x11F and "
+        "0x120");
+  }
+  if (game_data_ == nullptr ||
+      game_data_->palette_groups.dungeon_main.empty()) {
+    return absl::FailedPreconditionError("Dungeon palette data is unavailable");
+  }
+
+  auto& room = rooms_[room_id];
+  if (!room.IsLoaded()) {
+    RETURN_IF_ERROR(room_loader_.LoadRoom(room_id, room));
+  }
+  ApplyEntranceRenderContext(room_id);
+  room.PrepareForRender();
+
+  const int palette_id = room.ResolveDungeonPaletteId();
+  const auto& dungeon_palettes = game_data_->palette_groups.dungeon_main;
+  if (palette_id < 0 ||
+      palette_id >= static_cast<int>(dungeon_palettes.size())) {
+    return absl::OutOfRangeError(
+        "Room resolves to an unavailable dungeon palette");
+  }
+  auto room_palette = dungeon_palettes[palette_id];
+  ASSIGN_OR_RETURN(auto palette_group,
+                   gfx::CreatePaletteGroupFromLargePalette(room_palette));
+
+  const absl::Status open_status = object_tile_editor_panel_->OpenForObject(
+      object.id_, room_id, &rooms_, palette_group);
+  if (!open_status.ok()) {
+    // A modified hidden session rejects replacement to prevent data loss.
+    // Surface that existing session so the user can apply, revert, or use the
+    // explicit discard action described by the returned status.
+    if (object_tile_editor_panel_->IsOpen()) {
+      (void)dependencies_.window_manager->OpenWindow(
+          object_tile_editor_panel_->GetId());
+    }
+    return open_status;
+  }
+  if (!dependencies_.window_manager->OpenWindow(
+          object_tile_editor_panel_->GetId())) {
+    object_tile_editor_panel_->Close();
+    return absl::NotFoundError(
+        "Object Tile Editor window is not registered in this session");
+  }
+  return absl::OkStatus();
+}
+
 void DungeonEditorV2::SwapRoomInPanel(int old_room_id, int new_room_id) {
   // Defer the swap until after the current frame's draw phase completes
   // This prevents modifying data structures while ImGui is still using them
@@ -2127,6 +2208,21 @@ void DungeonEditorV2::WireViewerPanelCallbacks(DungeonCanvasViewer* viewer) {
   viewer->SetEditGraphicsCallback(
       [this](int target_room_id, const zelda3::RoomObject& object) {
         OpenGraphicsEditorForObject(target_room_id, object);
+      });
+  viewer->SetEditObjectTilesCallback(
+      [this](int target_room_id, const zelda3::RoomObject& object) {
+        const absl::Status status =
+            OpenObjectTileEditorForObject(target_room_id, object);
+        if (status.ok()) {
+          return;
+        }
+        LOG_ERROR("DungeonEditorV2", "Edit Object Tiles failed: %s",
+                  status.message().data());
+        if (dependencies_.toast_manager) {
+          dependencies_.toast_manager->Show(
+              absl::StrFormat("Edit Object Tiles failed: %s", status.message()),
+              ToastType::kError);
+        }
       });
   viewer->SetSaveRoomCallback([this](int target_room_id) {
     auto status = SaveRoom(target_room_id);
@@ -2489,10 +2585,6 @@ void DungeonEditorV2::SyncPanelsToRoom(int room_id) {
     if (viewer) {
       water_fill_panel_->SetInteraction(&viewer->object_interaction());
     }
-  }
-
-  if (object_tile_editor_panel_) {
-    object_tile_editor_panel_->SetCurrentPaletteGroup(current_palette_group_);
   }
 
   if (room_tag_editor_panel_) {

--- a/src/app/editor/dungeon/dungeon_editor_v2.h
+++ b/src/app/editor/dungeon/dungeon_editor_v2.h
@@ -44,6 +44,7 @@ namespace editor {
 
 class CustomCollisionPanel;
 class DungeonEditorPaletteRefreshTestPeer;
+class DungeonEditorV2ObjectTileEditorTestPeer;
 class DungeonEditorV2RegularEntranceTestPeer;
 class DungeonEditorV2ReloadTestPeer;
 class DungeonEditorV2SpawnPointTestPeer;
@@ -251,6 +252,7 @@ class DungeonEditorV2 : public Editor {
 
  private:
   friend class DungeonEditorPaletteRefreshTestPeer;
+  friend class DungeonEditorV2ObjectTileEditorTestPeer;
   friend class DungeonEditorV2RegularEntranceTestPeer;
   friend class DungeonEditorV2ReloadTestPeer;
   friend class DungeonEditorV2SpawnPointTestPeer;
@@ -313,6 +315,8 @@ class DungeonEditorV2 : public Editor {
   void HandleObjectPlaced(const zelda3::RoomObject& obj);
   void OpenGraphicsEditorForObject(int room_id,
                                    const zelda3::RoomObject& object);
+  absl::Status OpenObjectTileEditorForObject(int room_id,
+                                             const zelda3::RoomObject& object);
 
   // Helper to get or create a viewer for a specific room
   DungeonCanvasViewer* GetViewerForRoom(int room_id);

--- a/src/app/editor/dungeon/dungeon_object_selector.cc
+++ b/src/app/editor/dungeon/dungeon_object_selector.cc
@@ -811,6 +811,31 @@ bool DungeonObjectSelector::DrawObjectPreview(const zelda3::RoomObject& object,
   return true;
 }
 
+absl::Status DungeonObjectSelector::OpenNewCustomObjectEditor(
+    int width, int height, const std::string& filename, int16_t object_id,
+    int room_id) {
+  if (tile_editor_panel_ == nullptr) {
+    return absl::FailedPreconditionError(
+        "Object Tile Editor panel is unavailable");
+  }
+
+  const absl::Status open_status = tile_editor_panel_->OpenForNewObject(
+      width, height, filename, object_id, room_id, rooms_);
+  if (!open_status.ok()) {
+    if (tile_editor_panel_->IsOpen() && open_tile_editor_window_callback_) {
+      (void)open_tile_editor_window_callback_();
+    }
+    return open_status;
+  }
+  if (!open_tile_editor_window_callback_ ||
+      !open_tile_editor_window_callback_()) {
+    tile_editor_panel_->Close();
+    return absl::NotFoundError(
+        "Object Tile Editor window is not registered in this session");
+  }
+  return absl::OkStatus();
+}
+
 void DungeonObjectSelector::DrawNewCustomObjectDialog() {
   const auto& theme = AgentUI::GetTheme();
   if (show_create_dialog_) {
@@ -876,16 +901,25 @@ void DungeonObjectSelector::DrawNewCustomObjectDialog() {
     if (!error_msg.empty()) {
       ImGui::TextColored(theme.status_error, "%s", error_msg.c_str());
     }
+    if (!custom_object_create_error_.empty()) {
+      ImGui::TextColored(theme.status_error, "%s",
+                         custom_object_create_error_.c_str());
+    }
 
     ImGui::Separator();
 
     if (!valid)
       ImGui::BeginDisabled();
     if (ImGui::Button(tr("Create"), ImVec2(120, 0))) {
-      tile_editor_panel_->OpenForNewObject(
+      const absl::Status status = OpenNewCustomObjectEditor(
           create_width_, create_height_, create_filename_,
-          static_cast<int16_t>(create_object_id_), current_room_id_, rooms_);
-      ImGui::CloseCurrentPopup();
+          static_cast<int16_t>(create_object_id_), current_room_id_);
+      if (status.ok()) {
+        custom_object_create_error_.clear();
+        ImGui::CloseCurrentPopup();
+      } else {
+        custom_object_create_error_ = std::string(status.message());
+      }
     }
     if (!valid)
       ImGui::EndDisabled();
@@ -963,6 +997,7 @@ void DungeonObjectSelector::DrawCustomObjectWorkshopPopup(float item_size) {
     if (tile_editor_panel_) {
       if (ImGui::Button(ICON_MD_ADD " New Custom Object", ImVec2(-1, 0))) {
         show_create_dialog_ = true;
+        custom_object_create_error_.clear();
         std::snprintf(create_filename_, sizeof(create_filename_),
                       "custom_%02x_%02d.bin", create_object_id_,
                       zelda3::CustomObjectManager::Get().GetSubtypeCount(

--- a/src/app/editor/dungeon/dungeon_object_selector.h
+++ b/src/app/editor/dungeon/dungeon_object_selector.h
@@ -7,6 +7,9 @@
 #include <map>
 #include <memory>
 #include <string>
+#include <utility>
+
+#include "absl/status/status.h"
 #include "app/editor/dungeon/dungeon_room_store.h"
 #include "app/editor/editor.h"
 #include "app/gfx/types/snes_palette.h"
@@ -25,6 +28,7 @@ namespace yaze {
 namespace editor {
 
 class ObjectTileEditorPanel;
+struct DungeonObjectSelectorTestAccess;
 
 /**
  * @brief Handles object selection, preview, and editing UI
@@ -91,6 +95,9 @@ class DungeonObjectSelector {
   void SetTileEditorPanel(ObjectTileEditorPanel* panel) {
     tile_editor_panel_ = panel;
   }
+  void SetOpenTileEditorWindowCallback(std::function<bool()> callback) {
+    open_tile_editor_window_callback_ = std::move(callback);
+  }
   void SetProject(project::YazeProject* project) { project_ = project; }
 
   // Invalidate preview and layout caches (e.g., after new custom object added)
@@ -115,6 +122,7 @@ class DungeonObjectSelector {
   static bool IsRepresentableChestObjectId(int object_id);
 
  private:
+  friend struct DungeonObjectSelectorTestAccess;
   bool MatchesObjectFilter(int obj_id, int filter_type);
   bool MatchesObjectSearch(int obj_id, const std::string& name,
                            int subtype = -1) const;
@@ -130,6 +138,9 @@ class DungeonObjectSelector {
   void DrawCustomObjectWorkshopButton(int custom_count);
   void DrawCustomObjectWorkshopPopup(float item_size);
   void DrawNewCustomObjectDialog();
+  absl::Status OpenNewCustomObjectEditor(int width, int height,
+                                         const std::string& filename,
+                                         int16_t object_id, int room_id);
 
   // Custom object creation dialog state
   bool show_create_dialog_ = false;
@@ -141,6 +152,8 @@ class DungeonObjectSelector {
 
   // References for custom object creation
   ObjectTileEditorPanel* tile_editor_panel_ = nullptr;
+  std::function<bool()> open_tile_editor_window_callback_;
+  std::string custom_object_create_error_;
   project::YazeProject* project_ = nullptr;
 
   Rom* rom_ = nullptr;

--- a/src/app/editor/dungeon/ui/window/object_tile_editor_panel.cc
+++ b/src/app/editor/dungeon/ui/window/object_tile_editor_panel.cc
@@ -10,6 +10,16 @@
 namespace yaze {
 namespace editor {
 
+namespace {
+
+void MixFingerprint(uint64_t* fingerprint, uint64_t value) {
+  constexpr uint64_t kFnvPrime = 1099511628211ULL;
+  *fingerprint ^= value;
+  *fingerprint *= kFnvPrime;
+}
+
+}  // namespace
+
 ObjectTileEditorPanel::ObjectTileEditorPanel(gfx::IRenderer* renderer, Rom* rom)
     : renderer_(renderer), rom_(rom) {
   tile_editor_ = std::make_unique<zelda3::ObjectTileEditor>(rom);
@@ -38,39 +48,70 @@ void ObjectTileEditorPanel::ResetTransientState() {
   atlas_dirty_ = true;
   show_shared_confirm_ = false;
   shared_object_count_ = 0;
+  pending_shared_confirmation_.reset();
   shared_tile_data_usage_override_ = -1;
+  source_impact_display_cache_key_.reset();
+  source_impact_display_cache_result_.reset();
   ClearActionStatus();
   ClearRenderedBitmaps();
 }
 
-void ObjectTileEditorPanel::OpenForObject(int16_t object_id, int room_id,
-                                          DungeonRoomStore* rooms) {
+absl::Status ObjectTileEditorPanel::OpenForObject(int16_t object_id,
+                                                  int room_id,
+                                                  DungeonRoomStore* rooms) {
+  return OpenForObject(object_id, room_id, rooms, current_palette_group_);
+}
+
+absl::Status ObjectTileEditorPanel::OpenForObject(
+    int16_t object_id, int room_id, DungeonRoomStore* rooms,
+    const gfx::PaletteGroup& palette_group) {
+  if (!zelda3::ObjectTileEditor::IsEditableStandardObject(object_id)) {
+    return absl::UnimplementedError(
+        "Standard object tile editing is supported only for audited objects "
+        "0x11F and 0x120");
+  }
+  if (rooms == nullptr) {
+    return absl::InvalidArgumentError(
+        "A dungeon room store is required to edit object tiles");
+  }
+  if (room_id < 0 || room_id >= static_cast<int>(rooms->size())) {
+    return absl::OutOfRangeError("Dungeon room id is outside the room store");
+  }
+  if (is_open_ && current_layout_.HasModifications()) {
+    return absl::FailedPreconditionError(
+        "Apply, revert, or close the current Object Tile Editor session "
+        "before opening another object");
+  }
+
+  auto& room = (*rooms)[room_id];
+  auto layout_or =
+      tile_editor_->CaptureEditableObjectLayout(object_id, room, palette_group);
+  if (!layout_or.ok()) {
+    return layout_or.status();
+  }
+
+  // Do not disturb a live editor session until every fail-closed capture check
+  // has passed. In particular, a bad selection must not discard unsaved edits.
   current_object_id_ = object_id;
   current_room_id_ = room_id;
   rooms_ = rooms;
+  current_palette_group_ = palette_group;
   is_new_object_ = false;
-  current_layout_ = {};
+  current_layout_ = std::move(*layout_or);
   ResetTransientState();
   is_open_ = true;
-
-  if (!rooms_ || current_room_id_ < 0 ||
-      current_room_id_ >= static_cast<int>(rooms_->size())) {
-    return;
-  }
-
-  auto& room = (*rooms_)[current_room_id_];
-  auto layout_or = tile_editor_->CaptureObjectLayout(object_id, room,
-                                                     current_palette_group_);
-  if (layout_or.ok()) {
-    current_layout_ = std::move(layout_or.value());
-    SelectFirstCellIfAvailable();
-  }
+  SelectFirstCellIfAvailable();
+  return absl::OkStatus();
 }
 
-void ObjectTileEditorPanel::OpenForNewObject(int width, int height,
-                                             const std::string& filename,
-                                             int16_t object_id, int room_id,
-                                             DungeonRoomStore* rooms) {
+absl::Status ObjectTileEditorPanel::OpenForNewObject(
+    int width, int height, const std::string& filename, int16_t object_id,
+    int room_id, DungeonRoomStore* rooms) {
+  if (is_open_ && current_layout_.HasModifications()) {
+    return absl::FailedPreconditionError(
+        "Apply, revert, or explicitly discard the current Object Tile Editor "
+        "session before creating another object");
+  }
   current_object_id_ = object_id;
   current_room_id_ = room_id;
   rooms_ = rooms;
@@ -81,6 +122,7 @@ void ObjectTileEditorPanel::OpenForNewObject(int width, int height,
   current_layout_ =
       zelda3::ObjectTileLayout::CreateEmpty(width, height, object_id, filename);
   SelectFirstCellIfAvailable();
+  return absl::OkStatus();
 }
 
 void ObjectTileEditorPanel::Close() {
@@ -93,6 +135,15 @@ void ObjectTileEditorPanel::Close() {
   ResetTransientState();
 }
 
+void ObjectTileEditorPanel::OnClose() {
+  // Hiding a modified editor window must not silently throw away tile edits.
+  // The session remains available when the workspace window is reopened; the
+  // explicit action-bar close remains the user's discard action.
+  if (!current_layout_.HasModifications()) {
+    Close();
+  }
+}
+
 void ObjectTileEditorPanel::SetCurrentPaletteGroup(
     const gfx::PaletteGroup& group) {
   current_palette_group_ = group;
@@ -100,21 +151,29 @@ void ObjectTileEditorPanel::SetCurrentPaletteGroup(
   atlas_dirty_ = true;
 }
 
+void ObjectTileEditorPanel::SetCurrentPaletteGroupForRoom(
+    int room_id, const gfx::PaletteGroup& group) {
+  if (is_open_ && current_room_id_ != room_id) {
+    return;
+  }
+  SetCurrentPaletteGroup(group);
+}
+
 std::string ObjectTileEditorPanel::BuildWindowTitle() const {
   if (is_new_object_) {
-    return absl::StrFormat(
-        ICON_MD_ADD_BOX " New Object (%dx%d) - %s###ObjTileEditor",
-        current_layout_.bounds_width, current_layout_.bounds_height,
-        current_layout_.custom_filename.c_str());
+    return absl::StrFormat(ICON_MD_ADD_BOX " New Object (%dx%d) - %s",
+                           current_layout_.bounds_width,
+                           current_layout_.bounds_height,
+                           current_layout_.custom_filename.c_str());
   }
 
   if (current_layout_.is_custom && !current_layout_.custom_filename.empty()) {
-    return absl::StrFormat(
-        ICON_MD_GRID_ON " Custom Object 0x%03X - %s###ObjTileEditor",
-        current_object_id_, current_layout_.custom_filename.c_str());
+    return absl::StrFormat(ICON_MD_GRID_ON " Custom Object 0x%03X - %s",
+                           current_object_id_,
+                           current_layout_.custom_filename.c_str());
   }
 
-  return absl::StrFormat(ICON_MD_GRID_ON " Object 0x%03X - %s###ObjTileEditor",
+  return absl::StrFormat(ICON_MD_GRID_ON " Object 0x%03X - %s",
                          current_object_id_,
                          zelda3::GetObjectName(current_object_id_).c_str());
 }
@@ -130,13 +189,17 @@ void ObjectTileEditorPanel::SelectFirstCellIfAvailable() {
   SyncSourceSelectionFromSelectedCell();
 }
 
-absl::StatusOr<int> ObjectTileEditorPanel::GetSharedTileDataUsageCount() const {
+absl::StatusOr<ObjectTileEditorPanel::SourceImpactSnapshot>
+ObjectTileEditorPanel::AnalyzeSourceImpactSnapshot() const {
   if (shared_tile_data_usage_override_ >= 0) {
-    return shared_tile_data_usage_override_;
+    uint64_t fingerprint = 1469598103934665603ULL;
+    MixFingerprint(&fingerprint,
+                   static_cast<uint64_t>(shared_tile_data_usage_override_));
+    return SourceImpactSnapshot{shared_tile_data_usage_override_, fingerprint};
   }
 
   if (current_layout_.is_custom) {
-    return 0;
+    return SourceImpactSnapshot{};
   }
   if (current_object_id_ < 0 ||
       current_layout_.object_id != current_object_id_) {
@@ -153,7 +216,94 @@ absl::StatusOr<int> ObjectTileEditorPanel::GetSharedTileDataUsageCount() const {
   if (!impact_or.ok()) {
     return impact_or.status();
   }
-  return static_cast<int>(impact_or->consumer_count());
+
+  uint64_t fingerprint = 1469598103934665603ULL;
+  MixFingerprint(&fingerprint, impact_or->affected_objects.size());
+  for (const auto& entry : impact_or->affected_objects) {
+    MixFingerprint(&fingerprint, 0xA11EC7EDULL);
+    MixFingerprint(&fingerprint, static_cast<uint16_t>(entry.object_id));
+    MixFingerprint(&fingerprint, entry.overlapping_ranges.size());
+    for (const auto& range : entry.overlapping_ranges) {
+      MixFingerprint(&fingerprint, range.begin);
+      MixFingerprint(&fingerprint, range.end);
+    }
+  }
+  MixFingerprint(&fingerprint, impact_or->runtime_consumers.size());
+  for (const auto& entry : impact_or->runtime_consumers) {
+    MixFingerprint(&fingerprint, 0x52754E71ULL);
+    MixFingerprint(&fingerprint, static_cast<uint64_t>(entry.consumer));
+    MixFingerprint(&fingerprint, entry.overlapping_ranges.size());
+    for (const auto& range : entry.overlapping_ranges) {
+      MixFingerprint(&fingerprint, range.begin);
+      MixFingerprint(&fingerprint, range.end);
+    }
+  }
+  return SourceImpactSnapshot{static_cast<int>(impact_or->consumer_count()),
+                              fingerprint};
+}
+
+absl::StatusOr<int> ObjectTileEditorPanel::GetSharedTileDataUsageCount() const {
+  auto snapshot_or = AnalyzeSourceImpactSnapshot();
+  if (!snapshot_or.ok()) {
+    return snapshot_or.status();
+  }
+  return snapshot_or->consumer_count;
+}
+
+uint64_t ObjectTileEditorPanel::BuildSourceImpactProvenanceFingerprint() const {
+  uint64_t fingerprint = 1469598103934665603ULL;
+  MixFingerprint(&fingerprint,
+                 static_cast<uint16_t>(current_layout_.object_id));
+  MixFingerprint(&fingerprint,
+                 static_cast<uint32_t>(current_layout_.tile_data_address));
+  MixFingerprint(&fingerprint, current_layout_.is_custom ? 1 : 0);
+  MixFingerprint(&fingerprint,
+                 static_cast<uint32_t>(current_layout_.bounds_width));
+  MixFingerprint(&fingerprint,
+                 static_cast<uint32_t>(current_layout_.bounds_height));
+  MixFingerprint(&fingerprint, current_layout_.cells.size());
+  for (const auto& cell : current_layout_.cells) {
+    MixFingerprint(&fingerprint, static_cast<uint32_t>(cell.rel_x));
+    MixFingerprint(&fingerprint, static_cast<uint32_t>(cell.rel_y));
+    MixFingerprint(&fingerprint, cell.original_word);
+    MixFingerprint(&fingerprint, cell.source_ref.has_value() ? 1 : 0);
+    if (cell.source_ref.has_value()) {
+      MixFingerprint(&fingerprint, cell.source_ref->span_index);
+      MixFingerprint(&fingerprint, cell.source_ref->word_index);
+    }
+  }
+  MixFingerprint(&fingerprint,
+                 current_layout_.source_provenance.has_value() ? 1 : 0);
+  if (current_layout_.source_provenance.has_value()) {
+    const auto& provenance = *current_layout_.source_provenance;
+    MixFingerprint(&fingerprint, static_cast<uint16_t>(provenance.object_id));
+    MixFingerprint(&fingerprint, provenance.descriptor_pc_address);
+    MixFingerprint(&fingerprint, provenance.expected_descriptor_word);
+    MixFingerprint(&fingerprint, provenance.spans.size());
+    for (const auto& span : provenance.spans) {
+      MixFingerprint(&fingerprint, span.pc_address);
+      MixFingerprint(&fingerprint, span.expected_words.size());
+      for (const uint16_t word : span.expected_words) {
+        MixFingerprint(&fingerprint, word);
+      }
+    }
+  }
+  return fingerprint;
+}
+
+absl::StatusOr<int>
+ObjectTileEditorPanel::GetDisplayedSharedTileDataUsageCount() {
+  const SourceImpactDisplayCacheKey key{
+      current_object_id_, BuildSourceImpactProvenanceFingerprint(),
+      rom_ != nullptr ? rom_->object_tile_revision() : 0};
+  if (source_impact_display_cache_key_ == key &&
+      source_impact_display_cache_result_.has_value()) {
+    return *source_impact_display_cache_result_;
+  }
+
+  source_impact_display_cache_key_ = key;
+  source_impact_display_cache_result_ = GetSharedTileDataUsageCount();
+  return *source_impact_display_cache_result_;
 }
 
 absl::StatusOr<bool> ObjectTileEditorPanel::HasSharedTileDataConflict() const {
@@ -183,22 +333,20 @@ void ObjectTileEditorPanel::RefreshRenderedViewsFromCurrentRoom() {
 }
 
 void ObjectTileEditorPanel::Draw(bool* p_open) {
-  if (!is_open_ || current_layout_.cells.empty())
+  if (!is_open_ || current_layout_.cells.empty()) {
+    if (p_open != nullptr) {
+      *p_open = false;
+    }
     return;
-
-  const std::string title = BuildWindowTitle();
-
-  ImGui::SetNextWindowSize(ImVec2(550, 500), ImGuiCond_FirstUseEver);
-  if (!ImGui::Begin(title.c_str(), &is_open_)) {
-    ImGui::End();
+  }
+  if (p_open != nullptr && !*p_open) {
     return;
   }
 
-  if (!is_open_) {
-    Close();
-    ImGui::End();
-    return;
-  }
+  const std::string session_title = BuildWindowTitle();
+  ImGui::TextUnformatted(session_title.c_str());
+  ImGui::TextDisabled(tr("Room 0x%03X"), current_room_id_);
+  ImGui::Separator();
 
   // Two-column layout: tile grid + source sheet
   if (ImGui::BeginTable(
@@ -221,33 +369,35 @@ void ObjectTileEditorPanel::Draw(bool* p_open) {
   ImGui::Separator();
   DrawTileProperties();
   ImGui::Separator();
-  DrawActionBar();
+  DrawActionBar(p_open);
 
-  HandleKeyboardShortcuts();
+  HandleKeyboardShortcuts(p_open);
 
   // Shared tile data confirmation modal
   if (show_shared_confirm_) {
-    ImGui::OpenPopup("Shared Tile Data");
+    ImGui::OpenPopup("Shared Tile Data (Global Edit)");
     show_shared_confirm_ = false;
   }
-  if (ImGui::BeginPopupModal("Shared Tile Data", nullptr,
+  if (ImGui::BeginPopupModal("Shared Tile Data (Global Edit)", nullptr,
                              ImGuiWindowFlags_AlwaysAutoResize)) {
     ImGui::Text(tr("This tile data is shared by %d consumers."),
                 shared_object_count_);
     ImGui::Text(tr("Changes will affect all of them."));
+    ImGui::TextWrapped(tr(
+        "This global ROM tile edit is not covered by Dungeon Editor Ctrl+Z."));
     ImGui::Spacing();
-    if (ImGui::Button(tr("Apply Anyway"), ImVec2(120, 0))) {
+    if (ImGui::Button(tr("Apply Global Edit"), ImVec2(150, 0))) {
       ApplyChanges(/*confirm_shared=*/false);
       ImGui::CloseCurrentPopup();
     }
     ImGui::SameLine();
     if (ImGui::Button(tr("Cancel"), ImVec2(120, 0))) {
+      pending_shared_confirmation_.reset();
+      shared_object_count_ = 0;
       ImGui::CloseCurrentPopup();
     }
     ImGui::EndPopup();
   }
-
-  ImGui::End();
 }
 
 void ObjectTileEditorPanel::RenderObjectPreview() {
@@ -565,37 +715,71 @@ void ObjectTileEditorPanel::ApplyChanges(bool confirm_shared) {
   // the second call after the user accepts the shared-data confirmation. A
   // malformed or unresolved object family must block the write rather than be
   // interpreted as an unshared source.
-  const auto shared_count_or = GetSharedTileDataUsageCount();
-  if (!shared_count_or.ok()) {
+  const auto impact_snapshot_or = AnalyzeSourceImpactSnapshot();
+  if (!impact_snapshot_or.ok()) {
     show_shared_confirm_ = false;
     shared_object_count_ = 0;
+    pending_shared_confirmation_.reset();
     SetActionStatus(
         ActionStatusTone::kError,
         absl::StrFormat(ICON_MD_ERROR
                         " Apply blocked: source impact could not be resolved: "
                         "%s",
-                        shared_count_or.status().message()));
+                        impact_snapshot_or.status().message()));
     return;
   }
-  const int shared_count = *shared_count_or;
+  const SourceImpactSnapshot impact_snapshot = *impact_snapshot_or;
+  const int shared_count = impact_snapshot.consumer_count;
   if (confirm_shared && shared_count > 1) {
     shared_object_count_ = shared_count;
+    pending_shared_confirmation_ = impact_snapshot;
     show_shared_confirm_ = true;
     SetActionStatus(
         ActionStatusTone::kWarning,
         absl::StrFormat(ICON_MD_WARNING
-                        " Confirm shared apply: %d consumers use this tile "
-                        "data.",
+                        " Confirm global apply: %d consumers use this tile "
+                        "data. This edit is not covered by Ctrl+Z.",
                         shared_count));
+    return;
+  }
+  const bool missing_required_confirmation =
+      shared_count > 1 && !pending_shared_confirmation_.has_value();
+  const bool confirmed_impact_changed =
+      pending_shared_confirmation_.has_value() &&
+      *pending_shared_confirmation_ != impact_snapshot;
+  if (!confirm_shared &&
+      (missing_required_confirmation || confirmed_impact_changed)) {
+    shared_object_count_ = shared_count;
+    pending_shared_confirmation_ = impact_snapshot;
+    show_shared_confirm_ = true;
+    SetActionStatus(
+        ActionStatusTone::kWarning,
+        absl::StrFormat(
+            ICON_MD_WARNING
+            " Source impact changed; review and confirm the updated global "
+            "apply for %d consumers. This edit is not covered by Ctrl+Z.",
+            shared_count));
     return;
   }
 
   show_shared_confirm_ = false;
   shared_object_count_ = 0;
+  pending_shared_confirmation_.reset();
 
   auto status = WriteBackCurrentLayout();
   if (status.ok()) {
-    // Re-render room after applying changes
+    if (!current_layout_.is_custom) {
+      if (rooms_ != nullptr) {
+        rooms_->ForEachMaterialized(
+            [](int, zelda3::Room& room) { room.MarkObjectsDirty(); });
+      }
+      if (on_standard_tiles_applied_) {
+        on_standard_tiles_applied_();
+      }
+    }
+
+    // Re-render the current room immediately. Other materialized rooms were
+    // marked dirty above and refresh lazily when their canvases draw.
     if (HasRenderableRoomContext()) {
       auto& room = (*rooms_)[current_room_id_];
       room.MarkObjectsDirty();
@@ -655,7 +839,7 @@ void ObjectTileEditorPanel::ApplyChanges(bool confirm_shared) {
       absl::StrFormat(ICON_MD_ERROR " Apply failed: %s", status.message()));
 }
 
-void ObjectTileEditorPanel::DrawActionBar() {
+void ObjectTileEditorPanel::DrawActionBar(bool* p_open) {
   const auto& theme = gui::ThemeManager::Get().GetCurrentTheme();
   int modified_count = 0;
   for (const auto& cell : current_layout_.cells) {
@@ -673,7 +857,7 @@ void ObjectTileEditorPanel::DrawActionBar() {
   // Shared tile data warning. Keep analysis errors visible here, but enforce
   // fail-closed behavior in ApplyChanges so the disabled-by-default standard
   // editor cannot silently turn an unknown impact into a write.
-  const auto shared_count_or = GetSharedTileDataUsageCount();
+  const auto shared_count_or = GetDisplayedSharedTileDataUsageCount();
   if (!shared_count_or.ok()) {
     ImGui::TextColored(gui::ConvertColorToImVec4(theme.error),
                        ICON_MD_ERROR " Source impact unavailable");
@@ -690,7 +874,7 @@ void ObjectTileEditorPanel::DrawActionBar() {
           tr("This object reuses tile data with %d consumers.\nApplying "
              "changes "
              "will update every object or runtime consumer in that shared "
-             "data group."),
+             "data group.\nThis global ROM edit is not covered by Ctrl+Z."),
           shared_count);
     }
     ImGui::SameLine();
@@ -721,8 +905,24 @@ void ObjectTileEditorPanel::DrawActionBar() {
 
   ImGui::SameLine();
 
-  if (ImGui::Button(ICON_MD_CLOSE " Close")) {
+  const char* close_label =
+      has_mods ? ICON_MD_CLOSE " Discard & Close" : ICON_MD_CLOSE " Close";
+  if (ImGui::Button(close_label)) {
+    if (p_open != nullptr) {
+      *p_open = false;
+    }
     Close();
+    return;
+  }
+  if (has_mods && ImGui::IsItemHovered()) {
+    ImGui::SetItemTooltip(
+        "%s", tr("Close the panel and discard all unapplied tile changes."));
+  }
+
+  if (!current_layout_.is_custom) {
+    ImGui::Spacing();
+    ImGui::TextDisabled(ICON_MD_INFO
+                        " Global ROM tile edit; not covered by Ctrl+Z.");
   }
 
   if (action_status_tone_ != ActionStatusTone::kNone &&
@@ -751,7 +951,25 @@ void ObjectTileEditorPanel::DrawActionBar() {
   }
 }
 
-void ObjectTileEditorPanel::HandleKeyboardShortcuts() {
+void ObjectTileEditorPanel::RequestSafeWindowClose(bool* p_open) {
+  if (current_layout_.HasModifications()) {
+    if (p_open != nullptr) {
+      *p_open = false;
+    }
+    SetActionStatus(
+        ActionStatusTone::kWarning, ICON_MD_WARNING
+        " Unapplied tile changes were kept. Reopen the panel to continue, or "
+        "use Discard & Close to throw them away.");
+    return;
+  }
+
+  if (p_open != nullptr) {
+    *p_open = false;
+  }
+  Close();
+}
+
+void ObjectTileEditorPanel::HandleKeyboardShortcuts(bool* p_open) {
   // Only handle shortcuts when this window is focused
   if (!ImGui::IsWindowFocused(ImGuiFocusedFlags_RootAndChildWindows))
     return;
@@ -836,8 +1054,9 @@ void ObjectTileEditorPanel::HandleKeyboardShortcuts() {
     if (selected_cell_index_ >= 0) {
       selected_cell_index_ = -1;
     } else {
-      Close();
+      RequestSafeWindowClose(p_open);
     }
+    return;
   }
 
   // Tab: cycle to next cell

--- a/src/app/editor/dungeon/ui/window/object_tile_editor_panel.h
+++ b/src/app/editor/dungeon/ui/window/object_tile_editor_panel.h
@@ -5,11 +5,13 @@
 #include <cstdint>
 #include <functional>
 #include <memory>
+#include <optional>
 #include <string>
 #include <utility>
 #include <vector>
 
 #include "absl/status/status.h"
+#include "absl/status/statusor.h"
 #include "app/editor/dungeon/dungeon_room_store.h"
 #include "app/editor/system/workspace/editor_panel.h"
 #include "app/gfx/backend/irenderer.h"
@@ -34,12 +36,14 @@ struct ObjectTileEditorPanelTestAccess;
  * cell in the grid, then pick a replacement tile from the source sheet.
  * Tile properties (palette, flip, priority) can be edited per-cell.
  *
- * Opened from the Object Editor panel via "Edit Tiles" button.
+ * Standard-object sessions open from the dungeon canvas selection menu. New
+ * custom-object sessions are prepared by the custom object workshop.
  */
 class ObjectTileEditorPanel : public WindowContent {
  public:
   using StandardWritePreflightCallback = std::function<absl::Status(
       const std::vector<std::pair<uint32_t, uint32_t>>&)>;
+  using StandardTilesAppliedCallback = std::function<void()>;
 
   ObjectTileEditorPanel(gfx::IRenderer* renderer, Rom* rom);
 
@@ -49,17 +53,25 @@ class ObjectTileEditorPanel : public WindowContent {
   std::string GetEditorCategory() const override { return "Dungeon"; }
   int GetPriority() const override { return 65; }
   float GetPreferredWidth() const override { return 550.0f; }
+  float GetPreferredHeight() const override { return 500.0f; }
 
   void Draw(bool* p_open) override;
+  void OnClose() override;
 
-  void OpenForObject(int16_t object_id, int room_id, DungeonRoomStore* rooms);
-  void OpenForNewObject(int width, int height, const std::string& filename,
-                        int16_t object_id, int room_id,
-                        DungeonRoomStore* rooms);
+  absl::Status OpenForObject(int16_t object_id, int room_id,
+                             DungeonRoomStore* rooms);
+  absl::Status OpenForObject(int16_t object_id, int room_id,
+                             DungeonRoomStore* rooms,
+                             const gfx::PaletteGroup& palette_group);
+  absl::Status OpenForNewObject(int width, int height,
+                                const std::string& filename, int16_t object_id,
+                                int room_id, DungeonRoomStore* rooms);
   void Close();
   bool IsOpen() const { return is_open_; }
 
   void SetCurrentPaletteGroup(const gfx::PaletteGroup& group);
+  void SetCurrentPaletteGroupForRoom(int room_id,
+                                     const gfx::PaletteGroup& group);
 
   // Callback fired on first successful save of a new object
   void SetObjectCreatedCallback(
@@ -70,6 +82,10 @@ class ObjectTileEditorPanel : public WindowContent {
   void SetStandardWritePreflightCallback(
       StandardWritePreflightCallback callback) {
     standard_write_preflight_ = std::move(callback);
+  }
+
+  void SetStandardTilesAppliedCallback(StandardTilesAppliedCallback callback) {
+    on_standard_tiles_applied_ = std::move(callback);
   }
 
  private:
@@ -86,16 +102,26 @@ class ObjectTileEditorPanel : public WindowContent {
   void ResetTransientState();
   std::string BuildWindowTitle() const;
   void SelectFirstCellIfAvailable();
+  struct SourceImpactSnapshot {
+    int consumer_count = 0;
+    uint64_t fingerprint = 0;
+
+    bool operator==(const SourceImpactSnapshot&) const = default;
+  };
+  absl::StatusOr<SourceImpactSnapshot> AnalyzeSourceImpactSnapshot() const;
   absl::StatusOr<int> GetSharedTileDataUsageCount() const;
+  absl::StatusOr<int> GetDisplayedSharedTileDataUsageCount();
   absl::StatusOr<bool> HasSharedTileDataConflict() const;
+  uint64_t BuildSourceImpactProvenanceFingerprint() const;
   bool HasRenderableRoomContext() const;
   void RefreshRenderedViewsFromCurrentRoom();
 
   void DrawTileGrid();
   void DrawSourceSheet();
   void DrawTileProperties();
-  void DrawActionBar();
-  void HandleKeyboardShortcuts();
+  void DrawActionBar(bool* p_open);
+  void HandleKeyboardShortcuts(bool* p_open);
+  void RequestSafeWindowClose(bool* p_open);
 
   void RenderObjectPreview();
   void RenderTile8Atlas();
@@ -128,7 +154,17 @@ class ObjectTileEditorPanel : public WindowContent {
   // Shared tile data confirmation
   bool show_shared_confirm_ = false;
   int shared_object_count_ = 0;
+  std::optional<SourceImpactSnapshot> pending_shared_confirmation_;
   int shared_tile_data_usage_override_ = -1;  // Test seam; production keeps -1.
+  struct SourceImpactDisplayCacheKey {
+    int16_t object_id = -1;
+    uint64_t provenance_fingerprint = 0;
+    uint64_t rom_revision = 0;
+
+    bool operator==(const SourceImpactDisplayCacheKey&) const = default;
+  };
+  std::optional<SourceImpactDisplayCacheKey> source_impact_display_cache_key_;
+  std::optional<absl::StatusOr<int>> source_impact_display_cache_result_;
   ActionStatusTone action_status_tone_ = ActionStatusTone::kNone;
   std::string action_status_message_;
 
@@ -136,6 +172,7 @@ class ObjectTileEditorPanel : public WindowContent {
   bool is_new_object_ = false;
   std::function<void(int, const std::string&)> on_object_created_;
   StandardWritePreflightCallback standard_write_preflight_;
+  StandardTilesAppliedCallback on_standard_tiles_applied_;
 
   // Context
   gfx::IRenderer* renderer_;

--- a/test/unit/editor/dungeon_canvas_viewer_navigation_test.cc
+++ b/test/unit/editor/dungeon_canvas_viewer_navigation_test.cc
@@ -108,6 +108,18 @@ class DungeonCanvasViewerTestPeer {
     return labels;
   }
 
+  static bool InvokeSelectionContextMenuItem(DungeonCanvasViewer& viewer,
+                                             int room_id,
+                                             const std::string& label) {
+    for (auto& item : viewer.BuildSelectionContextMenuItems(room_id)) {
+      if (item.label == label && item.callback) {
+        item.callback();
+        return true;
+      }
+    }
+    return false;
+  }
+
   static PendingScrollFrameSnapshot ConsumePendingScrollAndCaptureTransforms(
       DungeonCanvasViewer& viewer, int tile_x, int tile_y, float scale,
       ImVec2 initial_scroll, ImVec2 canvas_size) {
@@ -470,6 +482,58 @@ TEST(DungeonCanvasViewerContextMenuTest,
       labels.size());
   EXPECT_EQ(FindLabelIndex(labels, "Object Stream: BG1 Overlay"),
             labels.size());
+}
+
+TEST(DungeonCanvasViewerContextMenuTest,
+     SingleAllowlistedObjectOffersObjectTileEditorAction) {
+  ScopedImGuiContext imgui;
+  DungeonRoomStore rooms;
+  rooms[0].GetTileObjects().push_back(
+      zelda3::RoomObject{0x11F, 10, 10, 0x00, 0});
+
+  int opened_room = -1;
+  int opened_object = -1;
+  DungeonCanvasViewer viewer;
+  viewer.SetRooms(&rooms);
+  viewer.object_interaction().SetCurrentRoom(&rooms, 0);
+  viewer.object_interaction().SetSelectedObjects({0});
+  viewer.SetEditObjectTilesCallback(
+      [&](int room_id, const zelda3::RoomObject& object) {
+        opened_room = room_id;
+        opened_object = object.id_;
+      });
+
+  const auto labels =
+      DungeonCanvasViewerTestPeer::SelectionContextMenuLabels(viewer, 0);
+  EXPECT_LT(FindLabelIndex(labels, "Edit Object Tiles..."), labels.size());
+  EXPECT_TRUE(DungeonCanvasViewerTestPeer::InvokeSelectionContextMenuItem(
+      viewer, 0, "Edit Object Tiles..."));
+  EXPECT_EQ(opened_room, 0);
+  EXPECT_EQ(opened_object, 0x11F);
+}
+
+TEST(DungeonCanvasViewerContextMenuTest,
+     ObjectTileEditorActionRequiresOneAllowlistedSelection) {
+  ScopedImGuiContext imgui;
+  DungeonRoomStore rooms;
+  rooms[0].GetTileObjects().push_back(
+      zelda3::RoomObject{0x11F, 10, 10, 0x00, 0});
+  rooms[0].GetTileObjects().push_back(
+      zelda3::RoomObject{0x01, 12, 12, 0x00, 0});
+
+  DungeonCanvasViewer viewer;
+  viewer.SetRooms(&rooms);
+  viewer.object_interaction().SetCurrentRoom(&rooms, 0);
+  viewer.SetEditObjectTilesCallback([](int, const zelda3::RoomObject&) {});
+
+  viewer.object_interaction().SetSelectedObjects({1});
+  auto labels =
+      DungeonCanvasViewerTestPeer::SelectionContextMenuLabels(viewer, 0);
+  EXPECT_EQ(FindLabelIndex(labels, "Edit Object Tiles..."), labels.size());
+
+  viewer.object_interaction().SetSelectedObjects({0, 1});
+  labels = DungeonCanvasViewerTestPeer::SelectionContextMenuLabels(viewer, 0);
+  EXPECT_EQ(FindLabelIndex(labels, "Edit Object Tiles..."), labels.size());
 }
 
 TEST(DungeonCanvasViewerPingTest, TriggerCanvasPingRectClampsToCanvasBounds) {

--- a/test/unit/editor/dungeon_object_selector_palette_test.cc
+++ b/test/unit/editor/dungeon_object_selector_palette_test.cc
@@ -1,12 +1,26 @@
 #include "app/editor/dungeon/dungeon_object_selector.h"
 
 #include <cstddef>
+#include <vector>
 
+#include "app/editor/dungeon/ui/window/object_tile_editor_panel.h"
 #include "app/gfx/types/snes_palette.h"
 #include "gtest/gtest.h"
 
 namespace yaze {
 namespace editor {
+
+struct DungeonObjectSelectorTestAccess {
+  static absl::Status OpenNewCustomObjectEditor(DungeonObjectSelector& selector,
+                                                int width, int height,
+                                                const std::string& filename,
+                                                int16_t object_id,
+                                                int room_id) {
+    return selector.OpenNewCustomObjectEditor(width, height, filename,
+                                              object_id, room_id);
+  }
+};
+
 namespace {
 
 // Pins the cache-invalidation contract for DungeonObjectSelector's preview
@@ -73,6 +87,81 @@ TEST(DungeonObjectSelectorPaletteTest, ObjectPreviewsDefaultOn) {
   // graphics are unavailable.
   DungeonObjectSelector selector;
   EXPECT_TRUE(selector.object_previews_enabled_for_testing());
+}
+
+TEST(DungeonObjectSelectorCustomEditorTest,
+     NewCustomObjectSessionOpensWorkspaceWindow) {
+  Rom rom;
+  ASSERT_TRUE(rom.LoadFromData(std::vector<uint8_t>(0x200000, 0)).ok());
+  DungeonRoomStore rooms(&rom);
+  ObjectTileEditorPanel panel(nullptr, &rom);
+  DungeonObjectSelector selector(&rom);
+  selector.set_rooms(&rooms);
+  selector.SetTileEditorPanel(&panel);
+  int open_window_count = 0;
+  selector.SetOpenTileEditorWindowCallback([&open_window_count]() {
+    ++open_window_count;
+    return true;
+  });
+
+  const absl::Status status =
+      DungeonObjectSelectorTestAccess::OpenNewCustomObjectEditor(
+          selector, /*width=*/2, /*height=*/2, "custom_31_00.bin",
+          /*object_id=*/0x31, /*room_id=*/0);
+
+  ASSERT_TRUE(status.ok()) << status;
+  EXPECT_EQ(open_window_count, 1);
+  EXPECT_TRUE(panel.IsOpen());
+}
+
+TEST(DungeonObjectSelectorCustomEditorTest,
+     NewCustomObjectSessionFailsClosedWhenWindowIsUnavailable) {
+  Rom rom;
+  ASSERT_TRUE(rom.LoadFromData(std::vector<uint8_t>(0x200000, 0)).ok());
+  DungeonRoomStore rooms(&rom);
+  ObjectTileEditorPanel panel(nullptr, &rom);
+  DungeonObjectSelector selector(&rom);
+  selector.set_rooms(&rooms);
+  selector.SetTileEditorPanel(&panel);
+  selector.SetOpenTileEditorWindowCallback([]() { return false; });
+
+  const absl::Status status =
+      DungeonObjectSelectorTestAccess::OpenNewCustomObjectEditor(
+          selector, /*width=*/2, /*height=*/2, "custom_31_00.bin",
+          /*object_id=*/0x31, /*room_id=*/0);
+
+  EXPECT_TRUE(absl::IsNotFound(status));
+  EXPECT_FALSE(panel.IsOpen());
+}
+
+TEST(DungeonObjectSelectorCustomEditorTest,
+     NewCustomObjectSessionPreservesExistingUnappliedEdits) {
+  Rom rom;
+  ASSERT_TRUE(rom.LoadFromData(std::vector<uint8_t>(0x200000, 0)).ok());
+  DungeonRoomStore rooms(&rom);
+  ObjectTileEditorPanel panel(nullptr, &rom);
+  ASSERT_TRUE(panel
+                  .OpenForNewObject(/*width=*/2, /*height=*/2, "existing.bin",
+                                    /*object_id=*/0x31,
+                                    /*room_id=*/0, &rooms)
+                  .ok());
+  DungeonObjectSelector selector(&rom);
+  selector.set_rooms(&rooms);
+  selector.SetTileEditorPanel(&panel);
+  int open_window_count = 0;
+  selector.SetOpenTileEditorWindowCallback([&open_window_count]() {
+    ++open_window_count;
+    return true;
+  });
+
+  const absl::Status status =
+      DungeonObjectSelectorTestAccess::OpenNewCustomObjectEditor(
+          selector, /*width=*/1, /*height=*/1, "replacement.bin",
+          /*object_id=*/0x32, /*room_id=*/1);
+
+  EXPECT_TRUE(absl::IsFailedPrecondition(status));
+  EXPECT_EQ(open_window_count, 1);
+  EXPECT_TRUE(panel.IsOpen());
 }
 
 TEST(DungeonObjectSelectorSizeTest,

--- a/test/unit/editor/object_tile_editor_panel_test.cc
+++ b/test/unit/editor/object_tile_editor_panel_test.cc
@@ -3,16 +3,22 @@
 #include <chrono>
 #include <filesystem>
 #include <iterator>
+#include <memory>
 #include <optional>
 #include <string>
 #include <vector>
 
 #include "absl/strings/str_format.h"
+#include "app/editor/dungeon/dungeon_editor_v2.h"
 #include "app/editor/system/session/hack_manifest_save_validation.h"
+#include "app/editor/system/workspace/workspace_window_manager.h"
 #include "core/project.h"
 #include "gtest/gtest.h"
 #include "rom/snes.h"
 #include "zelda3/dungeon/custom_object.h"
+#include "zelda3/dungeon/dungeon_rom_addresses.h"
+#include "zelda3/dungeon/room_layer_manager.h"
+#include "zelda3/game_data.h"
 
 namespace yaze::editor {
 
@@ -86,9 +92,18 @@ struct ObjectTileEditorPanelTestAccess {
     return panel.current_object_id_;
   }
 
+  static uint16_t CurrentPaletteColor(const ObjectTileEditorPanel& panel,
+                                      int palette, int color) {
+    return panel.current_palette_group_.GetColor(palette, color).snes();
+  }
+
   static void SetCurrentObjectId(ObjectTileEditorPanel& panel,
                                  int16_t object_id) {
     panel.current_object_id_ = object_id;
+  }
+
+  static void SetOpen(ObjectTileEditorPanel& panel, bool open) {
+    panel.is_open_ = open;
   }
 
   static void SetSharedTileDataUsageOverride(ObjectTileEditorPanel& panel,
@@ -208,6 +223,17 @@ struct ObjectTileEditorPanelTestAccess {
     panel.current_layout_.cells[0].modified = true;
   }
 
+  static void ClearModifications(ObjectTileEditorPanel& panel) {
+    for (auto& cell : panel.current_layout_.cells) {
+      cell.modified = false;
+    }
+  }
+
+  static void RequestSafeWindowClose(ObjectTileEditorPanel& panel,
+                                     bool* p_open) {
+    panel.RequestSafeWindowClose(p_open);
+  }
+
   static void SetFirstCellTileAndPalette(ObjectTileEditorPanel& panel,
                                          uint16_t tile_id, uint8_t palette) {
     ASSERT_FALSE(panel.current_layout_.cells.empty());
@@ -240,9 +266,27 @@ struct ObjectTileEditorPanelTestAccess {
     return panel.GetSharedTileDataUsageCount();
   }
 
+  static absl::StatusOr<int> DisplayedSharedTileDataUsageCount(
+      ObjectTileEditorPanel& panel) {
+    return panel.GetDisplayedSharedTileDataUsageCount();
+  }
+
   static absl::StatusOr<bool> HasSharedTileDataConflict(
       const ObjectTileEditorPanel& panel) {
     return panel.HasSharedTileDataConflict();
+  }
+};
+
+class DungeonEditorV2ObjectTileEditorTestPeer {
+ public:
+  static absl::Status OpenObjectTileEditorForObject(
+      DungeonEditorV2& editor, int room_id, const zelda3::RoomObject& object) {
+    return editor.OpenObjectTileEditorForObject(room_id, object);
+  }
+
+  static void SetObjectTileEditorPanel(DungeonEditorV2& editor,
+                                       ObjectTileEditorPanel* panel) {
+    editor.object_tile_editor_panel_ = panel;
   }
 };
 
@@ -329,6 +373,67 @@ std::vector<uint8_t> MakeEditableStandardObjectRomData() {
   return data;
 }
 
+void SeedCoordinatorPaletteGroup(gfx::PaletteGroup* group, int palette_count,
+                                 int color_count, uint16_t seed) {
+  ASSERT_NE(group, nullptr);
+  group->clear();
+  for (int palette_index = 0; palette_index < palette_count; ++palette_index) {
+    gfx::SnesPalette palette;
+    for (int color_index = 0; color_index < color_count; ++color_index) {
+      palette.AddColor(gfx::SnesColor(static_cast<uint16_t>(
+          (seed + palette_index * color_count + color_index) & 0x7FFF)));
+    }
+    group->AddPalette(palette);
+  }
+}
+
+void ConfigureCoordinatorGameData(zelda3::GameData* game_data) {
+  ASSERT_NE(game_data, nullptr);
+  game_data->graphics_buffer.assign(zelda3::kNumGfxSheets * 4096, 0);
+  for (auto& ids : game_data->main_blockset_ids) {
+    ids.fill(0);
+  }
+  for (auto& ids : game_data->room_blockset_ids) {
+    ids.fill(0);
+  }
+  for (auto& ids : game_data->spriteset_ids) {
+    ids.fill(0);
+  }
+  for (auto& ids : game_data->paletteset_ids) {
+    ids.fill(0);
+  }
+
+  SeedCoordinatorPaletteGroup(&game_data->palette_groups.hud,
+                              /*palette_count=*/1, /*color_count=*/32,
+                              /*seed=*/0x0100);
+  SeedCoordinatorPaletteGroup(&game_data->palette_groups.dungeon_main,
+                              /*palette_count=*/4, /*color_count=*/90,
+                              /*seed=*/0x0200);
+  game_data->paletteset_ids[5][0] = 2;
+}
+
+void PrepareCoordinatorRoom(Rom* rom, zelda3::GameData* game_data,
+                            DungeonEditorV2* editor, int room_id) {
+  ASSERT_NE(rom, nullptr);
+  ASSERT_NE(game_data, nullptr);
+  ASSERT_NE(editor, nullptr);
+
+  const int layout_address = SnesToPc(zelda3::kRoomLayoutPointers.front());
+  ASSERT_GE(layout_address, 0);
+  ASSERT_LT(layout_address + 1, static_cast<int>(rom->size()));
+  rom->mutable_data()[layout_address] = 0xFF;
+  rom->mutable_data()[layout_address + 1] = 0xFF;
+  ASSERT_TRUE(rom->WriteWord(zelda3::kDungeonPalettePointerTable + 2,
+                             3 * zelda3::kDungeonPaletteBytes)
+                  .ok());
+
+  auto& room = editor->rooms()[room_id];
+  room = zelda3::Room(room_id, rom, game_data);
+  room.SetLoaded(true);
+  room.SetTileObjects({});
+  room.SetPalette(5);  // Resolves through the pointer table to palette 3.
+}
+
 absl::StatusOr<zelda3::ObjectTileLayout> CaptureEditableStandardLayout(
     Rom& rom, int16_t object_id = kEditableStandardObjectId) {
   zelda3::Room room(/*room_id=*/0, &rom, /*game_data=*/nullptr);
@@ -375,31 +480,118 @@ std::string ManifestProtectingPcRange(uint32_t begin, uint32_t end) {
       PcToSnes(begin), PcToSnes(end));
 }
 
-std::optional<int16_t> FindCapturableObjectId(Rom* rom, DungeonRoomStore* rooms,
-                                              int start_id = 0,
-                                              int end_id = 0x1FF) {
-  ObjectTileEditorPanel probe(nullptr, rom);
-  for (int id = start_id; id <= end_id; ++id) {
-    probe.OpenForObject(static_cast<int16_t>(id), /*room_id=*/0, rooms);
-    if (ObjectTileEditorPanelTestAccess::HasLayout(probe)) {
-      return static_cast<int16_t>(id);
-    }
-  }
-  return std::nullopt;
-}
-
 void OpenInjectedSharedStandardObjectSession(ObjectTileEditorPanel& panel,
                                              Rom& rom) {
-  panel.OpenForObject(kEditableStandardObjectId, /*room_id=*/-1, nullptr);
-
   auto layout_or = CaptureEditableStandardLayout(rom);
   ASSERT_TRUE(layout_or.ok()) << layout_or.status();
   ObjectTileEditorPanelTestAccess::SetLayout(panel, std::move(*layout_or));
+  ObjectTileEditorPanelTestAccess::SetCurrentObjectId(
+      panel, kEditableStandardObjectId);
+  ObjectTileEditorPanelTestAccess::SetOpen(panel, true);
   ObjectTileEditorPanelTestAccess::SetSelectedCellIndex(panel, 0);
   ObjectTileEditorPanelTestAccess::SyncSourceSelectionFromSelectedCell(panel);
 }
 
-TEST(ObjectTileEditorPanelTest, OpenForObjectInvalidRoomClearsPreviousLayout) {
+TEST(DungeonEditorV2ObjectTileEditorTest,
+     RegisteredPanelOpensWithResolvedRoomPalette) {
+  Rom rom;
+  ASSERT_TRUE(rom.LoadFromData(MakeEditableStandardObjectRomData()).ok());
+  zelda3::GameData game_data(&rom);
+  ConfigureCoordinatorGameData(&game_data);
+
+  WorkspaceWindowManager window_manager;
+  window_manager.RegisterSession(0);
+  window_manager.SetActiveSession(0);
+
+  DungeonEditorV2 editor(&rom);
+  EditorDependencies dependencies;
+  dependencies.rom = &rom;
+  dependencies.game_data = &game_data;
+  dependencies.window_manager = &window_manager;
+  editor.SetDependencies(dependencies);
+  editor.SetGameData(&game_data);
+  PrepareCoordinatorRoom(&rom, &game_data, &editor, /*room_id=*/0);
+
+  auto panel = std::make_unique<ObjectTileEditorPanel>(nullptr, &rom);
+  ObjectTileEditorPanel* panel_ptr = panel.get();
+  window_manager.RegisterWindowContent(std::move(panel));
+  DungeonEditorV2ObjectTileEditorTestPeer::SetObjectTileEditorPanel(editor,
+                                                                    panel_ptr);
+
+  ASSERT_FALSE(window_manager.IsWindowOpen(0, panel_ptr->GetId()));
+  const zelda3::RoomObject selected_object(kEditableStandardObjectId, /*x=*/0,
+                                           /*y=*/0, /*size=*/0, /*layer=*/0);
+  const absl::Status status =
+      DungeonEditorV2ObjectTileEditorTestPeer::OpenObjectTileEditorForObject(
+          editor, /*room_id=*/0, selected_object);
+
+  ASSERT_TRUE(status.ok()) << status;
+  EXPECT_TRUE(window_manager.IsWindowOpen(0, panel_ptr->GetId()));
+  EXPECT_TRUE(panel_ptr->IsOpen());
+  EXPECT_EQ(ObjectTileEditorPanelTestAccess::CurrentRoomId(*panel_ptr), 0);
+  EXPECT_EQ(ObjectTileEditorPanelTestAccess::CurrentObjectId(*panel_ptr),
+            kEditableStandardObjectId);
+  EXPECT_EQ(ObjectTileEditorPanelTestAccess::Rooms(*panel_ptr),
+            &editor.rooms());
+  ASSERT_TRUE(ObjectTileEditorPanelTestAccess::Layout(*panel_ptr)
+                  .source_provenance.has_value());
+
+  auto expected_palette = game_data.palette_groups.dungeon_main.palette_ref(3);
+  auto expected_group =
+      gfx::CreatePaletteGroupFromLargePalette(expected_palette);
+  ASSERT_TRUE(expected_group.ok()) << expected_group.status();
+  auto default_palette = game_data.palette_groups.dungeon_main.palette_ref(0);
+  auto default_group = gfx::CreatePaletteGroupFromLargePalette(default_palette);
+  ASSERT_TRUE(default_group.ok()) << default_group.status();
+  EXPECT_EQ(ObjectTileEditorPanelTestAccess::CurrentPaletteColor(
+                *panel_ptr, /*palette=*/0, /*color=*/0),
+            expected_group->GetColor(/*palette=*/0, /*color=*/0).snes());
+  EXPECT_NE(ObjectTileEditorPanelTestAccess::CurrentPaletteColor(
+                *panel_ptr, /*palette=*/0, /*color=*/0),
+            default_group->GetColor(/*palette=*/0, /*color=*/0).snes());
+}
+
+TEST(DungeonEditorV2ObjectTileEditorTest,
+     UnregisteredPanelFailsAndClosesCapturedSession) {
+  Rom rom;
+  ASSERT_TRUE(rom.LoadFromData(MakeEditableStandardObjectRomData()).ok());
+  zelda3::GameData game_data(&rom);
+  ConfigureCoordinatorGameData(&game_data);
+
+  WorkspaceWindowManager window_manager;
+  window_manager.RegisterSession(0);
+  window_manager.SetActiveSession(0);
+  ObjectTileEditorPanel unregistered_panel(nullptr, &rom);
+
+  DungeonEditorV2 editor(&rom);
+  EditorDependencies dependencies;
+  dependencies.rom = &rom;
+  dependencies.game_data = &game_data;
+  dependencies.window_manager = &window_manager;
+  editor.SetDependencies(dependencies);
+  editor.SetGameData(&game_data);
+  PrepareCoordinatorRoom(&rom, &game_data, &editor, /*room_id=*/0);
+  DungeonEditorV2ObjectTileEditorTestPeer::SetObjectTileEditorPanel(
+      editor, &unregistered_panel);
+
+  const zelda3::RoomObject selected_object(kEditableStandardObjectId, /*x=*/0,
+                                           /*y=*/0, /*size=*/0, /*layer=*/0);
+  const absl::Status status =
+      DungeonEditorV2ObjectTileEditorTestPeer::OpenObjectTileEditorForObject(
+          editor, /*room_id=*/0, selected_object);
+
+  EXPECT_TRUE(absl::IsNotFound(status)) << status;
+  EXPECT_FALSE(window_manager.IsWindowOpen(0, unregistered_panel.GetId()));
+  EXPECT_FALSE(unregistered_panel.IsOpen());
+  EXPECT_FALSE(ObjectTileEditorPanelTestAccess::HasLayout(unregistered_panel));
+  EXPECT_EQ(ObjectTileEditorPanelTestAccess::CurrentRoomId(unregistered_panel),
+            -1);
+  EXPECT_EQ(
+      ObjectTileEditorPanelTestAccess::CurrentObjectId(unregistered_panel), -1);
+}
+
+TEST(ObjectTileEditorPanelTest,
+     OpenForObjectInvalidRoomPreservesPreviousLayout) {
   Rom rom;
   ASSERT_TRUE(rom.LoadFromData(std::vector<uint8_t>(0x200000, 0)).ok());
 
@@ -407,28 +599,34 @@ TEST(ObjectTileEditorPanelTest, OpenForObjectInvalidRoomClearsPreviousLayout) {
   panel.OpenForNewObject(/*width=*/2, /*height=*/2, "custom.bin",
                          /*object_id=*/0x123, /*room_id=*/0, nullptr);
   ASSERT_TRUE(ObjectTileEditorPanelTestAccess::HasLayout(panel));
+  ObjectTileEditorPanelTestAccess::ClearModifications(panel);
   ObjectTileEditorPanelTestAccess::SeedRenderedBitmaps(panel);
   ASSERT_TRUE(ObjectTileEditorPanelTestAccess::HasActivePreview(panel));
   ASSERT_TRUE(ObjectTileEditorPanelTestAccess::HasActiveAtlas(panel));
 
   DungeonRoomStore rooms(&rom);
-  panel.OpenForObject(/*object_id=*/0x40, /*room_id=*/-1, &rooms);
+  const absl::Status status =
+      panel.OpenForObject(kEditableStandardObjectId, /*room_id=*/-1, &rooms);
 
-  EXPECT_FALSE(ObjectTileEditorPanelTestAccess::HasLayout(panel));
-  EXPECT_EQ(ObjectTileEditorPanelTestAccess::SelectedCellIndex(panel), -1);
-  EXPECT_EQ(ObjectTileEditorPanelTestAccess::SelectedSourceTile(panel), -1);
-  EXPECT_FALSE(ObjectTileEditorPanelTestAccess::HasActivePreview(panel));
-  EXPECT_FALSE(ObjectTileEditorPanelTestAccess::HasActiveAtlas(panel));
+  EXPECT_TRUE(absl::IsOutOfRange(status));
+  EXPECT_TRUE(panel.IsOpen());
+  EXPECT_TRUE(ObjectTileEditorPanelTestAccess::HasLayout(panel));
+  EXPECT_EQ(ObjectTileEditorPanelTestAccess::CurrentObjectId(panel), 0x123);
+  EXPECT_EQ(ObjectTileEditorPanelTestAccess::CurrentRoomId(panel), 0);
+  EXPECT_EQ(ObjectTileEditorPanelTestAccess::SelectedCellIndex(panel), 0);
+  EXPECT_TRUE(ObjectTileEditorPanelTestAccess::HasActivePreview(panel));
+  EXPECT_TRUE(ObjectTileEditorPanelTestAccess::HasActiveAtlas(panel));
 }
 
 TEST(ObjectTileEditorPanelTest,
-     OpenForObjectCaptureFailureClearsPreviousLayout) {
+     OpenForObjectCaptureFailurePreservesPreviousLayout) {
   Rom rom;
 
   ObjectTileEditorPanel panel(nullptr, &rom);
   panel.OpenForNewObject(/*width=*/2, /*height=*/2, "custom.bin",
                          /*object_id=*/0x123, /*room_id=*/0, nullptr);
   ASSERT_TRUE(ObjectTileEditorPanelTestAccess::HasLayout(panel));
+  ObjectTileEditorPanelTestAccess::ClearModifications(panel);
   ObjectTileEditorPanelTestAccess::SeedRenderedBitmaps(panel);
   ASSERT_TRUE(ObjectTileEditorPanelTestAccess::HasActivePreview(panel));
   ASSERT_TRUE(ObjectTileEditorPanelTestAccess::HasActiveAtlas(panel));
@@ -436,16 +634,95 @@ TEST(ObjectTileEditorPanelTest,
   DungeonRoomStore rooms(&rom);
   (void)rooms[0];
 
-  panel.OpenForObject(/*object_id=*/0x40, /*room_id=*/0, &rooms);
+  const absl::Status status =
+      panel.OpenForObject(kEditableStandardObjectId, /*room_id=*/0, &rooms);
 
-  EXPECT_FALSE(ObjectTileEditorPanelTestAccess::HasLayout(panel));
-  EXPECT_EQ(ObjectTileEditorPanelTestAccess::SelectedCellIndex(panel), -1);
-  EXPECT_EQ(ObjectTileEditorPanelTestAccess::SelectedSourceTile(panel), -1);
-  EXPECT_FALSE(ObjectTileEditorPanelTestAccess::HasActivePreview(panel));
-  EXPECT_FALSE(ObjectTileEditorPanelTestAccess::HasActiveAtlas(panel));
+  EXPECT_TRUE(absl::IsFailedPrecondition(status));
+  EXPECT_TRUE(panel.IsOpen());
+  EXPECT_TRUE(ObjectTileEditorPanelTestAccess::HasLayout(panel));
+  EXPECT_EQ(ObjectTileEditorPanelTestAccess::CurrentObjectId(panel), 0x123);
+  EXPECT_EQ(ObjectTileEditorPanelTestAccess::CurrentRoomId(panel), 0);
+  EXPECT_EQ(ObjectTileEditorPanelTestAccess::SelectedCellIndex(panel), 0);
+  EXPECT_TRUE(ObjectTileEditorPanelTestAccess::HasActivePreview(panel));
+  EXPECT_TRUE(ObjectTileEditorPanelTestAccess::HasActiveAtlas(panel));
 }
 
-TEST(ObjectTileEditorPanelTest, CloseClearsTransientStateAndContext) {
+TEST(ObjectTileEditorPanelTest,
+     OpenForObjectRejectsNonAllowlistedObjectWithoutChangingSession) {
+  Rom rom;
+  ASSERT_TRUE(rom.LoadFromData(MakeEditableStandardObjectRomData()).ok());
+  DungeonRoomStore rooms(&rom);
+
+  ObjectTileEditorPanel panel(nullptr, &rom);
+  panel.OpenForNewObject(/*width=*/1, /*height=*/1, "custom.bin",
+                         /*object_id=*/0x31, /*room_id=*/0, &rooms);
+
+  const absl::Status status =
+      panel.OpenForObject(/*object_id=*/0x40, /*room_id=*/0, &rooms);
+
+  EXPECT_TRUE(absl::IsUnimplemented(status));
+  EXPECT_TRUE(panel.IsOpen());
+  EXPECT_TRUE(ObjectTileEditorPanelTestAccess::IsNewObject(panel));
+  EXPECT_EQ(ObjectTileEditorPanelTestAccess::CurrentObjectId(panel), 0x31);
+  EXPECT_FALSE(ObjectTileEditorPanelTestAccess::Layout(panel)
+                   .source_provenance.has_value());
+}
+
+TEST(ObjectTileEditorPanelTest,
+     OpenForObjectRejectsReplacingSessionWithUnappliedChanges) {
+  Rom rom;
+  ASSERT_TRUE(rom.LoadFromData(MakeEditableStandardObjectRomData()).ok());
+  DungeonRoomStore rooms(&rom);
+
+  ObjectTileEditorPanel panel(nullptr, &rom);
+  ASSERT_TRUE(
+      panel.OpenForObject(kEditableStandardObjectId, /*room_id=*/0, &rooms)
+          .ok());
+  ObjectTileEditorPanelTestAccess::SetFirstCellTileAndPalette(
+      panel, /*tile_id=*/0x123, /*palette=*/3);
+  const auto original_layout = ObjectTileEditorPanelTestAccess::Layout(panel);
+
+  const absl::Status status =
+      panel.OpenForObject(kTorchAliasObjectId, /*room_id=*/1, &rooms);
+
+  EXPECT_TRUE(absl::IsFailedPrecondition(status));
+  EXPECT_NE(std::string(status.message()).find("Apply, revert, or close"),
+            std::string::npos);
+  EXPECT_EQ(ObjectTileEditorPanelTestAccess::CurrentObjectId(panel),
+            kEditableStandardObjectId);
+  EXPECT_EQ(ObjectTileEditorPanelTestAccess::CurrentRoomId(panel), 0);
+  EXPECT_EQ(ObjectTileEditorPanelTestAccess::Layout(panel)
+                .cells.front()
+                .tile_info.id_,
+            original_layout.cells.front().tile_info.id_);
+  EXPECT_TRUE(ObjectTileEditorPanelTestAccess::HasModifications(panel));
+}
+
+TEST(ObjectTileEditorPanelTest, PaletteUpdatesStayBoundToTheOpenSessionRoom) {
+  Rom rom;
+  ASSERT_TRUE(rom.LoadFromData(MakeEditableStandardObjectRomData()).ok());
+  DungeonRoomStore rooms(&rom);
+  const gfx::PaletteGroup room_zero_palette = MakeTestPaletteGroup(1);
+  const gfx::PaletteGroup room_one_palette = MakeTestPaletteGroup(10);
+
+  ObjectTileEditorPanel panel(nullptr, &rom);
+  ASSERT_TRUE(panel
+                  .OpenForObject(kEditableStandardObjectId, /*room_id=*/0,
+                                 &rooms, room_zero_palette)
+                  .ok());
+  const uint16_t original_color =
+      ObjectTileEditorPanelTestAccess::CurrentPaletteColor(panel, 0, 0);
+
+  panel.SetCurrentPaletteGroupForRoom(/*room_id=*/1, room_one_palette);
+  EXPECT_EQ(ObjectTileEditorPanelTestAccess::CurrentPaletteColor(panel, 0, 0),
+            original_color);
+
+  panel.SetCurrentPaletteGroupForRoom(/*room_id=*/0, room_one_palette);
+  EXPECT_EQ(ObjectTileEditorPanelTestAccess::CurrentPaletteColor(panel, 0, 0),
+            room_one_palette.GetColor(0, 0).snes());
+}
+
+TEST(ObjectTileEditorPanelTest, ExplicitCloseClearsTransientStateAndContext) {
   Rom rom;
   ASSERT_TRUE(rom.LoadFromData(std::vector<uint8_t>(0x200000, 0)).ok());
 
@@ -475,6 +752,53 @@ TEST(ObjectTileEditorPanelTest, CloseClearsTransientStateAndContext) {
   EXPECT_FALSE(ObjectTileEditorPanelTestAccess::HasActiveAtlas(panel));
 }
 
+TEST(ObjectTileEditorPanelTest, OnClosePreservesModifiedSessionForReopen) {
+  Rom rom;
+  ASSERT_TRUE(rom.LoadFromData(MakeEditableStandardObjectRomData()).ok());
+  DungeonRoomStore rooms(&rom);
+
+  ObjectTileEditorPanel panel(nullptr, &rom);
+  ASSERT_TRUE(
+      panel.OpenForObject(kEditableStandardObjectId, /*room_id=*/0, &rooms)
+          .ok());
+  ObjectTileEditorPanelTestAccess::SetFirstCellTileAndPalette(
+      panel, /*tile_id=*/0x123, /*palette=*/3);
+
+  panel.OnClose();
+
+  EXPECT_TRUE(panel.IsOpen());
+  EXPECT_TRUE(ObjectTileEditorPanelTestAccess::HasLayout(panel));
+  EXPECT_TRUE(ObjectTileEditorPanelTestAccess::HasModifications(panel));
+  EXPECT_EQ(ObjectTileEditorPanelTestAccess::CurrentObjectId(panel),
+            kEditableStandardObjectId);
+  EXPECT_EQ(ObjectTileEditorPanelTestAccess::CurrentRoomId(panel), 0);
+}
+
+TEST(ObjectTileEditorPanelTest,
+     SafeWindowCloseHidesAndPreservesModifiedSession) {
+  Rom rom;
+  ASSERT_TRUE(rom.LoadFromData(MakeEditableStandardObjectRomData()).ok());
+  DungeonRoomStore rooms(&rom);
+
+  ObjectTileEditorPanel panel(nullptr, &rom);
+  ASSERT_TRUE(
+      panel.OpenForObject(kEditableStandardObjectId, /*room_id=*/0, &rooms)
+          .ok());
+  ObjectTileEditorPanelTestAccess::SetFirstCellTileAndPalette(
+      panel, /*tile_id=*/0x123, /*palette=*/3);
+  bool visible = true;
+
+  ObjectTileEditorPanelTestAccess::RequestSafeWindowClose(panel, &visible);
+
+  EXPECT_FALSE(visible);
+  EXPECT_TRUE(panel.IsOpen());
+  EXPECT_TRUE(ObjectTileEditorPanelTestAccess::HasModifications(panel));
+  EXPECT_TRUE(ObjectTileEditorPanelTestAccess::ActionStatusIsWarning(panel));
+  EXPECT_NE(ObjectTileEditorPanelTestAccess::ActionStatusMessage(panel).find(
+                "Unapplied tile changes were kept"),
+            std::string::npos);
+}
+
 TEST(ObjectTileEditorPanelTest, OpenForNewObjectClearsPendingSharedConfirm) {
   Rom rom;
   ASSERT_TRUE(rom.LoadFromData(std::vector<uint8_t>(0x200000, 0)).ok());
@@ -482,12 +806,15 @@ TEST(ObjectTileEditorPanelTest, OpenForNewObjectClearsPendingSharedConfirm) {
   ObjectTileEditorPanel panel(nullptr, &rom);
   panel.OpenForNewObject(/*width=*/2, /*height=*/2, "first.bin",
                          /*object_id=*/0x123, /*room_id=*/0, nullptr);
+  ObjectTileEditorPanelTestAccess::ClearModifications(panel);
   ObjectTileEditorPanelTestAccess::SeedTransientState(panel);
   ObjectTileEditorPanelTestAccess::SeedRenderedBitmaps(panel);
 
-  panel.OpenForNewObject(/*width=*/1, /*height=*/1, "second.bin",
-                         /*object_id=*/0x124, /*room_id=*/1, nullptr);
+  const absl::Status status = panel.OpenForNewObject(
+      /*width=*/1, /*height=*/1, "second.bin", /*object_id=*/0x124,
+      /*room_id=*/1, nullptr);
 
+  ASSERT_TRUE(status.ok()) << status;
   EXPECT_TRUE(panel.IsOpen());
   EXPECT_TRUE(ObjectTileEditorPanelTestAccess::HasLayout(panel));
   EXPECT_EQ(ObjectTileEditorPanelTestAccess::SelectedCellIndex(panel), 0);
@@ -502,6 +829,28 @@ TEST(ObjectTileEditorPanelTest, OpenForNewObjectClearsPendingSharedConfirm) {
   EXPECT_EQ(ObjectTileEditorPanelTestAccess::CurrentObjectId(panel), 0x124);
   EXPECT_FALSE(ObjectTileEditorPanelTestAccess::HasActivePreview(panel));
   EXPECT_FALSE(ObjectTileEditorPanelTestAccess::HasActiveAtlas(panel));
+}
+
+TEST(ObjectTileEditorPanelTest,
+     OpenForNewObjectRejectsReplacingModifiedSession) {
+  Rom rom;
+  ObjectTileEditorPanel panel(nullptr, &rom);
+  ASSERT_TRUE(panel
+                  .OpenForNewObject(/*width=*/2, /*height=*/2, "first.bin",
+                                    /*object_id=*/0x123, /*room_id=*/0, nullptr)
+                  .ok());
+  ASSERT_TRUE(ObjectTileEditorPanelTestAccess::HasModifications(panel));
+
+  const absl::Status status = panel.OpenForNewObject(
+      /*width=*/1, /*height=*/1, "second.bin", /*object_id=*/0x124,
+      /*room_id=*/1, nullptr);
+
+  EXPECT_TRUE(absl::IsFailedPrecondition(status));
+  EXPECT_EQ(ObjectTileEditorPanelTestAccess::CurrentObjectId(panel), 0x123);
+  EXPECT_EQ(ObjectTileEditorPanelTestAccess::CurrentRoomId(panel), 0);
+  EXPECT_EQ(ObjectTileEditorPanelTestAccess::Layout(panel).custom_filename,
+            "first.bin");
+  EXPECT_TRUE(ObjectTileEditorPanelTestAccess::HasModifications(panel));
 }
 
 TEST(ObjectTileEditorPanelTest,
@@ -524,18 +873,23 @@ TEST(ObjectTileEditorPanelTest,
 TEST(ObjectTileEditorPanelTest,
      OpenForObjectCapturedLayoutSelectsFirstCellAndSyncsSourceSelection) {
   Rom rom;
-  ASSERT_TRUE(rom.LoadFromData(std::vector<uint8_t>(0x200000, 0)).ok());
+  ASSERT_TRUE(rom.LoadFromData(MakeEditableStandardObjectRomData()).ok());
 
   DungeonRoomStore rooms(&rom);
   (void)rooms[0];
 
-  auto object_id = FindCapturableObjectId(&rom, &rooms);
-  ASSERT_TRUE(object_id.has_value());
-
   ObjectTileEditorPanel panel(nullptr, &rom);
-  panel.OpenForObject(*object_id, /*room_id=*/0, &rooms);
+  const absl::Status status =
+      panel.OpenForObject(kEditableStandardObjectId, /*room_id=*/0, &rooms);
 
+  ASSERT_TRUE(status.ok()) << status;
+  EXPECT_TRUE(panel.IsOpen());
   ASSERT_TRUE(ObjectTileEditorPanelTestAccess::HasLayout(panel));
+  ASSERT_TRUE(ObjectTileEditorPanelTestAccess::Layout(panel)
+                  .source_provenance.has_value());
+  EXPECT_EQ(ObjectTileEditorPanelTestAccess::Layout(panel)
+                .source_provenance->object_id,
+            kEditableStandardObjectId);
   EXPECT_EQ(ObjectTileEditorPanelTestAccess::SelectedCellIndex(panel), 0);
   EXPECT_EQ(ObjectTileEditorPanelTestAccess::SelectedSourceTile(panel),
             ObjectTileEditorPanelTestAccess::FirstCellTileId(panel));
@@ -584,6 +938,42 @@ TEST(ObjectTileEditorPanelTest,
   auto conflict_or =
       ObjectTileEditorPanelTestAccess::HasSharedTileDataConflict(panel);
   EXPECT_TRUE(absl::IsFailedPrecondition(conflict_or.status()));
+}
+
+TEST(ObjectTileEditorPanelTest,
+     DisplayImpactCacheUsesLayoutAndObjectTileRevision) {
+  Rom rom;
+  ASSERT_TRUE(rom.LoadFromData(MakeEditableStandardObjectRomData()).ok());
+  DungeonRoomStore rooms(&rom);
+
+  ObjectTileEditorPanel panel(nullptr, &rom);
+  ASSERT_TRUE(
+      panel.OpenForObject(kTorchAliasObjectId, /*room_id=*/0, &rooms).ok());
+
+  auto first_display_or =
+      ObjectTileEditorPanelTestAccess::DisplayedSharedTileDataUsageCount(panel);
+  ASSERT_TRUE(first_display_or.ok()) << first_display_or.status();
+  ASSERT_EQ(*first_display_or, 3);
+
+  // A raw mutation deliberately bypasses the revision contract. Display-only
+  // state may keep its cached result even while the user edits tile values,
+  // while every apply still analyzes fresh.
+  StoreWord(rom.mutable_vector(), /*Type 1 object 1 descriptor=*/0x8002,
+            0x8000);
+  ObjectTileEditorPanelTestAccess::SetFirstCellTileAndPalette(
+      panel, /*tile_id=*/0x123, /*palette=*/3);
+  auto cached_display_or =
+      ObjectTileEditorPanelTestAccess::DisplayedSharedTileDataUsageCount(panel);
+  ASSERT_TRUE(cached_display_or.ok()) << cached_display_or.status();
+  EXPECT_EQ(*cached_display_or, 3);
+  EXPECT_TRUE(absl::IsFailedPrecondition(
+      ObjectTileEditorPanelTestAccess::SharedTileDataUsageCount(panel)
+          .status()));
+
+  rom.AdvanceObjectTileRevision();
+  auto refreshed_display_or =
+      ObjectTileEditorPanelTestAccess::DisplayedSharedTileDataUsageCount(panel);
+  EXPECT_TRUE(absl::IsFailedPrecondition(refreshed_display_or.status()));
 }
 
 TEST(ObjectTileEditorPanelTest, RenderWithoutRoomContextClearsStaleBitmaps) {
@@ -692,7 +1082,7 @@ TEST(ObjectTileEditorPanelTest,
   EXPECT_TRUE(ObjectTileEditorPanelTestAccess::HasActionStatus(panel));
   EXPECT_TRUE(ObjectTileEditorPanelTestAccess::ActionStatusIsWarning(panel));
   EXPECT_NE(ObjectTileEditorPanelTestAccess::ActionStatusMessage(panel).find(
-                "Confirm shared apply"),
+                "Confirm global apply"),
             std::string::npos);
   EXPECT_TRUE(ObjectTileEditorPanelTestAccess::HasModifications(panel));
   EXPECT_EQ(ReadWordAt(rom, write_addr), original_word);
@@ -758,10 +1148,11 @@ TEST(ObjectTileEditorPanelTest,
   ASSERT_TRUE(rom.LoadFromData(MakeEditableStandardObjectRomData()).ok());
 
   ObjectTileEditorPanel panel(nullptr, &rom);
-  panel.OpenForObject(kTorchAliasObjectId, /*room_id=*/-1, nullptr);
   auto layout_or = CaptureEditableStandardLayout(rom, kTorchAliasObjectId);
   ASSERT_TRUE(layout_or.ok()) << layout_or.status();
   ObjectTileEditorPanelTestAccess::SetLayout(panel, std::move(*layout_or));
+  ObjectTileEditorPanelTestAccess::SetCurrentObjectId(panel,
+                                                      kTorchAliasObjectId);
   ObjectTileEditorPanelTestAccess::SetFirstCellTileAndPalette(
       panel, /*tile_id=*/0x123, /*palette=*/3);
 
@@ -816,6 +1207,139 @@ TEST(ObjectTileEditorPanelTest,
             std::string::npos);
   EXPECT_TRUE(ObjectTileEditorPanelTestAccess::HasModifications(panel));
   EXPECT_EQ(ReadWordAt(rom, write_addr), original_word);
+}
+
+TEST(ObjectTileEditorPanelTest,
+     FirstApplyIgnoresValidDisplayCacheAndReanalyzesFresh) {
+  Rom rom;
+  ASSERT_TRUE(rom.LoadFromData(MakeEditableStandardObjectRomData()).ok());
+  DungeonRoomStore rooms(&rom);
+
+  ObjectTileEditorPanel panel(nullptr, &rom);
+  ASSERT_TRUE(
+      panel.OpenForObject(kEditableStandardObjectId, /*room_id=*/0, &rooms)
+          .ok());
+  auto displayed_or =
+      ObjectTileEditorPanelTestAccess::DisplayedSharedTileDataUsageCount(panel);
+  ASSERT_TRUE(displayed_or.ok()) << displayed_or.status();
+
+  const int original_word = ReadWordAt(rom, kEditableSourcePcAddress);
+  ObjectTileEditorPanelTestAccess::SetFirstCellTileAndPalette(
+      panel, /*tile_id=*/0x123, /*palette=*/3);
+  StoreWord(rom.mutable_vector(), /*Type 1 object 1 descriptor=*/0x8002,
+            0x8000);
+
+  ObjectTileEditorPanelTestAccess::ApplyChanges(panel,
+                                                /*confirm_shared=*/true);
+
+  EXPECT_TRUE(ObjectTileEditorPanelTestAccess::ActionStatusIsError(panel));
+  EXPECT_FALSE(ObjectTileEditorPanelTestAccess::ShowSharedConfirm(panel));
+  EXPECT_TRUE(ObjectTileEditorPanelTestAccess::HasModifications(panel));
+  EXPECT_EQ(ReadWordAt(rom, kEditableSourcePcAddress), original_word);
+}
+
+TEST(ObjectTileEditorPanelTest, ConfirmedApplyReanalyzesFreshBeforeWriting) {
+  auto data = MakeEditableStandardObjectRomData();
+  StoreWord(data, /*Type 1 object 0 descriptor=*/0x8000, 0x0E96);
+  Rom rom;
+  ASSERT_TRUE(rom.LoadFromData(data).ok());
+  DungeonRoomStore rooms(&rom);
+
+  ObjectTileEditorPanel panel(nullptr, &rom);
+  ASSERT_TRUE(
+      panel.OpenForObject(kEditableStandardObjectId, /*room_id=*/0, &rooms)
+          .ok());
+  const int original_word = ReadWordAt(rom, kEditableSourcePcAddress);
+  ObjectTileEditorPanelTestAccess::SetFirstCellTileAndPalette(
+      panel, /*tile_id=*/0x123, /*palette=*/3);
+
+  ObjectTileEditorPanelTestAccess::ApplyChanges(panel,
+                                                /*confirm_shared=*/true);
+  ASSERT_TRUE(ObjectTileEditorPanelTestAccess::ShowSharedConfirm(panel));
+
+  StoreWord(rom.mutable_vector(), /*Type 1 object 1 descriptor=*/0x8002,
+            0x8000);
+  ObjectTileEditorPanelTestAccess::ApplyChanges(panel,
+                                                /*confirm_shared=*/false);
+
+  EXPECT_TRUE(ObjectTileEditorPanelTestAccess::ActionStatusIsError(panel));
+  EXPECT_FALSE(ObjectTileEditorPanelTestAccess::ShowSharedConfirm(panel));
+  EXPECT_TRUE(ObjectTileEditorPanelTestAccess::HasModifications(panel));
+  EXPECT_EQ(ReadWordAt(rom, kEditableSourcePcAddress), original_word);
+}
+
+TEST(ObjectTileEditorPanelTest,
+     ConfirmedApplyRepromptsWhenConsumerCountChanges) {
+  auto data = MakeEditableStandardObjectRomData();
+  StoreWord(data, /*Type 1 object 0 descriptor=*/0x8000, 0x0E96);
+  Rom rom;
+  ASSERT_TRUE(rom.LoadFromData(data).ok());
+  DungeonRoomStore rooms(&rom);
+
+  ObjectTileEditorPanel panel(nullptr, &rom);
+  ASSERT_TRUE(
+      panel.OpenForObject(kEditableStandardObjectId, /*room_id=*/0, &rooms)
+          .ok());
+  ObjectTileEditorPanelTestAccess::SetFirstCellTileAndPalette(
+      panel, /*tile_id=*/0x123, /*palette=*/3);
+  const int original_word = ReadWordAt(rom, kEditableSourcePcAddress);
+
+  ObjectTileEditorPanelTestAccess::ApplyChanges(panel,
+                                                /*confirm_shared=*/true);
+  ASSERT_TRUE(ObjectTileEditorPanelTestAccess::ShowSharedConfirm(panel));
+  ASSERT_EQ(ObjectTileEditorPanelTestAccess::SharedObjectCount(panel), 2);
+
+  StoreWord(rom.mutable_vector(), /*Type 1 object 7 descriptor=*/0x800E,
+            kEditableDescriptorWord);
+  ObjectTileEditorPanelTestAccess::ApplyChanges(panel,
+                                                /*confirm_shared=*/false);
+
+  EXPECT_TRUE(ObjectTileEditorPanelTestAccess::ShowSharedConfirm(panel));
+  EXPECT_EQ(ObjectTileEditorPanelTestAccess::SharedObjectCount(panel), 3);
+  EXPECT_TRUE(ObjectTileEditorPanelTestAccess::ActionStatusIsWarning(panel));
+  EXPECT_NE(ObjectTileEditorPanelTestAccess::ActionStatusMessage(panel).find(
+                "Source impact changed"),
+            std::string::npos);
+  EXPECT_TRUE(ObjectTileEditorPanelTestAccess::HasModifications(panel));
+  EXPECT_EQ(ReadWordAt(rom, kEditableSourcePcAddress), original_word);
+}
+
+TEST(ObjectTileEditorPanelTest,
+     ConfirmedApplyRepromptsWhenConsumerIdentityChangesAtSameCount) {
+  auto data = MakeEditableStandardObjectRomData();
+  StoreWord(data, /*Type 1 object 0 descriptor=*/0x8000, 0x0E96);
+  Rom rom;
+  ASSERT_TRUE(rom.LoadFromData(data).ok());
+  DungeonRoomStore rooms(&rom);
+
+  ObjectTileEditorPanel panel(nullptr, &rom);
+  ASSERT_TRUE(
+      panel.OpenForObject(kEditableStandardObjectId, /*room_id=*/0, &rooms)
+          .ok());
+  ObjectTileEditorPanelTestAccess::SetFirstCellTileAndPalette(
+      panel, /*tile_id=*/0x123, /*palette=*/3);
+  const int original_word = ReadWordAt(rom, kEditableSourcePcAddress);
+
+  ObjectTileEditorPanelTestAccess::ApplyChanges(panel,
+                                                /*confirm_shared=*/true);
+  ASSERT_TRUE(ObjectTileEditorPanelTestAccess::ShowSharedConfirm(panel));
+  ASSERT_EQ(ObjectTileEditorPanelTestAccess::SharedObjectCount(panel), 2);
+
+  StoreWord(rom.mutable_vector(), /*Type 1 object 0 descriptor=*/0x8000,
+            0x0E00);
+  StoreWord(rom.mutable_vector(), /*Type 1 object 7 descriptor=*/0x800E,
+            0x0E96);
+  ObjectTileEditorPanelTestAccess::ApplyChanges(panel,
+                                                /*confirm_shared=*/false);
+
+  EXPECT_TRUE(ObjectTileEditorPanelTestAccess::ShowSharedConfirm(panel));
+  EXPECT_EQ(ObjectTileEditorPanelTestAccess::SharedObjectCount(panel), 2);
+  EXPECT_TRUE(ObjectTileEditorPanelTestAccess::ActionStatusIsWarning(panel));
+  EXPECT_NE(ObjectTileEditorPanelTestAccess::ActionStatusMessage(panel).find(
+                "Source impact changed"),
+            std::string::npos);
+  EXPECT_TRUE(ObjectTileEditorPanelTestAccess::HasModifications(panel));
+  EXPECT_EQ(ReadWordAt(rom, kEditableSourcePcAddress), original_word);
 }
 
 TEST(ObjectTileEditorPanelTest,
@@ -879,6 +1403,40 @@ TEST(ObjectTileEditorPanelTest,
 }
 
 TEST(ObjectTileEditorPanelTest,
+     SuccessfulStandardApplyInvalidatesAllRoomsAndExternalViews) {
+  Rom rom;
+  ASSERT_TRUE(rom.LoadFromData(MakeEditableStandardObjectRomData()).ok());
+  DungeonRoomStore rooms(&rom);
+  auto& current_room = rooms[0];
+  auto& other_room = rooms[1];
+  zelda3::RoomLayerManager layer_manager;
+  (void)current_room.GetCompositeBitmap(layer_manager);
+  (void)other_room.GetCompositeBitmap(layer_manager);
+  ASSERT_FALSE(current_room.IsCompositeDirty());
+  ASSERT_FALSE(other_room.IsCompositeDirty());
+
+  ObjectTileEditorPanel panel(nullptr, &rom);
+  ASSERT_TRUE(
+      panel.OpenForObject(kEditableStandardObjectId, /*room_id=*/0, &rooms)
+          .ok());
+  ObjectTileEditorPanelTestAccess::SetSharedTileDataUsageOverride(
+      panel, /*shared_count=*/1);
+  ObjectTileEditorPanelTestAccess::SetFirstCellTileAndPalette(
+      panel, /*tile_id=*/0x123, /*palette=*/3);
+  int callback_count = 0;
+  panel.SetStandardTilesAppliedCallback(
+      [&callback_count]() { ++callback_count; });
+
+  ObjectTileEditorPanelTestAccess::ApplyChanges(panel,
+                                                /*confirm_shared=*/true);
+
+  EXPECT_EQ(callback_count, 1);
+  EXPECT_FALSE(ObjectTileEditorPanelTestAccess::HasModifications(panel));
+  EXPECT_TRUE(current_room.IsCompositeDirty());
+  EXPECT_TRUE(other_room.IsCompositeDirty());
+}
+
+TEST(ObjectTileEditorPanelTest,
      ManifestBlockedApplyPreservesRomAndModifiedRetryState) {
   Rom rom;
   ASSERT_TRUE(rom.LoadFromData(MakeEditableStandardObjectRomData()).ok());
@@ -902,7 +1460,10 @@ TEST(ObjectTileEditorPanelTest,
   project.rom_metadata.write_policy = project::RomWritePolicy::kBlock;
 
   int preflight_count = 0;
+  int applied_callback_count = 0;
   std::vector<std::pair<uint32_t, uint32_t>> observed_ranges;
+  panel.SetStandardTilesAppliedCallback(
+      [&applied_callback_count]() { ++applied_callback_count; });
   panel.SetStandardWritePreflightCallback(
       [&](const std::vector<std::pair<uint32_t, uint32_t>>& ranges) {
         ++preflight_count;
@@ -919,6 +1480,7 @@ TEST(ObjectTileEditorPanelTest,
                                                 /*confirm_shared=*/false);
 
   EXPECT_EQ(preflight_count, 1);
+  EXPECT_EQ(applied_callback_count, 0);
   EXPECT_EQ(observed_ranges,
             (std::vector<std::pair<uint32_t, uint32_t>>{
                 {kEditableSourcePcAddress, kEditableSourcePcAddress + 2}}));
@@ -939,6 +1501,7 @@ TEST(ObjectTileEditorPanelTest,
 
   EXPECT_FALSE(ObjectTileEditorPanelTestAccess::HasModifications(panel));
   EXPECT_NE(rom.vector(), original);
+  EXPECT_EQ(applied_callback_count, 1);
 }
 
 TEST(ObjectTileEditorPanelTest, UnrelatedManifestRangeAllowsStandardApply) {
@@ -1051,7 +1614,7 @@ TEST(ObjectTileEditorPanelTest,
   EXPECT_TRUE(ObjectTileEditorPanelTestAccess::HasActionStatus(panel));
   EXPECT_TRUE(ObjectTileEditorPanelTestAccess::ActionStatusIsWarning(panel));
   EXPECT_NE(ObjectTileEditorPanelTestAccess::ActionStatusMessage(panel).find(
-                "Confirm shared apply"),
+                "Confirm global apply"),
             std::string::npos);
   EXPECT_EQ(ReadWordAt(rom, reopened_write_addr), reopened_original_word);
 }


### PR DESCRIPTION
## What changed

- expose **Edit Object Tiles...** from the dungeon canvas for the audited standard objects `0x11F` and `0x120`
- open standard and custom object sessions through the real workspace window manager with resolved room palette context
- fail closed when a session cannot be captured or surfaced, and preserve unapplied edits on replacement, window close, or Escape
- show the bound object and room, explicit global-edit/Ctrl+Z warnings, and an explicit **Discard & Close** action
- re-evaluate shared-source impact immediately before writes and require confirmation again if consumer identity or count changes
- invalidate all materialized room object caches plus selector previews after a successful standard tile write

## Why

The backend write guards and source-impact analysis were not reachable from the dungeon editing workflow. Opening the editor also had data-loss and stale-preview risks: a new session could replace unapplied edits, workspace close behavior could discard state, and global tile writes refreshed only the current room.

This slice connects the guarded backend to a deliberately narrow UI entry point while keeping unsupported standard objects disabled.

## Stack

- base branch: `codex/object-tile-source-impact` (PR #185)
- exact parent: `7e157c9c9e5a6e12b3e5af6c6294ab4e168b3980`
- exact head: `d91eb7ee00d56a7231808e107fb5285341573661`
- tree: `891565c3fb72275ee9b96afb358c126465709bac`
- topic patch ID: `cd7b852b46d63288dea87a1617b550ebe73c034b`

## Verification

- `cmake --build --preset mac-ai --target yaze_test_unit -j 8`
- focused object-tile/dungeon integration filter: **51/51 passed**
- `scripts/pre-push.sh --build-dir build/presets/mac-ai`
  - build passed
  - unit smoke: **13/13 passed**
  - UI regression: **40/40 passed**
  - formatting passed
- independent strict diff review: no blocking findings

## Known limits

- standard tile writes are global ROM edits and are not integrated with Dungeon Editor Ctrl+Z; the UI warns before apply
- no Yaze GUI/manual ROM session or ROM save/reopen/readback was run for this slice
- the stack must merge in order: #184, #185, then this PR
