### PR TITLE
Fail closed on pending graphics sheet saves

### DIFF
--- a/docs/public/reference/feature-coverage-report.md
+++ b/docs/public/reference/feature-coverage-report.md
@@ -17,7 +17,7 @@ AppData/Library/XDG.
 | Overworld Editor | Beta | Overworld edits persist to ROM; version-gated for vanilla/v2/v3. Tile16 palette inconsistencies, paste not tracked in undo, sprite workflow incomplete. |
 | Dungeon Editor | Beta | Room objects, sprites, headers, torches, custom collision, chests, and pot items persist to ROM; shared undo/redo. Focused regression coverage exists for save-path writers, `DungeonEditorSystem`, and editor save-flag gating, and recent workbench/nav compaction protects visible room area better in constrained layouts. Remaining gaps are 12+ unknown object types, specific visual discrepancies, selector/browser preview parity, and pits/blocks still using legacy blob-preservation saves. Optional connected-room/grouped-room overview work remains exploratory rather than part of the current baseline editor path. |
 | Palette Editor | Beta | Palette changes persist to ROM; JSON import/export not implemented. |
-| Graphics Editor | Beta | Tile/sheet edits persist to ROM; undo/redo via UndoManager. |
+| Graphics Editor | Beta | Tile/sheet editing and undo/redo are available, but pending sheet edits currently block ROM save because the graphics serializer is not yet safe; sheet persistence is unavailable. |
 | Sprite Editor | Beta | Sprite viewing/editing works with undo/redo; deeper workflow coverage is still limited. |
 | Message Editor | Stable | Text edits persist to ROM. |
 | Screen Editor | WIP | Dungeon-map undo/redo is implemented; pause-menu world-map editing is present but needs stronger UX/test coverage; cut/copy/paste/find remain incomplete. |

--- a/src/app/editor/editor_manager.cc
+++ b/src/app/editor/editor_manager.cc
@@ -4080,7 +4080,7 @@ absl::Status EditorManager::SaveRomInternal(
     return absl::FailedPreconditionError(absl::StrFormat(
         "Save blocked: graphics sheet edits are pending, but graphics ROM "
         "persistence is not safely available (Save Graphics Sheets is %s). "
-        "Export or discard the edits before saving the ROM.",
+        "Discard the graphics sheet edits before saving the ROM.",
         core::FeatureFlags::get().kSaveGraphicsSheet ? "enabled" : "disabled"));
   }
 

--- a/src/app/editor/editor_manager.cc
+++ b/src/app/editor/editor_manager.cc
@@ -4071,6 +4071,19 @@ absl::Status EditorManager::SaveRomInternal(
     }
   } lifecycle_project_guard{&rom_lifecycle_, &current_project_};
 
