### PR TITLE
Publish minecart track source safely

### DIFF
--- a/src/app/editor/dungeon/dungeon_editor_v2_persistence.cc
+++ b/src/app/editor/dungeon/dungeon_editor_v2_persistence.cc
@@ -78,6 +78,11 @@ namespace yaze::editor {
 
 namespace {
 
+constexpr char kMinecartDraftSaveBlockMessage[] =
+    "Minecart Track Editor has unpublished drafts. ROM Save/Apply never "
+    "publishes ASM source; use Publish Tracks in the Minecart Track Editor "
+    "or discard the drafts first.";
+
 absl::Status SaveWaterFillZones(Rom* rom, DungeonRoomStore& rooms) {
   if (!rom || !rom->is_loaded()) {
     return absl::FailedPreconditionError("ROM not loaded");
@@ -524,9 +529,7 @@ absl::Status DungeonEditorV2::RunWithSaveTransaction(
 absl::Status DungeonEditorV2::Save() {
   if (minecart_track_editor_panel_ != nullptr &&
       minecart_track_editor_panel_->HasUnpublishedChanges()) {
-    return absl::FailedPreconditionError(
-        "Minecart Track Editor drafts cannot yet be published safely; "
-        "explicitly discard them before using Save or Apply Room");
+    return absl::FailedPreconditionError(kMinecartDraftSaveBlockMessage);
   }
   if (!rom_ || !rom_->is_loaded()) {
     return absl::FailedPreconditionError("ROM not loaded");
@@ -923,9 +926,7 @@ std::vector<std::pair<uint32_t, uint32_t>> DungeonEditorV2::CollectWriteRanges()
 absl::Status DungeonEditorV2::SaveRoom(int room_id) {
   if (minecart_track_editor_panel_ != nullptr &&
       minecart_track_editor_panel_->HasUnpublishedChanges()) {
-    return absl::FailedPreconditionError(
-        "Minecart Track Editor drafts cannot yet be published safely; "
-        "explicitly discard them before using Save or Apply Room");
+    return absl::FailedPreconditionError(kMinecartDraftSaveBlockMessage);
   }
   if (object_tile_editor_panel_ != nullptr &&
       object_tile_editor_panel_->HasUnappliedChanges()) {

--- a/src/app/editor/dungeon/minecart_track_source.cc
+++ b/src/app/editor/dungeon/minecart_track_source.cc
@@ -5,24 +5,24 @@
 #include <cctype>
 #include <cstddef>
 #include <string>
-#include <string_view>
 #include <utility>
 #include <vector>
 
 #include "absl/status/status.h"
 #include "absl/strings/str_format.h"
+#include "absl/strings/string_view.h"
 
 namespace yaze::editor {
 namespace {
 
-constexpr std::string_view kPlannedTrackGuard =
+constexpr absl::string_view kPlannedTrackGuard =
     "if !ENABLE_MINECART_PLANNED_TRACK_TABLE == 1";
-constexpr std::array<std::string_view, 3> kSectionLabels = {
+constexpr std::array<absl::string_view, 3> kSectionLabels = {
     ".TrackStartingRooms", ".TrackStartingX", ".TrackStartingY"};
 
 struct SourceLine {
   size_t offset;
-  std::string_view text;
+  absl::string_view text;
 };
 
 struct ParsedToken {
@@ -44,7 +44,7 @@ bool IsHexDigit(char value) {
   return std::isxdigit(static_cast<unsigned char>(value)) != 0;
 }
 
-std::string_view Trim(std::string_view value) {
+absl::string_view Trim(absl::string_view value) {
   while (!value.empty() && IsSpace(value.front())) {
     value.remove_prefix(1);
   }
@@ -54,20 +54,20 @@ std::string_view Trim(std::string_view value) {
   return value;
 }
 
-std::string_view CodeForLine(std::string_view line) {
+absl::string_view CodeForLine(absl::string_view line) {
   const size_t comment = line.find(';');
   return Trim(line.substr(0, comment));
 }
 
-std::vector<SourceLine> SplitLines(std::string_view source) {
+std::vector<SourceLine> SplitLines(absl::string_view source) {
   std::vector<SourceLine> lines;
   size_t offset = 0;
   while (offset < source.size()) {
     const size_t newline = source.find('\n', offset);
     const size_t end =
-        newline == std::string_view::npos ? source.size() : newline;
+        newline == absl::string_view::npos ? source.size() : newline;
     lines.push_back({offset, source.substr(offset, end - offset)});
-    if (newline == std::string_view::npos) {
+    if (newline == absl::string_view::npos) {
       break;
     }
     offset = newline + 1;
@@ -76,10 +76,10 @@ std::vector<SourceLine> SplitLines(std::string_view source) {
 }
 
 absl::StatusOr<std::vector<ParsedToken>> ParseDwLine(const SourceLine& line,
-                                                     std::string_view label) {
+                                                     absl::string_view label) {
   const size_t comment = line.text.find(';');
   const size_t code_end =
-      comment == std::string_view::npos ? line.text.size() : comment;
+      comment == absl::string_view::npos ? line.text.size() : comment;
   size_t cursor = 0;
   while (cursor < code_end && IsSpace(line.text[cursor])) {
     ++cursor;
@@ -160,7 +160,7 @@ absl::StatusOr<std::vector<ParsedToken>> ParseDwLine(const SourceLine& line,
 
 absl::StatusOr<ParsedSection> ParseSection(const std::vector<SourceLine>& lines,
                                            size_t first_line, size_t end_line,
-                                           std::string_view label) {
+                                           absl::string_view label) {
   enum class GuardState { kPrefix, kEnabled, kDisabled, kComplete };
   GuardState state = GuardState::kPrefix;
   bool saw_guard = false;
@@ -172,7 +172,7 @@ absl::StatusOr<ParsedSection> ParseSection(const std::vector<SourceLine>& lines,
 
   for (size_t line_index = first_line + 1; line_index < end_line;
        ++line_index) {
-    const std::string_view code = CodeForLine(lines[line_index].text);
+    const absl::string_view code = CodeForLine(lines[line_index].text);
     if (code.empty()) {
       continue;
     }
@@ -261,7 +261,7 @@ absl::Status ValidateTrack(const MinecartTrack& track, size_t index) {
                         index, index, track.id));
   }
   for (const auto& [field_name, value] :
-       std::array<std::pair<std::string_view, int>, 3>{
+       std::array<std::pair<absl::string_view, int>, 3>{
            {{"room_id", track.room_id},
             {"start_x", track.start_x},
             {"start_y", track.start_y}}}) {

--- a/src/app/editor/dungeon/minecart_track_source.cc
+++ b/src/app/editor/dungeon/minecart_track_source.cc
@@ -1,0 +1,377 @@
+#include "app/editor/dungeon/minecart_track_source.h"
+
+#include <algorithm>
+#include <array>
+#include <cctype>
+#include <cstddef>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+#include "absl/status/status.h"
+#include "absl/strings/str_format.h"
+
+namespace yaze::editor {
+namespace {
+
+constexpr std::string_view kPlannedTrackGuard =
+    "if !ENABLE_MINECART_PLANNED_TRACK_TABLE == 1";
+constexpr std::array<std::string_view, 3> kSectionLabels = {
+    ".TrackStartingRooms", ".TrackStartingX", ".TrackStartingY"};
+
+struct SourceLine {
+  size_t offset;
+  std::string_view text;
+};
+
+struct ParsedToken {
+  int value;
+  MinecartTrackSourceTokenSpan span;
+};
+
+struct ParsedSection {
+  std::array<int, kMinecartTrackSlotCount> values{};
+  MinecartTrackSourceDocument::FieldTokenSpans editable_spans{};
+  bool guarded = false;
+};
+
+bool IsSpace(char value) {
+  return std::isspace(static_cast<unsigned char>(value)) != 0;
+}
+
+bool IsHexDigit(char value) {
+  return std::isxdigit(static_cast<unsigned char>(value)) != 0;
+}
+
+std::string_view Trim(std::string_view value) {
+  while (!value.empty() && IsSpace(value.front())) {
+    value.remove_prefix(1);
+  }
+  while (!value.empty() && IsSpace(value.back())) {
+    value.remove_suffix(1);
+  }
+  return value;
+}
+
+std::string_view CodeForLine(std::string_view line) {
+  const size_t comment = line.find(';');
+  return Trim(line.substr(0, comment));
+}
+
+std::vector<SourceLine> SplitLines(std::string_view source) {
+  std::vector<SourceLine> lines;
+  size_t offset = 0;
+  while (offset < source.size()) {
+    const size_t newline = source.find('\n', offset);
+    const size_t end =
+        newline == std::string_view::npos ? source.size() : newline;
+    lines.push_back({offset, source.substr(offset, end - offset)});
+    if (newline == std::string_view::npos) {
+      break;
+    }
+    offset = newline + 1;
+  }
+  return lines;
+}
+
+absl::StatusOr<std::vector<ParsedToken>> ParseDwLine(const SourceLine& line,
+                                                     std::string_view label) {
+  const size_t comment = line.text.find(';');
+  const size_t code_end =
+      comment == std::string_view::npos ? line.text.size() : comment;
+  size_t cursor = 0;
+  while (cursor < code_end && IsSpace(line.text[cursor])) {
+    ++cursor;
+  }
+  if (cursor + 2 > code_end ||
+      std::tolower(static_cast<unsigned char>(line.text[cursor])) != 'd' ||
+      std::tolower(static_cast<unsigned char>(line.text[cursor + 1])) != 'w' ||
+      cursor + 2 == code_end || !IsSpace(line.text[cursor + 2])) {
+    return absl::InvalidArgumentError(absl::StrFormat(
+        "Unexpected statement in %s: %s", label, CodeForLine(line.text)));
+  }
+  cursor += 2;
+
+  std::vector<ParsedToken> tokens;
+  bool requires_token = true;
+  while (true) {
+    while (cursor < code_end && IsSpace(line.text[cursor])) {
+      ++cursor;
+    }
+    if (cursor == code_end) {
+      if (requires_token) {
+        return absl::InvalidArgumentError(
+            absl::StrFormat("Empty operand in %s", label));
+      }
+      break;
+    }
+
+    const size_t token_start = cursor;
+    if (line.text[cursor] != '$' || cursor + 5 > code_end ||
+        !std::all_of(
+            line.text.begin() + static_cast<std::ptrdiff_t>(cursor + 1),
+            line.text.begin() + static_cast<std::ptrdiff_t>(cursor + 5),
+            IsHexDigit)) {
+      return absl::InvalidArgumentError(
+          absl::StrFormat("%s values must use exact 16-bit $hhhh operands: %s",
+                          label, CodeForLine(line.text)));
+    }
+    cursor += 5;
+    if (cursor < code_end && IsHexDigit(line.text[cursor])) {
+      return absl::InvalidArgumentError(
+          absl::StrFormat("%s contains an over-wide 16-bit operand: %s", label,
+                          CodeForLine(line.text)));
+    }
+
+    int value = 0;
+    for (size_t digit = token_start + 1; digit < token_start + 5; ++digit) {
+      const char hex = line.text[digit];
+      value <<= 4;
+      if (hex >= '0' && hex <= '9') {
+        value += hex - '0';
+      } else {
+        value += 10 + std::tolower(static_cast<unsigned char>(hex)) - 'a';
+      }
+    }
+    tokens.push_back({value, {line.offset + token_start, 5}});
+    requires_token = false;
+
+    while (cursor < code_end && IsSpace(line.text[cursor])) {
+      ++cursor;
+    }
+    if (cursor == code_end) {
+      break;
+    }
+    if (line.text[cursor] != ',') {
+      return absl::InvalidArgumentError(
+          absl::StrFormat("Unexpected operand separator in %s: %s", label,
+                          CodeForLine(line.text)));
+    }
+    ++cursor;
+    requires_token = true;
+  }
+  if (tokens.empty()) {
+    return absl::InvalidArgumentError(
+        absl::StrFormat("Empty dw statement in %s", label));
+  }
+  return tokens;
+}
+
+absl::StatusOr<ParsedSection> ParseSection(const std::vector<SourceLine>& lines,
+                                           size_t first_line, size_t end_line,
+                                           std::string_view label) {
+  enum class GuardState { kPrefix, kEnabled, kDisabled, kComplete };
+  GuardState state = GuardState::kPrefix;
+  bool saw_guard = false;
+  bool saw_else = false;
+  bool saw_endif = false;
+  std::vector<ParsedToken> prefix;
+  std::vector<ParsedToken> enabled;
+  std::vector<ParsedToken> disabled;
+
+  for (size_t line_index = first_line + 1; line_index < end_line;
+       ++line_index) {
+    const std::string_view code = CodeForLine(lines[line_index].text);
+    if (code.empty()) {
+      continue;
+    }
+    if (code == kPlannedTrackGuard) {
+      if (state != GuardState::kPrefix || saw_guard) {
+        return absl::InvalidArgumentError(
+            absl::StrFormat("Nested or repeated guard in %s", label));
+      }
+      saw_guard = true;
+      state = GuardState::kEnabled;
+      continue;
+    }
+    if (code == "else") {
+      if (!saw_guard || state != GuardState::kEnabled || saw_else) {
+        return absl::InvalidArgumentError(
+            absl::StrFormat("Unexpected else in %s", label));
+      }
+      saw_else = true;
+      state = GuardState::kDisabled;
+      continue;
+    }
+    if (code == "endif") {
+      if (!saw_else || state != GuardState::kDisabled || saw_endif) {
+        return absl::InvalidArgumentError(
+            absl::StrFormat("Unexpected endif in %s", label));
+      }
+      saw_endif = true;
+      state = GuardState::kComplete;
+      continue;
+    }
+    if (state == GuardState::kComplete) {
+      return absl::InvalidArgumentError(absl::StrFormat(
+          "Unexpected content after guarded table in %s: %s", label, code));
+    }
+
+    auto tokens_or = ParseDwLine(lines[line_index], label);
+    if (!tokens_or.ok()) {
+      return tokens_or.status();
+    }
+    std::vector<ParsedToken>* destination = &prefix;
+    if (state == GuardState::kEnabled) {
+      destination = &enabled;
+    } else if (state == GuardState::kDisabled) {
+      destination = &disabled;
+    }
+    destination->insert(destination->end(), tokens_or->begin(),
+                        tokens_or->end());
+  }
+
+  ParsedSection result;
+  std::vector<ParsedToken> active;
+  if (!saw_guard) {
+    if (prefix.size() != kMinecartTrackSlotCount) {
+      return absl::InvalidArgumentError(
+          absl::StrFormat("%s must contain exactly %zu values; found %zu",
+                          label, kMinecartTrackSlotCount, prefix.size()));
+    }
+    active = std::move(prefix);
+  } else {
+    if (!saw_else || !saw_endif) {
+      return absl::InvalidArgumentError(
+          absl::StrFormat("Incomplete planned-track guard in %s", label));
+    }
+    if (prefix.size() != 4 || enabled.size() != 28 || disabled.size() != 28) {
+      return absl::InvalidArgumentError(absl::StrFormat(
+          "%s guarded layout requires exactly 4 prefix, 28 enabled, and 28 "
+          "disabled values; found %zu, %zu, and %zu",
+          label, prefix.size(), enabled.size(), disabled.size()));
+    }
+    active = std::move(prefix);
+    active.insert(active.end(), enabled.begin(), enabled.end());
+    result.guarded = true;
+  }
+
+  for (size_t index = 0; index < kMinecartTrackSlotCount; ++index) {
+    result.values[index] = active[index].value;
+    result.editable_spans[index] = active[index].span;
+  }
+  return result;
+}
+
+absl::Status ValidateTrack(const MinecartTrack& track, size_t index) {
+  if (track.id != static_cast<int>(index)) {
+    return absl::InvalidArgumentError(
+        absl::StrFormat("Minecart track ID at slot %zu must be %zu; found %d",
+                        index, index, track.id));
+  }
+  for (const auto& [field_name, value] :
+       std::array<std::pair<std::string_view, int>, 3>{
+           {{"room_id", track.room_id},
+            {"start_x", track.start_x},
+            {"start_y", track.start_y}}}) {
+    if (value < 0 || value > 0xFFFF) {
+      return absl::InvalidArgumentError(absl::StrFormat(
+          "Minecart track %zu %s must be a 16-bit value; found %d", index,
+          field_name, value));
+    }
+  }
+  return absl::OkStatus();
+}
+
+std::string FormatHexWord(int value) {
+  return absl::StrFormat("$%04X", value);
+}
+
+}  // namespace
+
+absl::StatusOr<MinecartTrackSourceDocument> MinecartTrackSourceDocument::Parse(
+    std::string source_bytes) {
+  const std::vector<SourceLine> lines = SplitLines(source_bytes);
+  std::array<size_t, kSectionLabels.size()> section_lines{};
+  for (size_t section = 0; section < kSectionLabels.size(); ++section) {
+    int matches = 0;
+    for (size_t line = 0; line < lines.size(); ++line) {
+      if (CodeForLine(lines[line].text) == kSectionLabels[section]) {
+        section_lines[section] = line;
+        ++matches;
+      }
+    }
+    if (matches != 1) {
+      return absl::InvalidArgumentError(
+          absl::StrFormat("Expected exactly one %s label, found %d",
+                          kSectionLabels[section], matches));
+    }
+    if (section > 0 && section_lines[section] <= section_lines[section - 1]) {
+      return absl::InvalidArgumentError(
+          "Minecart table sections must be ordered Rooms, X, then Y");
+    }
+  }
+
+  std::array<ParsedSection, kSectionLabels.size()> parsed_sections;
+  for (size_t section = 0; section < kSectionLabels.size(); ++section) {
+    const size_t end_line = section + 1 < kSectionLabels.size()
+                                ? section_lines[section + 1]
+                                : lines.size();
+    auto parsed_or = ParseSection(lines, section_lines[section], end_line,
+                                  kSectionLabels[section]);
+    if (!parsed_or.ok()) {
+      return parsed_or.status();
+    }
+    parsed_sections[section] = std::move(*parsed_or);
+  }
+  if (parsed_sections[0].guarded != parsed_sections[1].guarded ||
+      parsed_sections[0].guarded != parsed_sections[2].guarded) {
+    return absl::InvalidArgumentError(
+        "Minecart sections must use the same flat or guarded layout");
+  }
+
+  MinecartTrackSourceDocument document;
+  document.source_bytes_ = std::move(source_bytes);
+  document.guarded_ = parsed_sections[0].guarded;
+  document.tracks_.reserve(kMinecartTrackSlotCount);
+  for (size_t index = 0; index < kMinecartTrackSlotCount; ++index) {
+    document.tracks_.push_back(
+        {static_cast<int>(index), parsed_sections[0].values[index],
+         parsed_sections[1].values[index], parsed_sections[2].values[index]});
+  }
+  for (size_t field = 0; field < parsed_sections.size(); ++field) {
+    document.editable_token_spans_[field] =
+        parsed_sections[field].editable_spans;
+  }
+  return document;
+}
+
+absl::StatusOr<std::string> MinecartTrackSourceDocument::Render(
+    const std::vector<MinecartTrack>& tracks) const {
+  if (tracks.size() != kMinecartTrackSlotCount) {
+    return absl::InvalidArgumentError(absl::StrFormat(
+        "Minecart source requires exactly %zu tracks; found %zu",
+        kMinecartTrackSlotCount, tracks.size()));
+  }
+  for (size_t index = 0; index < tracks.size(); ++index) {
+    const absl::Status status = ValidateTrack(tracks[index], index);
+    if (!status.ok()) {
+      return status;
+    }
+  }
+
+  std::string rendered = source_bytes_;
+  for (size_t index = 0; index < tracks.size(); ++index) {
+    const std::array<int, 3> original = {
+        tracks_[index].room_id, tracks_[index].start_x, tracks_[index].start_y};
+    const std::array<int, 3> updated = {
+        tracks[index].room_id, tracks[index].start_x, tracks[index].start_y};
+    for (size_t field = 0; field < updated.size(); ++field) {
+      if (updated[field] == original[field]) {
+        continue;
+      }
+      const MinecartTrackSourceTokenSpan span =
+          editable_token_spans_[field][index];
+      if (span.length != 5 || span.offset + span.length > rendered.size() ||
+          rendered[span.offset] != '$') {
+        return absl::DataLossError(
+            "Minecart source token span no longer matches the parsed bytes");
+      }
+      rendered.replace(span.offset, span.length, FormatHexWord(updated[field]));
+    }
+  }
+  return rendered;
+}
+
+}  // namespace yaze::editor

--- a/src/app/editor/dungeon/minecart_track_source.h
+++ b/src/app/editor/dungeon/minecart_track_source.h
@@ -1,0 +1,67 @@
+#ifndef YAZE_APP_EDITOR_DUNGEON_MINECART_TRACK_SOURCE_H_
+#define YAZE_APP_EDITOR_DUNGEON_MINECART_TRACK_SOURCE_H_
+
+#include <array>
+#include <cstddef>
+#include <string>
+#include <vector>
+
+#include "absl/status/statusor.h"
+
+namespace yaze::editor {
+
+inline constexpr size_t kMinecartTrackSlotCount = 32;
+
+struct MinecartTrack {
+  int id;
+  int room_id;
+  int start_x;
+  int start_y;
+
+  bool operator==(const MinecartTrack&) const = default;
+};
+
+struct MinecartTrackSourceTokenSpan {
+  size_t offset = 0;
+  size_t length = 0;
+
+  bool operator==(const MinecartTrackSourceTokenSpan&) const = default;
+};
+
+// Losslessly models the three minecart `dw` tables. Parsing retains the exact
+// source bytes and the spans of only the active table tokens. Rendering can
+// therefore replace edited `$hhhh` operands without reconstructing comments,
+// whitespace, guard directives, or the guarded disabled branches.
+class MinecartTrackSourceDocument {
+ public:
+  using FieldTokenSpans =
+      std::array<MinecartTrackSourceTokenSpan, kMinecartTrackSlotCount>;
+  using EditableTokenSpans = std::array<FieldTokenSpans, 3>;
+
+  static absl::StatusOr<MinecartTrackSourceDocument> Parse(
+      std::string source_bytes);
+
+  absl::StatusOr<std::string> Render(
+      const std::vector<MinecartTrack>& tracks) const;
+
+  [[nodiscard]] const std::string& source_bytes() const {
+    return source_bytes_;
+  }
+  [[nodiscard]] const std::vector<MinecartTrack>& tracks() const {
+    return tracks_;
+  }
+  [[nodiscard]] const EditableTokenSpans& editable_token_spans() const {
+    return editable_token_spans_;
+  }
+  [[nodiscard]] bool guarded() const { return guarded_; }
+
+ private:
+  std::string source_bytes_;
+  std::vector<MinecartTrack> tracks_;
+  EditableTokenSpans editable_token_spans_{};
+  bool guarded_ = false;
+};
+
+}  // namespace yaze::editor
+
+#endif  // YAZE_APP_EDITOR_DUNGEON_MINECART_TRACK_SOURCE_H_

--- a/src/app/editor/dungeon/ui/window/minecart_track_editor_panel.cc
+++ b/src/app/editor/dungeon/ui/window/minecart_track_editor_panel.cc
@@ -32,6 +32,11 @@ constexpr int kTrackSlotCount = static_cast<int>(kMinecartTrackSlotCount);
 constexpr int kDefaultTrackRoom = 0x89;
 constexpr int kDefaultTrackX = 0x1300;
 constexpr int kDefaultTrackY = 0x1100;
+#if defined(__EMSCRIPTEN__)
+constexpr bool kSourcePublishingAvailable = false;
+#else
+constexpr bool kSourcePublishingAvailable = true;
+#endif
 
 const core::SourceArtifactPublisherLabels kMinecartSourcePublisherLabels{
     .subject = "minecart track source",
@@ -592,19 +597,34 @@ void MinecartTrackEditorPanel::Draw(bool* p_open) {
 
   ImGui::Text(tr("Minecart Track Editor"));
   ImGui::TextDisabled(
-      tr("Publish explicitly updates the manifest-owned ASM source. Project "
-         "and dungeon saves never publish these drafts."));
+      tr("Publish Tracks changes the manifest-owned ASM source only; it does "
+         "not update the open ROM."));
+  ImGui::TextDisabled(
+      tr("After publishing, save pending dungeon/ROM edits to the development "
+         "ROM, rebuild the patched ROM, then reopen/reload the patched ROM in "
+         "Yaze before testing."));
+#if defined(__EMSCRIPTEN__)
+  ImGui::TextDisabled(
+      tr("Source publishing is unavailable in browser builds; drafts are "
+         "retained."));
+#endif
   const bool has_unpublished_changes = HasUnpublishedChanges();
-  if (!has_unpublished_changes) {
+  const bool can_publish =
+      has_unpublished_changes && kSourcePublishingAvailable;
+  if (!can_publish) {
     ImGui::BeginDisabled();
   }
   if (ImGui::Button(ICON_MD_SAVE " Publish Tracks")) {
     const absl::Status status = SaveTracks();
-    status_message_ = status.ok() ? "Minecart track source published."
-                                  : std::string(status.message());
+    status_message_ =
+        status.ok()
+            ? "Minecart ASM source published only. Save pending dungeon/ROM "
+              "edits to the development ROM, rebuild the patched ROM, then "
+              "reopen/reload the patched ROM in Yaze before testing."
+            : std::string(status.message());
     show_success_ = status.ok();
   }
-  if (!has_unpublished_changes) {
+  if (!can_publish) {
     ImGui::EndDisabled();
   }
   ImGui::SameLine();

--- a/src/app/editor/dungeon/ui/window/minecart_track_editor_panel.cc
+++ b/src/app/editor/dungeon/ui/window/minecart_track_editor_panel.cc
@@ -1,20 +1,22 @@
 #include "minecart_track_editor_panel.h"
 
 #include <algorithm>
-#include <cctype>
 #include <filesystem>
 #include <fstream>
-#include <iomanip>
-#include <sstream>
-#include <string_view>
+#include <iterator>
+#include <memory>
 #include <system_error>
+#include <utility>
+#include <vector>
 
 #include "absl/status/status.h"
 #include "absl/strings/str_format.h"
 #include "absl/strings/str_split.h"
+#include "core/source_artifact_publisher.h"
 #include "imgui/imgui.h"
 #include "imgui/misc/cpp/imgui_stdlib.h"
 #include "util/i18n/tr.h"
+#include "util/macro.h"
 
 #include "app/gui/core/icons.h"
 #include "app/gui/core/input.h"
@@ -26,33 +28,15 @@
 namespace yaze::editor {
 
 namespace {
-constexpr int kTrackSlotCount = 32;
+constexpr int kTrackSlotCount = static_cast<int>(kMinecartTrackSlotCount);
 constexpr int kDefaultTrackRoom = 0x89;
 constexpr int kDefaultTrackX = 0x1300;
 constexpr int kDefaultTrackY = 0x1100;
-constexpr std::string_view kTrackSourceRelativePath =
-    "Sprites/Objects/data/minecart_tracks.asm";
-constexpr std::string_view kPlannedTrackGuard =
-    "if !ENABLE_MINECART_PLANNED_TRACK_TABLE == 1";
 
-std::string Trim(std::string_view value) {
-  size_t first = 0;
-  while (first < value.size() &&
-         std::isspace(static_cast<unsigned char>(value[first]))) {
-    ++first;
-  }
-  size_t last = value.size();
-  while (last > first &&
-         std::isspace(static_cast<unsigned char>(value[last - 1]))) {
-    --last;
-  }
-  return std::string(value.substr(first, last - first));
-}
-
-std::string StripCommentAndTrim(const std::string& line) {
-  const size_t comment = line.find(';');
-  return Trim(std::string_view(line).substr(0, comment));
-}
+const core::SourceArtifactPublisherLabels kMinecartSourcePublisherLabels{
+    .subject = "minecart track source",
+    .published_file = "published minecart track source",
+};
 
 bool IsStrictDescendant(const std::filesystem::path& path,
                         const std::filesystem::path& root) {
@@ -66,47 +50,19 @@ bool IsStrictDescendant(const std::filesystem::path& path,
   return path_it != path.end();
 }
 
-absl::StatusOr<std::vector<int>> ParseDwValues(const std::string& line,
-                                               const std::string& label) {
-  const std::string code = StripCommentAndTrim(line);
-  if (code.size() < 2 ||
-      std::tolower(static_cast<unsigned char>(code[0])) != 'd' ||
-      std::tolower(static_cast<unsigned char>(code[1])) != 'w' ||
-      (code.size() > 2 && !std::isspace(static_cast<unsigned char>(code[2])))) {
-    return absl::InvalidArgumentError(
-        absl::StrFormat("Unexpected statement in %s: %s", label, code));
+absl::StatusOr<std::string> ReadSourceFile(const std::filesystem::path& path) {
+  std::ifstream input(path, std::ios::binary);
+  if (!input.is_open()) {
+    return absl::NotFoundError(
+        absl::StrFormat("Could not open minecart source: %s", path.string()));
   }
-
-  const std::string operands = Trim(std::string_view(code).substr(2));
-  if (operands.empty()) {
-    return absl::InvalidArgumentError(
-        absl::StrFormat("Empty dw statement in %s", label));
+  std::string content{std::istreambuf_iterator<char>(input),
+                      std::istreambuf_iterator<char>()};
+  if (!input.good() && !input.eof()) {
+    return absl::DataLossError(
+        absl::StrFormat("Could not read minecart source: %s", path.string()));
   }
-
-  std::vector<int> values;
-  for (absl::string_view operand_view : absl::StrSplit(operands, ',')) {
-    const std::string operand =
-        Trim(std::string_view(operand_view.data(), operand_view.size()));
-    if (operand.size() < 2 || operand.size() > 5 || operand[0] != '$' ||
-        !std::all_of(operand.begin() + 1, operand.end(), [](char c) {
-          return std::isxdigit(static_cast<unsigned char>(c));
-        })) {
-      return absl::InvalidArgumentError(absl::StrFormat(
-          "Invalid 16-bit hex value in %s: %s", label, operand));
-    }
-    try {
-      const unsigned long value = std::stoul(operand.substr(1), nullptr, 16);
-      if (value > 0xFFFF) {
-        return absl::InvalidArgumentError(
-            absl::StrFormat("Value out of range in %s: %s", label, operand));
-      }
-      values.push_back(static_cast<int>(value));
-    } catch (...) {
-      return absl::InvalidArgumentError(absl::StrFormat(
-          "Invalid 16-bit hex value in %s: %s", label, operand));
-    }
-  }
-  return values;
+  return content;
 }
 
 std::string FormatHexList(const std::vector<uint16_t>& values) {
@@ -152,9 +108,12 @@ std::vector<uint16_t> ParseHexList(const std::string& input) {
 void MinecartTrackEditorPanel::ResetTrackSession() {
   tracks_.clear();
   loaded_tracks_.clear();
+  source_document_.reset();
+  loaded_source_identity_.reset();
+  loaded_source_path_.clear();
+  loaded_source_sha256_.clear();
   load_attempted_ = false;
   loaded_ = false;
-  source_is_guarded_ = false;
   CancelCoordinatePicking();
   audit_dirty_ = true;
 }
@@ -193,6 +152,26 @@ absl::Status MinecartTrackEditorPanel::SetProject(
   return absl::OkStatus();
 }
 
+absl::Status MinecartTrackEditorPanel::ValidateLoadedManifestIdentity() const {
+  if (project_ == nullptr || !project_->hack_manifest.loaded()) {
+    return absl::FailedPreconditionError(
+        "A loaded hack manifest is required to publish minecart tracks");
+  }
+  const auto& current_source =
+      project_->hack_manifest.minecart_track_layout().source;
+  if (!current_source.has_value()) {
+    return absl::FailedPreconditionError(
+        "Hack manifest does not define minecart_tracks.source");
+  }
+  if (!loaded_source_identity_.has_value() ||
+      *current_source != *loaded_source_identity_) {
+    return absl::FailedPreconditionError(
+        "Hack manifest minecart_tracks.source changed after the tracks were "
+        "loaded; drafts were kept");
+  }
+  return absl::OkStatus();
+}
+
 absl::StatusOr<std::filesystem::path>
 MinecartTrackEditorPanel::ResolveTrackSourcePath() const {
   if (project_ != nullptr && project_->filepath != bound_project_filepath_) {
@@ -203,6 +182,15 @@ MinecartTrackEditorPanel::ResolveTrackSourcePath() const {
   if (project_ == nullptr || bound_project_filepath_.empty()) {
     return absl::FailedPreconditionError(
         "An open project descriptor is required for minecart tracks");
+  }
+  if (!project_->hack_manifest.loaded()) {
+    return absl::FailedPreconditionError(
+        "A loaded hack manifest is required for minecart tracks");
+  }
+  const auto& source = project_->hack_manifest.minecart_track_layout().source;
+  if (!source.has_value()) {
+    return absl::FailedPreconditionError(
+        "Hack manifest does not define minecart_tracks.source");
   }
 
   std::error_code ec;
@@ -224,7 +212,17 @@ MinecartTrackEditorPanel::ResolveTrackSourcePath() const {
   }
 
   const std::filesystem::path candidate =
-      project_root / kTrackSourceRelativePath;
+      (project_root / source->path).lexically_normal();
+  const std::filesystem::file_status candidate_status =
+      std::filesystem::symlink_status(candidate, ec);
+  if (ec) {
+    return absl::NotFoundError(
+        absl::StrFormat("Minecart source not found: %s", candidate.string()));
+  }
+  if (std::filesystem::is_symlink(candidate_status)) {
+    return absl::PermissionDeniedError(
+        "Minecart source may not be a symbolic link");
+  }
   const std::filesystem::path resolved =
       std::filesystem::canonical(candidate, ec);
   if (ec) {
@@ -593,14 +591,22 @@ void MinecartTrackEditorPanel::Draw(bool* p_open) {
   }
 
   ImGui::Text(tr("Minecart Track Editor"));
-  ImGui::TextColored(
-      ImVec4(1.0f, 0.8f, 0.2f, 1.0f), ICON_MD_WARNING
-      " Source publishing is disabled in this build; edits remain drafts "
-      "until discarded.");
+  ImGui::TextDisabled(
+      tr("Publish explicitly updates the manifest-owned ASM source. Project "
+         "and dungeon saves never publish these drafts."));
   const bool has_unpublished_changes = HasUnpublishedChanges();
-  ImGui::BeginDisabled();
-  ImGui::Button(ICON_MD_SAVE " Publish Unavailable");
-  ImGui::EndDisabled();
+  if (!has_unpublished_changes) {
+    ImGui::BeginDisabled();
+  }
+  if (ImGui::Button(ICON_MD_SAVE " Publish Tracks")) {
+    const absl::Status status = SaveTracks();
+    status_message_ = status.ok() ? "Minecart track source published."
+                                  : std::string(status.message());
+    show_success_ = status.ok();
+  }
+  if (!has_unpublished_changes) {
+    ImGui::EndDisabled();
+  }
   ImGui::SameLine();
   if (!has_unpublished_changes) {
     ImGui::BeginDisabled();
@@ -993,52 +999,40 @@ void MinecartTrackEditorPanel::Draw(bool* p_open) {
 absl::Status MinecartTrackEditorPanel::LoadTracks() {
   load_attempted_ = true;
 
-  auto path_or = ResolveTrackSourcePath();
-  if (!path_or.ok()) {
-    return path_or.status();
+  if (project_ == nullptr || !project_->hack_manifest.loaded() ||
+      !project_->hack_manifest.minecart_track_layout().source.has_value()) {
+    return absl::FailedPreconditionError(
+        "Hack manifest does not define minecart_tracks.source");
+  }
+  const core::MinecartTrackLayout::Source source_identity =
+      *project_->hack_manifest.minecart_track_layout().source;
+
+  std::filesystem::path source_path;
+  ASSIGN_OR_RETURN(source_path, ResolveTrackSourcePath());
+  std::string source_bytes;
+  ASSIGN_OR_RETURN(source_bytes, ReadSourceFile(source_path));
+  auto document_or =
+      MinecartTrackSourceDocument::Parse(std::move(source_bytes));
+  if (!document_or.ok()) {
+    return document_or.status();
+  }
+  if (!project_->hack_manifest.minecart_track_layout().source.has_value() ||
+      *project_->hack_manifest.minecart_track_layout().source !=
+          source_identity) {
+    return absl::AbortedError(
+        "Hack manifest minecart_tracks.source changed while loading tracks");
   }
 
-  std::ifstream file(*path_or, std::ios::binary);
-  if (!file.is_open()) {
-    return absl::NotFoundError(absl::StrFormat(
-        "Could not open minecart source: %s", path_or->string()));
-  }
-  std::stringstream buffer;
-  buffer << file.rdbuf();
-  if (file.bad()) {
-    return absl::DataLossError(absl::StrFormat(
-        "Could not read minecart source: %s", path_or->string()));
-  }
-  const std::string content = buffer.str();
-
-  auto rooms_or = ParseSection(content, ".TrackStartingRooms");
-  if (!rooms_or.ok()) {
-    return rooms_or.status();
-  }
-  auto xs_or = ParseSection(content, ".TrackStartingX");
-  if (!xs_or.ok()) {
-    return xs_or.status();
-  }
-  auto ys_or = ParseSection(content, ".TrackStartingY");
-  if (!ys_or.ok()) {
-    return ys_or.status();
-  }
-  if (rooms_or->guarded != xs_or->guarded ||
-      rooms_or->guarded != ys_or->guarded) {
-    return absl::InvalidArgumentError(
-        "Minecart sections must use the same flat or guarded layout");
-  }
-
-  std::vector<MinecartTrack> candidate_tracks;
-  candidate_tracks.reserve(kTrackSlotCount);
-  for (size_t i = 0; i < kTrackSlotCount; ++i) {
-    candidate_tracks.push_back({static_cast<int>(i), rooms_or->values[i],
-                                xs_or->values[i], ys_or->values[i]});
-  }
+  std::vector<MinecartTrack> candidate_tracks = document_or->tracks();
+  const std::string source_sha256 =
+      core::ComputeSourceArtifactSha256(document_or->source_bytes());
 
   tracks_ = candidate_tracks;
   loaded_tracks_ = std::move(candidate_tracks);
-  source_is_guarded_ = rooms_or->guarded;
+  source_document_ = std::move(*document_or);
+  loaded_source_identity_ = source_identity;
+  loaded_source_path_ = std::move(source_path);
+  loaded_source_sha256_ = source_sha256;
   loaded_ = true;
   audit_dirty_ = true;
   status_message_.clear();
@@ -1046,144 +1040,119 @@ absl::Status MinecartTrackEditorPanel::LoadTracks() {
   return absl::OkStatus();
 }
 
-absl::StatusOr<MinecartTrackEditorPanel::ParsedSection>
-MinecartTrackEditorPanel::ParseSection(const std::string& content,
-                                       const std::string& label) {
-  std::vector<std::string> lines;
-  std::stringstream stream(content);
-  std::string line;
-  while (std::getline(stream, line)) {
-    lines.push_back(line);
-  }
-
-  size_t section_line = 0;
-  int label_count = 0;
-  for (size_t i = 0; i < lines.size(); ++i) {
-    if (StripCommentAndTrim(lines[i]) == label) {
-      section_line = i;
-      ++label_count;
-    }
-  }
-  if (label_count != 1) {
-    return absl::InvalidArgumentError(absl::StrFormat(
-        "Expected exactly one %s label, found %d", label, label_count));
-  }
-
-  size_t section_end = lines.size();
-  for (size_t i = section_line + 1; i < lines.size(); ++i) {
-    const std::string code = StripCommentAndTrim(lines[i]);
-    if (!code.empty() && code[0] == '.') {
-      section_end = i;
-      break;
-    }
-  }
-
-  enum class GuardState { kPrefix, kEnabled, kDisabled, kComplete };
-  GuardState state = GuardState::kPrefix;
-  bool saw_guard = false;
-  bool saw_else = false;
-  bool saw_endif = false;
-  std::vector<int> prefix;
-  std::vector<int> enabled;
-  std::vector<int> disabled;
-
-  for (size_t i = section_line + 1; i < section_end; ++i) {
-    const std::string code = StripCommentAndTrim(lines[i]);
-    if (code.empty()) {
-      continue;
-    }
-    if (code == kPlannedTrackGuard) {
-      if (state != GuardState::kPrefix || saw_guard) {
-        return absl::InvalidArgumentError(
-            absl::StrFormat("Nested or repeated guard in %s", label));
-      }
-      saw_guard = true;
-      state = GuardState::kEnabled;
-      continue;
-    }
-    if (code == "else") {
-      if (!saw_guard || state != GuardState::kEnabled || saw_else) {
-        return absl::InvalidArgumentError(
-            absl::StrFormat("Unexpected else in %s", label));
-      }
-      saw_else = true;
-      state = GuardState::kDisabled;
-      continue;
-    }
-    if (code == "endif") {
-      if (!saw_else || state != GuardState::kDisabled || saw_endif) {
-        return absl::InvalidArgumentError(
-            absl::StrFormat("Unexpected endif in %s", label));
-      }
-      saw_endif = true;
-      state = GuardState::kComplete;
-      continue;
-    }
-    if (state == GuardState::kComplete) {
-      return absl::InvalidArgumentError(absl::StrFormat(
-          "Unexpected content after guarded table in %s: %s", label, code));
-    }
-
-    auto values_or = ParseDwValues(lines[i], label);
-    if (!values_or.ok()) {
-      return values_or.status();
-    }
-    std::vector<int>* destination = &prefix;
-    if (state == GuardState::kEnabled) {
-      destination = &enabled;
-    } else if (state == GuardState::kDisabled) {
-      destination = &disabled;
-    }
-    destination->insert(destination->end(), values_or->begin(),
-                        values_or->end());
-  }
-
-  ParsedSection result;
-  if (!saw_guard) {
-    if (prefix.size() != kTrackSlotCount) {
-      return absl::InvalidArgumentError(
-          absl::StrFormat("%s must contain exactly %d values; found %zu", label,
-                          kTrackSlotCount, prefix.size()));
-    }
-    result.values = std::move(prefix);
-    return result;
-  }
-
-  if (!saw_else || !saw_endif) {
-    return absl::InvalidArgumentError(
-        absl::StrFormat("Incomplete planned-track guard in %s", label));
-  }
-  if (prefix.size() + enabled.size() != kTrackSlotCount ||
-      prefix.size() + disabled.size() != kTrackSlotCount) {
-    return absl::InvalidArgumentError(absl::StrFormat(
-        "%s guarded branches must each resolve to exactly %d values; found "
-        "%zu enabled and %zu disabled",
-        label, kTrackSlotCount, prefix.size() + enabled.size(),
-        prefix.size() + disabled.size()));
-  }
-
-  result.values = prefix;
-  result.values.insert(result.values.end(), enabled.begin(), enabled.end());
-  result.guarded = true;
-  return result;
-}
-
 absl::Status MinecartTrackEditorPanel::SaveTracks() {
-  if (!loaded_) {
+  if (!loaded_ || !source_document_.has_value() ||
+      !loaded_source_identity_.has_value() || loaded_source_path_.empty() ||
+      loaded_source_sha256_.empty()) {
     return absl::FailedPreconditionError("Minecart tracks are not loaded");
   }
   if (!HasUnpublishedChanges()) {
     return absl::FailedPreconditionError(
-        "No unpublished minecart track drafts to save");
+        "No unpublished minecart track drafts to publish");
   }
-  if (source_is_guarded_) {
+#if defined(__EMSCRIPTEN__)
+  return absl::FailedPreconditionError(
+      "Minecart source publishing is unavailable in browser builds because "
+      "durable atomic filesystem publication cannot be guaranteed; drafts "
+      "were kept");
+#else
+  RETURN_IF_ERROR(RefreshProjectBinding());
+  RETURN_IF_ERROR(ValidateLoadedManifestIdentity());
+
+  std::filesystem::path source_path;
+  ASSIGN_OR_RETURN(source_path, ResolveTrackSourcePath());
+  if (source_path != loaded_source_path_) {
     return absl::FailedPreconditionError(
-        "Guarded minecart source publishing is disabled until a lossless "
-        "publisher is available; drafts were kept");
+        "Minecart source path changed after the tracks were loaded; drafts "
+        "were kept");
   }
-  return absl::UnimplementedError(
-      "Minecart source publishing is disabled until atomic source guards are "
-      "available; drafts were kept");
+
+  std::unique_ptr<core::SourceArtifactPublicationLock> publication_lock;
+  ASSIGN_OR_RETURN(publication_lock,
+                   core::AcquireSourceArtifactPublicationLock(
+                       {source_path}, kMinecartSourcePublisherLabels));
+
+  // Recheck every source identity after acquiring the durable publication
+  // lock. A manifest reload or path replacement must fail before mutation.
+  RETURN_IF_ERROR(ValidateLoadedManifestIdentity());
+  std::filesystem::path locked_source_path;
+  ASSIGN_OR_RETURN(locked_source_path, ResolveTrackSourcePath());
+  if (locked_source_path != loaded_source_path_) {
+    return absl::FailedPreconditionError(
+        "Minecart source path changed while acquiring its publication lock; "
+        "drafts were kept");
+  }
+
+  std::string source_before;
+  ASSIGN_OR_RETURN(source_before, ReadSourceFile(locked_source_path));
+  const std::string source_sha256_before =
+      core::ComputeSourceArtifactSha256(source_before);
+  if (source_sha256_before != loaded_source_sha256_ ||
+      source_before != source_document_->source_bytes()) {
+    return absl::AbortedError(absl::StrFormat(
+        "Minecart source SHA-256 CAS failed: expected %s, got %s; drafts were "
+        "kept",
+        loaded_source_sha256_, source_sha256_before));
+  }
+
+  std::string source_after;
+  ASSIGN_OR_RETURN(source_after, source_document_->Render(tracks_));
+  auto published_document_or = MinecartTrackSourceDocument::Parse(source_after);
+  if (!published_document_or.ok()) {
+    return absl::DataLossError(
+        absl::StrFormat("Rendered minecart source failed strict validation: %s",
+                        published_document_or.status().message()));
+  }
+  if (published_document_or->tracks() != tracks_) {
+    return absl::DataLossError(
+        "Rendered minecart source did not reproduce the draft tracks");
+  }
+  const std::string source_sha256_after =
+      core::ComputeSourceArtifactSha256(source_after);
+  const std::vector<MinecartTrack> draft_tracks = tracks_;
+
+  std::vector<core::SourceArtifactUpdate> updates;
+  updates.push_back(core::SourceArtifactUpdate{
+      .target = locked_source_path,
+      .before = source_before,
+      .after = source_after,
+  });
+  RETURN_IF_ERROR(core::PublishSourceArtifacts(
+      *publication_lock, std::move(updates), loaded_source_sha256_,
+      [&]() -> absl::Status {
+        std::string reopened_source;
+        ASSIGN_OR_RETURN(reopened_source, ReadSourceFile(locked_source_path));
+        if (reopened_source != source_after ||
+            core::ComputeSourceArtifactSha256(reopened_source) !=
+                source_sha256_after) {
+          return absl::DataLossError(
+              "Published minecart source failed exact SHA-256 readback");
+        }
+        auto reopened_document_or =
+            MinecartTrackSourceDocument::Parse(std::move(reopened_source));
+        if (!reopened_document_or.ok()) {
+          return absl::DataLossError(absl::StrFormat(
+              "Published minecart source failed strict readback validation: "
+              "%s",
+              reopened_document_or.status().message()));
+        }
+        if (reopened_document_or->tracks() != draft_tracks) {
+          return absl::DataLossError(
+              "Published minecart source track readback did not match the "
+              "draft");
+        }
+        return absl::OkStatus();
+      }));
+
+  tracks_ = published_document_or->tracks();
+  loaded_tracks_ = tracks_;
+  source_document_ = std::move(*published_document_or);
+  loaded_source_path_ = std::move(locked_source_path);
+  loaded_source_sha256_ = source_sha256_after;
+  CancelCoordinatePicking();
+  audit_dirty_ = true;
+  return absl::OkStatus();
+#endif
 }
 
 }  // namespace yaze::editor

--- a/src/app/editor/dungeon/ui/window/minecart_track_editor_panel.h
+++ b/src/app/editor/dungeon/ui/window/minecart_track_editor_panel.h
@@ -5,32 +5,21 @@
 #include <cstdint>
 #include <filesystem>
 #include <functional>
+#include <optional>
 #include <string>
 #include <unordered_map>
+#include <utility>
 #include <vector>
 
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
 #include "app/editor/dungeon/dungeon_room_store.h"
+#include "app/editor/dungeon/minecart_track_source.h"
+#include "app/editor/system/workspace/editor_panel.h"
 #include "app/gui/core/icons.h"
 #include "core/project.h"
 #include "rom/rom.h"
 #include "zelda3/dungeon/room.h"
-
-namespace yaze::editor {
-
-struct MinecartTrack {
-  int id;
-  int room_id;
-  int start_x;
-  int start_y;
-
-  bool operator==(const MinecartTrack&) const = default;
-};
-
-}  // namespace yaze::editor
-
-#include "app/editor/system/workspace/editor_panel.h"
 
 namespace yaze::editor {
 
@@ -75,14 +64,8 @@ class MinecartTrackEditorPanel : public WindowContent {
   }
 
  private:
-  struct ParsedSection {
-    std::vector<int> values;
-    bool guarded = false;
-  };
-
   absl::Status LoadTracks();
-  static absl::StatusOr<ParsedSection> ParseSection(const std::string& content,
-                                                    const std::string& label);
+  absl::Status ValidateLoadedManifestIdentity() const;
   absl::Status RefreshProjectBinding();
   void ResetTrackSession();
   void StartCoordinatePicking(int track_index);
@@ -104,6 +87,10 @@ class MinecartTrackEditorPanel : public WindowContent {
 
   std::vector<MinecartTrack> tracks_;
   std::vector<MinecartTrack> loaded_tracks_;
+  std::optional<MinecartTrackSourceDocument> source_document_;
+  std::optional<core::MinecartTrackLayout::Source> loaded_source_identity_;
+  std::filesystem::path loaded_source_path_;
+  std::string loaded_source_sha256_;
   std::string bound_project_filepath_;
   Rom* rom_ = nullptr;
   DungeonRoomStore* rooms_ = nullptr;
@@ -114,7 +101,6 @@ class MinecartTrackEditorPanel : public WindowContent {
   bool audit_dirty_ = true;
   bool load_attempted_ = false;
   bool loaded_ = false;
-  bool source_is_guarded_ = false;
   std::string status_message_;
   bool show_success_ = false;
   float success_timer_ = 0.0f;

--- a/src/app/editor/editor_library.cmake
+++ b/src/app/editor/editor_library.cmake
@@ -29,6 +29,7 @@ set(
   app/editor/dungeon/dungeon_editor_v2_undo.cc
   app/editor/dungeon/dungeon_object_interaction.cc
   app/editor/dungeon/dungeon_object_selector.cc
+  app/editor/dungeon/minecart_track_source.cc
   app/editor/dungeon/object_selection.cc
   app/editor/dungeon/dungeon_room_loader.cc
   app/editor/dungeon/dungeon_room_selector.cc

--- a/src/core/hack_manifest.cc
+++ b/src/core/hack_manifest.cc
@@ -84,7 +84,8 @@ absl::Status ValidateProjectRelativeSourcePath(
   }
 
   const fs::path path(configured_path);
-  if (path.is_absolute() || path.has_root_name() || !path.has_filename()) {
+  if (path.is_absolute() || path.has_root_name() || path.has_root_directory() ||
+      !path.has_filename()) {
     return absl::InvalidArgumentError(
         absl::StrFormat("%s must be a project-relative file path", field_name));
   }

--- a/src/core/hack_manifest.cc
+++ b/src/core/hack_manifest.cc
@@ -72,6 +72,35 @@ absl::StatusOr<AddressOwnership> ParseOwnership(const std::string& str) {
       absl::StrFormat("Unknown ownership string '%s'", str));
 }
 
+absl::Status ValidateProjectRelativeSourcePath(
+    const std::string& configured_path, absl::string_view field_name) {
+  namespace fs = std::filesystem;
+  if (configured_path.empty() ||
+      configured_path.find('\\') != std::string::npos ||
+      configured_path.find(':') != std::string::npos ||
+      configured_path.find('\0') != std::string::npos) {
+    return absl::InvalidArgumentError(absl::StrFormat(
+        "%s must be a non-empty portable project-relative path", field_name));
+  }
+
+  const fs::path path(configured_path);
+  if (path.is_absolute() || path.has_root_name() || !path.has_filename()) {
+    return absl::InvalidArgumentError(
+        absl::StrFormat("%s must be a project-relative file path", field_name));
+  }
+  for (const fs::path& component : path) {
+    if (component == "." || component == "..") {
+      return absl::InvalidArgumentError(absl::StrFormat(
+          "%s may not contain '.' or '..' components", field_name));
+    }
+  }
+  if (path.lexically_normal().generic_string() != configured_path) {
+    return absl::InvalidArgumentError(absl::StrFormat(
+        "%s must be a normalized project-relative path", field_name));
+  }
+  return absl::OkStatus();
+}
+
 bool IsAsmOwned(AddressOwnership ownership) {
   switch (ownership) {
     case AddressOwnership::kHookPatched:
@@ -672,6 +701,7 @@ void HackManifest::Reset() {
   sram_map_.clear();
   sram_variables_.clear();
   message_layout_ = MessageLayout{};
+  minecart_track_layout_ = MinecartTrackLayout{};
   dungeon_stream_layouts_.clear();
   build_pipeline_ = BuildPipeline{};
   project_registry_ = ProjectRegistry{};
@@ -915,6 +945,72 @@ absl::Status HackManifest::LoadFromString(const std::string& json_content) {
               source["generated_asm_include_path"].get<std::string>(),
       };
     }
+  }
+
+  // Minecart track source contract
+  if (root.contains("minecart_tracks")) {
+    const auto& minecart_tracks = root["minecart_tracks"];
+    if (!minecart_tracks.is_object()) {
+      return absl::InvalidArgumentError("minecart_tracks must be an object");
+    }
+    constexpr std::array<absl::string_view, 1> kMinecartTrackKeys = {"source"};
+    for (const auto& item : minecart_tracks.items()) {
+      if (std::find(kMinecartTrackKeys.begin(), kMinecartTrackKeys.end(),
+                    item.key()) == kMinecartTrackKeys.end()) {
+        return absl::InvalidArgumentError(absl::StrFormat(
+            "minecart_tracks contains unknown field '%s'", item.key()));
+      }
+    }
+    if (!minecart_tracks.contains("source")) {
+      return absl::InvalidArgumentError(
+          "minecart_tracks.source is required when minecart_tracks is present");
+    }
+
+    const auto& source = minecart_tracks["source"];
+    if (!source.is_object()) {
+      return absl::InvalidArgumentError(
+          "minecart_tracks.source must be an object");
+    }
+    constexpr std::array<absl::string_view, 3> kSourceKeys = {
+        "format", "version", "path"};
+    for (const auto& item : source.items()) {
+      if (std::find(kSourceKeys.begin(), kSourceKeys.end(), item.key()) ==
+          kSourceKeys.end()) {
+        return absl::InvalidArgumentError(absl::StrFormat(
+            "minecart_tracks.source contains unknown field '%s'", item.key()));
+      }
+    }
+    for (absl::string_view key : kSourceKeys) {
+      if (!source.contains(key)) {
+        return absl::InvalidArgumentError(
+            absl::StrFormat("minecart_tracks.source.%s is required", key));
+      }
+    }
+    if (!source["format"].is_string() ||
+        source["format"].get<std::string>() != "yaze-minecart-track-table") {
+      return absl::InvalidArgumentError(
+          "minecart_tracks.source.format must be "
+          "'yaze-minecart-track-table'");
+    }
+    const auto source_version_or = ParseBoundedNonnegativeInteger(
+        source["version"], "minecart_tracks.source.version",
+        static_cast<uint64_t>(std::numeric_limits<int>::max()));
+    if (!source_version_or.ok() || *source_version_or != 1) {
+      return absl::InvalidArgumentError(
+          "minecart_tracks.source.version must be integer 1");
+    }
+    if (!source["path"].is_string()) {
+      return absl::InvalidArgumentError(
+          "minecart_tracks.source.path must be a string");
+    }
+    const std::string source_path = source["path"].get<std::string>();
+    RETURN_IF_ERROR(ValidateProjectRelativeSourcePath(
+        source_path, "minecart_tracks.source.path"));
+    minecart_track_layout_.source = MinecartTrackLayout::Source{
+        .format = source["format"].get<std::string>(),
+        .version = *source_version_or,
+        .path = source_path,
+    };
   }
 
   total_hooks_ = protected_regions.total_hooks;

--- a/src/core/hack_manifest.h
+++ b/src/core/hack_manifest.h
@@ -110,6 +110,21 @@ struct MessageLayout {
 };
 
 /**
+ * @brief Canonical source metadata for the ASM-owned minecart track table.
+ */
+struct MinecartTrackLayout {
+  struct Source {
+    std::string format;
+    int version = 0;
+    std::string path;
+
+    bool operator==(const Source&) const = default;
+  };
+
+  std::optional<Source> source;
+};
+
+/**
  * @brief Build pipeline information.
  */
 struct BuildPipeline {
@@ -393,6 +408,12 @@ class HackManifest {
 
   [[nodiscard]] bool IsExpandedMessage(uint16_t message_id) const;
 
+  // ─── Minecart Tracks ──────────────────────────────────────
+
+  [[nodiscard]] const MinecartTrackLayout& minecart_track_layout() const {
+    return minecart_track_layout_;
+  }
+
   // ─── Dungeon Stream Allocation Layouts ────────────────────────────
 
   /**
@@ -529,6 +550,9 @@ class HackManifest {
 
   // Message layout
   MessageLayout message_layout_{};
+
+  // Optional canonical source contract for the minecart track table.
+  MinecartTrackLayout minecart_track_layout_{};
 
   // Explicit dungeon stream layouts, indexed by stream kind.
   std::unordered_map<DungeonStreamType, DungeonStreamLayout>

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -300,6 +300,7 @@ if(YAZE_BUILD_TESTS)
     unit/editor/dungeon_object_selector_palette_test.cc
     unit/editor/dungeon_workbench_toolbar_test.cc
     unit/editor/object_tile_editor_panel_test.cc
+    unit/editor/minecart_track_source_test.cc
     unit/editor/minecart_track_editor_panel_test.cc
     unit/editor/toast_dedup_test.cc
     unit/editor/tile_painting_manager_test.cc
@@ -595,6 +596,7 @@ if(YAZE_BUILD_TESTS)
     unit/editor/dungeon_workbench_toolbar_test.cc
     unit/editor/dungeon_workbench_content_test.cc
     unit/editor/object_tile_editor_panel_test.cc
+    unit/editor/minecart_track_source_test.cc
     unit/editor/minecart_track_editor_panel_test.cc
     unit/editor/project_manager_validator_test.cc
     unit/editor/tile_painting_manager_test.cc

--- a/test/unit/core/hack_manifest_test.cc
+++ b/test/unit/core/hack_manifest_test.cc
@@ -81,6 +81,7 @@ void ExpectManifestLoadFailure(const std::string& json,
   EXPECT_FALSE(manifest.HasDungeonStreamLayouts());
   EXPECT_TRUE(manifest.protected_regions().empty());
   EXPECT_TRUE(manifest.editor_managed_regions().empty());
+  EXPECT_FALSE(manifest.minecart_track_layout().source.has_value());
   EXPECT_FALSE(manifest.IsEditorManaged(0x228880));
   EXPECT_NE(std::string(status.message()).find(message_fragment),
             std::string::npos)
@@ -525,6 +526,80 @@ TEST(HackManifestTest, RejectsMalformedMessageSourceMetadata) {
        "canonical_bundle_path must be"},
       {R"json({"manifest_version":3,"messages":{"source":{"format":"yaze-message-bundle","version":1,"canonical_bundle_path":"messages.json","generated_asm_include_path":"messages.asm","extra":true}}})json",
        "unknown field"},
+  };
+
+  for (const auto& [json, expected_message] : invalid_manifests) {
+    SCOPED_TRACE(json);
+    ExpectManifestLoadFailure(json, expected_message);
+  }
+}
+
+TEST(HackManifestTest, ParsesOptionalMinecartTrackSourceMetadata) {
+  constexpr const char* kJson = R"json(
+{
+  "manifest_version": 3,
+  "minecart_tracks": {
+    "source": {
+      "format": "yaze-minecart-track-table",
+      "version": 1,
+      "path": "Sprites/Objects/data/minecart_tracks.asm"
+    }
+  }
+}
+)json";
+
+  HackManifest manifest;
+  ASSERT_TRUE(manifest.LoadFromString(kJson).ok());
+  ASSERT_TRUE(manifest.minecart_track_layout().source.has_value());
+  EXPECT_EQ(manifest.minecart_track_layout().source->format,
+            "yaze-minecart-track-table");
+  EXPECT_EQ(manifest.minecart_track_layout().source->version, 1);
+  EXPECT_EQ(manifest.minecart_track_layout().source->path,
+            "Sprites/Objects/data/minecart_tracks.asm");
+
+  ASSERT_TRUE(
+      manifest
+          .LoadFromString(R"json({"manifest_version":3,"hack_name":"B"})json")
+          .ok());
+  EXPECT_FALSE(manifest.minecart_track_layout().source.has_value());
+}
+
+TEST(HackManifestTest, RejectsMalformedMinecartTrackSourceMetadata) {
+  const std::pair<const char*, const char*> invalid_manifests[] = {
+      {R"json({"manifest_version":3,"minecart_tracks":[]})json",
+       "minecart_tracks must be an object"},
+      {R"json({"manifest_version":3,"minecart_tracks":{}})json",
+       "minecart_tracks.source is required"},
+      {R"json({"manifest_version":3,"minecart_tracks":{"source":{},"extra":true}})json",
+       "minecart_tracks contains unknown field"},
+      {R"json({"manifest_version":3,"minecart_tracks":{"source":[]}})json",
+       "minecart_tracks.source must be an object"},
+      {R"json({"manifest_version":3,"minecart_tracks":{"source":{}}})json",
+       "minecart_tracks.source.format is required"},
+      {R"json({"manifest_version":3,"minecart_tracks":{"source":{"format":"other","version":1,"path":"minecart_tracks.asm"}}})json",
+       "format must be"},
+      {R"json({"manifest_version":3,"minecart_tracks":{"source":{"format":"yaze-minecart-track-table","version":"1","path":"minecart_tracks.asm"}}})json",
+       "version must be integer 1"},
+      {R"json({"manifest_version":3,"minecart_tracks":{"source":{"format":"yaze-minecart-track-table","version":2,"path":"minecart_tracks.asm"}}})json",
+       "version must be integer 1"},
+      {R"json({"manifest_version":3,"minecart_tracks":{"source":{"format":"yaze-minecart-track-table","version":1,"path":7}}})json",
+       "path must be a string"},
+      {R"json({"manifest_version":3,"minecart_tracks":{"source":{"format":"yaze-minecart-track-table","version":1,"path":""}}})json",
+       "non-empty portable"},
+      {R"json({"manifest_version":3,"minecart_tracks":{"source":{"format":"yaze-minecart-track-table","version":1,"path":"/tmp/minecart_tracks.asm"}}})json",
+       "project-relative file path"},
+      {R"json({"manifest_version":3,"minecart_tracks":{"source":{"format":"yaze-minecart-track-table","version":1,"path":"C:/tmp/minecart_tracks.asm"}}})json",
+       "portable project-relative"},
+      {R"json({"manifest_version":3,"minecart_tracks":{"source":{"format":"yaze-minecart-track-table","version":1,"path":"../minecart_tracks.asm"}}})json",
+       "may not contain"},
+      {R"json({"manifest_version":3,"minecart_tracks":{"source":{"format":"yaze-minecart-track-table","version":1,"path":"Sprites/./minecart_tracks.asm"}}})json",
+       "may not contain"},
+      {R"json({"manifest_version":3,"minecart_tracks":{"source":{"format":"yaze-minecart-track-table","version":1,"path":"Sprites\\minecart_tracks.asm"}}})json",
+       "portable project-relative"},
+      {R"json({"manifest_version":3,"minecart_tracks":{"source":{"format":"yaze-minecart-track-table","version":1,"path":"Sprites//minecart_tracks.asm"}}})json",
+       "normalized project-relative"},
+      {R"json({"manifest_version":3,"minecart_tracks":{"source":{"format":"yaze-minecart-track-table","version":1,"path":"minecart_tracks.asm","extra":true}}})json",
+       "source contains unknown field"},
   };
 
   for (const auto& [json, expected_message] : invalid_manifests) {

--- a/test/unit/editor/minecart_track_editor_panel_test.cc
+++ b/test/unit/editor/minecart_track_editor_panel_test.cc
@@ -4,6 +4,7 @@
 #include <filesystem>
 #include <fstream>
 #include <sstream>
+#include <stdexcept>
 #include <string>
 #include <vector>
 
@@ -43,6 +44,10 @@ class ScopedTestProject {
     project_.filepath = (root_ / "Oracle-of-Secrets.yaze").string();
     project_.code_folder = (root_ / "Core").string();
     std::ofstream(project_.filepath) << "name=Minecart Test\n";
+    const absl::Status manifest_status = LoadManifest();
+    if (!manifest_status.ok()) {
+      throw std::runtime_error(std::string(manifest_status.message()));
+    }
   }
 
   ~ScopedTestProject() {
@@ -57,10 +62,35 @@ class ScopedTestProject {
   std::filesystem::path source_path() const {
     return root_ / kTrackSourceRelativePath;
   }
+  std::filesystem::path source_path(const std::string& relative_path) const {
+    return root_ / relative_path;
+  }
+
+  absl::Status LoadManifest(
+      const std::string& relative_path = kTrackSourceRelativePath) {
+    return project_.hack_manifest.LoadFromString(absl::StrFormat(
+        R"json({
+          "manifest_version": 3,
+          "minecart_tracks": {
+            "source": {
+              "format": "yaze-minecart-track-table",
+              "version": 1,
+              "path": "%s"
+            }
+          }
+        })json",
+        relative_path));
+  }
 
   void WriteSource(const std::string& contents) {
-    std::filesystem::create_directories(source_path().parent_path());
-    std::ofstream file(source_path(), std::ios::binary | std::ios::trunc);
+    WriteSourceAt(kTrackSourceRelativePath, contents);
+  }
+
+  void WriteSourceAt(const std::string& relative_path,
+                     const std::string& contents) {
+    const std::filesystem::path path = source_path(relative_path);
+    std::filesystem::create_directories(path.parent_path());
+    std::ofstream file(path, std::ios::binary | std::ios::trunc);
     file << contents;
   }
 
@@ -168,7 +198,8 @@ TEST(MinecartTrackEditorPanelTest,
   EXPECT_FALSE(panel.HasUnpublishedChanges());
 }
 
-TEST(MinecartTrackEditorPanelTest, FlatSourceRequiresExactly32Entries) {
+TEST(MinecartTrackEditorPanelTest,
+     FlatSourcePublishesExplicitlyAndRebasesTheDraft) {
   ScopedTestProject fixture;
   fixture.WriteSource(MakeFlatSource(32));
 
@@ -185,9 +216,13 @@ TEST(MinecartTrackEditorPanelTest, FlatSourceRequiresExactly32Entries) {
   MinecartTrack draft = panel.GetTracks().front();
   draft.room_id = 0x0777;
   ASSERT_TRUE(panel.UpdateTrack(0, draft).ok());
-  EXPECT_TRUE(absl::IsUnimplemented(panel.SaveTracks()));
-  EXPECT_EQ(fixture.ReadSource(), source_before);
-  EXPECT_TRUE(panel.HasUnpublishedChanges());
+  ASSERT_TRUE(panel.SaveTracks().ok());
+  std::string expected_source = source_before;
+  expected_source.replace(expected_source.find("$0100"), 5, "$0777");
+  EXPECT_EQ(fixture.ReadSource(), expected_source);
+  EXPECT_FALSE(panel.HasUnpublishedChanges());
+  EXPECT_EQ(panel.GetTracks().front().room_id, 0x0777);
+  EXPECT_TRUE(absl::IsFailedPrecondition(panel.SaveTracks()));
 }
 
 TEST(MinecartTrackEditorPanelTest,
@@ -324,7 +359,86 @@ TEST(MinecartTrackEditorPanelTest, RejectsSourceSymlinkOutsideProjectRoot) {
 }
 
 TEST(MinecartTrackEditorPanelTest,
-     GuardedPublicationAndDungeonSavesFailBeforeAnyMutation) {
+     MissingManifestSourceFailsClosedBeforeLoading) {
+  ScopedTestProject fixture;
+  fixture.WriteSource(MakeFlatSource(32));
+  const std::string source_before = fixture.ReadSource();
+  fixture.project()->hack_manifest.Clear();
+
+  MinecartTrackEditorPanel panel;
+  ASSERT_TRUE(panel.SetProject(fixture.project()).ok());
+  const absl::Status status = panel.ReloadTracks();
+
+  EXPECT_TRUE(absl::IsFailedPrecondition(status)) << status;
+  EXPECT_NE(std::string(status.message()).find("minecart_tracks.source"),
+            std::string::npos);
+  EXPECT_TRUE(panel.GetTracks().empty());
+  EXPECT_EQ(fixture.ReadSource(), source_before);
+}
+
+TEST(MinecartTrackEditorPanelTest,
+     ManifestIdentityChangeRejectsPublishAndPreservesDraft) {
+  constexpr char kAlternateSource[] = "Data/alternate_minecart_tracks.asm";
+  ScopedTestProject fixture;
+  fixture.WriteSource(MakeFlatSource(32));
+  fixture.WriteSourceAt(kAlternateSource,
+                        MakeFlatSource(32, /*room_base=*/0x0300));
+  const std::string original_source = fixture.ReadSource();
+  const std::string alternate_source = [&]() {
+    std::ifstream file(fixture.source_path(kAlternateSource), std::ios::binary);
+    std::stringstream buffer;
+    buffer << file.rdbuf();
+    return buffer.str();
+  }();
+
+  MinecartTrackEditorPanel panel;
+  ASSERT_TRUE(panel.SetProject(fixture.project()).ok());
+  ASSERT_TRUE(panel.ReloadTracks().ok());
+  MinecartTrack draft = panel.GetTracks()[0];
+  draft.room_id = 0x0777;
+  ASSERT_TRUE(panel.UpdateTrack(0, draft).ok());
+  ASSERT_TRUE(fixture.LoadManifest(kAlternateSource).ok());
+
+  const absl::Status status = panel.SaveTracks();
+  EXPECT_TRUE(absl::IsFailedPrecondition(status)) << status;
+  EXPECT_NE(std::string(status.message()).find("changed"), std::string::npos);
+  EXPECT_EQ(fixture.ReadSource(), original_source);
+  std::ifstream alternate_file(fixture.source_path(kAlternateSource),
+                               std::ios::binary);
+  std::stringstream alternate_buffer;
+  alternate_buffer << alternate_file.rdbuf();
+  EXPECT_EQ(alternate_buffer.str(), alternate_source);
+  EXPECT_EQ(panel.GetTracks()[0].room_id, 0x0777);
+  EXPECT_TRUE(panel.HasUnpublishedChanges());
+}
+
+TEST(MinecartTrackEditorPanelTest,
+     ExternalSourceChangeFailsCasAndPreservesExternalBytesAndDraft) {
+  ScopedTestProject fixture;
+  fixture.WriteSource(MakeFlatSource(32));
+
+  MinecartTrackEditorPanel panel;
+  ASSERT_TRUE(panel.SetProject(fixture.project()).ok());
+  ASSERT_TRUE(panel.ReloadTracks().ok());
+  MinecartTrack draft = panel.GetTracks()[0];
+  draft.room_id = 0x0777;
+  ASSERT_TRUE(panel.UpdateTrack(0, draft).ok());
+
+  const std::string external_source =
+      fixture.ReadSource() + "\n; external author update\n";
+  fixture.WriteSource(external_source);
+  const absl::Status status = panel.SaveTracks();
+
+  EXPECT_TRUE(absl::IsAborted(status)) << status;
+  EXPECT_NE(std::string(status.message()).find("CAS failed"),
+            std::string::npos);
+  EXPECT_EQ(fixture.ReadSource(), external_source);
+  EXPECT_EQ(panel.GetTracks()[0].room_id, 0x0777);
+  EXPECT_TRUE(panel.HasUnpublishedChanges());
+}
+
+TEST(MinecartTrackEditorPanelTest,
+     DungeonSavesBlockDraftsThenGuardedPublicationRebases) {
   ScopedTestProject fixture;
   fixture.WriteSource(MakeGuardedSource());
   MinecartTrackEditorPanel panel;
@@ -336,13 +450,6 @@ TEST(MinecartTrackEditorPanelTest,
   ASSERT_TRUE(panel.UpdateTrack(0, draft).ok());
   ASSERT_TRUE(panel.HasUnpublishedChanges());
   const std::string source_before = fixture.ReadSource();
-
-  const absl::Status publish_status = panel.SaveTracks();
-  EXPECT_TRUE(absl::IsFailedPrecondition(publish_status)) << publish_status;
-  EXPECT_NE(std::string(publish_status.message()).find("Guarded"),
-            std::string::npos);
-  EXPECT_EQ(fixture.ReadSource(), source_before);
-  EXPECT_TRUE(panel.HasUnpublishedChanges());
 
   Rom rom;
   ASSERT_TRUE(rom.LoadFromData(std::vector<uint8_t>(0x200000, 0)).ok());
@@ -371,7 +478,11 @@ TEST(MinecartTrackEditorPanelTest,
   EXPECT_EQ(fixture.ReadSource(), source_before);
   EXPECT_TRUE(panel.HasUnpublishedChanges());
 
-  ASSERT_TRUE(panel.DiscardUnpublishedChanges().ok());
+  ASSERT_TRUE(panel.SaveTracks().ok());
+  std::string expected_source = source_before;
+  expected_source.replace(expected_source.find("$0200"), 5, "$0777");
+  EXPECT_EQ(fixture.ReadSource(), expected_source);
+  EXPECT_FALSE(panel.HasUnpublishedChanges());
   EXPECT_FALSE(editor.HasPendingDungeonChanges());
 }
 

--- a/test/unit/editor/minecart_track_editor_panel_test.cc
+++ b/test/unit/editor/minecart_track_editor_panel_test.cc
@@ -462,8 +462,16 @@ TEST(MinecartTrackEditorPanelTest,
   EXPECT_TRUE(editor.HasPendingDungeonChanges());
   const absl::Status save_status = editor.Save();
   EXPECT_TRUE(absl::IsFailedPrecondition(save_status)) << save_status;
-  EXPECT_NE(std::string(save_status.message()).find("Minecart"),
-            std::string::npos);
+  EXPECT_NE(std::string(save_status.message())
+                .find("ROM Save/Apply never publishes ASM source"),
+            std::string::npos)
+      << save_status;
+  EXPECT_NE(std::string(save_status.message()).find("Publish Tracks"),
+            std::string::npos)
+      << save_status;
+  EXPECT_NE(std::string(save_status.message()).find("discard the drafts"),
+            std::string::npos)
+      << save_status;
   EXPECT_EQ(rom.vector(), rom_before);
   EXPECT_EQ(rom.dirty(), dirty_before);
   EXPECT_EQ(fixture.ReadSource(), source_before);
@@ -471,8 +479,16 @@ TEST(MinecartTrackEditorPanelTest,
 
   const absl::Status save_room_status = editor.SaveRoom(0);
   EXPECT_TRUE(absl::IsFailedPrecondition(save_room_status)) << save_room_status;
-  EXPECT_NE(std::string(save_room_status.message()).find("Minecart"),
-            std::string::npos);
+  EXPECT_NE(std::string(save_room_status.message())
+                .find("ROM Save/Apply never publishes ASM source"),
+            std::string::npos)
+      << save_room_status;
+  EXPECT_NE(std::string(save_room_status.message()).find("Publish Tracks"),
+            std::string::npos)
+      << save_room_status;
+  EXPECT_NE(std::string(save_room_status.message()).find("discard the drafts"),
+            std::string::npos)
+      << save_room_status;
   EXPECT_EQ(rom.vector(), rom_before);
   EXPECT_EQ(rom.dirty(), dirty_before);
   EXPECT_EQ(fixture.ReadSource(), source_before);

--- a/test/unit/editor/minecart_track_source_test.cc
+++ b/test/unit/editor/minecart_track_source_test.cc
@@ -1,0 +1,208 @@
+#include "app/editor/dungeon/minecart_track_source.h"
+
+#include <algorithm>
+#include <array>
+#include <sstream>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+#include "absl/status/status.h"
+#include "absl/strings/str_format.h"
+#include "gtest/gtest.h"
+
+namespace yaze::editor {
+namespace {
+
+void AppendDwValues(std::stringstream& stream, int first_value, int count,
+                    std::string_view indent = "    ") {
+  for (int i = 0; i < count; i += 4) {
+    stream << indent << "dw ";
+    for (int j = 0; j < 4 && i + j < count; ++j) {
+      if (j > 0) {
+        stream << ", ";
+      }
+      stream << absl::StrFormat("$%04X", first_value + i + j);
+    }
+    stream << "  ; values " << i << "\n";
+  }
+}
+
+std::string MakeFlatSection(std::string_view label, int first_value,
+                            int count = 32) {
+  std::stringstream stream;
+  stream << "  " << label << "\r\n";
+  for (int i = 0; i < count; i += 4) {
+    stream << "\tdw ";
+    for (int j = 0; j < 4 && i + j < count; ++j) {
+      if (j > 0) {
+        stream << ",  ";
+      }
+      stream << absl::StrFormat("$%04X", first_value + i + j);
+    }
+    stream << " ; keep flat formatting\r\n";
+  }
+  return stream.str();
+}
+
+std::string MakeFlatSource(int room_count = 32) {
+  return "; header stays byte-for-byte\r\n" +
+         MakeFlatSection(".TrackStartingRooms", 0x0100, room_count) +
+         "; between rooms and x\n" +
+         MakeFlatSection(".TrackStartingX", 0x1000) +
+         MakeFlatSection(".TrackStartingY", 0x2000);
+}
+
+std::string MakeGuardedSection(std::string_view label, int first_value,
+                               int prefix_count = 4, int enabled_count = 28,
+                               int disabled_count = 28) {
+  std::stringstream stream;
+  stream << "  " << label << "\n";
+  AppendDwValues(stream, first_value, prefix_count, "  ");
+  stream << "  if !ENABLE_MINECART_PLANNED_TRACK_TABLE == 1\n";
+  AppendDwValues(stream, first_value + prefix_count, enabled_count);
+  stream << "  else\n"
+         << "    ; disabled branch must never be rewritten\n";
+  AppendDwValues(stream, 0, disabled_count);
+  stream << "  endif\n";
+  return stream.str();
+}
+
+std::string MakeGuardedSource(int room_prefix = 4, int room_enabled = 28,
+                              int room_disabled = 28) {
+  return "; canonical guarded source\n" +
+         MakeGuardedSection(".TrackStartingRooms", 0x0200, room_prefix,
+                            room_enabled, room_disabled) +
+         "\n; coordinate comments remain untouched\n" +
+         MakeGuardedSection(".TrackStartingX", 0x1100) +
+         MakeGuardedSection(".TrackStartingY", 0x2100);
+}
+
+bool IsWithinSpan(size_t offset, const MinecartTrackSourceTokenSpan& span) {
+  return offset >= span.offset && offset < span.offset + span.length;
+}
+
+}  // namespace
+
+TEST(MinecartTrackSourceTest, ParsesFlatTablesAndRetainsExactTokenSpans) {
+  const std::string source = MakeFlatSource();
+  auto document_or = MinecartTrackSourceDocument::Parse(source);
+
+  ASSERT_TRUE(document_or.ok()) << document_or.status();
+  EXPECT_FALSE(document_or->guarded());
+  EXPECT_EQ(document_or->source_bytes(), source);
+  ASSERT_EQ(document_or->tracks().size(), kMinecartTrackSlotCount);
+  EXPECT_EQ(document_or->tracks().front(),
+            (MinecartTrack{0, 0x0100, 0x1000, 0x2000}));
+  EXPECT_EQ(document_or->tracks().back(),
+            (MinecartTrack{31, 0x011F, 0x101F, 0x201F}));
+
+  for (const auto& field : document_or->editable_token_spans()) {
+    for (const MinecartTrackSourceTokenSpan span : field) {
+      EXPECT_EQ(span.length, 5u);
+      ASSERT_LE(span.offset + span.length, source.size());
+      EXPECT_EQ(source.substr(span.offset, span.length).front(), '$');
+    }
+  }
+}
+
+TEST(MinecartTrackSourceTest,
+     GuardedRenderChangesOnlySelectedPrefixAndEnabledTokens) {
+  std::string source = MakeGuardedSource();
+  source.replace(source.find("$0201"), 5, "$02a1");
+  auto document_or = MinecartTrackSourceDocument::Parse(source);
+  ASSERT_TRUE(document_or.ok()) << document_or.status();
+  ASSERT_TRUE(document_or->guarded());
+
+  std::vector<MinecartTrack> edited = document_or->tracks();
+  edited[0].room_id = 0x0777;   // Four-entry prefix.
+  edited[4].start_x = 0x1888;   // Enabled branch.
+  edited[31].start_y = 0x2999;  // Last enabled token.
+  auto rendered_or = document_or->Render(edited);
+  ASSERT_TRUE(rendered_or.ok()) << rendered_or.status();
+  ASSERT_EQ(rendered_or->size(), source.size());
+
+  const std::array<MinecartTrackSourceTokenSpan, 3> changed_spans = {
+      document_or->editable_token_spans()[0][0],
+      document_or->editable_token_spans()[1][4],
+      document_or->editable_token_spans()[2][31]};
+  for (size_t offset = 0; offset < source.size(); ++offset) {
+    if (source[offset] == (*rendered_or)[offset]) {
+      continue;
+    }
+    EXPECT_TRUE(std::any_of(
+        changed_spans.begin(), changed_spans.end(),
+        [&](const auto& span) { return IsWithinSpan(offset, span); }))
+        << "Unexpected byte change at offset " << offset;
+  }
+  EXPECT_EQ(rendered_or->substr(changed_spans[0].offset, 5), "$0777");
+  EXPECT_EQ(rendered_or->substr(changed_spans[1].offset, 5), "$1888");
+  EXPECT_EQ(rendered_or->substr(changed_spans[2].offset, 5), "$2999");
+  EXPECT_NE(rendered_or->find("$02a1"), std::string::npos);
+
+  auto reparsed_or = MinecartTrackSourceDocument::Parse(*rendered_or);
+  ASSERT_TRUE(reparsed_or.ok()) << reparsed_or.status();
+  EXPECT_EQ(reparsed_or->tracks(), edited);
+}
+
+TEST(MinecartTrackSourceTest, RejectsMalformedCountsTokensAndLayouts) {
+  std::vector<std::string> invalid_sources = {
+      MakeFlatSource(0),
+      MakeFlatSource(31),
+      MakeFlatSource(33),
+      MakeGuardedSource(/*room_prefix=*/3),
+      MakeGuardedSource(/*room_prefix=*/5),
+      MakeGuardedSource(/*room_prefix=*/4, /*room_enabled=*/27),
+      MakeGuardedSource(/*room_prefix=*/4, /*room_enabled=*/29),
+      MakeGuardedSource(/*room_prefix=*/4, /*room_enabled=*/28,
+                        /*room_disabled=*/27),
+      MakeGuardedSource(/*room_prefix=*/4, /*room_enabled=*/28,
+                        /*room_disabled=*/29),
+  };
+
+  std::string short_token = MakeFlatSource();
+  short_token.replace(short_token.find("$0100"), 5, "$100");
+  invalid_sources.push_back(std::move(short_token));
+  std::string wide_token = MakeFlatSource();
+  wide_token.replace(wide_token.find("$0100"), 5, "$00100");
+  invalid_sources.push_back(std::move(wide_token));
+  invalid_sources.push_back(MakeFlatSection(".TrackStartingRooms", 0x0100) +
+                            MakeGuardedSection(".TrackStartingX", 0x1100) +
+                            MakeGuardedSection(".TrackStartingY", 0x2100));
+  invalid_sources.push_back(MakeFlatSection(".TrackStartingX", 0x1000) +
+                            MakeFlatSection(".TrackStartingRooms", 0x0100) +
+                            MakeFlatSection(".TrackStartingY", 0x2000));
+  invalid_sources.push_back(MakeFlatSource() +
+                            MakeFlatSection(".TrackStartingRooms", 0x3000));
+
+  for (const std::string& source : invalid_sources) {
+    SCOPED_TRACE(source);
+    EXPECT_FALSE(MinecartTrackSourceDocument::Parse(source).ok());
+  }
+}
+
+TEST(MinecartTrackSourceTest, RenderValidatesTrackCountIdsAndWords) {
+  auto document_or = MinecartTrackSourceDocument::Parse(MakeFlatSource());
+  ASSERT_TRUE(document_or.ok()) << document_or.status();
+
+  std::vector<MinecartTrack> tracks = document_or->tracks();
+  tracks.pop_back();
+  EXPECT_TRUE(absl::IsInvalidArgument(document_or->Render(tracks).status()));
+
+  tracks = document_or->tracks();
+  tracks[7].id = 8;
+  EXPECT_TRUE(absl::IsInvalidArgument(document_or->Render(tracks).status()));
+
+  for (int MinecartTrack::* field :
+       {&MinecartTrack::room_id, &MinecartTrack::start_x,
+        &MinecartTrack::start_y}) {
+    tracks = document_or->tracks();
+    tracks[3].*field = -1;
+    EXPECT_TRUE(absl::IsInvalidArgument(document_or->Render(tracks).status()));
+    tracks[3].*field = 0x10000;
+    EXPECT_TRUE(absl::IsInvalidArgument(document_or->Render(tracks).status()));
+  }
+}
+
+}  // namespace yaze::editor


### PR DESCRIPTION
## Summary
- add a strict optional `minecart_tracks.source` manifest contract and a lossless parser/renderer for flat and guarded ASM track tables
- publish track edits explicitly through the shared lock/CAS/atomic-write/readback path while keeping Save and Save Room fail-closed when unpublished drafts exist
- make the OoS workflow explicit: publish ASM, save pending ROM edits to the development ROM, rebuild the patched ROM, then reopen/reload it before testing
- disable publishing on browser builds while retaining drafts and actionable guidance

## Safety behavior
- publication is opt-in through **Publish Tracks**; ordinary ROM Save/Apply never writes ASM source
- manifest identity, canonical path, exact source bytes, and SHA-256 are revalidated under the durable source-artifact lock
- formatting, comments, guards, and disabled table branches round-trip byte-for-byte; only active `$hhhh` token spans change
- failures preserve the draft and leave Save/Save Room blocked until publish or discard

## Verification
- `yaze_test_quick_unit_editor --gtest_filter='MinecartTrackSourceTest.*:MinecartTrackEditorPanelTest.*'` — 14/14 passed
- `yaze_test_quick_unit_core --gtest_filter='HackManifestTest.*:SourceArtifactPublisherTest.*'` — 39/39 passed
- `scripts/pre-push.sh --build-dir build/presets/mac-ai-fast` — passed (build + 13 smoke tests + formatting/change-aware UI checks)
- actual Oracle of Secrets source parsed and round-tripped byte-exact in a read-only temporary harness; selected edits changed only expected token bytes

## Integration
- Oracle-of-Secrets PR #120 is merged and supplies the generated manifest contract consumed here
- no ROM, emulator state, or Oracle source file is modified by this PR

## Known residuals
- publishing cannot make the later ROM save/build/reload sequence atomic; the UI now states that boundary explicitly
- non-cooperating external writers and parent-directory replacement remain outside the cooperative lock contract
- browser publishing remains intentionally unavailable
