### PR TITLE
Make custom collision imports idempotent

### DIFF
--- a/docs/internal/agents/rom-safety-guardrails.md
+++ b/docs/internal/agents/rom-safety-guardrails.md
@@ -75,6 +75,14 @@ This repo is used to edit ROM hacks (including Oracle of Secrets). Treat ROM wri
   `dungeon-import-water-fill-json` use the same transaction and required-backup
   contract, then immediately save the active ROM. With `--sandbox`, the active
   target is the sandbox copy; the source ROM is not saved or backed up.
+- Custom-collision imports compare each requested room with the decoded ROM
+  map. An exact write-mode replay is a no-op: `changed_rooms` is `0`,
+  `write_status` and `save_status` are `not-needed`, and the handler creates no
+  ROM backup or post-comparison save. `unchanged_rooms` counts matching listed
+  entries; `replace_all_clears` counts only unlisted maps that actually need
+  clearing. `cleared_rooms` combines listed empty targets with those actual
+  replace-all clears. Sandbox setup still materializes its copy before this
+  comparison.
 - Import `--report` is accepted only with a non-sandbox `--dry-run`; every
   write-mode or sandbox invocation rejects it before ROM loading or sandbox
   creation. Report paths must not alias the active ROM. The guard is rechecked
@@ -297,7 +305,11 @@ Safety semantics:
 - `--dry-run` performs full parsing/validation and emits impact counts without writing.
 - Without `--dry-run`, imports immediately save the active ROM with a required
   backup. `--sandbox` redirects that one save and its backup to the sandbox
-  copy, leaving the source ROM and source directory unchanged.
+  copy, leaving the source ROM and source directory unchanged. An exact
+  custom-collision replay is the exception: it reports
+  `write_status=not-needed` and `save_status=not-needed` without creating a
+  backup or saving the active ROM after comparison. `--sandbox` still creates
+  its sandbox copy before the handler can determine that the import is exact.
 - `--mock-rom` is an explicit in-memory test mode and cannot be combined with
   `--sandbox`; the command rejects that combination before creating a sandbox.
 - `--report <path>` is non-sandbox dry-run-only and writes machine-readable

--- a/docs/public/reference/z3ed-command-reference.md
+++ b/docs/public/reference/z3ed-command-reference.md
@@ -169,6 +169,12 @@ These commands operate directly on ROM data (no GUI required).
 - `dungeon-get-room-tiles --room <hex>` *(stubbed)*
 - `dungeon-set-room-property --room <hex> --property <name> --value <value> [--manifest <path>]`
 
+`dungeon-import-custom-collision-json` compares decoded room maps before
+writing. Replaying an exact source reports zero `changed_rooms` and
+`write_status`/`save_status` as `not-needed`; it does not create a backup or
+save the active ROM after comparison. `--sandbox` still materializes its copy
+before the comparison.
+
 `dungeon-place-object` is a dry-run unless `--write` is supplied. Both modes
 execute the same immutable capacity preflight. In-place edits can proceed
 without a manifest, but a shared or growing object stream fails closed unless