+  // GraphicsEditor tracks pixel edits in its model, not in the ROM buffer.
+  // The previous global graphics writer was a success-returning stub, and
+  // the editor-specific writer is not yet safe to join this coordinated save.
+  // Block before any serializer can mutate the ROM rather than report a save
+  // that silently omitted the pending sheets.
+  if (current_editor_set->HasPendingGraphicsChanges()) {
+    return absl::FailedPreconditionError(absl::StrFormat(
+        "Save blocked: graphics sheet edits are pending, but graphics ROM "
+        "persistence is not safely available (Save Graphics Sheets is %s). "
+        "Export or discard the edits before saving the ROM.",
+        core::FeatureFlags::get().kSaveGraphicsSheet ? "enabled" : "disabled"));
+  }
+
   // --- State machine checks (delegated to RomLifecycleManager) ---
   if (rom_lifecycle_.IsRomWriteConfirmPending()) {
     return absl::CancelledError("Save pending confirmation");
@@ -4172,11 +4185,6 @@ absl::Status EditorManager::SaveRomInternal(
     RETURN_IF_ERROR(EnsureEditorAssetsLoaded(EditorType::kMessage));
     RETURN_IF_ERROR(
         save_editor(current_editor_set->GetEditor(EditorType::kMessage)));
-  }
-
-  if (core::FeatureFlags::get().kSaveGraphicsSheet) {
-    RETURN_IF_ERROR(zelda3::SaveAllGraphicsData(
-        *current_rom, gfx::Arena::Get().gfx_sheets()));
   }
 
   // Oracle guardrails: refuse to write obviously corrupted ROM layouts.
@@ -5959,11 +5967,12 @@ absl::Status EditorManager::DiscardPendingRomBackupRestore() {
   }
 
   const size_t session_index = GetCurrentSessionIndex();
-  if (HasPendingDungeonChangesForSession(session_index) ||
+  if (session->editors.HasPendingGraphicsChanges() ||
+      HasPendingDungeonChangesForSession(session_index) ||
       gfx::PaletteManager::Get().HasUnsavedChanges(&session->game_data)) {
     return absl::FailedPreconditionError(
-        "Resolve pending dungeon or palette edits before discarding the "
-        "restored backup");
+        "Resolve pending graphics, dungeon, or palette edits before "
+        "discarding the restored backup");
   }
 
   const std::string backing_path = session->rom.filename();
@@ -6420,6 +6429,7 @@ bool EditorManager::SessionHasPendingRomWork(size_t session_index) const {
       static_cast<RomSession*>(session_coordinator_->GetSession(session_index));
   return session != nullptr &&
          ((session->rom.is_loaded() && session->rom.dirty()) ||
+          session->editors.HasPendingGraphicsChanges() ||
           HasPendingDungeonChangesForSession(session_index) ||
           gfx::PaletteManager::Get().HasUnsavedChanges(&session->game_data));
 }
@@ -6509,6 +6519,8 @@ std::string EditorManager::DescribePendingUnsavedWork(
       session != nullptr && session->rom.is_loaded() && session->rom.dirty();
   const bool pending_dungeon_changes =
       HasPendingDungeonChangesForSession(session_index);
+  const bool pending_graphics_changes =
+      session != nullptr && session->editors.HasPendingGraphicsChanges();
   const int pending_rooms = PendingDungeonRoomCountForSession(session_index);
   const size_t pending_palette_colors =
       PendingPaletteColorCountForSession(session_index);
@@ -6528,6 +6540,9 @@ std::string EditorManager::DescribePendingUnsavedWork(
     work.push_back(absl::StrFormat("%zu unapplied palette color%s",
                                    pending_palette_colors,
                                    pending_palette_colors == 1 ? "" : "s"));
+  }
+  if (pending_graphics_changes) {
+    work.emplace_back("unapplied graphics sheet edits");
   }
   if (rom_dirty) {
     work.emplace_back("unsaved ROM-buffer changes");
@@ -6558,7 +6573,8 @@ std::string EditorManager::DescribeAllPendingUnsavedWork() const {
   }
 
   return absl::StrFormat(
-      "%d sessions have unsaved ROM, dungeon, palette, or project work.",
+      "%d sessions have unsaved ROM, graphics, dungeon, palette, or project "
+      "work.",
       modified_sessions);
 }
 

--- a/src/app/editor/graphics/graphics_editor.h
+++ b/src/app/editor/graphics/graphics_editor.h
@@ -25,6 +25,8 @@
 namespace yaze {
 namespace editor {
 
+class GraphicsEditorSaveStoplossTestPeer;
+
 // Super Donkey prototype graphics offsets (from leaked dev materials)
 const std::string kSuperDonkeyTiles[] = {
     "97C05", "98219", "9871E", "98C00", "99084", "995AF", "99DE0", "9A27E",
@@ -85,6 +87,8 @@ class GraphicsEditor : public Editor {
   absl::Status Find() override { return absl::UnimplementedError("Find"); }
   void ContributeStatus(StatusBar* status_bar) override;
 
+  bool HasPendingGraphicsChanges() const { return state_.HasUnsavedChanges(); }
+
   // Set the ROM pointer (propagates to panels that cache `Rom*`.)
   void set_rom(Rom* rom) {
     rom_ = rom;
@@ -133,6 +137,8 @@ class GraphicsEditor : public Editor {
   Rom* rom() const { return rom_; }
 
  private:
+  friend class GraphicsEditorSaveStoplossTestPeer;
+
   // Editor-level shortcut handling
   void HandleEditorShortcuts();
 

--- a/src/app/editor/graphics/graphics_undo_actions.h
+++ b/src/app/editor/graphics/graphics_undo_actions.h
@@ -3,6 +3,7 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <functional>
 #include <string>
 #include <utility>
 #include <vector>
@@ -25,14 +26,16 @@ namespace editor {
  */
 class GraphicsPixelEditAction : public UndoAction {
  public:
-  GraphicsPixelEditAction(uint16_t sheet_id,
-                          std::vector<uint8_t> before_data,
+  using MarkDirtyFn = std::function<void(uint16_t)>;
+
+  GraphicsPixelEditAction(uint16_t sheet_id, std::vector<uint8_t> before_data,
                           std::vector<uint8_t> after_data,
-                          std::string description)
+                          std::string description, MarkDirtyFn mark_dirty)
       : sheet_id_(sheet_id),
         before_data_(std::move(before_data)),
         after_data_(std::move(after_data)),
-        description_(std::move(description)) {}
+        description_(std::move(description)),
+        mark_dirty_(std::move(mark_dirty)) {}
 
   absl::Status Undo() override {
     auto* sheets = gfx::Arena::Get().mutable_gfx_sheets();
@@ -43,6 +46,7 @@ class GraphicsPixelEditAction : public UndoAction {
     auto& sheet = sheets->at(sheet_id_);
     sheet.set_data(before_data_);
     gfx::Arena::Get().NotifySheetModified(sheet_id_);
+    MarkDirty();
     return absl::OkStatus();
   }
 
@@ -55,6 +59,7 @@ class GraphicsPixelEditAction : public UndoAction {
     auto& sheet = sheets->at(sheet_id_);
     sheet.set_data(after_data_);
     gfx::Arena::Get().NotifySheetModified(sheet_id_);
+    MarkDirty();
     return absl::OkStatus();
   }
 
@@ -71,10 +76,17 @@ class GraphicsPixelEditAction : public UndoAction {
   }
 
  private:
+  void MarkDirty() {
+    if (mark_dirty_) {
+      mark_dirty_(sheet_id_);
+    }
+  }
+
   uint16_t sheet_id_;
   std::vector<uint8_t> before_data_;
   std::vector<uint8_t> after_data_;
   std::string description_;
+  MarkDirtyFn mark_dirty_;
 };
 
 }  // namespace editor

--- a/src/app/editor/graphics/pixel_editor_panel.cc
+++ b/src/app/editor/graphics/pixel_editor_panel.cc
@@ -1029,7 +1029,10 @@ void PixelEditorPanel::FinalizeUndoAction() {
         absl::StrFormat("Edit pixels on sheet %02X", pending_undo_sheet_id_);
     undo_manager_->Push(std::make_unique<GraphicsPixelEditAction>(
         pending_undo_sheet_id_, std::move(pending_undo_before_data_),
-        std::move(after_data), std::move(description)));
+        std::move(after_data), std::move(description),
+        [state = state_](uint16_t sheet_id) {
+          state->MarkSheetModified(sheet_id);
+        }));
   }
 
   has_pending_undo_ = false;

--- a/src/app/editor/graphics/ui/editing/pixel_editor_view.cc
+++ b/src/app/editor/graphics/ui/editing/pixel_editor_view.cc
@@ -1029,7 +1029,10 @@ void PixelEditorView::FinalizeUndoAction() {
         absl::StrFormat("Edit pixels on sheet %02X", pending_undo_sheet_id_);
     undo_manager_->Push(std::make_unique<GraphicsPixelEditAction>(
         pending_undo_sheet_id_, std::move(pending_undo_before_data_),
-        std::move(after_data), std::move(description)));
+        std::move(after_data), std::move(description),
+        [state = state_](uint16_t sheet_id) {
+          state->MarkSheetModified(sheet_id);
+        }));
   }
 
   has_pending_undo_ = false;

--- a/src/app/editor/session_types.cc
+++ b/src/app/editor/session_types.cc
@@ -233,6 +233,14 @@ EditorSet::CollectDungeonWriteRanges() const {
   return {};
 }
 
+bool EditorSet::HasPendingGraphicsChanges() const {
+  if (auto* editor =
+          static_cast<GraphicsEditor*>(FindEditor(EditorType::kGraphics))) {
+    return editor->HasPendingGraphicsChanges();
+  }
+  return false;
+}
+
 zelda3::Overworld* EditorSet::GetOverworldData() const {
   if (auto* editor =
           static_cast<OverworldEditor*>(FindEditor(EditorType::kOverworld))) {

--- a/src/app/editor/session_types.h
+++ b/src/app/editor/session_types.h
@@ -93,6 +93,7 @@ class EditorSet {
   int LoadedDungeonRoomCount() const;
   int TotalDungeonRoomCount() const;
   std::vector<std::pair<uint32_t, uint32_t>> CollectDungeonWriteRanges() const;
+  bool HasPendingGraphicsChanges() const;
   zelda3::Overworld* GetOverworldData() const;
 
   // Deprecated named accessors (legacy compatibility)

--- a/src/app/editor/shell/feedback/popup_manager.cc
+++ b/src/app/editor/shell/feedback/popup_manager.cc
@@ -449,7 +449,8 @@ void PopupManager::DrawRomBackupManagerPopup() {
     TextWrapped(
         tr("A restored backup is staged in this session. Save ROM to commit "
            "it. Discard reloads the backing ROM and abandons staged ROM-buffer "
-           "edits; resolve pending dungeon or palette edits first."));
+           "edits; resolve pending graphics, dungeon, or palette edits "
+           "first."));
     if (Button(ICON_MD_UNDO " Discard Restored Backup")) {
       auto status = editor_manager_->DiscardPendingRomBackupRestore();
       if (!status.ok()) {

--- a/src/app/editor/system/session/session_coordinator.cc
+++ b/src/app/editor/system/session/session_coordinator.cc
@@ -1275,6 +1275,10 @@ bool SessionCoordinator::IsSessionModified(size_t index) const {
     return true;
   }
 
+  if (session->editors.HasPendingGraphicsChanges()) {
+    return true;
+  }
+
   if (gfx::PaletteManager::Get().HasUnsavedChanges(&session->game_data)) {
     return true;
   }

--- a/test/unit/editor/editor_manager_rom_write_policy_test.cc
+++ b/test/unit/editor/editor_manager_rom_write_policy_test.cc
@@ -991,7 +991,7 @@ TEST(EditorManagerBackupRestoreTest,
   EXPECT_EQ(discard_status.code(), absl::StatusCode::kFailedPrecondition)
       << discard_status;
   EXPECT_NE(std::string(discard_status.message())
-                .find("pending dungeon or palette edits"),
+                .find("pending graphics, dungeon, or palette edits"),
             std::string::npos);
   EXPECT_EQ(manager->GetCurrentRom(), active_rom);
   ASSERT_TRUE(active_rom->ReadByte(kPcOffset).ok());
@@ -1061,7 +1061,7 @@ TEST(EditorManagerBackupRestoreTest,
   EXPECT_EQ(discard_status.code(), absl::StatusCode::kFailedPrecondition)
       << discard_status;
   EXPECT_NE(std::string(discard_status.message())
-                .find("pending dungeon or palette edits"),
+                .find("pending graphics, dungeon, or palette edits"),
             std::string::npos);
   EXPECT_EQ(manager->GetCurrentRom(), active_rom);
   ASSERT_TRUE(active_rom->ReadByte(kPcOffset).ok());

--- a/test/unit/editor/editor_manager_rom_write_policy_test.cc
+++ b/test/unit/editor/editor_manager_rom_write_policy_test.cc
@@ -7,6 +7,7 @@
 #include <memory>
 #include <string>
 #include <thread>
+#include <utility>
 #include <vector>
 
 #include "absl/status/status.h"
@@ -15,7 +16,10 @@
 #include "app/editor/dungeon/dungeon_editor_v2.h"
 #include "app/editor/dungeon/ui/window/overlay_manager_panel.h"
 #include "app/editor/editor_manager.h"
+#include "app/editor/graphics/graphics_editor.h"
+#include "app/editor/graphics/graphics_undo_actions.h"
 #include "app/gfx/backend/null_renderer.h"
+#include "app/gfx/resource/arena.h"
 #include "app/gfx/types/snes_palette.h"
 #include "app/gfx/util/palette_manager.h"
 #include "core/features.h"
@@ -27,6 +31,13 @@
 #include "imgui/imgui.h"
 
 namespace yaze::editor {
+
+class GraphicsEditorSaveStoplossTestPeer {
+ public:
+  static void MarkSheetModified(GraphicsEditor* editor, uint16_t sheet_id) {
+    editor->state_.MarkSheetModified(sheet_id);
+  }
+};
 
 class DungeonEditorV2ReloadTestPeer {
  public:
@@ -95,6 +106,15 @@ struct ScopedDirectoryCleanup {
     std::error_code ec;
     std::filesystem::remove_all(path, ec);
   }
+};
+
+struct ScopedGraphicsSheetRestore {
+  explicit ScopedGraphicsSheetRestore(gfx::Bitmap* sheet)
+      : sheet(sheet), original(std::move(*sheet)) {}
+  ~ScopedGraphicsSheetRestore() { *sheet = std::move(original); }
+
+  gfx::Bitmap* sheet;
+  gfx::Bitmap original;
 };
 
 struct ScopedImGuiContext {
@@ -1619,6 +1639,143 @@ TEST(EditorManagerRomWritePolicyTest,
   EXPECT_FALSE(std::filesystem::exists(target_a));
   EXPECT_EQ(ReadByteAt(source_a, 0x1234), 0x00);
   EXPECT_EQ(ReadByteAt(source_b, 0x1234), 0x00);
+}
+
+TEST(GraphicsSaveStoplossTest,
+     CleanSaveDoesNotMaterializeTheLazyGraphicsEditor) {
+  FeatureFlagsGuard guard;
+  ScopedImGuiContext imgui;
+
+  auto renderer = std::make_unique<gfx::NullRenderer>();
+  auto manager = std::make_unique<EditorManager>();
+  manager->Initialize(renderer.get(), "");
+  manager->SetAssetLoadMode(AssetLoadMode::kLazy);
+  manager->user_settings().prefs().backup_before_save = false;
+
+  const auto rom_path = MakeTempFilePath("yaze_clean_graphics_save.sfc");
+  ScopedFileCleanup cleanup{rom_path};
+  WriteTestRom(rom_path, "CLEAN GRAPHICS SAVE");
+
+  ASSERT_OK(manager->OpenRomOrProject(rom_path.string()));
+  DisableRomWritesForTest();
+  core::FeatureFlags::get().kSaveGraphicsSheet = true;
+
+  auto* editor_set = manager->GetCurrentEditorSet();
+  ASSERT_NE(editor_set, nullptr);
+  EXPECT_EQ(editor_set->GetExistingEditor(EditorType::kGraphics), nullptr);
+  EXPECT_FALSE(editor_set->HasPendingGraphicsChanges());
+  EXPECT_EQ(editor_set->GetExistingEditor(EditorType::kGraphics), nullptr);
+
+  auto* project = manager->GetCurrentProject();
+  ASSERT_NE(project, nullptr);
+  project->workspace_settings.backup_on_save = false;
+  project->rom_metadata.expected_hash.clear();
+
+  ASSERT_OK(manager->SaveRom());
+  EXPECT_EQ(editor_set->GetExistingEditor(EditorType::kGraphics), nullptr);
+}
+
+TEST(GraphicsSaveStoplossTest,
+     PendingSheetsBlockBothSaveScopeStatesBeforeSerialization) {
+  FeatureFlagsGuard guard;
+  ScopedImGuiContext imgui;
+
+  auto renderer = std::make_unique<gfx::NullRenderer>();
+  auto manager = std::make_unique<EditorManager>();
+  manager->Initialize(renderer.get(), "");
+  manager->SetAssetLoadMode(AssetLoadMode::kLazy);
+
+  const auto rom_path = MakeTempFilePath("yaze_pending_graphics_save.sfc");
+  ScopedFileCleanup cleanup{rom_path};
+  WriteTestRom(rom_path, "PENDING GRAPHICS");
+
+  ASSERT_OK(manager->OpenRomOrProject(rom_path.string()));
+  DisableRomWritesForTest();
+
+  auto* project = manager->GetCurrentProject();
+  ASSERT_NE(project, nullptr);
+  project->workspace_settings.backup_on_save = false;
+  project->rom_metadata.expected_hash.clear();
+
+  auto* editor_set = manager->GetCurrentEditorSet();
+  ASSERT_NE(editor_set, nullptr);
+  auto* graphics =
+      editor_set->GetEditorAs<GraphicsEditor>(EditorType::kGraphics);
+  ASSERT_NE(graphics, nullptr);
+  GraphicsEditorSaveStoplossTestPeer::MarkSheetModified(graphics, 0x20);
+  ASSERT_TRUE(editor_set->HasPendingGraphicsChanges());
+
+  Rom* rom = manager->GetCurrentRom();
+  ASSERT_NE(rom, nullptr);
+  EXPECT_FALSE(rom->dirty());
+  EXPECT_TRUE(manager->session_coordinator()->IsSessionModified(
+      manager->GetCurrentSessionIndex()));
+
+  manager->Quit();
+  EXPECT_TRUE(manager->HasPendingUnsavedSessionAction());
+  manager->CancelPendingUnsavedSessionAction();
+
+  const bool screen_existed =
+      editor_set->GetExistingEditor(EditorType::kScreen) != nullptr;
+  const bool dungeon_existed =
+      editor_set->GetExistingEditor(EditorType::kDungeon) != nullptr;
+  const bool overworld_existed =
+      editor_set->GetExistingEditor(EditorType::kOverworld) != nullptr;
+
+  constexpr uint32_t kPcOffset = 0x1234;
+  constexpr uint8_t kPendingRomByte = 0xA5;
+  ASSERT_OK(rom->WriteByte(kPcOffset, kPendingRomByte));
+
+  for (const bool graphics_scope_enabled : {false, true}) {
+    core::FeatureFlags::get().kSaveGraphicsSheet = graphics_scope_enabled;
+    const auto status = manager->SaveRom();
+
+    EXPECT_EQ(status.code(), absl::StatusCode::kFailedPrecondition) << status;
+    EXPECT_NE(
+        std::string(status.message()).find("graphics sheet edits are pending"),
+        std::string::npos);
+    EXPECT_NE(std::string(status.message())
+                  .find(graphics_scope_enabled ? "enabled" : "disabled"),
+              std::string::npos);
+    EXPECT_EQ(ReadByteAt(rom_path, kPcOffset), 0x00);
+    ASSERT_TRUE(rom->ReadByte(kPcOffset).ok());
+    EXPECT_EQ(*rom->ReadByte(kPcOffset), kPendingRomByte);
+    EXPECT_TRUE(editor_set->HasPendingGraphicsChanges());
+  }
+
+  EXPECT_EQ(editor_set->GetExistingEditor(EditorType::kScreen) != nullptr,
+            screen_existed);
+  EXPECT_EQ(editor_set->GetExistingEditor(EditorType::kDungeon) != nullptr,
+            dungeon_existed);
+  EXPECT_EQ(editor_set->GetExistingEditor(EditorType::kOverworld) != nullptr,
+            overworld_existed);
+}
+
+TEST(GraphicsSaveStoplossTest, PixelUndoAndRedoRemarkTheSheetDirty) {
+  constexpr uint16_t kSheetId = 0x20;
+  const std::vector<uint8_t> before_data = {0x01, 0x02, 0x03, 0x04};
+  const std::vector<uint8_t> after_data = {0x05, 0x06, 0x07, 0x08};
+
+  GraphicsEditorState state;
+  auto& sheet = gfx::Arena::Get().mutable_gfx_sheets()->at(kSheetId);
+  ScopedGraphicsSheetRestore restore_sheet(&sheet);
+  sheet.set_data(after_data);
+
+  GraphicsPixelEditAction action(
+      kSheetId, before_data, after_data, "Edit pixels",
+      [&state](uint16_t sheet_id) { state.MarkSheetModified(sheet_id); });
+
+  ASSERT_FALSE(state.HasUnsavedChanges());
+  ASSERT_OK(action.Undo());
+  EXPECT_EQ(sheet.vector(), before_data);
+  EXPECT_TRUE(state.HasUnsavedChanges());
+  EXPECT_TRUE(state.modified_sheets.contains(kSheetId));
+
+  state.ClearModifiedSheets();
+  ASSERT_OK(action.Redo());
+  EXPECT_EQ(sheet.vector(), after_data);
+  EXPECT_TRUE(state.HasUnsavedChanges());
+  EXPECT_TRUE(state.modified_sheets.contains(kSheetId));
 }
 
 }  // namespace


### PR DESCRIPTION
## Summary
- fail closed before any ROM serializer when the Graphics Editor still has pending sheet edits
- treat those edits as session work for quit/close, backup-discard, and pending-work descriptions without materializing a lazy editor
- stop calling the success-returning `SaveAllGraphicsData` stub from the coordinated save path
- re-mark a sheet dirty when pixel undo/redo changes it after a prior save attempt
- correct the feature coverage report so graphics sheet persistence is no longer overstated

## Why
`kSaveGraphicsSheet` could be enabled while the global graphics writer returned success without writing anything. With it disabled, the save path also omitted pending sheet edits. Either state could produce a successful ROM-save result while leaving Graphics Editor model changes out of the file.

This patch deliberately does **not** enable `GraphicsEditor::Save()`: that writer lacks coordinated-save transaction hooks, does unbounded in-place compressed writes, and ignores individual `WriteByte` statuses. Until it is made safe, pending sheet edits block the ROM save instead of being silently dropped.

## Verification
- `cmake --build build/presets/mac-ai-fast --target yaze_test_quick_unit_editor --parallel 8`
- `yaze_test_quick_unit_editor --gtest_filter='GraphicsSaveStoplossTest.*'` — 3/3 passed
- `scripts/pre-push.sh` through the repository hook with `YAZE_PREPUSH_BUILD_DIR=build/presets/mac-ai-fast` — build, 13 smoke tests, formatting, and change-aware checks passed
- independent findings-first review: no blocking findings

## Follow-ups
- Screen Editor save stop-loss remains a separate domain.
- Polyhedral editor cached edits need their own lifecycle guard; its explicit **Save 3D objects** action already writes to the ROM buffer.
- Safe graphics-sheet persistence still requires bounded allocation/write fences, transaction rollback, status propagation, and reopen/readback verification.
