### PR TITLE
fix(dungeon): guard unapplied tile layouts

### DIFF
--- a/docs/public/reference/changelog.md
+++ b/docs/public/reference/changelog.md
@@ -18,7 +18,8 @@
   rewrites, while keeping aliased, overlapping, and growing streams on the
   copy-on-write append path.
 - Included unapplied Object Tile Editor layouts in dungeon/session dirty
-  detection and blocked Save until those edits are applied or discarded.
+  detection and blocked Save or Apply Room until those edits are applied or
+  discarded.
 
 ## 0.7.2 (July 17, 2026)
 

--- a/docs/public/reference/changelog.md
+++ b/docs/public/reference/changelog.md
@@ -17,6 +17,8 @@
 - Reused uniquely owned custom-collision blobs for same-size or smaller
   rewrites, while keeping aliased, overlapping, and growing streams on the
   copy-on-write append path.
+- Included unapplied Object Tile Editor layouts in dungeon/session dirty
+  detection and blocked Save until those edits are applied or discarded.
 
 ## 0.7.2 (July 17, 2026)
 

--- a/src/app/editor/dungeon/dungeon_editor_v2.cc
+++ b/src/app/editor/dungeon/dungeon_editor_v2.cc
@@ -1283,6 +1283,10 @@ bool DungeonEditorV2::HasPendingRoomChanges() const {
 }
 
 bool DungeonEditorV2::HasPendingDungeonChanges() const {
+  if (object_tile_editor_panel_ != nullptr &&
+      object_tile_editor_panel_->HasUnappliedChanges()) {
+    return true;
+  }
   if (HasPendingRoomChanges()) {
     return true;
   }

--- a/src/app/editor/dungeon/dungeon_editor_v2.h
+++ b/src/app/editor/dungeon/dungeon_editor_v2.h
@@ -148,7 +148,7 @@ class DungeonEditorV2 : public Editor {
   // Room-specific pending state used by room counts and room-level UI.
   int PendingRoomCount() const;
   bool HasPendingRoomChanges() const;
-  // All dungeon save domains, including global entrance/spawn/pit metadata.
+  // All dungeon save domains plus unapplied editor-local work.
   bool HasPendingDungeonChanges() const;
   bool CurrentRoomHasPendingChanges() const;
   int TotalRoomCount() const { return static_cast<int>(rooms_.size()); }

--- a/src/app/editor/dungeon/dungeon_editor_v2_persistence.cc
+++ b/src/app/editor/dungeon/dungeon_editor_v2_persistence.cc
@@ -529,7 +529,7 @@ absl::Status DungeonEditorV2::Save() {
       object_tile_editor_panel_->HasUnappliedChanges()) {
     return absl::FailedPreconditionError(
         "Apply or explicitly discard Object Tile Editor changes before "
-        "saving the dungeon");
+        "using Save or Apply Room");
   }
 
   const auto& flags = core::FeatureFlags::get().dungeon;
@@ -915,6 +915,12 @@ std::vector<std::pair<uint32_t, uint32_t>> DungeonEditorV2::CollectWriteRanges()
 }
 
 absl::Status DungeonEditorV2::SaveRoom(int room_id) {
+  if (object_tile_editor_panel_ != nullptr &&
+      object_tile_editor_panel_->HasUnappliedChanges()) {
+    return absl::FailedPreconditionError(
+        "Apply or explicitly discard Object Tile Editor changes before "
+        "using Save or Apply Room");
+  }
   return RunWithSaveTransaction([this, room_id]() -> absl::Status {
     if (room_id < 0 || room_id >= static_cast<int>(rooms_.size())) {
       return absl::InvalidArgumentError("Invalid room ID");

--- a/src/app/editor/dungeon/dungeon_editor_v2_persistence.cc
+++ b/src/app/editor/dungeon/dungeon_editor_v2_persistence.cc
@@ -525,6 +525,12 @@ absl::Status DungeonEditorV2::Save() {
   if (!rom_ || !rom_->is_loaded()) {
     return absl::FailedPreconditionError("ROM not loaded");
   }
+  if (object_tile_editor_panel_ != nullptr &&
+      object_tile_editor_panel_->HasUnappliedChanges()) {
+    return absl::FailedPreconditionError(
+        "Apply or explicitly discard Object Tile Editor changes before "
+        "saving the dungeon");
+  }
 
   const auto& flags = core::FeatureFlags::get().dungeon;
   std::optional<zelda3::ChestSavePlan> chest_save_plan;

--- a/src/app/editor/dungeon/ui/window/object_tile_editor_panel.h
+++ b/src/app/editor/dungeon/ui/window/object_tile_editor_panel.h
@@ -68,6 +68,9 @@ class ObjectTileEditorPanel : public WindowContent {
                                 int room_id, DungeonRoomStore* rooms);
   void Close();
   bool IsOpen() const { return is_open_; }
+  bool HasUnappliedChanges() const {
+    return current_layout_.HasModifications();
+  }
 
   void SetCurrentPaletteGroup(const gfx::PaletteGroup& group);
   void SetCurrentPaletteGroupForRoom(int room_id,

--- a/test/unit/editor/object_tile_editor_panel_test.cc
+++ b/test/unit/editor/object_tile_editor_panel_test.cc
@@ -809,6 +809,14 @@ TEST(DungeonEditorV2ObjectTileEditorTest,
   EXPECT_EQ(rom.dirty(), dirty_before_save);
   EXPECT_TRUE(panel.HasUnappliedChanges());
 
+  const absl::Status save_room_status = editor.SaveRoom(/*room_id=*/0);
+  EXPECT_TRUE(absl::IsFailedPrecondition(save_room_status)) << save_room_status;
+  EXPECT_NE(std::string(save_room_status.message()).find("Object Tile Editor"),
+            std::string::npos);
+  EXPECT_EQ(rom.vector(), rom_before_save);
+  EXPECT_EQ(rom.dirty(), dirty_before_save);
+  EXPECT_TRUE(panel.HasUnappliedChanges());
+
   panel.Close();
   EXPECT_FALSE(panel.HasUnappliedChanges());
   EXPECT_FALSE(editor.HasPendingDungeonChanges());

--- a/test/unit/editor/object_tile_editor_panel_test.cc
+++ b/test/unit/editor/object_tile_editor_panel_test.cc
@@ -774,6 +774,46 @@ TEST(ObjectTileEditorPanelTest, OnClosePreservesModifiedSessionForReopen) {
   EXPECT_EQ(ObjectTileEditorPanelTestAccess::CurrentRoomId(panel), 0);
 }
 
+TEST(DungeonEditorV2ObjectTileEditorTest,
+     UnappliedLayoutMarksSessionPendingAndBlocksSaveUntilDiscarded) {
+  Rom rom;
+  ASSERT_TRUE(rom.LoadFromData(MakeEditableStandardObjectRomData()).ok());
+  DungeonRoomStore rooms(&rom);
+  ObjectTileEditorPanel panel(nullptr, &rom);
+  DungeonEditorV2 editor(&rom);
+  DungeonEditorV2ObjectTileEditorTestPeer::SetObjectTileEditorPanel(editor,
+                                                                    &panel);
+
+  ASSERT_TRUE(
+      panel.OpenForObject(kEditableStandardObjectId, /*room_id=*/0, &rooms)
+          .ok());
+  EXPECT_FALSE(panel.HasUnappliedChanges());
+  EXPECT_FALSE(editor.HasPendingDungeonChanges());
+
+  ObjectTileEditorPanelTestAccess::SetFirstCellTileAndPalette(
+      panel, /*tile_id=*/0x123, /*palette=*/3);
+  ASSERT_TRUE(panel.HasUnappliedChanges());
+  EXPECT_TRUE(editor.HasPendingDungeonChanges());
+  const auto rom_before_save = rom.vector();
+  const bool dirty_before_save = rom.dirty();
+
+  panel.OnClose();
+  EXPECT_TRUE(panel.HasUnappliedChanges());
+  EXPECT_TRUE(editor.HasPendingDungeonChanges());
+
+  const absl::Status save_status = editor.Save();
+  EXPECT_TRUE(absl::IsFailedPrecondition(save_status)) << save_status;
+  EXPECT_NE(std::string(save_status.message()).find("Object Tile Editor"),
+            std::string::npos);
+  EXPECT_EQ(rom.vector(), rom_before_save);
+  EXPECT_EQ(rom.dirty(), dirty_before_save);
+  EXPECT_TRUE(panel.HasUnappliedChanges());
+
+  panel.Close();
+  EXPECT_FALSE(panel.HasUnappliedChanges());
+  EXPECT_FALSE(editor.HasPendingDungeonChanges());
+}
+
 TEST(ObjectTileEditorPanelTest,
      SafeWindowCloseHidesAndPreservesModifiedSession) {
   Rom rom;


### PR DESCRIPTION
## Summary
- expose unapplied Object Tile Editor layout state as a dungeon/session dirty domain
- preserve that state when the panel is hidden so open/switch/close/quit guards can warn instead of silently discarding work
- fail Dungeon Editor Save and Apply Room before any serializer mutation until the layout is applied or explicitly discarded
- document the save behavior and cover hide/Save/Apply Room/discard lifecycle with ROM-byte and dirty-state assertions

## Verification
- `ObjectTileEditorPanelTest.*:DungeonEditorV2ObjectTileEditorTest.*` — 38/38 passed
- focused aggregate/session guard checks — 3/3 passed
- `./scripts/pre-push.sh --build-dir build/presets/mac-ai` — passed (build, 13 smoke tests, formatting, 40 change-aware UI regressions)
- independent strict review — no blocker/high/medium findings

## Runtime scope
Automated editor/backend fixtures only. No GUI session was launched and no project or canonical ROM was written.
