### PR TITLE
feat(dungeon): edit dedicated spawn points in UI

### DIFF
--- a/docs/internal/architecture/dungeon_editor_system.md
+++ b/docs/internal/architecture/dungeon_editor_system.md
@@ -76,10 +76,10 @@ if (ImGui::BeginChild("##RoomsList", ImVec2(0, 0), true)) {
   prediction/preflight ranges and save/reopen coverage. It preserves 9-bit room
   semantics, the quadrant-only byte at PC `0x15C2B`, the full 16-bit overworld
   door tilemap at PC `0x15C32`, and seven 16-bit entrance IDs at PC `0x15C40`.
-- Spawn properties remain read-only in the UI until it binds directly to
-  `DungeonSpawnPoint`. The legacy combined `RoomEntrance` spawn views still
-  fail closed if marked dirty; spawn editing must not reuse that regular-field
-  model.
+- The standalone Entrance Properties panel edits spawn slots through
+  `DungeonSpawnPoint`, and entrance selection/listing resolves their dedicated
+  room and main-GFX fields. The legacy combined `RoomEntrance` property view
+  remains read-only and directs users to that panel.
 
 ## Recent Additions
 
@@ -149,7 +149,8 @@ Subsystem for accurate SNES-style layer compositing of dungeon room renders.
 2. **Save Pipeline Follow-up**:
    - Keep pit-damage edits within the fixed-capacity membership table; treat repointing or capacity expansion as a separate ROM-layout feature.
    - Treat pushable-block table repointing/expansion as a separate ROM-layout feature; the current encoder intentionally stays within the vanilla four-region cap. It fails closed for dirty-but-unloaded room state and when an edit would empty the global table: `LoadAndBuildRoom` scans at least one entry before comparing the byte-length immediate, so zero is not a safe runtime limit without an engine patch. Successful compaction rebases loaded block slot identities only after all ROM writes commit, and the editor transaction snapshot restores those identities if a later save stage rolls back.
-   - Bind the read-only spawn property UI to `DungeonSpawnPoint` before enabling interactive spawn edits.
+   - Consolidate or remove the remaining legacy read-only spawn inspector in
+     the room selector now that Entrance Properties owns dedicated spawn edits.
    - Add broader integration coverage for door/chest/pot/collision/entrance/write flows beyond the current unit and ROM-safety tests.
 3. **Test Coverage**: Add integration tests that:
    - Place/delete objects and verify `Room::EncodeObjects` output changes in ROM.

--- a/src/app/editor/dungeon/dungeon_editor_v2.cc
+++ b/src/app/editor/dungeon/dungeon_editor_v2.cc
@@ -231,6 +231,7 @@ absl::Status DungeonEditorV2::RefreshRomBackedState() {
 
   room_selector_.set_rooms(&rooms_);
   room_selector_.set_entrances(&entrances_);
+  room_selector_.set_spawn_points(&spawn_points_);
 
   if (dungeon_editor_system_) {
     dungeon_editor_system_->SetGameData(game_data_);
@@ -623,7 +624,7 @@ void DungeonEditorV2::Initialize() {
   }
 
   window_manager->RegisterWindowContent(std::make_unique<DungeonEntrancesPanel>(
-      &entrances_, &current_entrance_id_,
+      &entrances_, &spawn_points_, &current_entrance_id_,
       [this](int entrance_id) { OnEntranceSelected(entrance_id); }));
 
   // Note: RoomGraphicsContent and PaletteEditorContent are registered
@@ -655,6 +656,7 @@ absl::Status DungeonEditorV2::Load() {
 
   room_selector_.set_rooms(&rooms_);
   room_selector_.set_entrances(&entrances_);
+  room_selector_.set_spawn_points(&spawn_points_);
   room_selector_.set_active_rooms(active_rooms_);
   room_selector_.SetRoomSelectedCallback(
       [this](int room_id) { OnRoomSelected(room_id); });
@@ -1769,8 +1771,23 @@ void DungeonEditorV2::OnEntranceSelected(int entrance_id) {
   }
   current_entrance_id_ = entrance_id;
   room_selector_.set_current_entrance_id(entrance_id);
-  int room_id = entrances_[entrance_id].room_;
+
+  const int room_id = ResolveEntranceRoomId(entrance_id);
+  if (room_id < 0 || room_id >= static_cast<int>(rooms_.size())) {
+    return;
+  }
   OnRoomSelected(room_id);
+}
+
+int DungeonEditorV2::ResolveEntranceRoomId(int entrance_id) const {
+  if (entrance_id < 0 || entrance_id >= static_cast<int>(entrances_.size())) {
+    return -1;
+  }
+  if (entrance_id < zelda3::kNumDungeonSpawnPoints) {
+    const auto& spawn = spawn_points_[entrance_id];
+    return spawn.spawn_id() == entrance_id ? spawn.room_id : -1;
+  }
+  return entrances_[entrance_id].room_;
 }
 
 uint8_t DungeonEditorV2::ResolveSelectedEntranceBlocksetForRoom(
@@ -1782,6 +1799,14 @@ uint8_t DungeonEditorV2::ResolveSelectedEntranceBlocksetForRoom(
       current_entrance_id_ >= static_cast<int>(entrances_.size())) {
     return 0xFF;
   }
+  if (current_entrance_id_ < zelda3::kNumDungeonSpawnPoints) {
+    const auto& spawn = spawn_points_[current_entrance_id_];
+    if (spawn.spawn_id() != current_entrance_id_ || spawn.room_id != room_id) {
+      return 0xFF;
+    }
+    return spawn.main_gfx;
+  }
+
   const auto& entrance = entrances_[current_entrance_id_];
   if (entrance.room_ != room_id) {
     return 0xFF;

--- a/src/app/editor/dungeon/dungeon_editor_v2.h
+++ b/src/app/editor/dungeon/dungeon_editor_v2.h
@@ -292,6 +292,7 @@ class DungeonEditorV2 : public Editor {
   void OnRoomSelected(int room_id, bool request_focus = true);
   void OnRoomSelected(int room_id, RoomSelectionIntent intent);
   void OnEntranceSelected(int entrance_id);
+  int ResolveEntranceRoomId(int entrance_id) const;
 
   // Sync all sub-panels to the current room configuration
   void SyncPanelsToRoom(int room_id);

--- a/src/app/editor/dungeon/dungeon_entrance_edit_policy.h
+++ b/src/app/editor/dungeon/dungeon_entrance_edit_policy.h
@@ -1,13 +1,14 @@
 #ifndef YAZE_APP_EDITOR_DUNGEON_DUNGEON_ENTRANCE_EDIT_POLICY_H_
 #define YAZE_APP_EDITOR_DUNGEON_DUNGEON_ENTRANCE_EDIT_POLICY_H_
 
+#include "zelda3/dungeon/dungeon_spawn_point.h"
 #include "zelda3/dungeon/room_entrance.h"
 
 namespace yaze::editor {
 
 inline constexpr char kDungeonSpawnReadOnlyReason[] =
-    "Spawn properties are read-only until the UI binds to the dedicated "
-    "DungeonSpawnPoint model.";
+    "Spawn properties are read-only in this legacy view. Use Entrance "
+    "Properties to edit the dedicated DungeonSpawnPoint record.";
 
 inline bool CanEditDungeonEntrance(int slot_index,
                                    const zelda3::RoomEntrance& entrance) {
@@ -23,6 +24,21 @@ inline bool MarkDungeonEntranceDirtyIfEditable(int slot_index,
     return false;
   }
   entrance.MarkDirty();
+  return true;
+}
+
+inline bool CanEditDungeonSpawnPoint(int slot_index,
+                                     const zelda3::DungeonSpawnPoint& spawn) {
+  return slot_index >= 0 && slot_index < zelda3::kNumDungeonSpawnPoints &&
+         spawn.spawn_id() == slot_index;
+}
+
+inline bool MarkDungeonSpawnPointDirtyIfEditable(
+    int slot_index, zelda3::DungeonSpawnPoint& spawn, bool properties_changed) {
+  if (!properties_changed || !CanEditDungeonSpawnPoint(slot_index, spawn)) {
+    return false;
+  }
+  spawn.MarkDirty();
   return true;
 }
 

--- a/src/app/editor/dungeon/dungeon_room_selector.cc
+++ b/src/app/editor/dungeon/dungeon_room_selector.cc
@@ -301,9 +301,12 @@ void DungeonRoomSelector::RebuildEntranceFilterCache() {
       }
     }
 
-    int room_id = (entrances_ && i < static_cast<int>(entrances_->size()))
-                      ? (*entrances_)[i].room_
-                      : 0;
+    int room_id = 0;
+    if (i < kNumSpawnPoints && spawn_points_) {
+      room_id = (*spawn_points_)[i].room_id;
+    } else if (entrances_ && i < static_cast<int>(entrances_->size())) {
+      room_id = (*entrances_)[i].room_;
+    }
 
     char filter_text[256];
     snprintf(filter_text, sizeof(filter_text), "%s %03X", display_name.c_str(),
@@ -459,9 +462,12 @@ void DungeonRoomSelector::DrawEntranceSelectorInternal(bool show_properties) {
           display_name = zelda3::GetEntranceLabel(entrance_id);
         }
 
-        int room_id = (i < static_cast<int>(entrances_->size()))
-                          ? (*entrances_)[i].room_
-                          : 0;
+        int room_id = 0;
+        if (i < kNumSpawnPoints && spawn_points_) {
+          room_id = (*spawn_points_)[i].room_id;
+        } else if (i < static_cast<int>(entrances_->size())) {
+          room_id = (*entrances_)[i].room_;
+        }
 
         ImGui::TableNextRow();
         ImGui::TableNextColumn();

--- a/src/app/editor/dungeon/dungeon_room_selector.h
+++ b/src/app/editor/dungeon/dungeon_room_selector.h
@@ -10,6 +10,7 @@
 #include "app/editor/editor.h"
 #include "imgui/imgui.h"
 #include "rom/rom.h"
+#include "zelda3/dungeon/dungeon_spawn_point.h"
 #include "zelda3/dungeon/room.h"
 #include "zelda3/dungeon/room_entrance.h"
 #include "zelda3/game_data.h"
@@ -85,6 +86,11 @@ class DungeonRoomSelector {
                                 zelda3::kNumDungeonEntranceSlots>* entrances) {
     entrances_ = entrances;
   }
+  void set_spawn_points(
+      std::array<zelda3::DungeonSpawnPoint, zelda3::kNumDungeonSpawnPoints>*
+          spawn_points) {
+    spawn_points_ = spawn_points;
+  }
 
   // Callback for room selection events (single-click / default)
   void SetRoomSelectedCallback(std::function<void(int)> callback) {
@@ -125,6 +131,8 @@ class DungeonRoomSelector {
   DungeonRoomStore* rooms_ = nullptr;
   std::array<zelda3::RoomEntrance, zelda3::kNumDungeonEntranceSlots>*
       entrances_ = nullptr;
+  std::array<zelda3::DungeonSpawnPoint, zelda3::kNumDungeonSpawnPoints>*
+      spawn_points_ = nullptr;
 
   // Callback for room selection events (single-click / default)
   std::function<void(int)> room_selected_callback_;

--- a/src/app/editor/dungeon/ui/window/dungeon_entrances_panel.h
+++ b/src/app/editor/dungeon/ui/window/dungeon_entrances_panel.h
@@ -1,8 +1,11 @@
 #ifndef YAZE_APP_EDITOR_DUNGEON_PANELS_DUNGEON_ENTRANCES_PANEL_H_
 #define YAZE_APP_EDITOR_DUNGEON_PANELS_DUNGEON_ENTRANCES_PANEL_H_
 
+#include <array>
+#include <cstdio>
 #include <functional>
 #include <string>
+#include <utility>
 
 #include "app/editor/dungeon/dungeon_entrance_edit_policy.h"
 #include "app/editor/system/workspace/editor_panel.h"
@@ -28,11 +31,14 @@ namespace editor {
  */
 class DungeonEntrancesPanel : public WindowContent {
  public:
-  DungeonEntrancesPanel(std::array<zelda3::RoomEntrance,
-                                   zelda3::kNumDungeonEntranceSlots>* entrances,
-                        int* current_entrance_id,
-                        std::function<void(int)> on_entrance_selected)
+  DungeonEntrancesPanel(
+      std::array<zelda3::RoomEntrance, zelda3::kNumDungeonEntranceSlots>*
+          entrances,
+      std::array<zelda3::DungeonSpawnPoint, zelda3::kNumDungeonSpawnPoints>*
+          spawn_points,
+      int* current_entrance_id, std::function<void(int)> on_entrance_selected)
       : entrances_(entrances),
+        spawn_points_(spawn_points),
         current_entrance_id_(current_entrance_id),
         on_entrance_selected_(std::move(on_entrance_selected)) {}
 
@@ -51,86 +57,18 @@ class DungeonEntrancesPanel : public WindowContent {
   // ==========================================================================
 
   void Draw(bool* p_open) override {
-    if (!entrances_ || !current_entrance_id_)
+    if (!entrances_ || !spawn_points_ || !current_entrance_id_)
       return;
     if (*current_entrance_id_ < 0 ||
         *current_entrance_id_ >= static_cast<int>(entrances_->size())) {
       *current_entrance_id_ = 0;
     }
 
-    auto& current_entrance = (*entrances_)[*current_entrance_id_];
-    const bool properties_editable =
-        CanEditDungeonEntrance(*current_entrance_id_, current_entrance);
-    bool changed = false;
-
-    // Entrance properties
-    ImGui::Text(tr("Entrance ID: %04X"), current_entrance.entrance_id_);
-    if (!properties_editable) {
-      ImGui::TextWrapped(tr(kDungeonSpawnReadOnlyReason));
+    if (*current_entrance_id_ < zelda3::kNumDungeonSpawnPoints) {
+      DrawSpawnPointProperties(*current_entrance_id_);
+    } else {
+      DrawRegularEntranceProperties(*current_entrance_id_);
     }
-    ImGui::BeginDisabled(!properties_editable);
-    changed |= gui::InputHexWord("Room ID", &current_entrance.room_);
-    ImGui::SameLine();
-    changed |= gui::InputHexByte("Dungeon ID", &current_entrance.dungeon_id_,
-                                 50.f, true);
-
-    changed |=
-        gui::InputHexByte("Blockset", &current_entrance.blockset_, 50.f, true);
-    ImGui::SameLine();
-    changed |= gui::InputHexByte("Music", &current_entrance.music_, 50.f, true);
-    ImGui::SameLine();
-    changed |= gui::InputHexByte("Floor", &current_entrance.floor_);
-
-    ImGui::Separator();
-
-    changed |= gui::InputHexWord("Player X   ", &current_entrance.x_position_);
-    ImGui::SameLine();
-    changed |= gui::InputHexWord("Player Y   ", &current_entrance.y_position_);
-
-    changed |=
-        gui::InputHexWord("Camera X", &current_entrance.camera_trigger_x_);
-    ImGui::SameLine();
-    changed |=
-        gui::InputHexWord("Camera Y", &current_entrance.camera_trigger_y_);
-
-    changed |= gui::InputHexWord("Scroll X    ", &current_entrance.camera_x_);
-    ImGui::SameLine();
-    changed |= gui::InputHexWord("Scroll Y    ", &current_entrance.camera_y_);
-
-    changed |= gui::InputHexWord("Exit", &current_entrance.exit_, 50.f, true);
-
-    ImGui::Separator();
-    ImGui::Text(tr("Camera Boundaries"));
-    ImGui::Separator();
-    ImGui::Text(tr("\t\t\t\t\tNorth         East         South         West"));
-
-    changed |= gui::InputHexByte(
-        "Quadrant", &current_entrance.camera_boundary_qn_, 50.f, true);
-    ImGui::SameLine();
-    changed |= gui::InputHexByte("##QE", &current_entrance.camera_boundary_qe_,
-                                 50.f, true);
-    ImGui::SameLine();
-    changed |= gui::InputHexByte("##QS", &current_entrance.camera_boundary_qs_,
-                                 50.f, true);
-    ImGui::SameLine();
-    changed |= gui::InputHexByte("##QW", &current_entrance.camera_boundary_qw_,
-                                 50.f, true);
-
-    changed |= gui::InputHexByte(
-        "Full room", &current_entrance.camera_boundary_fn_, 50.f, true);
-    ImGui::SameLine();
-    changed |= gui::InputHexByte("##FE", &current_entrance.camera_boundary_fe_,
-                                 50.f, true);
-    ImGui::SameLine();
-    changed |= gui::InputHexByte("##FS", &current_entrance.camera_boundary_fs_,
-                                 50.f, true);
-    ImGui::SameLine();
-    changed |= gui::InputHexByte("##FW", &current_entrance.camera_boundary_fw_,
-                                 50.f, true);
-    ImGui::EndDisabled();
-
-    MarkDungeonEntranceDirtyIfEditable(*current_entrance_id_, current_entrance,
-                                       changed);
 
     ImGui::Separator();
 
@@ -164,7 +102,8 @@ class DungeonEntrancesPanel : public WindowContent {
           }
         }
 
-        int room_id = (*entrances_)[i].room_;
+        const int room_id = i < kNumSpawnPoints ? (*spawn_points_)[i].room_id
+                                                : (*entrances_)[i].room_;
         // Use unified ResourceLabelProvider for room names
         std::string room_name = zelda3::GetRoomLabel(room_id);
 
@@ -185,8 +124,161 @@ class DungeonEntrancesPanel : public WindowContent {
   }
 
  private:
+  void DrawSpawnPointProperties(int slot_index) {
+    auto& spawn = (*spawn_points_)[slot_index];
+    const bool properties_editable =
+        CanEditDungeonSpawnPoint(slot_index, spawn);
+    bool changed = false;
+
+    ImGui::Text(tr("Spawn Point %d"), slot_index);
+    if (!properties_editable) {
+      ImGui::TextWrapped(tr(
+          "Spawn point data is unavailable; reload the ROM before editing."));
+    }
+    ImGui::BeginDisabled(!properties_editable);
+
+    changed |= gui::InputHexWord("Entrance ID", &spawn.entrance_id);
+    changed |= gui::InputHexWord("Room ID", &spawn.room_id);
+    ImGui::SameLine();
+    changed |= gui::InputHexByte("Dungeon ID", &spawn.dungeon_id, 50.f, true);
+
+    changed |= gui::InputHexByte("Main GFX", &spawn.main_gfx, 50.f, true);
+    ImGui::SameLine();
+    changed |= gui::InputHexByte("Song", &spawn.song, 50.f, true);
+    ImGui::SameLine();
+    changed |= gui::InputHexByte("Floor", &spawn.floor);
+
+    ImGui::Separator();
+
+    changed |= gui::InputHexWord("Player X", &spawn.x_coordinate);
+    ImGui::SameLine();
+    changed |= gui::InputHexWord("Player Y", &spawn.y_coordinate);
+
+    changed |= gui::InputHexWord("Camera Trigger X", &spawn.camera_trigger_x);
+    ImGui::SameLine();
+    changed |= gui::InputHexWord("Camera Trigger Y", &spawn.camera_trigger_y);
+
+    changed |= gui::InputHexWord("Horizontal Scroll", &spawn.horizontal_scroll);
+    ImGui::SameLine();
+    changed |= gui::InputHexWord("Vertical Scroll", &spawn.vertical_scroll);
+
+    changed |= gui::InputHexWord("Overworld Door Tilemap",
+                                 &spawn.overworld_door_tilemap, 70.f, true);
+
+    ImGui::Separator();
+    changed |= gui::InputHexByte("Layer", &spawn.layer, 50.f, true);
+    ImGui::SameLine();
+    changed |= gui::InputHexByte("Spawn Quadrant", &spawn.quadrant, 50.f, true);
+    ImGui::SameLine();
+    changed |= gui::InputHexByte("Scroll Controller",
+                                 &spawn.camera_scroll_controller, 50.f, true);
+
+    ImGui::Separator();
+    ImGui::Text(tr("Camera Boundaries"));
+    ImGui::Separator();
+    ImGui::Text(tr("\t\t\t\t\tNorth         East         South         West"));
+
+    changed |=
+        gui::InputHexByte("Quadrant##SpawnBoundaryQN",
+                          &spawn.camera_scroll_boundaries[0], 50.f, true);
+    ImGui::SameLine();
+    changed |= gui::InputHexByte(
+        "##SpawnQE", &spawn.camera_scroll_boundaries[6], 50.f, true);
+    ImGui::SameLine();
+    changed |= gui::InputHexByte(
+        "##SpawnQS", &spawn.camera_scroll_boundaries[2], 50.f, true);
+    ImGui::SameLine();
+    changed |= gui::InputHexByte(
+        "##SpawnQW", &spawn.camera_scroll_boundaries[4], 50.f, true);
+
+    changed |= gui::InputHexByte(
+        "Full room", &spawn.camera_scroll_boundaries[1], 50.f, true);
+    ImGui::SameLine();
+    changed |= gui::InputHexByte(
+        "##SpawnFE", &spawn.camera_scroll_boundaries[7], 50.f, true);
+    ImGui::SameLine();
+    changed |= gui::InputHexByte(
+        "##SpawnFS", &spawn.camera_scroll_boundaries[3], 50.f, true);
+    ImGui::SameLine();
+    changed |= gui::InputHexByte(
+        "##SpawnFW", &spawn.camera_scroll_boundaries[5], 50.f, true);
+    ImGui::EndDisabled();
+
+    MarkDungeonSpawnPointDirtyIfEditable(slot_index, spawn, changed);
+  }
+
+  void DrawRegularEntranceProperties(int slot_index) {
+    auto& entrance = (*entrances_)[slot_index];
+    const bool properties_editable =
+        CanEditDungeonEntrance(slot_index, entrance);
+    bool changed = false;
+
+    ImGui::Text(tr("Entrance ID: %04X"), entrance.entrance_id_);
+    ImGui::BeginDisabled(!properties_editable);
+    changed |= gui::InputHexWord("Room ID", &entrance.room_);
+    ImGui::SameLine();
+    changed |=
+        gui::InputHexByte("Dungeon ID", &entrance.dungeon_id_, 50.f, true);
+
+    changed |= gui::InputHexByte("Blockset", &entrance.blockset_, 50.f, true);
+    ImGui::SameLine();
+    changed |= gui::InputHexByte("Music", &entrance.music_, 50.f, true);
+    ImGui::SameLine();
+    changed |= gui::InputHexByte("Floor", &entrance.floor_);
+
+    ImGui::Separator();
+
+    changed |= gui::InputHexWord("Player X   ", &entrance.x_position_);
+    ImGui::SameLine();
+    changed |= gui::InputHexWord("Player Y   ", &entrance.y_position_);
+
+    changed |= gui::InputHexWord("Camera X", &entrance.camera_trigger_x_);
+    ImGui::SameLine();
+    changed |= gui::InputHexWord("Camera Y", &entrance.camera_trigger_y_);
+
+    changed |= gui::InputHexWord("Scroll X    ", &entrance.camera_x_);
+    ImGui::SameLine();
+    changed |= gui::InputHexWord("Scroll Y    ", &entrance.camera_y_);
+
+    changed |= gui::InputHexWord("Exit", &entrance.exit_, 50.f, true);
+
+    ImGui::Separator();
+    ImGui::Text(tr("Camera Boundaries"));
+    ImGui::Separator();
+    ImGui::Text(tr("\t\t\t\t\tNorth         East         South         West"));
+
+    changed |= gui::InputHexByte("Quadrant", &entrance.camera_boundary_qn_,
+                                 50.f, true);
+    ImGui::SameLine();
+    changed |=
+        gui::InputHexByte("##QE", &entrance.camera_boundary_qe_, 50.f, true);
+    ImGui::SameLine();
+    changed |=
+        gui::InputHexByte("##QS", &entrance.camera_boundary_qs_, 50.f, true);
+    ImGui::SameLine();
+    changed |=
+        gui::InputHexByte("##QW", &entrance.camera_boundary_qw_, 50.f, true);
+
+    changed |= gui::InputHexByte("Full room", &entrance.camera_boundary_fn_,
+                                 50.f, true);
+    ImGui::SameLine();
+    changed |=
+        gui::InputHexByte("##FE", &entrance.camera_boundary_fe_, 50.f, true);
+    ImGui::SameLine();
+    changed |=
+        gui::InputHexByte("##FS", &entrance.camera_boundary_fs_, 50.f, true);
+    ImGui::SameLine();
+    changed |=
+        gui::InputHexByte("##FW", &entrance.camera_boundary_fw_, 50.f, true);
+    ImGui::EndDisabled();
+
+    MarkDungeonEntranceDirtyIfEditable(slot_index, entrance, changed);
+  }
+
   std::array<zelda3::RoomEntrance, zelda3::kNumDungeonEntranceSlots>*
       entrances_ = nullptr;
+  std::array<zelda3::DungeonSpawnPoint, zelda3::kNumDungeonSpawnPoints>*
+      spawn_points_ = nullptr;
   int* current_entrance_id_ = nullptr;
   std::function<void(int)> on_entrance_selected_;
 };

--- a/test/test_utils/dungeon_editor_v2_regular_entrance_test_peer.h
+++ b/test/test_utils/dungeon_editor_v2_regular_entrance_test_peer.h
@@ -24,8 +24,8 @@ class DungeonEditorV2RegularEntranceTestPeer {
   }
 };
 
-// Narrow test-only access to the dedicated production spawn model. The editor
-// UI remains read-only until it is bound directly to these spawn-only fields.
+// Narrow test-only access to the dedicated production spawn model and its
+// entrance-selection routing.
 class DungeonEditorV2SpawnPointTestPeer {
  public:
   static absl::Status LoadSpawnPointFromRom(DungeonEditorV2& editor,
@@ -41,6 +41,32 @@ class DungeonEditorV2SpawnPointTestPeer {
   static zelda3::DungeonSpawnPoint& SpawnPoint(DungeonEditorV2& editor,
                                                int spawn_id) {
     return editor.spawn_points_.at(static_cast<size_t>(spawn_id));
+  }
+
+  static int ResolveEntranceRoomId(const DungeonEditorV2& editor,
+                                   int slot_index) {
+    return editor.ResolveEntranceRoomId(slot_index);
+  }
+
+  static void SelectEntrance(DungeonEditorV2& editor, int slot_index) {
+    editor.OnEntranceSelected(slot_index);
+  }
+
+  static int SelectedEntranceSlot(const DungeonEditorV2& editor) {
+    return editor.current_entrance_id_;
+  }
+
+  static int SelectorEntranceSlot(const DungeonEditorV2& editor) {
+    return editor.room_selector_.current_entrance_id();
+  }
+
+  static void SetSelectedEntranceSlot(DungeonEditorV2& editor, int slot_index) {
+    editor.current_entrance_id_ = slot_index;
+  }
+
+  static uint8_t ResolveSelectedBlockset(const DungeonEditorV2& editor,
+                                         int room_id) {
+    return editor.ResolveSelectedEntranceBlocksetForRoom(room_id);
   }
 };
 

--- a/test/unit/editor/dungeon_editor_palette_refresh_test.cc
+++ b/test/unit/editor/dungeon_editor_palette_refresh_test.cc
@@ -670,8 +670,11 @@ TEST_F(DungeonEditorPaletteRefreshTest,
   constexpr uint8_t kEntranceBlockset = 3;
   editor_->current_room_id_ = 0;
   editor_->current_entrance_id_ = 0;
-  editor_->entrances_[0].room_ = kCompareRoomId;
-  editor_->entrances_[0].blockset_ = kEntranceBlockset;
+  auto spawn_or = zelda3::DungeonSpawnPoint::Load(rom_, 0);
+  ASSERT_TRUE(spawn_or.ok()) << spawn_or.status();
+  editor_->spawn_points_[0] = *spawn_or;
+  editor_->spawn_points_[0].room_id = kCompareRoomId;
+  editor_->spawn_points_[0].main_gfx = kEntranceBlockset;
 
   DungeonCanvasViewer* compare_viewer =
       editor_->GetWorkbenchCompareViewer(kCompareRoomId);

--- a/test/unit/editor/dungeon_editor_v2_rom_safety_test.cc
+++ b/test/unit/editor/dungeon_editor_v2_rom_safety_test.cc
@@ -805,6 +805,71 @@ TEST(DungeonEditorV2RomSafetyTest,
 }
 
 TEST(DungeonEditorV2RomSafetyTest,
+     SpawnSelectionUsesDedicatedRoomAndMainGfxFields) {
+  constexpr int kSpawnId = 1;
+  constexpr int kRoomId = 0x0123;
+  constexpr uint8_t kMainGfx = 0x42;
+  Rom rom;
+  ASSERT_TRUE(rom.LoadFromData(std::vector<uint8_t>(0x200000, 0)).ok());
+  auto editor = std::make_unique<DungeonEditorV2>(&rom);
+  ASSERT_TRUE(DungeonEditorV2SpawnPointTestPeer::LoadSpawnPointFromRom(*editor,
+                                                                       kSpawnId)
+                  .ok());
+  auto& spawn =
+      DungeonEditorV2SpawnPointTestPeer::SpawnPoint(*editor, kSpawnId);
+  spawn.room_id = kRoomId;
+  spawn.main_gfx = kMainGfx;
+
+  EXPECT_EQ(DungeonEditorV2SpawnPointTestPeer::ResolveEntranceRoomId(*editor,
+                                                                     kSpawnId),
+            kRoomId);
+
+  DungeonEditorV2SpawnPointTestPeer::SetSelectedEntranceSlot(*editor, kSpawnId);
+  EXPECT_EQ(DungeonEditorV2SpawnPointTestPeer::ResolveSelectedBlockset(*editor,
+                                                                       kRoomId),
+            kMainGfx);
+  EXPECT_EQ(DungeonEditorV2SpawnPointTestPeer::ResolveSelectedBlockset(
+                *editor, kRoomId - 1),
+            0xFF);
+}
+
+TEST(DungeonEditorV2RomSafetyTest,
+     SpawnSelectionRejectsUnloadedDedicatedRecord) {
+  Rom rom;
+  ASSERT_TRUE(rom.LoadFromData(std::vector<uint8_t>(0x200000, 0)).ok());
+  auto editor = std::make_unique<DungeonEditorV2>(&rom);
+
+  EXPECT_EQ(
+      DungeonEditorV2SpawnPointTestPeer::ResolveEntranceRoomId(*editor, 0), -1);
+  DungeonEditorV2SpawnPointTestPeer::SetSelectedEntranceSlot(*editor, 0);
+  EXPECT_EQ(
+      DungeonEditorV2SpawnPointTestPeer::ResolveSelectedBlockset(*editor, 0),
+      0xFF);
+}
+
+TEST(DungeonEditorV2RomSafetyTest,
+     UnnavigableSpawnSelectionKeepsEditorAndSelectorInSync) {
+  Rom rom;
+  ASSERT_TRUE(rom.LoadFromData(std::vector<uint8_t>(0x200000, 0)).ok());
+  auto editor = std::make_unique<DungeonEditorV2>(&rom);
+  *editor->mutable_current_room_id() = 5;
+
+  DungeonEditorV2SpawnPointTestPeer::SelectEntrance(*editor, 1);
+
+  EXPECT_EQ(DungeonEditorV2SpawnPointTestPeer::SelectedEntranceSlot(*editor),
+            1);
+  EXPECT_EQ(DungeonEditorV2SpawnPointTestPeer::SelectorEntranceSlot(*editor),
+            1);
+  EXPECT_EQ(*editor->mutable_current_room_id(), 5);
+
+  DungeonEditorV2SpawnPointTestPeer::SelectEntrance(*editor, -1);
+  EXPECT_EQ(DungeonEditorV2SpawnPointTestPeer::SelectedEntranceSlot(*editor),
+            1);
+  EXPECT_EQ(DungeonEditorV2SpawnPointTestPeer::SelectorEntranceSlot(*editor),
+            1);
+}
+
+TEST(DungeonEditorV2RomSafetyTest,
      SaveRoomPersistsDedicatedSpawnPointAndClearsDirtyState) {
   constexpr int kSpawnId = 1;
   Rom rom;

--- a/test/unit/editor/dungeon_entrance_edit_policy_test.cc
+++ b/test/unit/editor/dungeon_entrance_edit_policy_test.cc
@@ -41,5 +41,60 @@ TEST(DungeonEntranceEditPolicyTest, RegularPropertyChangeMarksRecordDirty) {
   EXPECT_TRUE(entrance.dirty());
 }
 
+TEST(DungeonEntranceEditPolicyTest,
+     LoadedSpawnPropertyChangeMarksMatchingRecordDirty) {
+  Rom rom;
+  ASSERT_TRUE(rom.LoadFromData(std::vector<uint8_t>(0x200000, 0)).ok());
+
+  for (int slot = 0; slot < zelda3::kNumDungeonSpawnPoints; ++slot) {
+    auto spawn_or = zelda3::DungeonSpawnPoint::Load(rom, slot);
+    ASSERT_TRUE(spawn_or.ok()) << spawn_or.status();
+    auto spawn = *spawn_or;
+
+    EXPECT_TRUE(CanEditDungeonSpawnPoint(slot, spawn));
+    EXPECT_FALSE(MarkDungeonSpawnPointDirtyIfEditable(slot, spawn, false));
+    EXPECT_FALSE(spawn.dirty());
+    EXPECT_TRUE(MarkDungeonSpawnPointDirtyIfEditable(slot, spawn, true));
+    EXPECT_TRUE(spawn.dirty());
+  }
+}
+
+TEST(DungeonEntranceEditPolicyTest,
+     DedicatedSpawnSlotCannotMarkDefaultModelDirtyBeforeLoad) {
+  zelda3::DungeonSpawnPoint default_model;
+
+  EXPECT_FALSE(CanEditDungeonSpawnPoint(0, default_model));
+  EXPECT_FALSE(MarkDungeonSpawnPointDirtyIfEditable(0, default_model, true));
+  EXPECT_FALSE(default_model.dirty());
+}
+
+TEST(DungeonEntranceEditPolicyTest, SpawnSlotCannotMarkMismatchedRecordDirty) {
+  Rom rom;
+  ASSERT_TRUE(rom.LoadFromData(std::vector<uint8_t>(0x200000, 0)).ok());
+  auto spawn_or = zelda3::DungeonSpawnPoint::Load(rom, 1);
+  ASSERT_TRUE(spawn_or.ok()) << spawn_or.status();
+  auto spawn = *spawn_or;
+
+  EXPECT_FALSE(CanEditDungeonSpawnPoint(0, spawn));
+  EXPECT_FALSE(MarkDungeonSpawnPointDirtyIfEditable(0, spawn, true));
+  EXPECT_FALSE(spawn.dirty());
+}
+
+TEST(DungeonEntranceEditPolicyTest,
+     InvalidSpawnSlotsCannotMarkLoadedRecordDirty) {
+  Rom rom;
+  ASSERT_TRUE(rom.LoadFromData(std::vector<uint8_t>(0x200000, 0)).ok());
+  auto spawn_or = zelda3::DungeonSpawnPoint::Load(rom, 0);
+  ASSERT_TRUE(spawn_or.ok()) << spawn_or.status();
+
+  for (const int invalid_slot : {-1, zelda3::kNumDungeonSpawnPoints}) {
+    auto spawn = *spawn_or;
+    EXPECT_FALSE(CanEditDungeonSpawnPoint(invalid_slot, spawn));
+    EXPECT_FALSE(
+        MarkDungeonSpawnPointDirtyIfEditable(invalid_slot, spawn, true));
+    EXPECT_FALSE(spawn.dirty());
+  }
+}
+
 }  // namespace
 }  // namespace yaze::editor


### PR DESCRIPTION
## Summary
- bind spawn slots 0-6 to the dedicated `DungeonSpawnPoint` model
- route spawn navigation, listing, and render context through dedicated room/main-GFX fields
- fail closed on unloaded or mismatched records while keeping selection state synchronized
- keep the legacy compatibility inspector read-only and document the new ownership boundary

## Verification
- `cmake --build build/presets/mac-ai --target yaze_test_unit --parallel 8`
- focused combined filter: 56/56 passed
- `scripts/pre-push.sh --build-dir build/presets/mac-ai`
- independent strict review: no blockers

No GUI, emulator, project ROM, or canonical ROM was used or modified.