--- a/src/cli/handlers/game/dungeon_collision_commands.cc
+++ b/src/cli/handlers/game/dungeon_collision_commands.cc
@@ -1222,15 +1222,13 @@ absl::Status DungeonImportCustomCollisionJsonCommandHandler::Execute(
 
     int populated_rooms = 0;
     int cleared_rooms = 0;
+    int changed_rooms = 0;
+    int unchanged_rooms = 0;
     std::unordered_set<int> touched_rooms;
     for (const auto& imported : imported_rooms) {
       touched_rooms.insert(imported.room_id);
-      auto& room = rooms[imported.room_id];
-      room.custom_collision().tiles.fill(0);
-      room.custom_collision().has_data = false;
-      room.MarkCustomCollisionDirty();
+      zelda3::CustomCollisionMap desired;
 
-      bool has_nonzero = false;
       for (const auto& tile : imported.tiles) {
         const int offset = static_cast<int>(tile.offset);
         if (offset < 0 || offset >= kCollisionGridSize * kCollisionGridSize) {
@@ -1239,16 +1237,28 @@ absl::Status DungeonImportCustomCollisionJsonCommandHandler::Execute(
         if (tile.value == 0) {
           continue;
         }
-        room.SetCollisionTile(offset % kCollisionGridSize,
-                              offset / kCollisionGridSize, tile.value);
-        has_nonzero = true;
+        desired.tiles[static_cast<size_t>(offset)] = tile.value;
+        desired.has_data = true;
       }
 
-      if (has_nonzero) {
+      if (desired.has_data) {
         ++populated_rooms;
       } else {
         ++cleared_rooms;
       }
+
+      ASSIGN_OR_RETURN(const auto current,
+                       zelda3::LoadCustomCollisionMap(rom, imported.room_id));
+      if (current.has_data == desired.has_data &&
+          current.tiles == desired.tiles) {
+        ++unchanged_rooms;
+        continue;
+      }
+
+      auto& room = rooms[imported.room_id];
+      room.custom_collision() = desired;
+      room.MarkCustomCollisionDirty();
+      ++changed_rooms;
     }
 
     int replace_all_clears = 0;
@@ -1257,24 +1267,36 @@ absl::Status DungeonImportCustomCollisionJsonCommandHandler::Execute(
         if (touched_rooms.contains(room_id)) {
           continue;
         }
+        ASSIGN_OR_RETURN(const auto current,
+                         zelda3::LoadCustomCollisionMap(rom, room_id));
+        if (!current.has_data) {
+          continue;
+        }
         auto& room = rooms[room_id];
         room.custom_collision().tiles.fill(0);
         room.custom_collision().has_data = false;
         room.MarkCustomCollisionDirty();
         ++cleared_rooms;
+        ++changed_rooms;
         ++replace_all_clears;
       }
     }
+    report["changed_rooms"] = changed_rooms;
+    report["unchanged_rooms"] = unchanged_rooms;
     report["replace_all_clears"] = replace_all_clears;
-
-    if (!dry_run) {
-      RETURN_IF_ERROR(SerializeAndPersistImport(rom, parser, &report, [&]() {
-        return zelda3::SaveAllCollision(rom, absl::MakeSpan(rooms));
-      }));
-    }
-
     report["populated_rooms"] = populated_rooms;
     report["cleared_rooms"] = cleared_rooms;
+
+    if (!dry_run) {
+      if (changed_rooms == 0) {
+        report["write_status"] = "not-needed";
+        report["save_status"] = "not-needed";
+      } else {
+        RETURN_IF_ERROR(SerializeAndPersistImport(rom, parser, &report, [&]() {
+          return zelda3::SaveAllCollision(rom, absl::MakeSpan(rooms));
+        }));
+      }
+    }
 
     formatter.BeginObject("Custom Collision Import");
     formatter.AddField("in_path", in_path);
@@ -1285,6 +1307,9 @@ absl::Status DungeonImportCustomCollisionJsonCommandHandler::Execute(
                        static_cast<int>(imported_rooms.size()));
     formatter.AddField("populated_rooms", populated_rooms);
     formatter.AddField("cleared_rooms", cleared_rooms);
+    formatter.AddField("changed_rooms", changed_rooms);
+    formatter.AddField("unchanged_rooms", unchanged_rooms);
+    formatter.AddField("replace_all_clears", replace_all_clears);
     if (!dry_run) {
       formatter.AddField("write_status",
                          report.value("write_status", std::string("unknown")));

--- a/test/unit/cli/dungeon_collision_json_commands_test.cc
+++ b/test/unit/cli/dungeon_collision_json_commands_test.cc
@@ -450,6 +450,8 @@ TEST(DungeonCollisionJsonCommandsTest,
   ASSERT_TRUE(status.ok()) << status;
   EXPECT_THAT(output, testing::HasSubstr("\"write_status\": \"success\""));
   EXPECT_THAT(output, testing::HasSubstr("\"save_status\": \"saved\""));
+  EXPECT_THAT(output, testing::HasSubstr("\"changed_rooms\": 1"));
+  EXPECT_THAT(output, testing::HasSubstr("\"unchanged_rooms\": 0"));
   EXPECT_FALSE(rom.dirty());
   EXPECT_NE(ReadFileBytes(rom_path), disk_before);
 
@@ -469,6 +471,168 @@ TEST(DungeonCollisionJsonCommandsTest,
   ASSERT_TRUE(preserved_or.ok()) << preserved_or.status();
   ASSERT_TRUE(preserved_or->has_data);
   EXPECT_EQ(preserved_or->tiles[130], 0xBA);
+}
+
+TEST(DungeonCollisionJsonCommandsTest,
+     CustomCollisionExactReplaySkipsWriteAndBackup) {
+  ScopedTempDirectory temp("custom_noop");
+  const auto rom_path = temp.path() / "target.sfc";
+  const auto in_path = temp.path() / "collision.json";
+
+  Rom rom;
+  ASSERT_TRUE(rom.LoadFromData(std::vector<uint8_t>(0x200000, 0x00)).ok());
+  zelda3::CustomCollisionMap existing_map;
+  existing_map.has_data = true;
+  existing_map.tiles[65] = 0xB7;
+  existing_map.tiles[66] = 8;
+  ASSERT_TRUE(zelda3::WriteTrackCollision(&rom, 0x25, existing_map).ok());
+  WriteRomFile(rom, rom_path);
+  rom.set_filename(rom_path.string());
+  rom.set_dirty(false);
+  ASSERT_TRUE(rom.WriteByte(0x100, 0x5A).ok());
+  ASSERT_TRUE(rom.dirty());
+  const std::vector<uint8_t> memory_before = rom.vector();
+  const std::vector<uint8_t> disk_before = ReadFileBytes(rom_path);
+
+  WriteFile(
+      in_path,
+      "{\n"
+      "  \"version\": 1,\n"
+      "  \"rooms\": [\n"
+      "    { \"room_id\": \"0x25\", \"tiles\": [ [65, \"0xB7\"], [66, 8] ] }\n"
+      "  ]\n"
+      "}\n");
+
+  handlers::DungeonImportCustomCollisionJsonCommandHandler handler;
+  std::string output;
+  const absl::Status status =
+      handler.Run({"--in", in_path.string(), "--format=json"}, &rom, &output);
+
+  ASSERT_TRUE(status.ok()) << status;
+  EXPECT_THAT(output, testing::HasSubstr("\"write_status\": \"not-needed\""));
+  EXPECT_THAT(output, testing::HasSubstr("\"save_status\": \"not-needed\""));
+  EXPECT_THAT(output, testing::HasSubstr("\"changed_rooms\": 0"));
+  EXPECT_THAT(output, testing::HasSubstr("\"unchanged_rooms\": 1"));
+  EXPECT_TRUE(rom.dirty());
+  EXPECT_EQ(rom.vector(), memory_before);
+  EXPECT_EQ(ReadFileBytes(rom_path), disk_before);
+  EXPECT_TRUE(FindBackupArtifacts(rom_path).empty());
+
+  auto map_or = zelda3::LoadCustomCollisionMap(&rom, 0x25);
+  ASSERT_TRUE(map_or.ok()) << map_or.status();
+  EXPECT_EQ(map_or->has_data, existing_map.has_data);
+  EXPECT_EQ(map_or->tiles, existing_map.tiles);
+}
+
+TEST(DungeonCollisionJsonCommandsTest,
+     CustomCollisionMixedReplayPreservesUnchangedPointer) {
+  ScopedTempDirectory temp("custom_mixed");
+  const auto rom_path = temp.path() / "target.sfc";
+  const auto in_path = temp.path() / "collision.json";
+
+  Rom rom;
+  ASSERT_TRUE(rom.LoadFromData(std::vector<uint8_t>(0x200000, 0x00)).ok());
+  zelda3::CustomCollisionMap unchanged_map;
+  unchanged_map.has_data = true;
+  unchanged_map.tiles[65] = 0xB7;
+  ASSERT_TRUE(zelda3::WriteTrackCollision(&rom, 0x25, unchanged_map).ok());
+  zelda3::CustomCollisionMap changed_map;
+  changed_map.has_data = true;
+  changed_map.tiles[130] = 0xBA;
+  ASSERT_TRUE(zelda3::WriteTrackCollision(&rom, 0x26, changed_map).ok());
+  WriteRomFile(rom, rom_path);
+  rom.set_filename(rom_path.string());
+  rom.set_dirty(false);
+  const std::vector<uint8_t> disk_before = ReadFileBytes(rom_path);
+  const int unchanged_pointer_offset =
+      zelda3::kCustomCollisionRoomPointers + (0x25 * 3);
+  const std::vector<uint8_t> unchanged_pointer_before(
+      rom.vector().begin() + unchanged_pointer_offset,
+      rom.vector().begin() + unchanged_pointer_offset + 3);
+
+  WriteFile(in_path,
+            "{\n"
+            "  \"version\": 1,\n"
+            "  \"rooms\": [\n"
+            "    { \"room_id\": \"0x25\", \"tiles\": [ [65, \"0xB7\"] ] },\n"
+            "    { \"room_id\": \"0x26\", \"tiles\": [ [130, \"0xBB\"] ] }\n"
+            "  ]\n"
+            "}\n");
+
+  handlers::DungeonImportCustomCollisionJsonCommandHandler handler;
+  std::string output;
+  const absl::Status status =
+      handler.Run({"--in", in_path.string(), "--format=json"}, &rom, &output);
+
+  ASSERT_TRUE(status.ok()) << status;
+  EXPECT_THAT(output, testing::HasSubstr("\"changed_rooms\": 1"));
+  EXPECT_THAT(output, testing::HasSubstr("\"unchanged_rooms\": 1"));
+  EXPECT_THAT(output, testing::HasSubstr("\"write_status\": \"success\""));
+  EXPECT_THAT(output, testing::HasSubstr("\"save_status\": \"saved\""));
+  EXPECT_EQ(
+      std::vector<uint8_t>(rom.vector().begin() + unchanged_pointer_offset,
+                           rom.vector().begin() + unchanged_pointer_offset + 3),
+      unchanged_pointer_before);
+  EXPECT_EQ(FindBackupArtifacts(rom_path).size(), 1u);
+  EXPECT_NE(ReadFileBytes(rom_path), disk_before);
+
+  auto unchanged_or = zelda3::LoadCustomCollisionMap(&rom, 0x25);
+  ASSERT_TRUE(unchanged_or.ok()) << unchanged_or.status();
+  EXPECT_EQ(unchanged_or->tiles, unchanged_map.tiles);
+  auto changed_or = zelda3::LoadCustomCollisionMap(&rom, 0x26);
+  ASSERT_TRUE(changed_or.ok()) << changed_or.status();
+  ASSERT_TRUE(changed_or->has_data);
+  EXPECT_EQ(changed_or->tiles[130], 0xBB);
+}
+
+TEST(DungeonCollisionJsonCommandsTest,
+     CustomCollisionReplaceAllClearsOnlyPointerBackedMaps) {
+  ScopedTempDirectory temp("custom_replace_selective");
+  Rom rom;
+  ASSERT_TRUE(rom.LoadFromData(std::vector<uint8_t>(0x200000, 0x00)).ok());
+  zelda3::CustomCollisionMap retained_map;
+  retained_map.has_data = true;
+  retained_map.tiles[65] = 0xB7;
+  ASSERT_TRUE(zelda3::WriteTrackCollision(&rom, 0x25, retained_map).ok());
+  zelda3::CustomCollisionMap populated_map;
+  populated_map.has_data = true;
+  populated_map.tiles[130] = 0xBA;
+  ASSERT_TRUE(zelda3::WriteTrackCollision(&rom, 0x26, populated_map).ok());
+  zelda3::CustomCollisionMap pointer_backed_empty_map;
+  pointer_backed_empty_map.has_data = true;
+  ASSERT_TRUE(
+      zelda3::WriteTrackCollision(&rom, 0x27, pointer_backed_empty_map).ok());
+
+  const auto in_path = temp.path() / "collision.json";
+  WriteFile(in_path,
+            "{\n"
+            "  \"version\": 1,\n"
+            "  \"rooms\": [\n"
+            "    { \"room_id\": \"0x25\", \"tiles\": [ [65, \"0xB7\"] ] }\n"
+            "  ]\n"
+            "}\n");
+
+  handlers::DungeonImportCustomCollisionJsonCommandHandler handler;
+  std::string output;
+  const absl::Status status =
+      handler.Run({"--in", in_path.string(), "--replace-all", "--force",
+                   "--mock-rom", "--format=json"},
+                  &rom, &output);
+
+  ASSERT_TRUE(status.ok()) << status;
+  EXPECT_THAT(output, testing::HasSubstr("\"changed_rooms\": 2"));
+  EXPECT_THAT(output, testing::HasSubstr("\"unchanged_rooms\": 1"));
+  EXPECT_THAT(output, testing::HasSubstr("\"replace_all_clears\": 2"));
+  EXPECT_THAT(output, testing::HasSubstr("\"cleared_rooms\": 2"));
+  auto retained_or = zelda3::LoadCustomCollisionMap(&rom, 0x25);
+  ASSERT_TRUE(retained_or.ok()) << retained_or.status();
+  EXPECT_EQ(retained_or->tiles, retained_map.tiles);
+  auto populated_or = zelda3::LoadCustomCollisionMap(&rom, 0x26);
+  ASSERT_TRUE(populated_or.ok()) << populated_or.status();
+  EXPECT_FALSE(populated_or->has_data);
+  auto empty_or = zelda3::LoadCustomCollisionMap(&rom, 0x27);
+  ASSERT_TRUE(empty_or.ok()) << empty_or.status();
+  EXPECT_FALSE(empty_or->has_data);
 }
 
 TEST(DungeonCollisionJsonCommandsTest,


### PR DESCRIPTION
## Summary
- compare each requested custom-collision map with the decoded ROM state before marking it dirty
- skip transaction, required backup, and ROM save when a write-mode import is already exact
- report `changed_rooms`, `unchanged_rooms`, and actual `replace_all_clears`
- make `--replace-all` clear only pointer-backed maps that are actually present
- document no-op and sandbox-materialization semantics

## Why
`SaveAllCollision` serializes dirty populated rooms through append-only `WriteTrackCollision`. The JSON import handler previously marked every imported room dirty on every invocation, so replaying the same canonical source consumed custom-collision bank space even though the decoded maps were unchanged.

## Impact
Exact canonical replays now return `write_status=not-needed` and `save_status=not-needed`, preserve any unrelated in-memory dirty state, and create no backup or post-comparison ROM write. Mixed imports still persist changed rooms while leaving unchanged room pointers byte-identical.

## Verification
- `cmake --build build/presets/mac-ai --target yaze_test_unit --parallel 8`
- `build/presets/mac-ai/bin/Debug/yaze_test_unit --gtest_filter='DungeonCollisionJsonCommandsTest.CustomCollision*'` — 14/14 passed
- `YAZE_PREPUSH_BUILD_DIR=build/presets/mac-ai git push -u origin codex/collision-import-noop` — build, 13/13 smoke tests, formatting passed
- independent strict review — no blocking findings
- Oracle canonical-source audit on a copy of `oos168.sfc` (SHA-256 `b13ef69ede313756dcf560bf0f993663d68d0365609f2c20dcdec2c17f31f7b9`): dry-run and write both reported 18 unchanged / 0 changed; write returned both statuses `not-needed`; hash and backup count remained unchanged
