### PR TITLE
fix(dungeon): reuse bounded collision blobs

### DIFF
--- a/docs/internal/agents/rom-safety-guardrails.md
+++ b/docs/internal/agents/rom-safety-guardrails.md
@@ -100,7 +100,10 @@ This repo is used to edit ROM hacks (including Oracle of Secrets). Treat ROM wri
 - `dungeon-generate-track-collision --write` applies the same contract to a
   single room or the complete `--rooms` batch. Batch serialization and the one
   required-backup disk save are all-or-nothing; a later-room failure restores
-  every earlier room mutation.
+  every earlier room mutation. The collision serializer reuses the selected
+  room's current data only when its complete encoded span is uniquely owned
+  and the replacement fits. Aliases, interior overlaps, and larger
+  replacements remain copy-on-write appends.
 - Other CLI writers that still set only `backup=true` remain best-effort and
   must be audited before opting into the strict transaction path.
 

--- a/docs/public/reference/changelog.md
+++ b/docs/public/reference/changelog.md
@@ -14,6 +14,9 @@
   required backup, atomic save, whole-ROM diff, and external reopen/readback.
 - Disabled legacy `palette-set-color --write` because it could report an
   in-memory mutation as persisted; its read-only preview remains available.
+- Reused uniquely owned custom-collision blobs for same-size or smaller
+  rewrites, while keeping aliased, overlapping, and growing streams on the
+  copy-on-write append path.
 
 ## 0.7.2 (July 17, 2026)
 

--- a/src/zelda3/dungeon/track_collision_generator.cc
+++ b/src/zelda3/dungeon/track_collision_generator.cc
@@ -27,6 +27,60 @@ constexpr uint16_t kCollisionEndMarker = 0xFFFF;
 constexpr int kFallbackTrackFootprintWidthTiles = 2;
 constexpr int kFallbackTrackFootprintHeightTiles = 2;
 
