### PR TITLE
fix(dungeon): guard minecart track drafts

### DIFF
--- a/src/app/editor/dungeon/dungeon_editor_v2.cc
+++ b/src/app/editor/dungeon/dungeon_editor_v2.cc
@@ -784,11 +784,10 @@ absl::Status DungeonEditorV2::Load() {
     minecart_track_editor_panel_ = minecart_panel.get();
 
     if (dependencies_.project) {
-      minecart_track_editor_panel_->SetProjectRoot(
-          dependencies_.project->code_folder);
+      RETURN_IF_ERROR(
+          minecart_track_editor_panel_->SetProject(dependencies_.project));
       minecart_track_editor_panel_->SetRooms(&rooms_);
       minecart_track_editor_panel_->SetRom(rom_);
-      minecart_track_editor_panel_->SetProject(dependencies_.project);
       minecart_track_editor_panel_->SetRoomNavigationCallback(
           [this](int room_id) { OnRoomSelected(room_id); });
     }
@@ -1283,6 +1282,10 @@ bool DungeonEditorV2::HasPendingRoomChanges() const {
 }
 
 bool DungeonEditorV2::HasPendingDungeonChanges() const {
+  if (minecart_track_editor_panel_ != nullptr &&
+      minecart_track_editor_panel_->HasUnpublishedChanges()) {
+    return true;
+  }
   if (object_tile_editor_panel_ != nullptr &&
       object_tile_editor_panel_->HasUnappliedChanges()) {
     return true;

--- a/src/app/editor/dungeon/dungeon_editor_v2.h
+++ b/src/app/editor/dungeon/dungeon_editor_v2.h
@@ -44,6 +44,7 @@ namespace editor {
 
 class CustomCollisionPanel;
 class DungeonEditorPaletteRefreshTestPeer;
+class DungeonEditorV2MinecartTrackTestPeer;
 class DungeonEditorV2ObjectTileEditorTestPeer;
 class DungeonEditorV2RegularEntranceTestPeer;
 class DungeonEditorV2ReloadTestPeer;
@@ -252,6 +253,7 @@ class DungeonEditorV2 : public Editor {
 
  private:
   friend class DungeonEditorPaletteRefreshTestPeer;
+  friend class DungeonEditorV2MinecartTrackTestPeer;
   friend class DungeonEditorV2ObjectTileEditorTestPeer;
   friend class DungeonEditorV2RegularEntranceTestPeer;
   friend class DungeonEditorV2ReloadTestPeer;

--- a/src/app/editor/dungeon/dungeon_editor_v2_persistence.cc
+++ b/src/app/editor/dungeon/dungeon_editor_v2_persistence.cc
@@ -522,6 +522,12 @@ absl::Status DungeonEditorV2::RunWithSaveTransaction(
 }
 
 absl::Status DungeonEditorV2::Save() {
+  if (minecart_track_editor_panel_ != nullptr &&
+      minecart_track_editor_panel_->HasUnpublishedChanges()) {
+    return absl::FailedPreconditionError(
+        "Minecart Track Editor drafts cannot yet be published safely; "
+        "explicitly discard them before using Save or Apply Room");
+  }
   if (!rom_ || !rom_->is_loaded()) {
     return absl::FailedPreconditionError("ROM not loaded");
   }
@@ -915,6 +921,12 @@ std::vector<std::pair<uint32_t, uint32_t>> DungeonEditorV2::CollectWriteRanges()
 }
 
 absl::Status DungeonEditorV2::SaveRoom(int room_id) {
+  if (minecart_track_editor_panel_ != nullptr &&
+      minecart_track_editor_panel_->HasUnpublishedChanges()) {
+    return absl::FailedPreconditionError(
+        "Minecart Track Editor drafts cannot yet be published safely; "
+        "explicitly discard them before using Save or Apply Room");
+  }
   if (object_tile_editor_panel_ != nullptr &&
       object_tile_editor_panel_->HasUnappliedChanges()) {
     return absl::FailedPreconditionError(

--- a/src/app/editor/dungeon/ui/window/minecart_track_editor_panel.cc
+++ b/src/app/editor/dungeon/ui/window/minecart_track_editor_panel.cc
@@ -550,6 +550,10 @@ void MinecartTrackEditorPanel::Draw(bool* p_open) {
   }
 
   ImGui::Text(tr("Minecart Track Editor"));
+  ImGui::TextColored(
+      ImVec4(1.0f, 0.8f, 0.2f, 1.0f), ICON_MD_WARNING
+      " Source publishing is disabled in this build; edits remain drafts "
+      "until discarded.");
   const bool has_unpublished_changes = HasUnpublishedChanges();
   if (!has_unpublished_changes) {
     ImGui::BeginDisabled();

--- a/src/app/editor/dungeon/ui/window/minecart_track_editor_panel.cc
+++ b/src/app/editor/dungeon/ui/window/minecart_track_editor_panel.cc
@@ -85,7 +85,8 @@ absl::StatusOr<std::vector<int>> ParseDwValues(const std::string& line,
 
   std::vector<int> values;
   for (absl::string_view operand_view : absl::StrSplit(operands, ',')) {
-    const std::string operand = Trim(operand_view);
+    const std::string operand =
+        Trim(std::string_view(operand_view.data(), operand_view.size()));
     if (operand.size() < 2 || operand.size() > 5 || operand[0] != '$' ||
         !std::all_of(operand.begin() + 1, operand.end(), [](char c) {
           return std::isxdigit(static_cast<unsigned char>(c));

--- a/src/app/editor/dungeon/ui/window/minecart_track_editor_panel.cc
+++ b/src/app/editor/dungeon/ui/window/minecart_track_editor_panel.cc
@@ -158,6 +158,22 @@ void MinecartTrackEditorPanel::ResetTrackSession() {
   audit_dirty_ = true;
 }
 
+absl::Status MinecartTrackEditorPanel::RefreshProjectBinding() {
+  const std::string current_filepath = project_ ? project_->filepath : "";
+  if (current_filepath == bound_project_filepath_) {
+    return absl::OkStatus();
+  }
+  if (HasUnpublishedChanges()) {
+    return absl::FailedPreconditionError(
+        "Project descriptor moved; discard minecart track drafts before "
+        "rebinding the source");
+  }
+
+  bound_project_filepath_ = current_filepath;
+  ResetTrackSession();
+  return absl::OkStatus();
+}
+
 absl::Status MinecartTrackEditorPanel::SetProject(
     project::YazeProject* project) {
   const std::string next_filepath = project ? project->filepath : "";
@@ -178,6 +194,11 @@ absl::Status MinecartTrackEditorPanel::SetProject(
 
 absl::StatusOr<std::filesystem::path>
 MinecartTrackEditorPanel::ResolveTrackSourcePath() const {
+  if (project_ != nullptr && project_->filepath != bound_project_filepath_) {
+    return absl::FailedPreconditionError(
+        "Project descriptor moved; reload minecart tracks to rebind the "
+        "source");
+  }
   if (project_ == nullptr || bound_project_filepath_.empty()) {
     return absl::FailedPreconditionError(
         "An open project descriptor is required for minecart tracks");
@@ -250,6 +271,10 @@ absl::Status MinecartTrackEditorPanel::DiscardUnpublishedChanges() {
 }
 
 absl::Status MinecartTrackEditorPanel::ReloadTracks() {
+  const absl::Status binding_status = RefreshProjectBinding();
+  if (!binding_status.ok()) {
+    return binding_status;
+  }
   if (HasUnpublishedChanges()) {
     return absl::FailedPreconditionError(
         "Discard minecart track drafts before reloading the source");
@@ -338,6 +363,12 @@ void MinecartTrackEditorPanel::DrawOverlaySettings() {
 }
 
 const std::vector<MinecartTrack>& MinecartTrackEditorPanel::GetTracks() {
+  const absl::Status binding_status = RefreshProjectBinding();
+  if (!binding_status.ok()) {
+    status_message_ = std::string(binding_status.message());
+    show_success_ = false;
+    return tracks_;
+  }
   if (!load_attempted_) {
     const absl::Status status = LoadTracks();
     if (!status.ok()) {
@@ -531,7 +562,18 @@ void MinecartTrackEditorPanel::RebuildAuditCache() {
 }
 
 void MinecartTrackEditorPanel::Draw(bool* p_open) {
-  if (project_ == nullptr || bound_project_filepath_.empty()) {
+  if (project_ == nullptr) {
+    ImGui::TextColored(ImVec4(1, 0, 0, 1),
+                       tr("Open a project to edit minecart tracks."));
+    return;
+  }
+
+  const absl::Status binding_status = RefreshProjectBinding();
+  if (!binding_status.ok()) {
+    status_message_ = std::string(binding_status.message());
+    show_success_ = false;
+  }
+  if (bound_project_filepath_.empty()) {
     ImGui::TextColored(ImVec4(1, 0, 0, 1),
                        tr("Open a project to edit minecart tracks."));
     return;
@@ -555,17 +597,9 @@ void MinecartTrackEditorPanel::Draw(bool* p_open) {
       " Source publishing is disabled in this build; edits remain drafts "
       "until discarded.");
   const bool has_unpublished_changes = HasUnpublishedChanges();
-  if (!has_unpublished_changes) {
-    ImGui::BeginDisabled();
-  }
-  if (ImGui::Button(ICON_MD_SAVE " Save Tracks")) {
-    const absl::Status status = SaveTracks();
-    status_message_ = std::string(status.message());
-    show_success_ = status.ok();
-  }
-  if (!has_unpublished_changes) {
-    ImGui::EndDisabled();
-  }
+  ImGui::BeginDisabled();
+  ImGui::Button(ICON_MD_SAVE " Publish Unavailable");
+  ImGui::EndDisabled();
   ImGui::SameLine();
   if (!has_unpublished_changes) {
     ImGui::BeginDisabled();
@@ -594,7 +628,10 @@ void MinecartTrackEditorPanel::Draw(bool* p_open) {
   if (ImGui::Button(ICON_MD_SAVE " Save Project")) {
     auto status = project_->Save();
     if (status.ok()) {
-      status_message_ = "Project saved.";
+      status_message_ = has_unpublished_changes
+                            ? "Project saved; minecart track drafts remain "
+                              "unsaved."
+                            : "Project saved.";
       show_success_ = true;
     } else {
       status_message_ =

--- a/src/app/editor/dungeon/ui/window/minecart_track_editor_panel.cc
+++ b/src/app/editor/dungeon/ui/window/minecart_track_editor_panel.cc
@@ -1,7 +1,14 @@
 #include "minecart_track_editor_panel.h"
+
+#include <algorithm>
+#include <cctype>
+#include <filesystem>
 #include <fstream>
 #include <iomanip>
 #include <sstream>
+#include <string_view>
+#include <system_error>
+
 #include "absl/status/status.h"
 #include "absl/strings/str_format.h"
 #include "absl/strings/str_split.h"
@@ -9,9 +16,6 @@
 #include "imgui/misc/cpp/imgui_stdlib.h"
 #include "util/i18n/tr.h"
 
-#include <filesystem>
-#include <iostream>
-#include <regex>
 #include "app/gui/core/icons.h"
 #include "app/gui/core/input.h"
 #include "app/gui/core/style_guard.h"
@@ -26,6 +30,83 @@ constexpr int kTrackSlotCount = 32;
 constexpr int kDefaultTrackRoom = 0x89;
 constexpr int kDefaultTrackX = 0x1300;
 constexpr int kDefaultTrackY = 0x1100;
+constexpr std::string_view kTrackSourceRelativePath =
+    "Sprites/Objects/data/minecart_tracks.asm";
+constexpr std::string_view kPlannedTrackGuard =
+    "if !ENABLE_MINECART_PLANNED_TRACK_TABLE == 1";
+
+std::string Trim(std::string_view value) {
+  size_t first = 0;
+  while (first < value.size() &&
+         std::isspace(static_cast<unsigned char>(value[first]))) {
+    ++first;
+  }
+  size_t last = value.size();
+  while (last > first &&
+         std::isspace(static_cast<unsigned char>(value[last - 1]))) {
+    --last;
+  }
+  return std::string(value.substr(first, last - first));
+}
+
+std::string StripCommentAndTrim(const std::string& line) {
+  const size_t comment = line.find(';');
+  return Trim(std::string_view(line).substr(0, comment));
+}
+
+bool IsStrictDescendant(const std::filesystem::path& path,
+                        const std::filesystem::path& root) {
+  auto path_it = path.begin();
+  auto root_it = root.begin();
+  for (; root_it != root.end(); ++root_it, ++path_it) {
+    if (path_it == path.end() || *path_it != *root_it) {
+      return false;
+    }
+  }
+  return path_it != path.end();
+}
+
+absl::StatusOr<std::vector<int>> ParseDwValues(const std::string& line,
+                                               const std::string& label) {
+  const std::string code = StripCommentAndTrim(line);
+  if (code.size() < 2 ||
+      std::tolower(static_cast<unsigned char>(code[0])) != 'd' ||
+      std::tolower(static_cast<unsigned char>(code[1])) != 'w' ||
+      (code.size() > 2 && !std::isspace(static_cast<unsigned char>(code[2])))) {
+    return absl::InvalidArgumentError(
+        absl::StrFormat("Unexpected statement in %s: %s", label, code));
+  }
+
+  const std::string operands = Trim(std::string_view(code).substr(2));
+  if (operands.empty()) {
+    return absl::InvalidArgumentError(
+        absl::StrFormat("Empty dw statement in %s", label));
+  }
+
+  std::vector<int> values;
+  for (absl::string_view operand_view : absl::StrSplit(operands, ',')) {
+    const std::string operand = Trim(operand_view);
+    if (operand.size() < 2 || operand.size() > 5 || operand[0] != '$' ||
+        !std::all_of(operand.begin() + 1, operand.end(), [](char c) {
+          return std::isxdigit(static_cast<unsigned char>(c));
+        })) {
+      return absl::InvalidArgumentError(absl::StrFormat(
+          "Invalid 16-bit hex value in %s: %s", label, operand));
+    }
+    try {
+      const unsigned long value = std::stoul(operand.substr(1), nullptr, 16);
+      if (value > 0xFFFF) {
+        return absl::InvalidArgumentError(
+            absl::StrFormat("Value out of range in %s: %s", label, operand));
+      }
+      values.push_back(static_cast<int>(value));
+    } catch (...) {
+      return absl::InvalidArgumentError(absl::StrFormat(
+          "Invalid 16-bit hex value in %s: %s", label, operand));
+    }
+  }
+  return values;
+}
 
 std::string FormatHexList(const std::vector<uint16_t>& values) {
   std::string out;
@@ -67,12 +148,113 @@ std::vector<uint16_t> ParseHexList(const std::string& input) {
 }
 }  // namespace
 
-void MinecartTrackEditorPanel::SetProjectRoot(const std::string& root) {
-  if (project_root_ != root) {
-    project_root_ = root;
-    loaded_ = false;  // Trigger reload on next draw
-    audit_dirty_ = true;
+void MinecartTrackEditorPanel::ResetTrackSession() {
+  tracks_.clear();
+  loaded_tracks_.clear();
+  load_attempted_ = false;
+  loaded_ = false;
+  source_is_guarded_ = false;
+  CancelCoordinatePicking();
+  audit_dirty_ = true;
+}
+
+absl::Status MinecartTrackEditorPanel::SetProject(
+    project::YazeProject* project) {
+  const std::string next_filepath = project ? project->filepath : "";
+  if (project_ == project && bound_project_filepath_ == next_filepath) {
+    return absl::OkStatus();
   }
+  if (HasUnpublishedChanges()) {
+    return absl::FailedPreconditionError(
+        "Discard minecart track drafts before changing projects");
+  }
+
+  project_ = project;
+  bound_project_filepath_ = next_filepath;
+  overlay_inputs_initialized_ = false;
+  ResetTrackSession();
+  return absl::OkStatus();
+}
+
+absl::StatusOr<std::filesystem::path>
+MinecartTrackEditorPanel::ResolveTrackSourcePath() const {
+  if (project_ == nullptr || bound_project_filepath_.empty()) {
+    return absl::FailedPreconditionError(
+        "An open project descriptor is required for minecart tracks");
+  }
+
+  std::error_code ec;
+  std::filesystem::path descriptor_path(bound_project_filepath_);
+  if (descriptor_path.is_relative()) {
+    descriptor_path = std::filesystem::absolute(descriptor_path, ec);
+    if (ec) {
+      return absl::InvalidArgumentError(absl::StrFormat(
+          "Could not resolve project descriptor path: %s", ec.message()));
+    }
+  }
+
+  const std::filesystem::path project_root =
+      std::filesystem::weakly_canonical(descriptor_path.parent_path(), ec);
+  if (ec || project_root.empty() ||
+      !std::filesystem::is_directory(project_root, ec) || ec) {
+    return absl::InvalidArgumentError(
+        "Project descriptor parent is not an existing directory");
+  }
+
+  const std::filesystem::path candidate =
+      project_root / kTrackSourceRelativePath;
+  const std::filesystem::path resolved =
+      std::filesystem::canonical(candidate, ec);
+  if (ec) {
+    return absl::NotFoundError(
+        absl::StrFormat("Minecart source not found: %s", candidate.string()));
+  }
+  if (!IsStrictDescendant(resolved, project_root)) {
+    return absl::PermissionDeniedError(
+        "Minecart source resolves outside the project root");
+  }
+  if (!std::filesystem::is_regular_file(resolved, ec) || ec) {
+    return absl::InvalidArgumentError(
+        "Minecart source must be an existing regular file");
+  }
+  return resolved;
+}
+
+bool MinecartTrackEditorPanel::HasUnpublishedChanges() const {
+  return loaded_ && tracks_ != loaded_tracks_;
+}
+
+absl::Status MinecartTrackEditorPanel::UpdateTrack(size_t track_index,
+                                                   const MinecartTrack& track) {
+  if (!loaded_) {
+    return absl::FailedPreconditionError("Minecart tracks are not loaded");
+  }
+  if (track_index >= tracks_.size()) {
+    return absl::InvalidArgumentError("Minecart track index is out of range");
+  }
+  MinecartTrack updated = track;
+  updated.id = static_cast<int>(track_index);
+  tracks_[track_index] = updated;
+  audit_dirty_ = true;
+  return absl::OkStatus();
+}
+
+absl::Status MinecartTrackEditorPanel::DiscardUnpublishedChanges() {
+  if (!loaded_) {
+    return absl::FailedPreconditionError("Minecart tracks are not loaded");
+  }
+  tracks_ = loaded_tracks_;
+  CancelCoordinatePicking();
+  audit_dirty_ = true;
+  return absl::OkStatus();
+}
+
+absl::Status MinecartTrackEditorPanel::ReloadTracks() {
+  if (HasUnpublishedChanges()) {
+    return absl::FailedPreconditionError(
+        "Discard minecart track drafts before reloading the source");
+  }
+  return LoadTracks();
 }
 
 void MinecartTrackEditorPanel::InitializeOverlayInputs() {
@@ -156,8 +338,12 @@ void MinecartTrackEditorPanel::DrawOverlaySettings() {
 }
 
 const std::vector<MinecartTrack>& MinecartTrackEditorPanel::GetTracks() {
-  if (!loaded_) {
-    LoadTracks();
+  if (!load_attempted_) {
+    const absl::Status status = LoadTracks();
+    if (!status.ok()) {
+      status_message_ = std::string(status.message());
+      show_success_ = false;
+    }
   }
   return tracks_;
 }
@@ -345,13 +531,18 @@ void MinecartTrackEditorPanel::RebuildAuditCache() {
 }
 
 void MinecartTrackEditorPanel::Draw(bool* p_open) {
-  if (project_root_.empty()) {
-    ImGui::TextColored(ImVec4(1, 0, 0, 1), tr("Project root not set."));
+  if (project_ == nullptr || bound_project_filepath_.empty()) {
+    ImGui::TextColored(ImVec4(1, 0, 0, 1),
+                       tr("Open a project to edit minecart tracks."));
     return;
   }
 
-  if (!loaded_) {
-    LoadTracks();
+  if (!load_attempted_) {
+    const absl::Status status = LoadTracks();
+    if (!status.ok()) {
+      status_message_ = std::string(status.message());
+      show_success_ = false;
+    }
   }
 
   if (audit_dirty_) {
@@ -359,8 +550,37 @@ void MinecartTrackEditorPanel::Draw(bool* p_open) {
   }
 
   ImGui::Text(tr("Minecart Track Editor"));
+  const bool has_unpublished_changes = HasUnpublishedChanges();
+  if (!has_unpublished_changes) {
+    ImGui::BeginDisabled();
+  }
   if (ImGui::Button(ICON_MD_SAVE " Save Tracks")) {
-    SaveTracks();
+    const absl::Status status = SaveTracks();
+    status_message_ = std::string(status.message());
+    show_success_ = status.ok();
+  }
+  if (!has_unpublished_changes) {
+    ImGui::EndDisabled();
+  }
+  ImGui::SameLine();
+  if (!has_unpublished_changes) {
+    ImGui::BeginDisabled();
+  }
+  if (ImGui::Button(ICON_MD_RESTORE " Discard Drafts")) {
+    const absl::Status status = DiscardUnpublishedChanges();
+    status_message_ = status.ok() ? "Minecart track drafts discarded."
+                                  : std::string(status.message());
+    show_success_ = status.ok();
+  }
+  if (!has_unpublished_changes) {
+    ImGui::EndDisabled();
+  }
+  ImGui::SameLine();
+  if (ImGui::Button(ICON_MD_REFRESH " Reload Source")) {
+    const absl::Status status = ReloadTracks();
+    status_message_ = status.ok() ? "Minecart track source reloaded."
+                                  : std::string(status.message());
+    show_success_ = status.ok();
   }
   ImGui::SameLine();
   const bool can_save_project = project_ && project_->project_opened();
@@ -457,6 +677,7 @@ void MinecartTrackEditorPanel::Draw(bool* p_open) {
       if (yaze::gui::InputHexWordCustom(
               absl::StrFormat("##Room%d", track.id).c_str(), &room_id, 60.0f)) {
         track.room_id = room_id;
+        audit_dirty_ = true;
       }
 
       ImGui::TableNextColumn();
@@ -465,6 +686,7 @@ void MinecartTrackEditorPanel::Draw(bool* p_open) {
               absl::StrFormat("##StartX%d", track.id).c_str(), &start_x,
               60.0f)) {
         track.start_x = start_x;
+        audit_dirty_ = true;
       }
 
       ImGui::TableNextColumn();
@@ -473,6 +695,7 @@ void MinecartTrackEditorPanel::Draw(bool* p_open) {
               absl::StrFormat("##StartY%d", track.id).c_str(), &start_y,
               60.0f)) {
         track.start_y = start_y;
+        audit_dirty_ = true;
       }
 
       // Pick button to select coordinates from canvas
@@ -725,143 +948,200 @@ void MinecartTrackEditorPanel::Draw(bool* p_open) {
   }
 }
 
-void MinecartTrackEditorPanel::LoadTracks() {
-  std::filesystem::path path = std::filesystem::path(project_root_) /
-                               "Sprites/Objects/data/minecart_tracks.asm";
+absl::Status MinecartTrackEditorPanel::LoadTracks() {
+  load_attempted_ = true;
 
-  if (!std::filesystem::exists(path)) {
-    status_message_ = "File not found: " + path.string();
-    show_success_ = false;
-    loaded_ = true;  // Prevent retry loop
-    tracks_.clear();
-    return;
+  auto path_or = ResolveTrackSourcePath();
+  if (!path_or.ok()) {
+    return path_or.status();
   }
 
-  std::ifstream file(path);
+  std::ifstream file(*path_or, std::ios::binary);
+  if (!file.is_open()) {
+    return absl::NotFoundError(absl::StrFormat(
+        "Could not open minecart source: %s", path_or->string()));
+  }
   std::stringstream buffer;
   buffer << file.rdbuf();
-  std::string content = buffer.str();
-
-  std::vector<int> rooms;
-  std::vector<int> xs;
-  std::vector<int> ys;
-
-  if (!ParseSection(content, ".TrackStartingRooms", rooms) ||
-      !ParseSection(content, ".TrackStartingX", xs) ||
-      !ParseSection(content, ".TrackStartingY", ys)) {
-    status_message_ = "Error parsing file format.";
-    show_success_ = false;
-  } else {
-    tracks_.clear();
-    size_t count = std::min({rooms.size(), xs.size(), ys.size()});
-    for (size_t i = 0; i < count; ++i) {
-      tracks_.push_back({(int)i, rooms[i], xs[i], ys[i]});
-    }
-    while (tracks_.size() < kTrackSlotCount) {
-      tracks_.push_back({static_cast<int>(tracks_.size()), kDefaultTrackRoom,
-                         kDefaultTrackX, kDefaultTrackY});
-    }
-    status_message_ = "";
-    show_success_ = true;
+  if (file.bad()) {
+    return absl::DataLossError(absl::StrFormat(
+        "Could not read minecart source: %s", path_or->string()));
   }
-  audit_dirty_ = true;
+  const std::string content = buffer.str();
+
+  auto rooms_or = ParseSection(content, ".TrackStartingRooms");
+  if (!rooms_or.ok()) {
+    return rooms_or.status();
+  }
+  auto xs_or = ParseSection(content, ".TrackStartingX");
+  if (!xs_or.ok()) {
+    return xs_or.status();
+  }
+  auto ys_or = ParseSection(content, ".TrackStartingY");
+  if (!ys_or.ok()) {
+    return ys_or.status();
+  }
+  if (rooms_or->guarded != xs_or->guarded ||
+      rooms_or->guarded != ys_or->guarded) {
+    return absl::InvalidArgumentError(
+        "Minecart sections must use the same flat or guarded layout");
+  }
+
+  std::vector<MinecartTrack> candidate_tracks;
+  candidate_tracks.reserve(kTrackSlotCount);
+  for (size_t i = 0; i < kTrackSlotCount; ++i) {
+    candidate_tracks.push_back({static_cast<int>(i), rooms_or->values[i],
+                                xs_or->values[i], ys_or->values[i]});
+  }
+
+  tracks_ = candidate_tracks;
+  loaded_tracks_ = std::move(candidate_tracks);
+  source_is_guarded_ = rooms_or->guarded;
   loaded_ = true;
-}
-
-bool MinecartTrackEditorPanel::ParseSection(const std::string& content,
-                                            const std::string& label,
-                                            std::vector<int>& out_values) {
-  size_t pos = content.find(label);
-  if (pos == std::string::npos)
-    return false;
-
-  // Start searching after the label
-  size_t start = pos + label.length();
-
-  // Find lines starting with 'dw'
-  std::regex dw_regex(R"(dw\s+((?:\$[0-9A-Fa-f]{4}(?:,\s*)?)+))");
-
-  // Create a substring from start to end or next label (simplified: just search until next dot label or end)
-  // Actually, searching line by line is safer.
-  std::stringstream ss(content.substr(start));
-  std::string line;
-  while (std::getline(ss, line)) {
-    // Stop if we hit another label
-    size_t trimmed_start = line.find_first_not_of(" \t");
-    if (trimmed_start != std::string::npos && line[trimmed_start] == '.')
-      break;
-
-    std::smatch match;
-    if (std::regex_search(line, match, dw_regex)) {
-      std::string values_str = match[1];
-      std::stringstream val_ss(values_str);
-      std::string segment;
-      while (std::getline(val_ss, segment, ',')) {
-        // Trim
-        segment.erase(0, segment.find_first_not_of(" \t$"));
-        // Parse hex
-        try {
-          out_values.push_back(std::stoi(segment, nullptr, 16));
-        } catch (...) {}
-      }
-    }
-  }
-  return true;
-}
-
-void MinecartTrackEditorPanel::SaveTracks() {
-  std::filesystem::path path = std::filesystem::path(project_root_) /
-                               "Sprites/Objects/data/minecart_tracks.asm";
-
-  std::ofstream file(path);
-  if (!file.is_open()) {
-    status_message_ = "Failed to open file for writing.";
-    show_success_ = false;
-    return;
-  }
-
-  std::vector<int> rooms, xs, ys;
-  for (const auto& t : tracks_) {
-    rooms.push_back(t.room_id);
-    xs.push_back(t.start_x);
-    ys.push_back(t.start_y);
-  }
-
-  file << "  ; This is which room each track should start in if it hasn't "
-          "already\n";
-  file << "  ; been given a track.\n";
-  file << FormatSection(".TrackStartingRooms", rooms);
-  file << "\n";
-
-  file << "  ; This is where within the room each track should start in if it "
-          "hasn't\n";
-  file << "  ; already been given a position. This is necessary to allow for "
-          "more\n";
-  file << "  ; than one stopping point to be in one room.\n";
-  file << FormatSection(".TrackStartingX", xs);
-  file << "\n";
-
-  file << FormatSection(".TrackStartingY", ys);
-
-  status_message_ = "Tracks saved successfully!";
+  audit_dirty_ = true;
+  status_message_.clear();
   show_success_ = true;
+  return absl::OkStatus();
 }
 
-std::string MinecartTrackEditorPanel::FormatSection(
-    const std::string& label, const std::vector<int>& values) {
-  std::stringstream ss;
-  ss << "  " << label << "\n";
-
-  for (size_t i = 0; i < values.size(); i += 8) {
-    ss << "  dw ";
-    for (size_t j = 0; j < 8 && i + j < values.size(); ++j) {
-      if (j > 0)
-        ss << ", ";
-      ss << absl::StrFormat("$%04X", values[i + j]);
-    }
-    ss << "\n";
+absl::StatusOr<MinecartTrackEditorPanel::ParsedSection>
+MinecartTrackEditorPanel::ParseSection(const std::string& content,
+                                       const std::string& label) {
+  std::vector<std::string> lines;
+  std::stringstream stream(content);
+  std::string line;
+  while (std::getline(stream, line)) {
+    lines.push_back(line);
   }
-  return ss.str();
+
+  size_t section_line = 0;
+  int label_count = 0;
+  for (size_t i = 0; i < lines.size(); ++i) {
+    if (StripCommentAndTrim(lines[i]) == label) {
+      section_line = i;
+      ++label_count;
+    }
+  }
+  if (label_count != 1) {
+    return absl::InvalidArgumentError(absl::StrFormat(
+        "Expected exactly one %s label, found %d", label, label_count));
+  }
+
+  size_t section_end = lines.size();
+  for (size_t i = section_line + 1; i < lines.size(); ++i) {
+    const std::string code = StripCommentAndTrim(lines[i]);
+    if (!code.empty() && code[0] == '.') {
+      section_end = i;
+      break;
+    }
+  }
+
+  enum class GuardState { kPrefix, kEnabled, kDisabled, kComplete };
+  GuardState state = GuardState::kPrefix;
+  bool saw_guard = false;
+  bool saw_else = false;
+  bool saw_endif = false;
+  std::vector<int> prefix;
+  std::vector<int> enabled;
+  std::vector<int> disabled;
+
+  for (size_t i = section_line + 1; i < section_end; ++i) {
+    const std::string code = StripCommentAndTrim(lines[i]);
+    if (code.empty()) {
+      continue;
+    }
+    if (code == kPlannedTrackGuard) {
+      if (state != GuardState::kPrefix || saw_guard) {
+        return absl::InvalidArgumentError(
+            absl::StrFormat("Nested or repeated guard in %s", label));
+      }
+      saw_guard = true;
+      state = GuardState::kEnabled;
+      continue;
+    }
+    if (code == "else") {
+      if (!saw_guard || state != GuardState::kEnabled || saw_else) {
+        return absl::InvalidArgumentError(
+            absl::StrFormat("Unexpected else in %s", label));
+      }
+      saw_else = true;
+      state = GuardState::kDisabled;
+      continue;
+    }
+    if (code == "endif") {
+      if (!saw_else || state != GuardState::kDisabled || saw_endif) {
+        return absl::InvalidArgumentError(
+            absl::StrFormat("Unexpected endif in %s", label));
+      }
+      saw_endif = true;
+      state = GuardState::kComplete;
+      continue;
+    }
+    if (state == GuardState::kComplete) {
+      return absl::InvalidArgumentError(absl::StrFormat(
+          "Unexpected content after guarded table in %s: %s", label, code));
+    }
+
+    auto values_or = ParseDwValues(lines[i], label);
+    if (!values_or.ok()) {
+      return values_or.status();
+    }
+    std::vector<int>* destination = &prefix;
+    if (state == GuardState::kEnabled) {
+      destination = &enabled;
+    } else if (state == GuardState::kDisabled) {
+      destination = &disabled;
+    }
+    destination->insert(destination->end(), values_or->begin(),
+                        values_or->end());
+  }
+
+  ParsedSection result;
+  if (!saw_guard) {
+    if (prefix.size() != kTrackSlotCount) {
+      return absl::InvalidArgumentError(
+          absl::StrFormat("%s must contain exactly %d values; found %zu", label,
+                          kTrackSlotCount, prefix.size()));
+    }
+    result.values = std::move(prefix);
+    return result;
+  }
+
+  if (!saw_else || !saw_endif) {
+    return absl::InvalidArgumentError(
+        absl::StrFormat("Incomplete planned-track guard in %s", label));
+  }
+  if (prefix.size() + enabled.size() != kTrackSlotCount ||
+      prefix.size() + disabled.size() != kTrackSlotCount) {
+    return absl::InvalidArgumentError(absl::StrFormat(
+        "%s guarded branches must each resolve to exactly %d values; found "
+        "%zu enabled and %zu disabled",
+        label, kTrackSlotCount, prefix.size() + enabled.size(),
+        prefix.size() + disabled.size()));
+  }
+
+  result.values = prefix;
+  result.values.insert(result.values.end(), enabled.begin(), enabled.end());
+  result.guarded = true;
+  return result;
+}
+
+absl::Status MinecartTrackEditorPanel::SaveTracks() {
+  if (!loaded_) {
+    return absl::FailedPreconditionError("Minecart tracks are not loaded");
+  }
+  if (!HasUnpublishedChanges()) {
+    return absl::FailedPreconditionError(
+        "No unpublished minecart track drafts to save");
+  }
+  if (source_is_guarded_) {
+    return absl::FailedPreconditionError(
+        "Guarded minecart source publishing is disabled until a lossless "
+        "publisher is available; drafts were kept");
+  }
+  return absl::UnimplementedError(
+      "Minecart source publishing is disabled until atomic source guards are "
+      "available; drafts were kept");
 }
 
 }  // namespace yaze::editor

--- a/src/app/editor/dungeon/ui/window/minecart_track_editor_panel.h
+++ b/src/app/editor/dungeon/ui/window/minecart_track_editor_panel.h
@@ -83,6 +83,7 @@ class MinecartTrackEditorPanel : public WindowContent {
   absl::Status LoadTracks();
   static absl::StatusOr<ParsedSection> ParseSection(const std::string& content,
                                                     const std::string& label);
+  absl::Status RefreshProjectBinding();
   void ResetTrackSession();
   void StartCoordinatePicking(int track_index);
   void CancelCoordinatePicking();

--- a/src/app/editor/dungeon/ui/window/minecart_track_editor_panel.h
+++ b/src/app/editor/dungeon/ui/window/minecart_track_editor_panel.h
@@ -3,11 +3,14 @@
 
 #include <array>
 #include <cstdint>
+#include <filesystem>
 #include <functional>
 #include <string>
 #include <unordered_map>
 #include <vector>
 
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
 #include "app/editor/dungeon/dungeon_room_store.h"
 #include "app/gui/core/icons.h"
 #include "core/project.h"
@@ -21,6 +24,8 @@ struct MinecartTrack {
   int room_id;
   int start_x;
   int start_y;
+
+  bool operator==(const MinecartTrack&) const = default;
 };
 
 }  // namespace yaze::editor
@@ -31,8 +36,7 @@ namespace yaze::editor {
 
 class MinecartTrackEditorPanel : public WindowContent {
  public:
-  explicit MinecartTrackEditorPanel(const std::string& start_root = "")
-      : project_root_(start_root) {}
+  MinecartTrackEditorPanel() = default;
 
   // WindowContent overrides
   std::string GetId() const override { return "dungeon.minecart_tracks"; }
@@ -43,18 +47,18 @@ class MinecartTrackEditorPanel : public WindowContent {
   void Draw(bool* p_open) override;
 
   // Custom methods
-  void SetProjectRoot(const std::string& root);
   void SetRooms(DungeonRoomStore* rooms) {
     rooms_ = rooms;
     audit_dirty_ = true;
   }
-  void SetProject(project::YazeProject* project) {
-    project_ = project;
-    overlay_inputs_initialized_ = false;
-    audit_dirty_ = true;
-  }
+  absl::Status SetProject(project::YazeProject* project);
   void SetRom(Rom* rom) { rom_ = rom; }
-  void SaveTracks();
+  absl::Status SaveTracks();
+  absl::Status ReloadTracks();
+  absl::Status DiscardUnpublishedChanges();
+  bool HasUnpublishedChanges() const;
+  absl::StatusOr<std::filesystem::path> ResolveTrackSourcePath() const;
+  absl::Status UpdateTrack(size_t track_index, const MinecartTrack& track);
 
   // Coordinate picking from dungeon canvas
   // When picking mode is active, the next canvas click will set the coordinates
@@ -71,11 +75,15 @@ class MinecartTrackEditorPanel : public WindowContent {
   }
 
  private:
-  void LoadTracks();
-  bool ParseSection(const std::string& content, const std::string& label,
-                    std::vector<int>& out_values);
-  std::string FormatSection(const std::string& label,
-                            const std::vector<int>& values);
+  struct ParsedSection {
+    std::vector<int> values;
+    bool guarded = false;
+  };
+
+  absl::Status LoadTracks();
+  static absl::StatusOr<ParsedSection> ParseSection(const std::string& content,
+                                                    const std::string& label);
+  void ResetTrackSession();
   void StartCoordinatePicking(int track_index);
   void CancelCoordinatePicking();
   void RebuildAuditCache();
@@ -94,7 +102,8 @@ class MinecartTrackEditorPanel : public WindowContent {
   };
 
   std::vector<MinecartTrack> tracks_;
-  std::string project_root_;
+  std::vector<MinecartTrack> loaded_tracks_;
+  std::string bound_project_filepath_;
   Rom* rom_ = nullptr;
   DungeonRoomStore* rooms_ = nullptr;
   project::YazeProject* project_ = nullptr;
@@ -102,7 +111,9 @@ class MinecartTrackEditorPanel : public WindowContent {
   std::unordered_map<int, std::vector<int>> track_usage_rooms_;
   std::vector<bool> track_subtype_used_;
   bool audit_dirty_ = true;
+  bool load_attempted_ = false;
   bool loaded_ = false;
+  bool source_is_guarded_ = false;
   std::string status_message_;
   bool show_success_ = false;
   float success_timer_ = 0.0f;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -299,6 +299,7 @@ if(YAZE_BUILD_TESTS)
     unit/editor/dungeon_object_selector_palette_test.cc
     unit/editor/dungeon_workbench_toolbar_test.cc
     unit/editor/object_tile_editor_panel_test.cc
+    unit/editor/minecart_track_editor_panel_test.cc
     unit/editor/toast_dedup_test.cc
     unit/editor/tile_painting_manager_test.cc
     unit/editor/tile16_editor_action_state_test.cc
@@ -592,6 +593,7 @@ if(YAZE_BUILD_TESTS)
     unit/editor/dungeon_workbench_toolbar_test.cc
     unit/editor/dungeon_workbench_content_test.cc
     unit/editor/object_tile_editor_panel_test.cc
+    unit/editor/minecart_track_editor_panel_test.cc
     unit/editor/project_manager_validator_test.cc
     unit/editor/tile_painting_manager_test.cc
     unit/editor/tile16_editor_shortcuts_test.cc

--- a/test/unit/editor/minecart_track_editor_panel_test.cc
+++ b/test/unit/editor/minecart_track_editor_panel_test.cc
@@ -255,6 +255,51 @@ TEST(MinecartTrackEditorPanelTest,
   EXPECT_EQ(panel.GetTracks()[0].room_id, 0x0300);
 }
 
+TEST(MinecartTrackEditorPanelTest,
+     DescriptorRelocationRebindsWhenCleanAndPreservesDraftWhenDirty) {
+  ScopedTestProject first_project;
+  first_project.WriteSource(MakeFlatSource(32, /*room_base=*/0x0100));
+  ScopedTestProject second_project;
+  second_project.WriteSource(MakeFlatSource(32, /*room_base=*/0x0300));
+
+  project::YazeProject* project = first_project.project();
+  const std::string first_filepath = project->filepath;
+  const std::string second_filepath = second_project.project()->filepath;
+  MinecartTrackEditorPanel panel;
+  ASSERT_TRUE(panel.SetProject(project).ok());
+  ASSERT_TRUE(panel.ReloadTracks().ok());
+  EXPECT_EQ(panel.GetTracks()[0].room_id, 0x0100);
+
+  project->filepath = second_filepath;
+  ASSERT_TRUE(panel.ReloadTracks().ok());
+  EXPECT_EQ(panel.GetTracks()[0].room_id, 0x0300);
+  ASSERT_TRUE(panel.ResolveTrackSourcePath().ok());
+  EXPECT_EQ(*panel.ResolveTrackSourcePath(),
+            std::filesystem::canonical(second_project.source_path()));
+
+  MinecartTrack draft = panel.GetTracks()[0];
+  draft.room_id = 0x0777;
+  ASSERT_TRUE(panel.UpdateTrack(0, draft).ok());
+  project->filepath = first_filepath;
+
+  const absl::Status relocation_status = panel.ReloadTracks();
+  EXPECT_TRUE(absl::IsFailedPrecondition(relocation_status))
+      << relocation_status;
+  EXPECT_NE(std::string(relocation_status.message()).find("descriptor moved"),
+            std::string::npos);
+  EXPECT_EQ(panel.GetTracks()[0].room_id, 0x0777);
+  EXPECT_TRUE(panel.HasUnpublishedChanges());
+  EXPECT_TRUE(
+      absl::IsFailedPrecondition(panel.ResolveTrackSourcePath().status()));
+
+  project->filepath = second_filepath;
+  ASSERT_TRUE(panel.ResolveTrackSourcePath().ok());
+  EXPECT_EQ(*panel.ResolveTrackSourcePath(),
+            std::filesystem::canonical(second_project.source_path()));
+  ASSERT_TRUE(panel.DiscardUnpublishedChanges().ok());
+  EXPECT_EQ(panel.GetTracks()[0].room_id, 0x0300);
+}
+
 TEST(MinecartTrackEditorPanelTest, RejectsSourceSymlinkOutsideProjectRoot) {
   ScopedTestProject fixture;
   std::filesystem::create_directories(fixture.source_path().parent_path());
@@ -264,12 +309,10 @@ TEST(MinecartTrackEditorPanelTest, RejectsSourceSymlinkOutsideProjectRoot) {
   std::error_code symlink_error;
   std::filesystem::create_symlink(outside_source, fixture.source_path(),
                                   symlink_error);
-  if (symlink_error == std::errc::operation_not_permitted ||
-      symlink_error == std::errc::permission_denied) {
+  if (symlink_error) {
     GTEST_SKIP() << "Symlink creation is not permitted: "
                  << symlink_error.message();
   }
-  ASSERT_FALSE(symlink_error) << symlink_error.message();
 
   MinecartTrackEditorPanel panel;
   ASSERT_TRUE(panel.SetProject(fixture.project()).ok());

--- a/test/unit/editor/minecart_track_editor_panel_test.cc
+++ b/test/unit/editor/minecart_track_editor_panel_test.cc
@@ -1,0 +1,335 @@
+#include "app/editor/dungeon/ui/window/minecart_track_editor_panel.h"
+
+#include <chrono>
+#include <filesystem>
+#include <fstream>
+#include <sstream>
+#include <string>
+#include <vector>
+
+#include "absl/status/status.h"
+#include "absl/strings/str_format.h"
+#include "app/editor/dungeon/dungeon_editor_v2.h"
+#include "core/project.h"
+#include "gtest/gtest.h"
+#include "rom/rom.h"
+
+namespace yaze::editor {
+
+class DungeonEditorV2MinecartTrackTestPeer {
+ public:
+  static void SetMinecartTrackEditorPanel(DungeonEditorV2& editor,
+                                          MinecartTrackEditorPanel* panel) {
+    editor.minecart_track_editor_panel_ = panel;
+  }
+};
+
+namespace {
+
+constexpr char kTrackSourceRelativePath[] =
+    "Sprites/Objects/data/minecart_tracks.asm";
+
+class ScopedTestProject {
+ public:
+  ScopedTestProject() {
+    const auto nonce =
+        std::chrono::steady_clock::now().time_since_epoch().count();
+    root_ = std::filesystem::temp_directory_path() /
+            ("yaze_minecart_stoploss_" + std::to_string(nonce));
+    outside_root_ = root_.string() + "_outside";
+    std::filesystem::create_directories(root_);
+    std::filesystem::create_directories(outside_root_);
+    project_.name = "Minecart Test";
+    project_.filepath = (root_ / "Oracle-of-Secrets.yaze").string();
+    project_.code_folder = (root_ / "Core").string();
+    std::ofstream(project_.filepath) << "name=Minecart Test\n";
+  }
+
+  ~ScopedTestProject() {
+    std::error_code ec;
+    std::filesystem::remove_all(root_, ec);
+    std::filesystem::remove_all(outside_root_, ec);
+  }
+
+  project::YazeProject* project() { return &project_; }
+  const std::filesystem::path& root() const { return root_; }
+  const std::filesystem::path& outside_root() const { return outside_root_; }
+  std::filesystem::path source_path() const {
+    return root_ / kTrackSourceRelativePath;
+  }
+
+  void WriteSource(const std::string& contents) {
+    std::filesystem::create_directories(source_path().parent_path());
+    std::ofstream file(source_path(), std::ios::binary | std::ios::trunc);
+    file << contents;
+  }
+
+  std::string ReadSource() const {
+    std::ifstream file(source_path(), std::ios::binary);
+    std::stringstream buffer;
+    buffer << file.rdbuf();
+    return buffer.str();
+  }
+
+ private:
+  std::filesystem::path root_;
+  std::filesystem::path outside_root_;
+  project::YazeProject project_;
+};
+
+void AppendDwValues(std::stringstream& stream, int first_value, int count) {
+  for (int i = 0; i < count; i += 8) {
+    stream << "  dw ";
+    for (int j = 0; j < 8 && i + j < count; ++j) {
+      if (j > 0) {
+        stream << ", ";
+      }
+      stream << absl::StrFormat("$%04X", first_value + i + j);
+    }
+    stream << "\n";
+  }
+}
+
+std::string MakeFlatSection(const std::string& label, int first_value,
+                            int count) {
+  std::stringstream stream;
+  stream << "  " << label << "\n";
+  AppendDwValues(stream, first_value, count);
+  return stream.str();
+}
+
+std::string MakeGuardedSection(const std::string& label, int first_value,
+                               int disabled_value, int enabled_count = 28,
+                               int disabled_count = 28) {
+  std::stringstream stream;
+  stream << "  " << label << "\n";
+  AppendDwValues(stream, first_value, 4);
+  stream << "  if !ENABLE_MINECART_PLANNED_TRACK_TABLE == 1\n";
+  AppendDwValues(stream, first_value + 4, enabled_count);
+  stream << "  else\n";
+  AppendDwValues(stream, disabled_value, disabled_count);
+  stream << "  endif\n";
+  return stream.str();
+}
+
+std::string MakeFlatSource(int count, int room_base = 0x0100) {
+  return MakeFlatSection(".TrackStartingRooms", room_base, count) + "\n" +
+         MakeFlatSection(".TrackStartingX", 0x1000, count) + "\n" +
+         MakeFlatSection(".TrackStartingY", 0x2000, count);
+}
+
+std::string MakeGuardedSource(int room_base = 0x0200) {
+  return MakeGuardedSection(".TrackStartingRooms", room_base, 0x0000) + "\n" +
+         MakeGuardedSection(".TrackStartingX", 0x1100, 0x0000) + "\n" +
+         MakeGuardedSection(".TrackStartingY", 0x2100, 0x0000);
+}
+
+std::string MakeGuardedSourceWithRoomBranchCounts(int enabled_count,
+                                                  int disabled_count) {
+  return MakeGuardedSection(".TrackStartingRooms", 0x0200, 0x0000,
+                            enabled_count, disabled_count) +
+         "\n" + MakeGuardedSection(".TrackStartingX", 0x1100, 0x0000) + "\n" +
+         MakeGuardedSection(".TrackStartingY", 0x2100, 0x0000);
+}
+
+std::string MakeMalformedSource() {
+  std::string source = MakeFlatSource(32);
+  const size_t first_dw = source.find("dw ");
+  source.replace(first_dw, 2, "db");
+  return source;
+}
+
+}  // namespace
+
+TEST(MinecartTrackEditorPanelTest,
+     ResolvesCanonicalSourceFromProjectRootAndParsesGuardedFirstBranch) {
+  ScopedTestProject fixture;
+  fixture.WriteSource(MakeGuardedSource(/*room_base=*/0x0200));
+
+  const std::filesystem::path wrong_source =
+      std::filesystem::path(fixture.project()->code_folder) /
+      kTrackSourceRelativePath;
+  std::filesystem::create_directories(wrong_source.parent_path());
+  std::ofstream(wrong_source) << MakeFlatSource(32, /*room_base=*/0x4400);
+
+  MinecartTrackEditorPanel panel;
+  ASSERT_TRUE(panel.SetProject(fixture.project()).ok());
+  ASSERT_TRUE(panel.ReloadTracks().ok());
+
+  const auto& tracks = panel.GetTracks();
+  ASSERT_EQ(tracks.size(), 32u);
+  EXPECT_EQ(tracks.front().room_id, 0x0200);
+  EXPECT_EQ(tracks[3].room_id, 0x0203);
+  EXPECT_EQ(tracks[4].room_id, 0x0204);
+  EXPECT_EQ(tracks.back().room_id, 0x021F);
+  ASSERT_TRUE(panel.ResolveTrackSourcePath().ok());
+  EXPECT_EQ(*panel.ResolveTrackSourcePath(),
+            std::filesystem::canonical(fixture.source_path()));
+  EXPECT_FALSE(panel.HasUnpublishedChanges());
+}
+
+TEST(MinecartTrackEditorPanelTest, FlatSourceRequiresExactly32Entries) {
+  ScopedTestProject fixture;
+  fixture.WriteSource(MakeFlatSource(32));
+
+  MinecartTrackEditorPanel panel;
+  ASSERT_TRUE(panel.SetProject(fixture.project()).ok());
+  ASSERT_TRUE(panel.ReloadTracks().ok());
+
+  ASSERT_EQ(panel.GetTracks().size(), 32u);
+  EXPECT_EQ(panel.GetTracks().front().room_id, 0x0100);
+  EXPECT_EQ(panel.GetTracks().back().room_id, 0x011F);
+  EXPECT_TRUE(absl::IsFailedPrecondition(panel.SaveTracks()));
+
+  const std::string source_before = fixture.ReadSource();
+  MinecartTrack draft = panel.GetTracks().front();
+  draft.room_id = 0x0777;
+  ASSERT_TRUE(panel.UpdateTrack(0, draft).ok());
+  EXPECT_TRUE(absl::IsUnimplemented(panel.SaveTracks()));
+  EXPECT_EQ(fixture.ReadSource(), source_before);
+  EXPECT_TRUE(panel.HasUnpublishedChanges());
+}
+
+TEST(MinecartTrackEditorPanelTest,
+     MalformedReloadPreservesPriorModelAndLoadedBaseline) {
+  ScopedTestProject fixture;
+  fixture.WriteSource(MakeFlatSource(32));
+
+  MinecartTrackEditorPanel panel;
+  ASSERT_TRUE(panel.SetProject(fixture.project()).ok());
+  ASSERT_TRUE(panel.ReloadTracks().ok());
+  const std::vector<MinecartTrack> original = panel.GetTracks();
+
+  for (const std::string& invalid_source :
+       {MakeMalformedSource(), MakeFlatSource(0), MakeFlatSource(33),
+        MakeGuardedSourceWithRoomBranchCounts(/*enabled_count=*/27,
+                                              /*disabled_count=*/28),
+        MakeGuardedSourceWithRoomBranchCounts(/*enabled_count=*/28,
+                                              /*disabled_count=*/29)}) {
+    fixture.WriteSource(invalid_source);
+    const absl::Status reload_status = panel.ReloadTracks();
+    EXPECT_FALSE(reload_status.ok()) << invalid_source;
+    EXPECT_EQ(panel.GetTracks(), original);
+    EXPECT_FALSE(panel.HasUnpublishedChanges());
+
+    MinecartTrack changed = original.front();
+    changed.room_id = 0x0777;
+    ASSERT_TRUE(panel.UpdateTrack(0, changed).ok());
+    EXPECT_TRUE(panel.HasUnpublishedChanges());
+    ASSERT_TRUE(panel.DiscardUnpublishedChanges().ok());
+    EXPECT_EQ(panel.GetTracks(), original);
+    EXPECT_FALSE(panel.HasUnpublishedChanges());
+  }
+}
+
+TEST(MinecartTrackEditorPanelTest,
+     DraftBlocksReloadAndProjectSwitchUntilExplicitDiscard) {
+  ScopedTestProject first_project;
+  first_project.WriteSource(MakeFlatSource(32, /*room_base=*/0x0100));
+  ScopedTestProject second_project;
+  second_project.WriteSource(MakeFlatSource(32, /*room_base=*/0x0300));
+
+  MinecartTrackEditorPanel panel;
+  ASSERT_TRUE(panel.SetProject(first_project.project()).ok());
+  ASSERT_TRUE(panel.ReloadTracks().ok());
+
+  MinecartTrack draft = panel.GetTracks()[0];
+  draft.room_id = 0x0777;
+  ASSERT_TRUE(panel.UpdateTrack(0, draft).ok());
+  EXPECT_TRUE(panel.HasUnpublishedChanges());
+  first_project.WriteSource(MakeFlatSource(32, /*room_base=*/0x0500));
+
+  EXPECT_TRUE(absl::IsFailedPrecondition(panel.ReloadTracks()));
+  EXPECT_EQ(panel.GetTracks()[0].room_id, 0x0777);
+  EXPECT_TRUE(
+      absl::IsFailedPrecondition(panel.SetProject(second_project.project())));
+  EXPECT_EQ(panel.GetTracks()[0].room_id, 0x0777);
+
+  ASSERT_TRUE(panel.DiscardUnpublishedChanges().ok());
+  EXPECT_FALSE(panel.HasUnpublishedChanges());
+  EXPECT_EQ(panel.GetTracks()[0].room_id, 0x0100);
+  ASSERT_TRUE(panel.ReloadTracks().ok());
+  EXPECT_EQ(panel.GetTracks()[0].room_id, 0x0500);
+  ASSERT_TRUE(panel.SetProject(second_project.project()).ok());
+  ASSERT_TRUE(panel.ReloadTracks().ok());
+  EXPECT_EQ(panel.GetTracks()[0].room_id, 0x0300);
+}
+
+TEST(MinecartTrackEditorPanelTest, RejectsSourceSymlinkOutsideProjectRoot) {
+  ScopedTestProject fixture;
+  std::filesystem::create_directories(fixture.source_path().parent_path());
+  const std::filesystem::path outside_source =
+      fixture.outside_root() / "minecart_tracks.asm";
+  std::ofstream(outside_source) << MakeFlatSource(32);
+  std::error_code symlink_error;
+  std::filesystem::create_symlink(outside_source, fixture.source_path(),
+                                  symlink_error);
+  if (symlink_error == std::errc::operation_not_permitted ||
+      symlink_error == std::errc::permission_denied) {
+    GTEST_SKIP() << "Symlink creation is not permitted: "
+                 << symlink_error.message();
+  }
+  ASSERT_FALSE(symlink_error) << symlink_error.message();
+
+  MinecartTrackEditorPanel panel;
+  ASSERT_TRUE(panel.SetProject(fixture.project()).ok());
+  const absl::Status status = panel.ReloadTracks();
+
+  EXPECT_TRUE(absl::IsPermissionDenied(status)) << status;
+  EXPECT_TRUE(panel.GetTracks().empty());
+  EXPECT_FALSE(panel.HasUnpublishedChanges());
+}
+
+TEST(MinecartTrackEditorPanelTest,
+     GuardedPublicationAndDungeonSavesFailBeforeAnyMutation) {
+  ScopedTestProject fixture;
+  fixture.WriteSource(MakeGuardedSource());
+  MinecartTrackEditorPanel panel;
+  ASSERT_TRUE(panel.SetProject(fixture.project()).ok());
+  ASSERT_TRUE(panel.ReloadTracks().ok());
+
+  MinecartTrack draft = panel.GetTracks()[0];
+  draft.room_id = 0x0777;
+  ASSERT_TRUE(panel.UpdateTrack(0, draft).ok());
+  ASSERT_TRUE(panel.HasUnpublishedChanges());
+  const std::string source_before = fixture.ReadSource();
+
+  const absl::Status publish_status = panel.SaveTracks();
+  EXPECT_TRUE(absl::IsFailedPrecondition(publish_status)) << publish_status;
+  EXPECT_NE(std::string(publish_status.message()).find("Guarded"),
+            std::string::npos);
+  EXPECT_EQ(fixture.ReadSource(), source_before);
+  EXPECT_TRUE(panel.HasUnpublishedChanges());
+
+  Rom rom;
+  ASSERT_TRUE(rom.LoadFromData(std::vector<uint8_t>(0x200000, 0)).ok());
+  DungeonEditorV2 editor(&rom);
+  DungeonEditorV2MinecartTrackTestPeer::SetMinecartTrackEditorPanel(editor,
+                                                                    &panel);
+  const std::vector<uint8_t> rom_before = rom.vector();
+  const bool dirty_before = rom.dirty();
+
+  EXPECT_TRUE(editor.HasPendingDungeonChanges());
+  const absl::Status save_status = editor.Save();
+  EXPECT_TRUE(absl::IsFailedPrecondition(save_status)) << save_status;
+  EXPECT_NE(std::string(save_status.message()).find("Minecart"),
+            std::string::npos);
+  EXPECT_EQ(rom.vector(), rom_before);
+  EXPECT_EQ(rom.dirty(), dirty_before);
+  EXPECT_EQ(fixture.ReadSource(), source_before);
+  EXPECT_TRUE(panel.HasUnpublishedChanges());
+
+  const absl::Status save_room_status = editor.SaveRoom(0);
+  EXPECT_TRUE(absl::IsFailedPrecondition(save_room_status)) << save_room_status;
+  EXPECT_NE(std::string(save_room_status.message()).find("Minecart"),
+            std::string::npos);
+  EXPECT_EQ(rom.vector(), rom_before);
+  EXPECT_EQ(rom.dirty(), dirty_before);
+  EXPECT_EQ(fixture.ReadSource(), source_before);
+  EXPECT_TRUE(panel.HasUnpublishedChanges());
+
+  ASSERT_TRUE(panel.DiscardUnpublishedChanges().ok());
+  EXPECT_FALSE(editor.HasPendingDungeonChanges());
+}
+
+}  // namespace yaze::editor


### PR DESCRIPTION
## Summary
- resolve minecart track source from the project descriptor root and reject source paths that escape it
- parse exactly 32 flat entries or the current guarded OoS table without padding malformed data
- preserve loaded baselines and expose explicit draft discard/reload behavior, including Save Project As relocation
- include minecart drafts in dungeon pending-state checks and block Save/Apply Room before any ROM mutation
- disable source publication until a lossless atomic CAS/readback publisher exists

## Verification
- `MinecartTrackEditorPanelTest.*`: 7/7 passed
- focused pending-state regression filter: 11/11 passed
- `scripts/pre-push.sh --build-dir build/presets/mac-ai`
  - smoke: 13/13
  - UI regression: 40/40
  - formatting: passed
- independent strict re-review: no blockers

## Deliberate follow-up
This PR is a stop-loss, not the final publisher. Both flat and guarded source writes remain disabled pending a manifest-owned, hash/CAS-guarded, atomic write/reopen/readback implementation.

No GUI, emulator, project ROM, or canonical ROM was used or modified.