+struct CollisionBlob {
+  int room_id = 0;
+  uint32_t start = 0;
+  uint32_t end = 0;
+};
+
+absl::StatusOr<uint32_t> FindCollisionBlobEnd(const std::vector<uint8_t>& data,
+                                              uint32_t start, size_t safe_end,
+                                              int room_id) {
+  size_t cursor = start;
+  bool single_mode = false;
+
+  while (cursor + 1 < safe_end) {
+    const uint16_t value = data[cursor] | (data[cursor + 1] << 8);
+    cursor += 2;
+    if (value == kCollisionEndMarker) {
+      return static_cast<uint32_t>(cursor);
+    }
+    if (value == kCollisionSingleTileMarker) {
+      single_mode = true;
+      continue;
+    }
+
+    if (single_mode) {
+      if (cursor >= safe_end) {
+        break;
+      }
+      ++cursor;
+      continue;
+    }
+
+    if (cursor + 1 >= safe_end) {
+      break;
+    }
+    const size_t width = data[cursor];
+    const size_t height = data[cursor + 1];
+    cursor += 2;
+    const size_t payload_size = width * height;
+    if (payload_size > safe_end - cursor) {
+      break;
+    }
+    cursor += payload_size;
+  }
+
+  return absl::FailedPreconditionError(absl::StrFormat(
+      "Custom collision data for room 0x%02X is unterminated before "
+      "WaterFill reserved region",
+      room_id));
+}
+
+bool BlobsOverlap(const CollisionBlob& lhs, const CollisionBlob& rhs) {
+  return lhs.start < rhs.end && rhs.start < lhs.end;
+}
+
 // Map corner type to its switch equivalent for promotion.
 TrackTileType PromoteCornerToSwitch(TrackTileType corner) {
   switch (corner) {
@@ -341,6 +395,8 @@ absl::Status WriteTrackCollision(Rom* rom, int room_id,
       std::min(static_cast<size_t>(data.size()),
                static_cast<size_t>(kCustomCollisionDataSoftEnd));
   uint32_t max_used_pc = static_cast<uint32_t>(kCustomCollisionDataPosition);
+  std::vector<CollisionBlob> blobs;
+  blobs.reserve(kNumberOfRooms);
   for (int r = 0; r < kNumberOfRooms; ++r) {
     int ptr_offset = kCustomCollisionRoomPointers + (r * 3);
     if (ptr_offset + 2 >= static_cast<int>(data.size()))
@@ -367,48 +423,32 @@ absl::Status WriteTrackCollision(Rom* rom, int room_id,
     if (pc >= data.size()) {
       return absl::OutOfRangeError("Custom collision pointer out of ROM range");
     }
-    // Walk past this room's data to find its end
-    size_t cursor = pc;
-    bool single_mode = false;
-    bool found_end_marker = false;
-    while (cursor + 1 < safe_end) {
-      uint16_t val = data[cursor] | (data[cursor + 1] << 8);
-      cursor += 2;
-      if (val == kCollisionEndMarker) {
-        found_end_marker = true;
-        break;
-      }
-      if (val == kCollisionSingleTileMarker) {
-        single_mode = true;
-        continue;
-      }
-      if (!single_mode) {
-        // Rectangle mode: skip width, height, then width*height bytes
-        if (cursor + 1 >= safe_end)
-          break;
-        uint8_t w = data[cursor];
-        uint8_t h = data[cursor + 1];
-        cursor += 2;
-        cursor += w * h;
-      } else {
-        // Single tile mode: skip 1 byte (tile value)
-        cursor += 1;
-      }
-    }
-    // If we hit the reserved region without an end marker, treat as corruption.
-    if (!found_end_marker && cursor + 1 >= safe_end) {
-      return absl::FailedPreconditionError(
-          absl::StrFormat("Custom collision data for room 0x%02X is "
-                          "unterminated before WaterFill reserved region",
-                          r));
-    }
-    if (cursor > max_used_pc) {
-      max_used_pc = static_cast<uint32_t>(cursor);
+    ASSIGN_OR_RETURN(const uint32_t end_pc,
+                     FindCollisionBlobEnd(data, pc, safe_end, r));
+    blobs.push_back(CollisionBlob{r, pc, end_pc});
+    if (end_pc > max_used_pc) {
+      max_used_pc = end_pc;
     }
   }
 
-  // Check if there's enough space
+  // Reuse the selected room's current blob only when its entire physical span
+  // is uniquely owned and the replacement fits. Aliased or overlapping blobs
+  // remain copy-on-write so editing one room cannot mutate another room.
   uint32_t write_pos = max_used_pc;
+  const auto target = std::find_if(
+      blobs.begin(), blobs.end(),
+      [room_id](const CollisionBlob& blob) { return blob.room_id == room_id; });
+  if (target != blobs.end() && encoded.size() <= target->end - target->start) {
+    const bool overlaps_other = std::any_of(
+        blobs.begin(), blobs.end(), [&](const CollisionBlob& other) {
+          return other.room_id != room_id && BlobsOverlap(*target, other);
+        });
+    if (!overlaps_other) {
+      write_pos = target->start;
+    }
+  }
+
+  // Append when there is no safe reusable span, then check available space.
   if (write_pos + encoded.size() > kCustomCollisionDataSoftEnd) {
     return absl::ResourceExhaustedError(absl::StrFormat(
         "Not enough collision data space. Need %d bytes at 0x%06X, "

--- a/src/zelda3/dungeon/track_collision_generator.h
+++ b/src/zelda3/dungeon/track_collision_generator.h
@@ -70,9 +70,9 @@ struct GeneratorOptions {
 absl::StatusOr<TrackCollisionResult> GenerateTrackCollision(
     Room* room, const GeneratorOptions& options = {});
 
-// Write a generated collision map into the ROM.
-// Updates the pointer table at kCustomCollisionRoomPointers and appends
-// encoded data in single-tile format after existing collision data.
+// Write a generated collision map into the ROM. Reuses a room's uniquely owned
+// blob when the replacement fits; otherwise appends encoded single-tile data
+// and updates the pointer table at kCustomCollisionRoomPointers.
 absl::Status WriteTrackCollision(Rom* rom, int room_id,
                                  const CustomCollisionMap& map);
 

--- a/test/unit/zelda3/dungeon/track_collision_generator_test.cc
+++ b/test/unit/zelda3/dungeon/track_collision_generator_test.cc
@@ -1,10 +1,16 @@
 #include "zelda3/dungeon/track_collision_generator.h"
 
 #include <algorithm>
+#include <cstdint>
+#include <initializer_list>
+#include <utility>
+#include <vector>
 
 #include <gtest/gtest.h>
 
+#include "rom/snes.h"
 #include "zelda3/dungeon/dimension_service.h"
+#include "zelda3/dungeon/dungeon_rom_addresses.h"
 #include "zelda3/dungeon/room.h"
 
 namespace yaze::zelda3 {
@@ -23,6 +29,42 @@ int CountExpectedTilesInBounds(const RoomObject& obj) {
     }
   }
   return count;
+}
+
+CustomCollisionMap MakeCollisionMap(
+    std::initializer_list<std::pair<int, uint8_t>> tiles) {
+  CustomCollisionMap map;
+  map.tiles.fill(0);
+  for (const auto& [offset, value] : tiles) {
+    map.tiles[static_cast<size_t>(offset)] = value;
+  }
+  map.has_data = tiles.size() != 0;
+  return map;
+}
+
+uint32_t ReadCollisionPointerPc(const Rom& rom, int room_id) {
+  const int pointer_offset = kCustomCollisionRoomPointers + (room_id * 3);
+  const auto& data = rom.vector();
+  const uint32_t snes_address = data[pointer_offset] |
+                                (data[pointer_offset + 1] << 8) |
+                                (data[pointer_offset + 2] << 16);
+  return SnesToPc(snes_address);
+}
+
+void CopyCollisionPointer(Rom* rom, int source_room_id, int target_room_id) {
+  const int source = kCustomCollisionRoomPointers + (source_room_id * 3);
+  const int target = kCustomCollisionRoomPointers + (target_room_id * 3);
+  for (int i = 0; i < 3; ++i) {
+    rom->mutable_data()[target + i] = rom->vector()[source + i];
+  }
+}
+
+void SetCollisionPointer(Rom* rom, int room_id, uint32_t pc_address) {
+  const uint32_t snes_address = PcToSnes(pc_address);
+  const int pointer_offset = kCustomCollisionRoomPointers + (room_id * 3);
+  rom->mutable_data()[pointer_offset] = snes_address & 0xFF;
+  rom->mutable_data()[pointer_offset + 1] = (snes_address >> 8) & 0xFF;
+  rom->mutable_data()[pointer_offset + 2] = (snes_address >> 16) & 0xFF;
 }
 
 TEST(TrackCollisionGeneratorTest, UsesDimensionServiceNotLegacyWidthHeight) {
@@ -93,6 +135,114 @@ TEST(TrackCollisionGeneratorTest, LegacyWidthHeightDoesNotChangeOutput) {
   EXPECT_EQ(res_a.corner_count, res_b.corner_count);
   EXPECT_EQ(res_a.switch_count, res_b.switch_count);
   EXPECT_EQ(res_a.collision_map.tiles, res_b.collision_map.tiles);
+}
+
+TEST(TrackCollisionGeneratorTest,
+     WriteReusesUniqueCurrentBlobWhenReplacementFits) {
+  Rom rom;
+  ASSERT_TRUE(
+      rom.LoadFromData(std::vector<uint8_t>(kCustomCollisionDataEnd, 0x00))
+          .ok());
+  const CustomCollisionMap initial =
+      MakeCollisionMap({{0, 0xB0}, {1, 0xB1}, {2, 0xB2}});
+  ASSERT_TRUE(WriteTrackCollision(&rom, 0x25, initial).ok());
+  const uint32_t initial_pointer = ReadCollisionPointerPc(rom, 0x25);
+  ASSERT_EQ(initial_pointer,
+            static_cast<uint32_t>(kCustomCollisionDataPosition));
+
+  const CustomCollisionMap replacement = MakeCollisionMap({{65, 0xB7}});
+  ASSERT_TRUE(WriteTrackCollision(&rom, 0x25, replacement).ok());
+
+  EXPECT_EQ(ReadCollisionPointerPc(rom, 0x25), initial_pointer);
+  auto loaded_or = LoadCustomCollisionMap(&rom, 0x25);
+  ASSERT_TRUE(loaded_or.ok()) << loaded_or.status();
+  EXPECT_EQ(loaded_or->tiles, replacement.tiles);
+
+  constexpr size_t kInitialEncodedSize = 2 + (3 * 3) + 2;
+  constexpr size_t kReplacementEncodedSize = 2 + 3 + 2;
+  const size_t append_candidate = initial_pointer + kInitialEncodedSize;
+  EXPECT_TRUE(std::all_of(
+      rom.vector().begin() + append_candidate,
+      rom.vector().begin() + append_candidate + kReplacementEncodedSize,
+      [](uint8_t value) { return value == 0; }));
+}
+
+TEST(TrackCollisionGeneratorTest,
+     WriteAppendsWhenReplacementExceedsCurrentBlob) {
+  Rom rom;
+  ASSERT_TRUE(
+      rom.LoadFromData(std::vector<uint8_t>(kCustomCollisionDataEnd, 0x00))
+          .ok());
+  ASSERT_TRUE(
+      WriteTrackCollision(&rom, 0x25, MakeCollisionMap({{0, 0xB0}})).ok());
+  const uint32_t initial_pointer = ReadCollisionPointerPc(rom, 0x25);
+
+  const CustomCollisionMap replacement =
+      MakeCollisionMap({{0, 0xB0}, {1, 0xB1}});
+  ASSERT_TRUE(WriteTrackCollision(&rom, 0x25, replacement).ok());
+
+  constexpr uint32_t kInitialEncodedSize = 2 + 3 + 2;
+  EXPECT_EQ(ReadCollisionPointerPc(rom, 0x25),
+            initial_pointer + kInitialEncodedSize);
+  auto loaded_or = LoadCustomCollisionMap(&rom, 0x25);
+  ASSERT_TRUE(loaded_or.ok()) << loaded_or.status();
+  EXPECT_EQ(loaded_or->tiles, replacement.tiles);
+}
+
+TEST(TrackCollisionGeneratorTest, WriteDoesNotReuseBlobSharedByAnotherRoom) {
+  Rom rom;
+  ASSERT_TRUE(
+      rom.LoadFromData(std::vector<uint8_t>(kCustomCollisionDataEnd, 0x00))
+          .ok());
+  const CustomCollisionMap shared = MakeCollisionMap({{0, 0xB0}, {1, 0xB1}});
+  ASSERT_TRUE(WriteTrackCollision(&rom, 0x25, shared).ok());
+  const uint32_t shared_pointer = ReadCollisionPointerPc(rom, 0x25);
+  CopyCollisionPointer(&rom, 0x25, 0x26);
+
+  const CustomCollisionMap replacement = MakeCollisionMap({{65, 0xB7}});
+  ASSERT_TRUE(WriteTrackCollision(&rom, 0x25, replacement).ok());
+
+  EXPECT_NE(ReadCollisionPointerPc(rom, 0x25), shared_pointer);
+  EXPECT_EQ(ReadCollisionPointerPc(rom, 0x26), shared_pointer);
+  auto shared_loaded_or = LoadCustomCollisionMap(&rom, 0x26);
+  ASSERT_TRUE(shared_loaded_or.ok()) << shared_loaded_or.status();
+  EXPECT_EQ(shared_loaded_or->tiles, shared.tiles);
+  auto replacement_loaded_or = LoadCustomCollisionMap(&rom, 0x25);
+  ASSERT_TRUE(replacement_loaded_or.ok()) << replacement_loaded_or.status();
+  EXPECT_EQ(replacement_loaded_or->tiles, replacement.tiles);
+}
+
+TEST(TrackCollisionGeneratorTest,
+     WriteDoesNotReuseBlobContainingAnotherRoomPointer) {
+  Rom rom;
+  ASSERT_TRUE(
+      rom.LoadFromData(std::vector<uint8_t>(kCustomCollisionDataEnd, 0x00))
+          .ok());
+
+  // Room 0x25 uses a rectangle whose four payload bytes also form a valid
+  // empty single-tile blob for room 0x26. Both streams decode, but their
+  // physical spans overlap and therefore cannot be edited in place safely.
+  const uint32_t outer_start = kCustomCollisionDataPosition;
+  ASSERT_TRUE(rom.WriteVector(outer_start, {0x00, 0x00, 0x04, 0x01, 0xF0, 0xF0,
+                                            0xFF, 0xFF, 0xFF, 0xFF})
+                  .ok());
+  SetCollisionPointer(&rom, 0x25, outer_start);
+  SetCollisionPointer(&rom, 0x26, outer_start + 4);
+
+  const CustomCollisionMap replacement = MakeCollisionMap({{65, 0xB7}});
+  ASSERT_TRUE(WriteTrackCollision(&rom, 0x25, replacement).ok());
+
+  constexpr uint32_t kOuterEncodedSize = 10;
+  EXPECT_EQ(ReadCollisionPointerPc(rom, 0x25), outer_start + kOuterEncodedSize);
+  EXPECT_EQ(ReadCollisionPointerPc(rom, 0x26), outer_start + 4);
+  auto interior_loaded_or = LoadCustomCollisionMap(&rom, 0x26);
+  ASSERT_TRUE(interior_loaded_or.ok()) << interior_loaded_or.status();
+  EXPECT_TRUE(std::all_of(interior_loaded_or->tiles.begin(),
+                          interior_loaded_or->tiles.end(),
+                          [](uint8_t value) { return value == 0; }));
+  auto replacement_loaded_or = LoadCustomCollisionMap(&rom, 0x25);
+  ASSERT_TRUE(replacement_loaded_or.ok()) << replacement_loaded_or.status();
+  EXPECT_EQ(replacement_loaded_or->tiles, replacement.tiles);
 }
 
 }  // namespace


### PR DESCRIPTION
## Summary
- reuse a room's existing custom-collision blob when its complete decoded span is uniquely owned and the replacement fits
- keep growing replacements, exact aliases, and interior-overlapping streams on the existing copy-on-write append path
- preserve WaterFill reserved-region fences and fail closed on malformed pointer-reachable streams
- document the bounded-rewrite rule in the ROM safety guardrails and changelog

## Verification
- `./build/presets/mac-ai/bin/Debug/yaze_test_unit --gtest_filter='TrackCollisionGeneratorTest.*'` — 7/7 passed
- `./build/presets/mac-ai/bin/Debug/yaze_test_unit --gtest_filter='DungeonTrackCollisionCommandsTest.*:DungeonCollisionJsonCommandsTest.CustomCollision*'` — 22/22 passed
- `./scripts/pre-push.sh --build-dir build/presets/mac-ai` — passed (build, 13 smoke tests, formatting; UI regression correctly skipped)
- independent read-only review found no blocking correctness or ROM-safety issues

## Runtime scope
Backend/unit-fixture change only. No GUI session was launched and no project or canonical ROM was written.
