### PR TITLE
Track minecart overlay project drafts safely

### DIFF
--- a/src/app/editor/dungeon/dungeon_editor_v2.cc
+++ b/src/app/editor/dungeon/dungeon_editor_v2.cc
@@ -78,6 +78,18 @@
 
 namespace yaze::editor {
 
+void DungeonEditorV2::SetDependencies(const EditorDependencies& deps) {
+  Editor::SetDependencies(deps);
+  if (minecart_track_editor_panel_) {
+    const absl::Status status =
+        minecart_track_editor_panel_->RebindProjectContext(deps.project);
+    if (!status.ok()) {
+      LOG_WARN("DungeonEditorV2", "Minecart project rebind failed: %s",
+               status.message());
+    }
+  }
+}
+
 namespace {
 
 bool IsTransientDungeonRoomWindowId(const std::string& card_id) {
@@ -797,17 +809,31 @@ absl::Status DungeonEditorV2::Load() {
             static_cast<EditorManager*>(dependencies_.custom_data)) {
       const size_t session_id = dependencies_.session_id;
       minecart_track_editor_panel_->SetProjectChangedCallback(
-          [editor_manager,
-           session_id](const project::DungeonOverlaySettings& overlay) {
-            if (editor_manager->GetCurrentSessionId() != session_id) {
-              return;
+          [editor_manager, session_id](
+              const project::DungeonOverlaySettings& overlay) -> absl::Status {
+            const auto* session_coordinator =
+                editor_manager->session_coordinator();
+            const auto* active_session =
+                session_coordinator ? session_coordinator->GetActiveRomSession()
+                                    : nullptr;
+            if (active_session == nullptr ||
+                active_session->session_id() != session_id) {
+              return absl::FailedPreconditionError(
+                  "Minecart overlay edit requires its session to be active");
             }
             editor_manager->GetCurrentProject()->dungeon_overlay = overlay;
             editor_manager->MarkCurrentProjectDirty();
+            return absl::OkStatus();
           });
       minecart_track_editor_panel_->SetProjectSaveCallback(
           [editor_manager, session_id]() -> absl::Status {
-            if (editor_manager->GetCurrentSessionId() != session_id) {
+            const auto* session_coordinator =
+                editor_manager->session_coordinator();
+            const auto* active_session =
+                session_coordinator ? session_coordinator->GetActiveRomSession()
+                                    : nullptr;
+            if (active_session == nullptr ||
+                active_session->session_id() != session_id) {
               return absl::FailedPreconditionError(
                   "Minecart project save requires its session to be active");
             }

--- a/src/app/editor/dungeon/dungeon_editor_v2.cc
+++ b/src/app/editor/dungeon/dungeon_editor_v2.cc
@@ -99,6 +99,7 @@ void DungeonEditorV2::ConfigureMinecartProjectCallbacks() {
   auto* editor_manager = static_cast<EditorManager*>(dependencies_.custom_data);
   if (editor_manager == nullptr) {
     minecart_track_editor_panel_->SetProjectChangedCallback({});
+    minecart_track_editor_panel_->SetProjectDraftChangedCallback({});
     minecart_track_editor_panel_->SetProjectSaveCallback({});
     return;
   }
@@ -114,6 +115,17 @@ void DungeonEditorV2::ConfigureMinecartProjectCallbacks() {
               "active");
         }
         editor_manager->GetCurrentProject()->dungeon_overlay = overlay;
+        editor_manager->MarkCurrentProjectDirty();
+        return absl::OkStatus();
+      });
+  minecart_track_editor_panel_->SetProjectDraftChangedCallback(
+      [editor_manager, session_id]() -> absl::Status {
+        if (!editor_manager->IsCurrentProjectContextOwnedBySession(
+                session_id)) {
+          return absl::FailedPreconditionError(
+              "Minecart overlay draft requires its project context to be "
+              "active");
+        }
         editor_manager->MarkCurrentProjectDirty();
         return absl::OkStatus();
       });
@@ -1360,6 +1372,17 @@ bool DungeonEditorV2::HasPendingDungeonChanges() const {
     return true;
   }
   return game_data_ != nullptr && game_data_->pit_damage_table.dirty();
+}
+
+bool DungeonEditorV2::HasPendingProjectDraftChanges() const {
+  return minecart_track_editor_panel_ != nullptr &&
+         minecart_track_editor_panel_->HasPendingProjectDraftChanges();
+}
+
+absl::Status DungeonEditorV2::PrepareProjectSave() {
+  return minecart_track_editor_panel_ != nullptr
+             ? minecart_track_editor_panel_->PrepareProjectSave()
+             : absl::OkStatus();
 }
 
 bool DungeonEditorV2::CurrentRoomHasPendingChanges() const {

--- a/src/app/editor/dungeon/dungeon_editor_v2.cc
+++ b/src/app/editor/dungeon/dungeon_editor_v2.cc
@@ -793,6 +793,27 @@ absl::Status DungeonEditorV2::Load() {
       minecart_track_editor_panel_->SetRoomNavigationCallback(
           [this](int room_id) { OnRoomSelected(room_id); });
     }
+    if (auto* editor_manager =
+            static_cast<EditorManager*>(dependencies_.custom_data)) {
+      const size_t session_id = dependencies_.session_id;
+      minecart_track_editor_panel_->SetProjectChangedCallback(
+          [editor_manager,
+           session_id](const project::DungeonOverlaySettings& overlay) {
+            if (editor_manager->GetCurrentSessionId() != session_id) {
+              return;
+            }
+            editor_manager->GetCurrentProject()->dungeon_overlay = overlay;
+            editor_manager->MarkCurrentProjectDirty();
+          });
+      minecart_track_editor_panel_->SetProjectSaveCallback(
+          [editor_manager, session_id]() -> absl::Status {
+            if (editor_manager->GetCurrentSessionId() != session_id) {
+              return absl::FailedPreconditionError(
+                  "Minecart project save requires its session to be active");
+            }
+            return editor_manager->SaveProject();
+          });
+    }
   } else {
     minecart_track_editor_panel_ = nullptr;
   }

--- a/src/app/editor/dungeon/dungeon_editor_v2.cc
+++ b/src/app/editor/dungeon/dungeon_editor_v2.cc
@@ -87,7 +87,46 @@ void DungeonEditorV2::SetDependencies(const EditorDependencies& deps) {
       LOG_WARN("DungeonEditorV2", "Minecart project rebind failed: %s",
                status.message());
     }
+    ConfigureMinecartProjectCallbacks();
   }
+}
+
+void DungeonEditorV2::ConfigureMinecartProjectCallbacks() {
+  if (minecart_track_editor_panel_ == nullptr) {
+    return;
+  }
+
+  auto* editor_manager = static_cast<EditorManager*>(dependencies_.custom_data);
+  if (editor_manager == nullptr) {
+    minecart_track_editor_panel_->SetProjectChangedCallback({});
+    minecart_track_editor_panel_->SetProjectSaveCallback({});
+    return;
+  }
+
+  const size_t session_id = dependencies_.session_id;
+  minecart_track_editor_panel_->SetProjectChangedCallback(
+      [editor_manager, session_id](
+          const project::DungeonOverlaySettings& overlay) -> absl::Status {
+        if (!editor_manager->IsCurrentProjectContextOwnedBySession(
+                session_id)) {
+          return absl::FailedPreconditionError(
+              "Minecart overlay edit requires its project context to be "
+              "active");
+        }
+        editor_manager->GetCurrentProject()->dungeon_overlay = overlay;
+        editor_manager->MarkCurrentProjectDirty();
+        return absl::OkStatus();
+      });
+  minecart_track_editor_panel_->SetProjectSaveCallback(
+      [editor_manager, session_id]() -> absl::Status {
+        if (!editor_manager->IsCurrentProjectContextOwnedBySession(
+                session_id)) {
+          return absl::FailedPreconditionError(
+              "Minecart project save requires its project context to be "
+              "active");
+        }
+        return editor_manager->SaveProject();
+      });
 }
 
 namespace {
@@ -805,41 +844,7 @@ absl::Status DungeonEditorV2::Load() {
       minecart_track_editor_panel_->SetRoomNavigationCallback(
           [this](int room_id) { OnRoomSelected(room_id); });
     }
-    if (auto* editor_manager =
-            static_cast<EditorManager*>(dependencies_.custom_data)) {
-      const size_t session_id = dependencies_.session_id;
-      minecart_track_editor_panel_->SetProjectChangedCallback(
-          [editor_manager, session_id](
-              const project::DungeonOverlaySettings& overlay) -> absl::Status {
-            const auto* session_coordinator =
-                editor_manager->session_coordinator();
-            const auto* active_session =
-                session_coordinator ? session_coordinator->GetActiveRomSession()
-                                    : nullptr;
-            if (active_session == nullptr ||
-                active_session->session_id() != session_id) {
-              return absl::FailedPreconditionError(
-                  "Minecart overlay edit requires its session to be active");
-            }
-            editor_manager->GetCurrentProject()->dungeon_overlay = overlay;
-            editor_manager->MarkCurrentProjectDirty();
-            return absl::OkStatus();
-          });
-      minecart_track_editor_panel_->SetProjectSaveCallback(
-          [editor_manager, session_id]() -> absl::Status {
-            const auto* session_coordinator =
-                editor_manager->session_coordinator();
-            const auto* active_session =
-                session_coordinator ? session_coordinator->GetActiveRomSession()
-                                    : nullptr;
-            if (active_session == nullptr ||
-                active_session->session_id() != session_id) {
-              return absl::FailedPreconditionError(
-                  "Minecart project save requires its session to be active");
-            }
-            return editor_manager->SaveProject();
-          });
-    }
+    ConfigureMinecartProjectCallbacks();
   } else {
     minecart_track_editor_panel_ = nullptr;
   }

--- a/src/app/editor/dungeon/dungeon_editor_v2.h
+++ b/src/app/editor/dungeon/dungeon_editor_v2.h
@@ -152,6 +152,8 @@ class DungeonEditorV2 : public Editor {
   bool HasPendingRoomChanges() const;
   // All dungeon save domains plus unapplied editor-local work.
   bool HasPendingDungeonChanges() const;
+  bool HasPendingProjectDraftChanges() const;
+  absl::Status PrepareProjectSave();
   bool CurrentRoomHasPendingChanges() const;
   int TotalRoomCount() const { return static_cast<int>(rooms_.size()); }
 

--- a/src/app/editor/dungeon/dungeon_editor_v2.h
+++ b/src/app/editor/dungeon/dungeon_editor_v2.h
@@ -308,6 +308,7 @@ class DungeonEditorV2 : public Editor {
   void ApplyEntranceRenderContext(int room_id);
   void ConfigureViewerRenderContext(DungeonCanvasViewer* viewer, int room_id);
   void WireViewerPanelCallbacks(DungeonCanvasViewer* viewer);
+  void ConfigureMinecartProjectCallbacks();
 
   // Show or create a standalone room panel
   void ShowRoomPanel(int room_id);

--- a/src/app/editor/dungeon/dungeon_editor_v2.h
+++ b/src/app/editor/dungeon/dungeon_editor_v2.h
@@ -130,6 +130,7 @@ class DungeonEditorV2 : public Editor {
   }
 
   // Editor interface
+  void SetDependencies(const EditorDependencies& deps) override;
   void Initialize() override;
   absl::Status Load() override;
   absl::Status Update() override;

--- a/src/app/editor/dungeon/ui/window/minecart_track_editor_panel.cc
+++ b/src/app/editor/dungeon/ui/window/minecart_track_editor_panel.cc
@@ -1,6 +1,7 @@
 #include "minecart_track_editor_panel.h"
 
 #include <algorithm>
+#include <charconv>
 #include <filesystem>
 #include <fstream>
 #include <iterator>
@@ -10,6 +11,7 @@
 #include <vector>
 
 #include "absl/status/status.h"
+#include "absl/strings/ascii.h"
 #include "absl/strings/str_format.h"
 #include "absl/strings/str_split.h"
 #include "core/source_artifact_publisher.h"
@@ -42,6 +44,14 @@ const core::SourceArtifactPublisherLabels kMinecartSourcePublisherLabels{
     .subject = "minecart track source",
     .published_file = "published minecart track source",
 };
+
+std::optional<core::MinecartTrackLayout::Source> ProjectSourceIdentity(
+    const project::YazeProject* project) {
+  if (project == nullptr || !project->hack_manifest.loaded()) {
+    return std::nullopt;
+  }
+  return project->hack_manifest.minecart_track_layout().source;
+}
 
 bool IsStrictDescendant(const std::filesystem::path& path,
                         const std::filesystem::path& root) {
@@ -81,29 +91,47 @@ std::string FormatHexList(const std::vector<uint16_t>& values) {
   return out;
 }
 
-std::vector<uint16_t> ParseHexList(const std::string& input) {
+absl::StatusOr<std::vector<uint16_t>> ParseHexList(const std::string& input) {
   std::vector<uint16_t> out;
-  for (absl::string_view token_view :
-       absl::StrSplit(input, absl::ByAnyChar(", \n\t"), absl::SkipEmpty())) {
-    if (token_view.empty()) {
-      continue;
+  const absl::string_view trimmed_input = absl::StripAsciiWhitespace(input);
+  if (trimmed_input.empty()) {
+    return out;
+  }
+
+  for (absl::string_view comma_group : absl::StrSplit(trimmed_input, ',')) {
+    comma_group = absl::StripAsciiWhitespace(comma_group);
+    if (comma_group.empty()) {
+      return absl::InvalidArgumentError("Overlay list contains an empty value");
     }
-    std::string token(token_view);
-    if (token[0] == '$') {
-      token = "0x" + token.substr(1);
-    }
-    int base = 10;
-    if (token.rfind("0x", 0) == 0 || token.rfind("0X", 0) == 0) {
-      token = token.substr(2);
-      base = 16;
-    }
-    try {
-      auto value = std::stoul(token, nullptr, base);
-      if (value <= 0xFFFF) {
-        out.push_back(static_cast<uint16_t>(value));
+
+    for (absl::string_view token : absl::StrSplit(
+             comma_group, absl::ByAnyChar(" \n\t\r"), absl::SkipEmpty())) {
+      const absl::string_view original_token = token;
+      int base = 10;
+      if (token.starts_with('$')) {
+        token.remove_prefix(1);
+        base = 16;
+      } else if (token.starts_with("0x") || token.starts_with("0X")) {
+        token.remove_prefix(2);
+        base = 16;
       }
-    } catch (...) {
-      continue;
+      if (token.empty()) {
+        return absl::InvalidArgumentError(absl::StrFormat(
+            "Overlay value is missing digits: %s", original_token));
+      }
+
+      uint32_t value = 0;
+      const auto [end, error] = std::from_chars(
+          token.data(), token.data() + token.size(), value, base);
+      if (error == std::errc::result_out_of_range || value > 0xFFFF) {
+        return absl::OutOfRangeError(absl::StrFormat(
+            "Overlay value is outside 16-bit range: %s", original_token));
+      }
+      if (error != std::errc() || end != token.data() + token.size()) {
+        return absl::InvalidArgumentError(
+            absl::StrFormat("Invalid overlay value: %s", original_token));
+      }
+      out.push_back(static_cast<uint16_t>(value));
     }
   }
   return out;
@@ -125,16 +153,20 @@ void MinecartTrackEditorPanel::ResetTrackSession() {
 
 absl::Status MinecartTrackEditorPanel::RefreshProjectBinding() {
   const std::string current_filepath = project_ ? project_->filepath : "";
-  if (current_filepath == bound_project_filepath_) {
+  const auto current_source_identity = ProjectSourceIdentity(project_);
+  if (current_filepath == bound_project_filepath_ &&
+      current_source_identity == bound_source_identity_) {
     return absl::OkStatus();
   }
   if (HasUnpublishedChanges()) {
     return absl::FailedPreconditionError(
-        "Project descriptor moved; discard minecart track drafts before "
-        "rebinding the source");
+        "Project descriptor moved or minecart source changed; discard "
+        "minecart track drafts before rebinding the source");
   }
 
   bound_project_filepath_ = current_filepath;
+  bound_source_identity_ = current_source_identity;
+  overlay_inputs_initialized_ = false;
   ResetTrackSession();
   return absl::OkStatus();
 }
@@ -142,7 +174,9 @@ absl::Status MinecartTrackEditorPanel::RefreshProjectBinding() {
 absl::Status MinecartTrackEditorPanel::SetProject(
     project::YazeProject* project) {
   const std::string next_filepath = project ? project->filepath : "";
-  if (project_ == project && bound_project_filepath_ == next_filepath) {
+  const auto next_source_identity = ProjectSourceIdentity(project);
+  if (project_ == project && bound_project_filepath_ == next_filepath &&
+      bound_source_identity_ == next_source_identity) {
     return absl::OkStatus();
   }
   if (HasUnpublishedChanges()) {
@@ -152,8 +186,26 @@ absl::Status MinecartTrackEditorPanel::SetProject(
 
   project_ = project;
   bound_project_filepath_ = next_filepath;
+  bound_source_identity_ = next_source_identity;
   overlay_inputs_initialized_ = false;
   ResetTrackSession();
+  return absl::OkStatus();
+}
+
+absl::Status MinecartTrackEditorPanel::RebindProjectContext(
+    project::YazeProject* project) {
+  const absl::Status status = SetProject(project);
+  if (!status.ok()) {
+    status_message_ = std::string(status.message());
+    show_success_ = false;
+    return status;
+  }
+
+  // SetProject intentionally treats a stable pointer/path as already bound.
+  // Project descriptors are reapplied into stable session storage, so force
+  // the model-backed text cache to observe the new revision here.
+  overlay_inputs_initialized_ = false;
+  InitializeOverlayInputs();
   return absl::OkStatus();
 }
 
@@ -303,34 +355,72 @@ void MinecartTrackEditorPanel::InitializeOverlayInputs() {
   overlay_inputs_initialized_ = true;
 }
 
-bool MinecartTrackEditorPanel::UpdateOverlayList(
-    const char* label, std::string& input, std::vector<uint16_t>& target) {
+bool MinecartTrackEditorPanel::UpdateOverlayList(const char* label,
+                                                 std::string& input,
+                                                 OverlayListMember member) {
   ImGui::InputText(label, &input);
   if (ImGui::IsItemDeactivatedAfterEdit()) {
-    return CommitOverlayList(input, target);
+    const absl::StatusOr<bool> changed = CommitOverlayList(input, member);
+    return changed.ok() && *changed;
   }
   return false;
 }
 
-bool MinecartTrackEditorPanel::CommitOverlayList(
-    const std::string& input, std::vector<uint16_t>& target) {
-  std::vector<uint16_t> parsed = ParseHexList(input);
-  if (parsed == target) {
+absl::StatusOr<bool> MinecartTrackEditorPanel::CommitOverlayList(
+    std::string& input, OverlayListMember member) {
+  if (project_ == nullptr) {
+    const absl::Status status =
+        absl::FailedPreconditionError("No project is bound to the panel");
+    status_message_ = std::string(status.message());
+    show_success_ = false;
+    return status;
+  }
+
+  const auto parsed_or = ParseHexList(input);
+  if (!parsed_or.ok()) {
+    status_message_ = absl::StrFormat("Overlay update rejected: %s",
+                                      parsed_or.status().message());
+    show_success_ = false;
+    return parsed_or.status();
+  }
+
+  project::DungeonOverlaySettings candidate = project_->dungeon_overlay;
+  std::vector<uint16_t>& candidate_target = candidate.*member;
+  if (*parsed_or == candidate_target) {
+    input = FormatHexList(*parsed_or);
+    status_message_.clear();
+    show_success_ = false;
     return false;
   }
 
-  target = std::move(parsed);
+  candidate_target = *parsed_or;
+  const absl::Status notify_status = NotifyProjectChanged(candidate);
+  if (!notify_status.ok()) {
+    input = FormatHexList(project_->dungeon_overlay.*member);
+    status_message_ =
+        absl::StrFormat("Overlay update rejected: %s", notify_status.message());
+    show_success_ = false;
+    return notify_status;
+  }
+
+  project_->dungeon_overlay = std::move(candidate);
+  input = FormatHexList(project_->dungeon_overlay.*member);
   audit_dirty_ = true;
-  NotifyProjectChanged();
+  status_message_ = "Overlay settings updated; save the project to persist.";
+  show_success_ = true;
   return true;
 }
 
-bool MinecartTrackEditorPanel::ResetOverlaySettings() {
+absl::StatusOr<bool> MinecartTrackEditorPanel::ResetOverlaySettings() {
   if (project_ == nullptr) {
-    return false;
+    const absl::Status status =
+        absl::FailedPreconditionError("No project is bound to the panel");
+    status_message_ = std::string(status.message());
+    show_success_ = false;
+    return status;
   }
 
-  auto& overlay = project_->dungeon_overlay;
+  project::DungeonOverlaySettings overlay = project_->dungeon_overlay;
   const bool changed =
       !overlay.track_tiles.empty() || !overlay.track_stop_tiles.empty() ||
       !overlay.track_switch_tiles.empty() ||
@@ -344,20 +434,36 @@ bool MinecartTrackEditorPanel::ResetOverlaySettings() {
   overlay.track_switch_tiles.clear();
   overlay.track_object_ids.clear();
   overlay.minecart_sprite_ids.clear();
+  const absl::Status notify_status = NotifyProjectChanged(overlay);
+  if (!notify_status.ok()) {
+    status_message_ =
+        absl::StrFormat("Overlay reset rejected: %s", notify_status.message());
+    show_success_ = false;
+    return notify_status;
+  }
+
+  project_->dungeon_overlay = std::move(overlay);
   overlay_track_tiles_input_.clear();
   overlay_track_stop_tiles_input_.clear();
   overlay_track_switch_tiles_input_.clear();
   overlay_track_object_ids_input_.clear();
   overlay_minecart_sprite_ids_input_.clear();
   audit_dirty_ = true;
-  NotifyProjectChanged();
+  status_message_ = "Overlay settings reset; save the project to persist.";
+  show_success_ = true;
   return true;
 }
 
-void MinecartTrackEditorPanel::NotifyProjectChanged() {
-  if (project_ != nullptr && project_changed_callback_) {
-    project_changed_callback_(project_->dungeon_overlay);
+absl::Status MinecartTrackEditorPanel::NotifyProjectChanged(
+    const project::DungeonOverlaySettings& overlay) {
+  if (project_ == nullptr) {
+    return absl::FailedPreconditionError("No project is bound to the panel");
   }
+  if (!project_changed_callback_) {
+    return absl::FailedPreconditionError(
+        "Project change tracking is unavailable for minecart overlays");
+  }
+  return project_changed_callback_(overlay);
 }
 
 absl::Status MinecartTrackEditorPanel::SaveProjectSettings() {
@@ -390,21 +496,23 @@ void MinecartTrackEditorPanel::DrawOverlaySettings() {
 
   bool changed = false;
   changed |= UpdateOverlayList("Track Tiles", overlay_track_tiles_input_,
-                               project_->dungeon_overlay.track_tiles);
-  changed |= UpdateOverlayList("Stop Tiles", overlay_track_stop_tiles_input_,
-                               project_->dungeon_overlay.track_stop_tiles);
+                               &project::DungeonOverlaySettings::track_tiles);
+  changed |=
+      UpdateOverlayList("Stop Tiles", overlay_track_stop_tiles_input_,
+                        &project::DungeonOverlaySettings::track_stop_tiles);
   changed |=
       UpdateOverlayList("Switch Tiles", overlay_track_switch_tiles_input_,
-                        project_->dungeon_overlay.track_switch_tiles);
+                        &project::DungeonOverlaySettings::track_switch_tiles);
   changed |=
       UpdateOverlayList("Track Object IDs", overlay_track_object_ids_input_,
-                        project_->dungeon_overlay.track_object_ids);
-  changed |= UpdateOverlayList("Minecart Sprite IDs",
-                               overlay_minecart_sprite_ids_input_,
-                               project_->dungeon_overlay.minecart_sprite_ids);
+                        &project::DungeonOverlaySettings::track_object_ids);
+  changed |= UpdateOverlayList(
+      "Minecart Sprite IDs", overlay_minecart_sprite_ids_input_,
+      &project::DungeonOverlaySettings::minecart_sprite_ids);
 
   if (ImGui::Button(tr("Reset Overlay Defaults"))) {
-    changed |= ResetOverlaySettings();
+    const absl::StatusOr<bool> reset = ResetOverlaySettings();
+    changed |= reset.ok() && *reset;
   }
 
   if (changed) {

--- a/src/app/editor/dungeon/ui/window/minecart_track_editor_panel.cc
+++ b/src/app/editor/dungeon/ui/window/minecart_track_editor_panel.cc
@@ -12,6 +12,7 @@
 
 #include "absl/status/status.h"
 #include "absl/strings/ascii.h"
+#include "absl/strings/match.h"
 #include "absl/strings/str_format.h"
 #include "absl/strings/str_split.h"
 #include "core/source_artifact_publisher.h"
@@ -117,10 +118,11 @@ absl::StatusOr<std::vector<uint16_t>> ParseHexList(const std::string& input) {
              comma_group, absl::ByAnyChar(" \n\t\r"), absl::SkipEmpty())) {
       const absl::string_view original_token = token;
       int base = 10;
-      if (token.starts_with('$')) {
+      if (absl::StartsWith(token, "$")) {
         token.remove_prefix(1);
         base = 16;
-      } else if (token.starts_with("0x") || token.starts_with("0X")) {
+      } else if (absl::StartsWith(token, "0x") ||
+                 absl::StartsWith(token, "0X")) {
         token.remove_prefix(2);
         base = 16;
       }

--- a/src/app/editor/dungeon/ui/window/minecart_track_editor_panel.cc
+++ b/src/app/editor/dungeon/ui/window/minecart_track_editor_panel.cc
@@ -305,13 +305,70 @@ void MinecartTrackEditorPanel::InitializeOverlayInputs() {
 
 bool MinecartTrackEditorPanel::UpdateOverlayList(
     const char* label, std::string& input, std::vector<uint16_t>& target) {
-  bool changed = ImGui::InputText(label, &input);
-  if (changed && ImGui::IsItemDeactivatedAfterEdit()) {
-    target = ParseHexList(input);
-    audit_dirty_ = true;
-    return true;
+  ImGui::InputText(label, &input);
+  if (ImGui::IsItemDeactivatedAfterEdit()) {
+    return CommitOverlayList(input, target);
   }
   return false;
+}
+
+bool MinecartTrackEditorPanel::CommitOverlayList(
+    const std::string& input, std::vector<uint16_t>& target) {
+  std::vector<uint16_t> parsed = ParseHexList(input);
+  if (parsed == target) {
+    return false;
+  }
+
+  target = std::move(parsed);
+  audit_dirty_ = true;
+  NotifyProjectChanged();
+  return true;
+}
+
+bool MinecartTrackEditorPanel::ResetOverlaySettings() {
+  if (project_ == nullptr) {
+    return false;
+  }
+
+  auto& overlay = project_->dungeon_overlay;
+  const bool changed =
+      !overlay.track_tiles.empty() || !overlay.track_stop_tiles.empty() ||
+      !overlay.track_switch_tiles.empty() ||
+      !overlay.track_object_ids.empty() || !overlay.minecart_sprite_ids.empty();
+  if (!changed) {
+    return false;
+  }
+
+  overlay.track_tiles.clear();
+  overlay.track_stop_tiles.clear();
+  overlay.track_switch_tiles.clear();
+  overlay.track_object_ids.clear();
+  overlay.minecart_sprite_ids.clear();
+  overlay_track_tiles_input_.clear();
+  overlay_track_stop_tiles_input_.clear();
+  overlay_track_switch_tiles_input_.clear();
+  overlay_track_object_ids_input_.clear();
+  overlay_minecart_sprite_ids_input_.clear();
+  audit_dirty_ = true;
+  NotifyProjectChanged();
+  return true;
+}
+
+void MinecartTrackEditorPanel::NotifyProjectChanged() {
+  if (project_ != nullptr && project_changed_callback_) {
+    project_changed_callback_(project_->dungeon_overlay);
+  }
+}
+
+absl::Status MinecartTrackEditorPanel::SaveProjectSettings() {
+  if (project_ == nullptr || !project_->project_opened()) {
+    return absl::FailedPreconditionError("No open project to save");
+  }
+  if (!project_save_callback_) {
+    return absl::FailedPreconditionError(
+        "Project save is unavailable outside the editor manager");
+  }
+  return project_save_callback_();
 }
 
 void MinecartTrackEditorPanel::DrawOverlaySettings() {
@@ -347,18 +404,7 @@ void MinecartTrackEditorPanel::DrawOverlaySettings() {
                                project_->dungeon_overlay.minecart_sprite_ids);
 
   if (ImGui::Button(tr("Reset Overlay Defaults"))) {
-    project_->dungeon_overlay.track_tiles.clear();
-    project_->dungeon_overlay.track_stop_tiles.clear();
-    project_->dungeon_overlay.track_switch_tiles.clear();
-    project_->dungeon_overlay.track_object_ids.clear();
-    project_->dungeon_overlay.minecart_sprite_ids.clear();
-    overlay_track_tiles_input_.clear();
-    overlay_track_stop_tiles_input_.clear();
-    overlay_track_switch_tiles_input_.clear();
-    overlay_track_object_ids_input_.clear();
-    overlay_minecart_sprite_ids_input_.clear();
-    audit_dirty_ = true;
-    changed = true;
+    changed |= ResetOverlaySettings();
   }
 
   if (changed) {
@@ -648,12 +694,13 @@ void MinecartTrackEditorPanel::Draw(bool* p_open) {
     show_success_ = status.ok();
   }
   ImGui::SameLine();
-  const bool can_save_project = project_ && project_->project_opened();
+  const bool can_save_project =
+      project_ && project_->project_opened() && project_save_callback_;
   if (!can_save_project) {
     ImGui::BeginDisabled();
   }
   if (ImGui::Button(ICON_MD_SAVE " Save Project")) {
-    auto status = project_->Save();
+    auto status = SaveProjectSettings();
     if (status.ok()) {
       status_message_ = has_unpublished_changes
                             ? "Project saved; minecart track drafts remain "

--- a/src/app/editor/dungeon/ui/window/minecart_track_editor_panel.cc
+++ b/src/app/editor/dungeon/ui/window/minecart_track_editor_panel.cc
@@ -91,6 +91,15 @@ std::string FormatHexList(const std::vector<uint16_t>& values) {
   return out;
 }
 
+bool OverlaySettingsEqual(const project::DungeonOverlaySettings& lhs,
+                          const project::DungeonOverlaySettings& rhs) {
+  return lhs.track_tiles == rhs.track_tiles &&
+         lhs.track_stop_tiles == rhs.track_stop_tiles &&
+         lhs.track_switch_tiles == rhs.track_switch_tiles &&
+         lhs.track_object_ids == rhs.track_object_ids &&
+         lhs.minecart_sprite_ids == rhs.minecart_sprite_ids;
+}
+
 absl::StatusOr<std::vector<uint16_t>> ParseHexList(const std::string& input) {
   std::vector<uint16_t> out;
   const absl::string_view trimmed_input = absl::StripAsciiWhitespace(input);
@@ -167,6 +176,7 @@ absl::Status MinecartTrackEditorPanel::RefreshProjectBinding() {
   bound_project_filepath_ = current_filepath;
   bound_source_identity_ = current_source_identity;
   overlay_inputs_initialized_ = false;
+  overlay_inputs_model_.reset();
   ResetTrackSession();
   return absl::OkStatus();
 }
@@ -188,6 +198,7 @@ absl::Status MinecartTrackEditorPanel::SetProject(
   bound_project_filepath_ = next_filepath;
   bound_source_identity_ = next_source_identity;
   overlay_inputs_initialized_ = false;
+  overlay_inputs_model_.reset();
   ResetTrackSession();
   return absl::OkStatus();
 }
@@ -201,11 +212,15 @@ absl::Status MinecartTrackEditorPanel::RebindProjectContext(
     return status;
   }
 
-  // SetProject intentionally treats a stable pointer/path as already bound.
-  // Project descriptors are reapplied into stable session storage, so force
-  // the model-backed text cache to observe the new revision here.
-  overlay_inputs_initialized_ = false;
-  InitializeOverlayInputs();
+  // Project descriptors are reapplied into stable session storage. Refresh a
+  // same-pointer binding only when the model changed; otherwise preserve text
+  // currently being edited until it can be validated and committed.
+  if (project != nullptr && (!overlay_inputs_model_.has_value() ||
+                             !OverlaySettingsEqual(*overlay_inputs_model_,
+                                                   project->dungeon_overlay))) {
+    overlay_inputs_initialized_ = false;
+    InitializeOverlayInputs();
+  }
   return absl::OkStatus();
 }
 
@@ -352,6 +367,7 @@ void MinecartTrackEditorPanel::InitializeOverlayInputs() {
       FormatHexList(project_->dungeon_overlay.track_object_ids);
   overlay_minecart_sprite_ids_input_ =
       FormatHexList(project_->dungeon_overlay.minecart_sprite_ids);
+  overlay_inputs_model_ = project_->dungeon_overlay;
   overlay_inputs_initialized_ = true;
 }
 
@@ -396,6 +412,7 @@ absl::StatusOr<bool> MinecartTrackEditorPanel::CommitOverlayList(
   std::vector<uint16_t>& candidate_target = candidate.*member;
   if (*parsed_or == candidate_target) {
     input = FormatHexList(*parsed_or);
+    overlay_inputs_model_ = project_->dungeon_overlay;
     status_message_.clear();
     show_success_ = false;
     return false;
@@ -413,9 +430,90 @@ absl::StatusOr<bool> MinecartTrackEditorPanel::CommitOverlayList(
 
   project_->dungeon_overlay = std::move(candidate);
   input = FormatHexList(project_->dungeon_overlay.*member);
+  overlay_inputs_model_ = project_->dungeon_overlay;
   audit_dirty_ = true;
   status_message_ = "Overlay settings updated; save the project to persist.";
   show_success_ = true;
+  return true;
+}
+
+absl::StatusOr<bool> MinecartTrackEditorPanel::CommitOverlayInputsForSave() {
+  if (project_ == nullptr) {
+    return absl::FailedPreconditionError("No project is bound to the panel");
+  }
+
+  InitializeOverlayInputs();
+  project::DungeonOverlaySettings candidate;
+  auto parse_field = [](const char* field_name, const std::string& input,
+                        std::vector<uint16_t>* target) -> absl::Status {
+    const auto parsed_or = ParseHexList(input);
+    if (!parsed_or.ok()) {
+      return absl::Status(
+          parsed_or.status().code(),
+          absl::StrFormat("%s: %s", field_name, parsed_or.status().message()));
+    }
+    *target = *parsed_or;
+    return absl::OkStatus();
+  };
+
+  absl::Status parse_status = parse_field(
+      "Track Tiles", overlay_track_tiles_input_, &candidate.track_tiles);
+  if (parse_status.ok()) {
+    parse_status = parse_field("Stop Tiles", overlay_track_stop_tiles_input_,
+                               &candidate.track_stop_tiles);
+  }
+  if (parse_status.ok()) {
+    parse_status =
+        parse_field("Switch Tiles", overlay_track_switch_tiles_input_,
+                    &candidate.track_switch_tiles);
+  }
+  if (parse_status.ok()) {
+    parse_status =
+        parse_field("Track Object IDs", overlay_track_object_ids_input_,
+                    &candidate.track_object_ids);
+  }
+  if (parse_status.ok()) {
+    parse_status =
+        parse_field("Minecart Sprite IDs", overlay_minecart_sprite_ids_input_,
+                    &candidate.minecart_sprite_ids);
+  }
+  if (!parse_status.ok()) {
+    status_message_ =
+        absl::StrFormat("Project save blocked: %s", parse_status.message());
+    show_success_ = false;
+    return parse_status;
+  }
+
+  auto normalize_inputs = [this]() {
+    overlay_track_tiles_input_ =
+        FormatHexList(project_->dungeon_overlay.track_tiles);
+    overlay_track_stop_tiles_input_ =
+        FormatHexList(project_->dungeon_overlay.track_stop_tiles);
+    overlay_track_switch_tiles_input_ =
+        FormatHexList(project_->dungeon_overlay.track_switch_tiles);
+    overlay_track_object_ids_input_ =
+        FormatHexList(project_->dungeon_overlay.track_object_ids);
+    overlay_minecart_sprite_ids_input_ =
+        FormatHexList(project_->dungeon_overlay.minecart_sprite_ids);
+    overlay_inputs_model_ = project_->dungeon_overlay;
+  };
+
+  if (OverlaySettingsEqual(candidate, project_->dungeon_overlay)) {
+    normalize_inputs();
+    return false;
+  }
+
+  const absl::Status notify_status = NotifyProjectChanged(candidate);
+  if (!notify_status.ok()) {
+    status_message_ =
+        absl::StrFormat("Project save blocked: %s", notify_status.message());
+    show_success_ = false;
+    return notify_status;
+  }
+
+  project_->dungeon_overlay = std::move(candidate);
+  normalize_inputs();
+  audit_dirty_ = true;
   return true;
 }
 
@@ -435,6 +533,7 @@ absl::StatusOr<bool> MinecartTrackEditorPanel::ResetOverlaySettings() {
       !overlay.track_object_ids.empty() || !overlay.minecart_sprite_ids.empty();
   if (!changed) {
     ClearOverlayInputs();
+    overlay_inputs_model_ = project_->dungeon_overlay;
     status_message_.clear();
     show_success_ = false;
     return false;
@@ -455,6 +554,7 @@ absl::StatusOr<bool> MinecartTrackEditorPanel::ResetOverlaySettings() {
 
   project_->dungeon_overlay = std::move(overlay);
   ClearOverlayInputs();
+  overlay_inputs_model_ = project_->dungeon_overlay;
   audit_dirty_ = true;
   status_message_ = "Overlay settings reset; save the project to persist.";
   show_success_ = true;
@@ -480,6 +580,10 @@ absl::Status MinecartTrackEditorPanel::SaveProjectSettings() {
   if (!project_save_callback_) {
     return absl::FailedPreconditionError(
         "Project save is unavailable outside the editor manager");
+  }
+  const absl::StatusOr<bool> committed = CommitOverlayInputsForSave();
+  if (!committed.ok()) {
+    return committed.status();
   }
   return project_save_callback_();
 }

--- a/src/app/editor/dungeon/ui/window/minecart_track_editor_panel.cc
+++ b/src/app/editor/dungeon/ui/window/minecart_track_editor_panel.cc
@@ -355,6 +355,14 @@ void MinecartTrackEditorPanel::InitializeOverlayInputs() {
   overlay_inputs_initialized_ = true;
 }
 
+void MinecartTrackEditorPanel::ClearOverlayInputs() {
+  overlay_track_tiles_input_.clear();
+  overlay_track_stop_tiles_input_.clear();
+  overlay_track_switch_tiles_input_.clear();
+  overlay_track_object_ids_input_.clear();
+  overlay_minecart_sprite_ids_input_.clear();
+}
+
 bool MinecartTrackEditorPanel::UpdateOverlayList(const char* label,
                                                  std::string& input,
                                                  OverlayListMember member) {
@@ -426,6 +434,9 @@ absl::StatusOr<bool> MinecartTrackEditorPanel::ResetOverlaySettings() {
       !overlay.track_switch_tiles.empty() ||
       !overlay.track_object_ids.empty() || !overlay.minecart_sprite_ids.empty();
   if (!changed) {
+    ClearOverlayInputs();
+    status_message_.clear();
+    show_success_ = false;
     return false;
   }
 
@@ -443,11 +454,7 @@ absl::StatusOr<bool> MinecartTrackEditorPanel::ResetOverlaySettings() {
   }
 
   project_->dungeon_overlay = std::move(overlay);
-  overlay_track_tiles_input_.clear();
-  overlay_track_stop_tiles_input_.clear();
-  overlay_track_switch_tiles_input_.clear();
-  overlay_track_object_ids_input_.clear();
-  overlay_minecart_sprite_ids_input_.clear();
+  ClearOverlayInputs();
   audit_dirty_ = true;
   status_message_ = "Overlay settings reset; save the project to persist.";
   show_success_ = true;

--- a/src/app/editor/dungeon/ui/window/minecart_track_editor_panel.cc
+++ b/src/app/editor/dungeon/ui/window/minecart_track_editor_panel.cc
@@ -316,6 +316,27 @@ bool MinecartTrackEditorPanel::HasUnpublishedChanges() const {
   return loaded_ && tracks_ != loaded_tracks_;
 }
 
+bool MinecartTrackEditorPanel::HasPendingProjectDraftChanges() const {
+  if (!overlay_inputs_initialized_ || project_ == nullptr) {
+    return false;
+  }
+  return overlay_track_tiles_input_ !=
+             FormatHexList(project_->dungeon_overlay.track_tiles) ||
+         overlay_track_stop_tiles_input_ !=
+             FormatHexList(project_->dungeon_overlay.track_stop_tiles) ||
+         overlay_track_switch_tiles_input_ !=
+             FormatHexList(project_->dungeon_overlay.track_switch_tiles) ||
+         overlay_track_object_ids_input_ !=
+             FormatHexList(project_->dungeon_overlay.track_object_ids) ||
+         overlay_minecart_sprite_ids_input_ !=
+             FormatHexList(project_->dungeon_overlay.minecart_sprite_ids);
+}
+
+absl::Status MinecartTrackEditorPanel::PrepareProjectSave() {
+  const absl::StatusOr<bool> committed = CommitOverlayInputsForSave();
+  return committed.ok() ? absl::OkStatus() : committed.status();
+}
+
 absl::Status MinecartTrackEditorPanel::UpdateTrack(size_t track_index,
                                                    const MinecartTrack& track) {
   if (!loaded_) {
@@ -382,7 +403,16 @@ void MinecartTrackEditorPanel::ClearOverlayInputs() {
 bool MinecartTrackEditorPanel::UpdateOverlayList(const char* label,
                                                  std::string& input,
                                                  OverlayListMember member) {
-  ImGui::InputText(label, &input);
+  if (ImGui::InputText(label, &input)) {
+    const absl::Status draft_status = NotifyProjectDraftChanged();
+    if (!draft_status.ok()) {
+      input = FormatHexList(project_->dungeon_overlay.*member);
+      status_message_ =
+          absl::StrFormat("Overlay draft rejected: %s", draft_status.message());
+      show_success_ = false;
+      return false;
+    }
+  }
   if (ImGui::IsItemDeactivatedAfterEdit()) {
     const absl::StatusOr<bool> changed = CommitOverlayList(input, member);
     return changed.ok() && *changed;
@@ -571,6 +601,17 @@ absl::Status MinecartTrackEditorPanel::NotifyProjectChanged(
         "Project change tracking is unavailable for minecart overlays");
   }
   return project_changed_callback_(overlay);
+}
+
+absl::Status MinecartTrackEditorPanel::NotifyProjectDraftChanged() {
+  if (project_ == nullptr) {
+    return absl::FailedPreconditionError("No project is bound to the panel");
+  }
+  if (!project_draft_changed_callback_) {
+    return absl::FailedPreconditionError(
+        "Project draft tracking is unavailable for minecart overlays");
+  }
+  return project_draft_changed_callback_();
 }
 
 absl::Status MinecartTrackEditorPanel::SaveProjectSettings() {

--- a/src/app/editor/dungeon/ui/window/minecart_track_editor_panel.h
+++ b/src/app/editor/dungeon/ui/window/minecart_track_editor_panel.h
@@ -89,6 +89,7 @@ class MinecartTrackEditorPanel : public WindowContent {
   bool IsDefaultTrack(const MinecartTrack& track) const;
   void DrawOverlaySettings();
   void InitializeOverlayInputs();
+  void ClearOverlayInputs();
 
   using OverlayListMember =
       std::vector<uint16_t> project::DungeonOverlaySettings::*;

--- a/src/app/editor/dungeon/ui/window/minecart_track_editor_panel.h
+++ b/src/app/editor/dungeon/ui/window/minecart_track_editor_panel.h
@@ -26,7 +26,7 @@ namespace yaze::editor {
 class MinecartTrackEditorPanel : public WindowContent {
  public:
   using ProjectChangedCallback =
-      std::function<void(const project::DungeonOverlaySettings&)>;
+      std::function<absl::Status(const project::DungeonOverlaySettings&)>;
   using ProjectSaveCallback = std::function<absl::Status()>;
 
   MinecartTrackEditorPanel() = default;
@@ -45,6 +45,9 @@ class MinecartTrackEditorPanel : public WindowContent {
     audit_dirty_ = true;
   }
   absl::Status SetProject(project::YazeProject* project);
+  // Reapply project-backed panel state even when the stable session project
+  // pointer and descriptor path did not change.
+  absl::Status RebindProjectContext(project::YazeProject* project);
   void SetRom(Rom* rom) { rom_ = rom; }
   absl::Status SaveTracks();
   absl::Status ReloadTracks();
@@ -86,12 +89,16 @@ class MinecartTrackEditorPanel : public WindowContent {
   bool IsDefaultTrack(const MinecartTrack& track) const;
   void DrawOverlaySettings();
   void InitializeOverlayInputs();
+
+  using OverlayListMember =
+      std::vector<uint16_t> project::DungeonOverlaySettings::*;
   bool UpdateOverlayList(const char* label, std::string& input,
-                         std::vector<uint16_t>& target);
-  bool CommitOverlayList(const std::string& input,
-                         std::vector<uint16_t>& target);
-  bool ResetOverlaySettings();
-  void NotifyProjectChanged();
+                         OverlayListMember member);
+  absl::StatusOr<bool> CommitOverlayList(std::string& input,
+                                         OverlayListMember member);
+  absl::StatusOr<bool> ResetOverlaySettings();
+  absl::Status NotifyProjectChanged(
+      const project::DungeonOverlaySettings& overlay);
   absl::Status SaveProjectSettings();
 
   struct RoomTrackAudit {
@@ -109,6 +116,7 @@ class MinecartTrackEditorPanel : public WindowContent {
   std::filesystem::path loaded_source_path_;
   std::string loaded_source_sha256_;
   std::string bound_project_filepath_;
+  std::optional<core::MinecartTrackLayout::Source> bound_source_identity_;
   Rom* rom_ = nullptr;
   DungeonRoomStore* rooms_ = nullptr;
   project::YazeProject* project_ = nullptr;

--- a/src/app/editor/dungeon/ui/window/minecart_track_editor_panel.h
+++ b/src/app/editor/dungeon/ui/window/minecart_track_editor_panel.h
@@ -25,6 +25,10 @@ namespace yaze::editor {
 
 class MinecartTrackEditorPanel : public WindowContent {
  public:
+  using ProjectChangedCallback =
+      std::function<void(const project::DungeonOverlaySettings&)>;
+  using ProjectSaveCallback = std::function<absl::Status()>;
+
   MinecartTrackEditorPanel() = default;
 
   // WindowContent overrides
@@ -62,8 +66,16 @@ class MinecartTrackEditorPanel : public WindowContent {
   void SetRoomNavigationCallback(RoomNavigationCallback callback) {
     room_navigation_callback_ = std::move(callback);
   }
+  void SetProjectChangedCallback(ProjectChangedCallback callback) {
+    project_changed_callback_ = std::move(callback);
+  }
+  void SetProjectSaveCallback(ProjectSaveCallback callback) {
+    project_save_callback_ = std::move(callback);
+  }
 
  private:
+  friend class MinecartTrackEditorPanelTestPeer;
+
   absl::Status LoadTracks();
   absl::Status ValidateLoadedManifestIdentity() const;
   absl::Status RefreshProjectBinding();
@@ -76,6 +88,11 @@ class MinecartTrackEditorPanel : public WindowContent {
   void InitializeOverlayInputs();
   bool UpdateOverlayList(const char* label, std::string& input,
                          std::vector<uint16_t>& target);
+  bool CommitOverlayList(const std::string& input,
+                         std::vector<uint16_t>& target);
+  bool ResetOverlaySettings();
+  void NotifyProjectChanged();
+  absl::Status SaveProjectSettings();
 
   struct RoomTrackAudit {
     bool has_track_collision = false;
@@ -115,6 +132,8 @@ class MinecartTrackEditorPanel : public WindowContent {
   bool has_picked_coords_ = false;
 
   RoomNavigationCallback room_navigation_callback_;
+  ProjectChangedCallback project_changed_callback_;
+  ProjectSaveCallback project_save_callback_;
 
   // Overlay config input state
   bool overlay_inputs_initialized_ = false;

--- a/src/app/editor/dungeon/ui/window/minecart_track_editor_panel.h
+++ b/src/app/editor/dungeon/ui/window/minecart_track_editor_panel.h
@@ -27,6 +27,7 @@ class MinecartTrackEditorPanel : public WindowContent {
  public:
   using ProjectChangedCallback =
       std::function<absl::Status(const project::DungeonOverlaySettings&)>;
+  using ProjectDraftChangedCallback = std::function<absl::Status()>;
   using ProjectSaveCallback = std::function<absl::Status()>;
 
   MinecartTrackEditorPanel() = default;
@@ -55,6 +56,8 @@ class MinecartTrackEditorPanel : public WindowContent {
   bool HasUnpublishedChanges() const;
   absl::StatusOr<std::filesystem::path> ResolveTrackSourcePath() const;
   absl::Status UpdateTrack(size_t track_index, const MinecartTrack& track);
+  bool HasPendingProjectDraftChanges() const;
+  absl::Status PrepareProjectSave();
 
   // Coordinate picking from dungeon canvas
   // When picking mode is active, the next canvas click will set the coordinates
@@ -71,6 +74,9 @@ class MinecartTrackEditorPanel : public WindowContent {
   }
   void SetProjectChangedCallback(ProjectChangedCallback callback) {
     project_changed_callback_ = std::move(callback);
+  }
+  void SetProjectDraftChangedCallback(ProjectDraftChangedCallback callback) {
+    project_draft_changed_callback_ = std::move(callback);
   }
   void SetProjectSaveCallback(ProjectSaveCallback callback) {
     project_save_callback_ = std::move(callback);
@@ -101,6 +107,7 @@ class MinecartTrackEditorPanel : public WindowContent {
   absl::StatusOr<bool> ResetOverlaySettings();
   absl::Status NotifyProjectChanged(
       const project::DungeonOverlaySettings& overlay);
+  absl::Status NotifyProjectDraftChanged();
   absl::Status SaveProjectSettings();
 
   struct RoomTrackAudit {
@@ -143,6 +150,7 @@ class MinecartTrackEditorPanel : public WindowContent {
 
   RoomNavigationCallback room_navigation_callback_;
   ProjectChangedCallback project_changed_callback_;
+  ProjectDraftChangedCallback project_draft_changed_callback_;
   ProjectSaveCallback project_save_callback_;
 
   // Overlay config input state

--- a/src/app/editor/dungeon/ui/window/minecart_track_editor_panel.h
+++ b/src/app/editor/dungeon/ui/window/minecart_track_editor_panel.h
@@ -97,6 +97,7 @@ class MinecartTrackEditorPanel : public WindowContent {
                          OverlayListMember member);
   absl::StatusOr<bool> CommitOverlayList(std::string& input,
                                          OverlayListMember member);
+  absl::StatusOr<bool> CommitOverlayInputsForSave();
   absl::StatusOr<bool> ResetOverlaySettings();
   absl::Status NotifyProjectChanged(
       const project::DungeonOverlaySettings& overlay);
@@ -146,6 +147,7 @@ class MinecartTrackEditorPanel : public WindowContent {
 
   // Overlay config input state
   bool overlay_inputs_initialized_ = false;
+  std::optional<project::DungeonOverlaySettings> overlay_inputs_model_;
   std::string overlay_track_tiles_input_;
   std::string overlay_track_stop_tiles_input_;
   std::string overlay_track_switch_tiles_input_;

--- a/src/app/editor/editor_manager.cc
+++ b/src/app/editor/editor_manager.cc
@@ -1275,6 +1275,21 @@ void EditorManager::CaptureActiveProjectEditingState() {
   session->project_file_editor_state = project_file_editor_.CaptureState();
 }
 
+absl::Status EditorManager::PrepareActiveProjectEditorDraftsForSave() {
+  if (!session_coordinator_) {
+    return absl::OkStatus();
+  }
+  auto* session = session_coordinator_->GetActiveRomSession();
+  if (session == nullptr || !session->editors.HasPendingProjectDraftChanges()) {
+    return absl::OkStatus();
+  }
+  if (!IsCurrentProjectContextOwnedBySession(session->session_id())) {
+    return absl::FailedPreconditionError(
+        "Project editor drafts require their project context to be active");
+  }
+  return session->editors.PrepareProjectSave();
+}
+
 void EditorManager::DetachActiveProjectContext() {
   CaptureActiveProjectContext();
   active_project_context_session_id_.reset();
@@ -5306,6 +5321,7 @@ absl::Status EditorManager::SaveProject() {
           "preserve that draft before saving project settings");
     }
   }
+  RETURN_IF_ERROR(PrepareActiveProjectEditorDraftsForSave());
   CaptureActiveProjectContext();
   if (!current_project_.project_opened()) {
     return CreateNewProject();
@@ -5370,7 +5386,9 @@ bool EditorManager::IsCurrentProjectDirty() const {
            project_management_panel_->IsProjectDirty();
   }
   const auto* session = session_coordinator_->GetActiveRomSession();
-  return session != nullptr && session->project_dirty;
+  return session != nullptr &&
+         (session->project_dirty ||
+          session->editors.HasPendingProjectDraftChanges());
 }
 
 absl::Status EditorManager::SaveActiveProjectEditingWork() {
@@ -5383,7 +5401,8 @@ absl::Status EditorManager::SaveActiveProjectEditingWork() {
   }
 
   CaptureActiveProjectEditingState();
-  const bool project_dirty = session->project_dirty;
+  const bool project_dirty = session->project_dirty ||
+                             session->editors.HasPendingProjectDraftChanges();
   const bool project_file_dirty =
       session->project_file_editor_state.initialized &&
       session->project_file_editor_state.modified;
@@ -5479,7 +5498,6 @@ absl::Status EditorManager::SaveProjectAs(const std::string& filepath) {
     return absl::InvalidArgumentError("Project file path cannot be empty");
   }
   CaptureActiveProjectEditingState();
-  CaptureActiveProjectContext();
   std::string file_path = filepath;
 
   // Ensure a project extension.
@@ -5499,6 +5517,9 @@ absl::Status EditorManager::SaveProjectAs(const std::string& filepath) {
           "raw Save As before overwriting that destination");
     }
   }
+
+  RETURN_IF_ERROR(PrepareActiveProjectEditorDraftsForSave());
+  CaptureActiveProjectContext();
 
   // Update project filepath and save
   std::string old_filepath = current_project_.filepath;
@@ -6415,6 +6436,7 @@ bool EditorManager::SessionHasPendingUnsavedWork(size_t session_index) const {
       static_cast<RomSession*>(session_coordinator_->GetSession(session_index));
   return session != nullptr &&
          (SessionHasPendingRomWork(session_index) || session->project_dirty ||
+          session->editors.HasPendingProjectDraftChanges() ||
           (session->project_file_editor_state.initialized &&
            session->project_file_editor_state.modified));
 }
@@ -6525,6 +6547,8 @@ std::string EditorManager::DescribePendingUnsavedWork(
   const size_t pending_palette_colors =
       PendingPaletteColorCountForSession(session_index);
   const bool project_dirty = session != nullptr && session->project_dirty;
+  const bool project_editor_draft =
+      session != nullptr && session->editors.HasPendingProjectDraftChanges();
   const bool project_file_dirty =
       session != nullptr && session->project_file_editor_state.initialized &&
       session->project_file_editor_state.modified;
@@ -6549,6 +6573,9 @@ std::string EditorManager::DescribePendingUnsavedWork(
   }
   if (project_dirty) {
     work.emplace_back("unsaved project settings");
+  }
+  if (project_editor_draft) {
+    work.emplace_back("an uncommitted project editor draft");
   }
   if (project_file_dirty) {
     work.emplace_back("an unsaved project-file draft");

--- a/src/app/editor/editor_manager.h
+++ b/src/app/editor/editor_manager.h
@@ -647,6 +647,7 @@ class EditorManager : public ISessionConfigurator, public IEditorSwitcher {
   void CaptureRuntimeFeatureFlags();
   void CaptureActiveProjectEditingState();
   void CaptureActiveProjectContext();
+  absl::Status PrepareActiveProjectEditorDraftsForSave();
   void DetachActiveProjectContext();
   void BindProjectContextToSession(RomSession* session,
                                    const project::YazeProject& project);

--- a/src/app/editor/editor_manager.h
+++ b/src/app/editor/editor_manager.h
@@ -456,6 +456,14 @@ class EditorManager : public ISessionConfigurator, public IEditorSwitcher {
   const project::YazeProject* GetCurrentProject() const {
     return &current_project_;
   }
+  // True only for the session whose project is currently restored into
+  // current_project_. SessionCoordinator also performs transient switches
+  // while drawing inactive sessions, so its active session is not sufficient
+  // for routing project mutations or saves.
+  bool IsCurrentProjectContextOwnedBySession(size_t session_id) const {
+    return active_project_context_session_id_.has_value() &&
+           *active_project_context_session_id_ == session_id;
+  }
   void MarkCurrentProjectDirty();
   bool IsCurrentProjectDirty() const;
   core::VersionManager* GetVersionManager() { return version_manager_; }

--- a/src/app/editor/session_types.cc
+++ b/src/app/editor/session_types.cc
@@ -241,6 +241,22 @@ bool EditorSet::HasPendingGraphicsChanges() const {
   return false;
 }
 
+bool EditorSet::HasPendingProjectDraftChanges() const {
+  if (auto* editor =
+          static_cast<DungeonEditorV2*>(FindEditor(EditorType::kDungeon))) {
+    return editor->HasPendingProjectDraftChanges();
+  }
+  return false;
+}
+
+absl::Status EditorSet::PrepareProjectSave() {
+  if (auto* editor =
+          static_cast<DungeonEditorV2*>(FindEditor(EditorType::kDungeon))) {
+    return editor->PrepareProjectSave();
+  }
+  return absl::OkStatus();
+}
+
 zelda3::Overworld* EditorSet::GetOverworldData() const {
   if (auto* editor =
           static_cast<OverworldEditor*>(FindEditor(EditorType::kOverworld))) {

--- a/src/app/editor/session_types.h
+++ b/src/app/editor/session_types.h
@@ -94,6 +94,8 @@ class EditorSet {
   int TotalDungeonRoomCount() const;
   std::vector<std::pair<uint32_t, uint32_t>> CollectDungeonWriteRanges() const;
   bool HasPendingGraphicsChanges() const;
+  bool HasPendingProjectDraftChanges() const;
+  absl::Status PrepareProjectSave();
   zelda3::Overworld* GetOverworldData() const;
 
   // Deprecated named accessors (legacy compatibility)

--- a/test/unit/editor/minecart_track_editor_panel_test.cc
+++ b/test/unit/editor/minecart_track_editor_panel_test.cc
@@ -25,6 +25,23 @@ class DungeonEditorV2MinecartTrackTestPeer {
   }
 };
 
+class MinecartTrackEditorPanelTestPeer {
+ public:
+  static bool CommitOverlayList(MinecartTrackEditorPanel& panel,
+                                const std::string& input,
+                                std::vector<uint16_t>& target) {
+    return panel.CommitOverlayList(input, target);
+  }
+
+  static bool ResetOverlaySettings(MinecartTrackEditorPanel& panel) {
+    return panel.ResetOverlaySettings();
+  }
+
+  static absl::Status SaveProjectSettings(MinecartTrackEditorPanel& panel) {
+    return panel.SaveProjectSettings();
+  }
+};
+
 namespace {
 
 constexpr char kTrackSourceRelativePath[] =
@@ -170,6 +187,89 @@ std::string MakeMalformedSource() {
 }
 
 }  // namespace
+
+TEST(MinecartTrackEditorPanelTest,
+     OverlayEditsNotifyProjectOnlyWhenSettingsChange) {
+  ScopedTestProject fixture;
+  auto* project_ptr = fixture.project();
+  project_ptr->dungeon_overlay.track_tiles = {0xB0, 0xB1};
+  project_ptr->dungeon_overlay.track_stop_tiles = {0xB7};
+
+  MinecartTrackEditorPanel panel;
+  ASSERT_TRUE(panel.SetProject(project_ptr).ok());
+
+  int changed_calls = 0;
+  project::DungeonOverlaySettings reported_overlay;
+  panel.SetProjectChangedCallback(
+      [&](const project::DungeonOverlaySettings& overlay) {
+        ++changed_calls;
+        reported_overlay = overlay;
+      });
+
+  EXPECT_FALSE(MinecartTrackEditorPanelTestPeer::CommitOverlayList(
+      panel, "0xB0, $00B1", project_ptr->dungeon_overlay.track_tiles));
+  EXPECT_EQ(changed_calls, 0);
+
+  EXPECT_TRUE(MinecartTrackEditorPanelTestPeer::CommitOverlayList(
+      panel, "$00C0, 0xC1", project_ptr->dungeon_overlay.track_tiles));
+  EXPECT_EQ(changed_calls, 1);
+  EXPECT_EQ(project_ptr->dungeon_overlay.track_tiles,
+            (std::vector<uint16_t>{0xC0, 0xC1}));
+  EXPECT_EQ(reported_overlay.track_tiles,
+            project_ptr->dungeon_overlay.track_tiles);
+  EXPECT_EQ(reported_overlay.track_stop_tiles,
+            project_ptr->dungeon_overlay.track_stop_tiles);
+
+  EXPECT_TRUE(MinecartTrackEditorPanelTestPeer::ResetOverlaySettings(panel));
+  EXPECT_EQ(changed_calls, 2);
+  EXPECT_TRUE(project_ptr->dungeon_overlay.track_tiles.empty());
+  EXPECT_TRUE(project_ptr->dungeon_overlay.track_stop_tiles.empty());
+  EXPECT_TRUE(reported_overlay.track_tiles.empty());
+  EXPECT_TRUE(reported_overlay.track_stop_tiles.empty());
+
+  EXPECT_FALSE(MinecartTrackEditorPanelTestPeer::ResetOverlaySettings(panel));
+  EXPECT_EQ(changed_calls, 2);
+}
+
+TEST(MinecartTrackEditorPanelTest,
+     FailedManagerOwnedProjectSavePreservesDirtyOverlayForRetry) {
+  ScopedTestProject fixture;
+  MinecartTrackEditorPanel panel;
+  ASSERT_TRUE(panel.SetProject(fixture.project()).ok());
+
+  bool project_dirty = false;
+  panel.SetProjectChangedCallback(
+      [&](const project::DungeonOverlaySettings&) { project_dirty = true; });
+  ASSERT_TRUE(MinecartTrackEditorPanelTestPeer::CommitOverlayList(
+      panel, "$00D0, $00D1",
+      fixture.project()->dungeon_overlay.track_switch_tiles));
+  ASSERT_TRUE(project_dirty);
+
+  int save_calls = 0;
+  panel.SetProjectSaveCallback([&]() -> absl::Status {
+    ++save_calls;
+    return absl::UnavailableError("descriptor write failed");
+  });
+  const absl::Status failed_save =
+      MinecartTrackEditorPanelTestPeer::SaveProjectSettings(panel);
+  EXPECT_TRUE(absl::IsUnavailable(failed_save)) << failed_save;
+  EXPECT_EQ(save_calls, 1);
+  EXPECT_TRUE(project_dirty);
+  EXPECT_EQ(fixture.project()->dungeon_overlay.track_switch_tiles,
+            (std::vector<uint16_t>{0xD0, 0xD1}));
+
+  panel.SetProjectSaveCallback([&]() -> absl::Status {
+    ++save_calls;
+    project_dirty = false;
+    return absl::OkStatus();
+  });
+  EXPECT_TRUE(
+      MinecartTrackEditorPanelTestPeer::SaveProjectSettings(panel).ok());
+  EXPECT_EQ(save_calls, 2);
+  EXPECT_FALSE(project_dirty);
+  EXPECT_EQ(fixture.project()->dungeon_overlay.track_switch_tiles,
+            (std::vector<uint16_t>{0xD0, 0xD1}));
+}
 
 TEST(MinecartTrackEditorPanelTest,
      ResolvesCanonicalSourceFromProjectRootAndParsesGuardedFirstBranch) {

--- a/test/unit/editor/minecart_track_editor_panel_test.cc
+++ b/test/unit/editor/minecart_track_editor_panel_test.cc
@@ -13,8 +13,12 @@
 #include "absl/status/status.h"
 #include "absl/strings/str_format.h"
 #include "app/editor/dungeon/dungeon_editor_v2.h"
+#include "app/editor/editor_manager.h"
+#include "app/gfx/backend/null_renderer.h"
+#include "core/features.h"
 #include "core/project.h"
 #include "gtest/gtest.h"
+#include "imgui/imgui.h"
 #include "rom/rom.h"
 
 namespace yaze::editor {
@@ -103,6 +107,52 @@ class MinecartTrackEditorPanelTestPeer {
 
 namespace {
 
+class CallbackEditor : public Editor {
+ public:
+  explicit CallbackEditor(std::function<absl::Status()> callback)
+      : callback_(std::move(callback)) {
+    type_ = EditorType::kDungeon;
+    active_ = true;
+  }
+
+  void Initialize() override {}
+  absl::Status Load() override { return absl::OkStatus(); }
+  absl::Status Save() override { return absl::OkStatus(); }
+  absl::Status Update() override { return callback_(); }
+  absl::Status Cut() override { return absl::OkStatus(); }
+  absl::Status Copy() override { return absl::OkStatus(); }
+  absl::Status Paste() override { return absl::OkStatus(); }
+  absl::Status Undo() override { return absl::OkStatus(); }
+  absl::Status Redo() override { return absl::OkStatus(); }
+  absl::Status Find() override { return absl::OkStatus(); }
+
+ private:
+  std::function<absl::Status()> callback_;
+};
+
+struct ScopedImGuiContext {
+  ScopedImGuiContext() {
+    context = ImGui::CreateContext();
+    ImGui::SetCurrentContext(context);
+    unsigned char* pixels = nullptr;
+    int width = 0;
+    int height = 0;
+    ImGui::GetIO().Fonts->GetTexDataAsRGBA32(&pixels, &width, &height);
+  }
+  ~ScopedImGuiContext() {
+    if (context != nullptr) {
+      ImGui::DestroyContext(context);
+    }
+  }
+
+  ImGuiContext* context = nullptr;
+};
+
+struct FeatureFlagsGuard {
+  core::FeatureFlags::Flags previous = core::FeatureFlags::get();
+  ~FeatureFlagsGuard() { core::FeatureFlags::get() = previous; }
+};
+
 constexpr char kTrackSourceRelativePath[] =
     "Sprites/Objects/data/minecart_tracks.asm";
 
@@ -181,6 +231,62 @@ class ScopedTestProject {
   std::filesystem::path root_;
   std::filesystem::path outside_root_;
   project::YazeProject project_;
+};
+
+class ScopedManagerProject {
+ public:
+  ScopedManagerProject(const std::string& suffix, const std::string& name,
+                       uint16_t track_tile) {
+    const auto nonce =
+        std::chrono::steady_clock::now().time_since_epoch().count();
+    root_ = std::filesystem::temp_directory_path() /
+            absl::StrFormat("yaze_minecart_manager_%s_%d", suffix, nonce);
+    std::filesystem::create_directories(root_);
+
+    rom_path_ = root_ / (suffix + ".sfc");
+    std::vector<uint8_t> rom_data(512 * 1024, 0);
+    constexpr size_t kTitleOffset = 0x7FC0;
+    for (size_t i = 0; i < name.size() && kTitleOffset + i < rom_data.size();
+         ++i) {
+      rom_data[kTitleOffset + i] = static_cast<uint8_t>(name[i]);
+    }
+    std::ofstream rom_file(rom_path_, std::ios::binary | std::ios::trunc);
+    rom_file.write(reinterpret_cast<const char*>(rom_data.data()),
+                   static_cast<std::streamsize>(rom_data.size()));
+    rom_file.close();
+
+    project_path_ = root_ / (suffix + ".yaze");
+    project::YazeProject project;
+    project.name = name;
+    project.filepath = project_path_.string();
+    project.rom_filename = rom_path_.string();
+    project.dungeon_overlay.track_tiles = {track_tile};
+    const absl::Status save_status = project.Save();
+    if (!save_status.ok()) {
+      throw std::runtime_error(std::string(save_status.message()));
+    }
+  }
+
+  ~ScopedManagerProject() {
+    std::error_code ec;
+    std::filesystem::remove_all(root_, ec);
+  }
+
+  const std::filesystem::path& project_path() const { return project_path_; }
+
+  project::YazeProject ReadProject() const {
+    project::YazeProject project;
+    const absl::Status status = project.Open(project_path_.string());
+    if (!status.ok()) {
+      throw std::runtime_error(std::string(status.message()));
+    }
+    return project;
+  }
+
+ private:
+  std::filesystem::path root_;
+  std::filesystem::path rom_path_;
+  std::filesystem::path project_path_;
 };
 
 void AppendDwValues(std::stringstream& stream, int first_value, int count) {
@@ -520,6 +626,204 @@ TEST(MinecartTrackEditorPanelTest,
   EXPECT_FALSE(project_dirty);
   EXPECT_EQ(fixture.project()->dungeon_overlay.track_switch_tiles,
             (std::vector<uint16_t>{0xD0, 0xD1}));
+}
+
+TEST(MinecartTrackEditorPanelTest,
+     SaveValidatesAllPendingOverlayInputsBeforeChangingProject) {
+  ScopedTestProject fixture;
+  fixture.project()->dungeon_overlay.track_tiles = {0xB0};
+  fixture.project()->dungeon_overlay.track_stop_tiles = {0xB7};
+  fixture.project()->dungeon_overlay.track_switch_tiles = {0xD0};
+  fixture.project()->dungeon_overlay.track_object_ids = {0x31};
+  fixture.project()->dungeon_overlay.minecart_sprite_ids = {0xA3};
+  const project::DungeonOverlaySettings original =
+      fixture.project()->dungeon_overlay;
+
+  MinecartTrackEditorPanel panel;
+  ASSERT_TRUE(panel.SetProject(fixture.project()).ok());
+  MinecartTrackEditorPanelTestPeer::InitializeOverlayInputs(panel);
+  MinecartTrackEditorPanelTestPeer::SetOverlayInputs(
+      panel, {"$00C0", "$00C1", "not-hex", "$0032", "$00A4"});
+
+  bool project_dirty = false;
+  int changed_calls = 0;
+  int save_calls = 0;
+  panel.SetProjectChangedCallback(
+      [&](const project::DungeonOverlaySettings&) -> absl::Status {
+        ++changed_calls;
+        project_dirty = true;
+        return absl::OkStatus();
+      });
+  panel.SetProjectSaveCallback([&]() -> absl::Status {
+    ++save_calls;
+    project_dirty = false;
+    return absl::OkStatus();
+  });
+
+  const absl::Status rejected =
+      MinecartTrackEditorPanelTestPeer::SaveProjectSettings(panel);
+  EXPECT_TRUE(absl::IsInvalidArgument(rejected)) << rejected;
+  EXPECT_EQ(changed_calls, 0);
+  EXPECT_EQ(save_calls, 0);
+  EXPECT_FALSE(project_dirty);
+  EXPECT_EQ(fixture.project()->dungeon_overlay.track_tiles,
+            original.track_tiles);
+  EXPECT_EQ(fixture.project()->dungeon_overlay.track_stop_tiles,
+            original.track_stop_tiles);
+  EXPECT_EQ(fixture.project()->dungeon_overlay.track_switch_tiles,
+            original.track_switch_tiles);
+  EXPECT_EQ(fixture.project()->dungeon_overlay.track_object_ids,
+            original.track_object_ids);
+  EXPECT_EQ(fixture.project()->dungeon_overlay.minecart_sprite_ids,
+            original.minecart_sprite_ids);
+  EXPECT_EQ(MinecartTrackEditorPanelTestPeer::OverlayInputs(panel),
+            (std::array<std::string, 5>{"$00C0", "$00C1", "not-hex", "$0032",
+                                        "$00A4"}));
+
+  MinecartTrackEditorPanelTestPeer::SetOverlayInputs(
+      panel, {"$00C0", "$00C1", "$00D1", "$0032", "$00A4"});
+  EXPECT_TRUE(
+      MinecartTrackEditorPanelTestPeer::SaveProjectSettings(panel).ok());
+  EXPECT_EQ(changed_calls, 1);
+  EXPECT_EQ(save_calls, 1);
+  EXPECT_FALSE(project_dirty);
+  EXPECT_EQ(fixture.project()->dungeon_overlay.track_tiles,
+            (std::vector<uint16_t>{0xC0}));
+  EXPECT_EQ(fixture.project()->dungeon_overlay.track_stop_tiles,
+            (std::vector<uint16_t>{0xC1}));
+  EXPECT_EQ(fixture.project()->dungeon_overlay.track_switch_tiles,
+            (std::vector<uint16_t>{0xD1}));
+  EXPECT_EQ(fixture.project()->dungeon_overlay.track_object_ids,
+            (std::vector<uint16_t>{0x32}));
+  EXPECT_EQ(fixture.project()->dungeon_overlay.minecart_sprite_ids,
+            (std::vector<uint16_t>{0xA4}));
+}
+
+TEST(MinecartTrackEditorPanelTest,
+     SameRevisionRebindPreservesFocusedInputAndManagerSaveCommitsIt) {
+  FeatureFlagsGuard flags_guard;
+  ScopedImGuiContext imgui;
+  ScopedManagerProject fixture("save_order", "Save Order", 0xB0);
+
+  auto renderer = std::make_unique<gfx::NullRenderer>();
+  auto manager = std::make_unique<EditorManager>();
+  manager->Initialize(renderer.get(), "");
+  manager->SetAssetLoadMode(AssetLoadMode::kLazy);
+  ASSERT_TRUE(manager->OpenRomOrProject(fixture.project_path().string()).ok());
+
+  auto* session =
+      static_cast<RomSession*>(manager->session_coordinator()->GetSession(0));
+  ASSERT_NE(session, nullptr);
+  auto* dungeon =
+      session->editors.GetEditorAs<DungeonEditorV2>(EditorType::kDungeon);
+  ASSERT_NE(dungeon, nullptr);
+
+  MinecartTrackEditorPanel panel;
+  DungeonEditorV2MinecartTrackTestPeer::SetMinecartTrackEditorPanel(*dungeon,
+                                                                    &panel);
+  manager->ConfigureSession(session);
+  MinecartTrackEditorPanelTestPeer::SetTrackTilesInput(panel, "$00C0");
+
+  // Benign same-revision dependency reapplication must not overwrite an
+  // InputText buffer that has not emitted its deactivation event yet.
+  manager->ConfigureSession(session);
+  EXPECT_EQ(MinecartTrackEditorPanelTestPeer::TrackTilesInput(panel), "$00C0");
+
+  ASSERT_TRUE(
+      MinecartTrackEditorPanelTestPeer::SaveProjectSettings(panel).ok());
+  EXPECT_EQ(manager->GetCurrentProject()->dungeon_overlay.track_tiles,
+            (std::vector<uint16_t>{0xC0}));
+  ASSERT_TRUE(session->project_context.has_value());
+  EXPECT_EQ(session->project_context->dungeon_overlay.track_tiles,
+            (std::vector<uint16_t>{0xC0}));
+  EXPECT_FALSE(session->project_dirty);
+  EXPECT_EQ(fixture.ReadProject().dungeon_overlay.track_tiles,
+            (std::vector<uint16_t>{0xC0}));
+
+  DungeonEditorV2MinecartTrackTestPeer::SetMinecartTrackEditorPanel(*dungeon,
+                                                                    nullptr);
+}
+
+TEST(MinecartTrackEditorPanelTest,
+     TransientInactiveSessionCannotMutateOrSaveUserProjectContext) {
+  FeatureFlagsGuard flags_guard;
+  ScopedImGuiContext imgui;
+  ScopedManagerProject fixture_a("context_a", "Context A", 0xA0);
+  ScopedManagerProject fixture_b("context_b", "Context B", 0xB0);
+
+  auto renderer = std::make_unique<gfx::NullRenderer>();
+  auto manager = std::make_unique<EditorManager>();
+  manager->Initialize(renderer.get(), "");
+  manager->SetAssetLoadMode(AssetLoadMode::kLazy);
+  ASSERT_TRUE(
+      manager->OpenRomOrProject(fixture_a.project_path().string()).ok());
+  ASSERT_TRUE(
+      manager->OpenRomOrProject(fixture_b.project_path().string()).ok());
+  manager->SwitchToSession(0);
+
+  auto* session_a =
+      static_cast<RomSession*>(manager->session_coordinator()->GetSession(0));
+  auto* session_b =
+      static_cast<RomSession*>(manager->session_coordinator()->GetSession(1));
+  ASSERT_NE(session_a, nullptr);
+  ASSERT_NE(session_b, nullptr);
+  ASSERT_TRUE(
+      manager->IsCurrentProjectContextOwnedBySession(session_a->session_id()));
+  ASSERT_FALSE(
+      manager->IsCurrentProjectContextOwnedBySession(session_b->session_id()));
+
+  auto* dungeon_b =
+      session_b->editors.GetEditorAs<DungeonEditorV2>(EditorType::kDungeon);
+  ASSERT_NE(dungeon_b, nullptr);
+  MinecartTrackEditorPanel panel_b;
+  DungeonEditorV2MinecartTrackTestPeer::SetMinecartTrackEditorPanel(*dungeon_b,
+                                                                    &panel_b);
+  manager->ConfigureSession(session_b);
+  MinecartTrackEditorPanelTestPeer::SetTrackTilesInput(panel_b, "$00C0");
+
+  absl::Status edit_status = absl::UnknownError("callback did not run");
+  absl::Status save_status = absl::UnknownError("callback did not run");
+  CallbackEditor transient_editor([&]() -> absl::Status {
+    edit_status =
+        MinecartTrackEditorPanelTestPeer::SaveProjectSettings(panel_b);
+    MinecartTrackEditorPanelTestPeer::SetTrackTilesInput(panel_b, "0xB0");
+    save_status =
+        MinecartTrackEditorPanelTestPeer::SaveProjectSettings(panel_b);
+    return absl::OkStatus();
+  });
+  session_b->editors.active_editors_.push_back(&transient_editor);
+
+  ImGuiIO& io = ImGui::GetIO();
+  io.DisplaySize = ImVec2(1280.0f, 720.0f);
+  io.DeltaTime = 1.0f / 60.0f;
+  ImGui::NewFrame();
+  manager->session_coordinator()->UpdateSessions();
+  ImGui::EndFrame();
+
+  session_b->editors.active_editors_.erase(
+      std::remove(session_b->editors.active_editors_.begin(),
+                  session_b->editors.active_editors_.end(), &transient_editor),
+      session_b->editors.active_editors_.end());
+  DungeonEditorV2MinecartTrackTestPeer::SetMinecartTrackEditorPanel(*dungeon_b,
+                                                                    nullptr);
+
+  EXPECT_TRUE(absl::IsFailedPrecondition(edit_status)) << edit_status;
+  EXPECT_TRUE(absl::IsFailedPrecondition(save_status)) << save_status;
+  EXPECT_EQ(manager->GetCurrentSessionId(), session_a->session_id());
+  EXPECT_EQ(manager->GetCurrentProject()->dungeon_overlay.track_tiles,
+            (std::vector<uint16_t>{0xA0}));
+  ASSERT_TRUE(session_a->project_context.has_value());
+  ASSERT_TRUE(session_b->project_context.has_value());
+  EXPECT_EQ(session_a->project_context->dungeon_overlay.track_tiles,
+            (std::vector<uint16_t>{0xA0}));
+  EXPECT_EQ(session_b->project_context->dungeon_overlay.track_tiles,
+            (std::vector<uint16_t>{0xB0}));
+  EXPECT_FALSE(session_a->project_dirty);
+  EXPECT_FALSE(session_b->project_dirty);
+  EXPECT_EQ(fixture_a.ReadProject().dungeon_overlay.track_tiles,
+            (std::vector<uint16_t>{0xA0}));
+  EXPECT_EQ(fixture_b.ReadProject().dungeon_overlay.track_tiles,
+            (std::vector<uint16_t>{0xB0}));
 }
 
 TEST(MinecartTrackEditorPanelTest,

--- a/test/unit/editor/minecart_track_editor_panel_test.cc
+++ b/test/unit/editor/minecart_track_editor_panel_test.cc
@@ -6,6 +6,7 @@
 #include <sstream>
 #include <stdexcept>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "absl/status/status.h"
@@ -27,18 +28,57 @@ class DungeonEditorV2MinecartTrackTestPeer {
 
 class MinecartTrackEditorPanelTestPeer {
  public:
-  static bool CommitOverlayList(MinecartTrackEditorPanel& panel,
-                                const std::string& input,
-                                std::vector<uint16_t>& target) {
-    return panel.CommitOverlayList(input, target);
+  static absl::StatusOr<bool> CommitOverlayList(
+      MinecartTrackEditorPanel& panel, std::string& input,
+      std::vector<uint16_t> project::DungeonOverlaySettings::* member) {
+    return panel.CommitOverlayList(input, member);
   }
 
-  static bool ResetOverlaySettings(MinecartTrackEditorPanel& panel) {
+  static absl::StatusOr<bool> CommitTrackTilesInput(
+      MinecartTrackEditorPanel& panel) {
+    return panel.CommitOverlayList(
+        panel.overlay_track_tiles_input_,
+        &project::DungeonOverlaySettings::track_tiles);
+  }
+
+  static absl::StatusOr<bool> ResetOverlaySettings(
+      MinecartTrackEditorPanel& panel) {
     return panel.ResetOverlaySettings();
   }
 
   static absl::Status SaveProjectSettings(MinecartTrackEditorPanel& panel) {
     return panel.SaveProjectSettings();
+  }
+
+  static void InitializeOverlayInputs(MinecartTrackEditorPanel& panel) {
+    panel.InitializeOverlayInputs();
+  }
+
+  static void SetTrackTilesInput(MinecartTrackEditorPanel& panel,
+                                 std::string input) {
+    panel.overlay_track_tiles_input_ = std::move(input);
+  }
+
+  static const std::string& TrackTilesInput(
+      const MinecartTrackEditorPanel& panel) {
+    return panel.overlay_track_tiles_input_;
+  }
+
+  static const std::string& StatusMessage(
+      const MinecartTrackEditorPanel& panel) {
+    return panel.status_message_;
+  }
+
+  static bool ShowSuccess(const MinecartTrackEditorPanel& panel) {
+    return panel.show_success_;
+  }
+
+  static void SetAuditDirty(MinecartTrackEditorPanel& panel, bool dirty) {
+    panel.audit_dirty_ = dirty;
+  }
+
+  static bool AuditDirty(const MinecartTrackEditorPanel& panel) {
+    return panel.audit_dirty_;
   }
 };
 
@@ -201,17 +241,26 @@ TEST(MinecartTrackEditorPanelTest,
   int changed_calls = 0;
   project::DungeonOverlaySettings reported_overlay;
   panel.SetProjectChangedCallback(
-      [&](const project::DungeonOverlaySettings& overlay) {
+      [&](const project::DungeonOverlaySettings& overlay) -> absl::Status {
         ++changed_calls;
         reported_overlay = overlay;
+        return absl::OkStatus();
       });
 
-  EXPECT_FALSE(MinecartTrackEditorPanelTestPeer::CommitOverlayList(
-      panel, "0xB0, $00B1", project_ptr->dungeon_overlay.track_tiles));
+  std::string unchanged_input = "0xB0, $00B1";
+  auto unchanged = MinecartTrackEditorPanelTestPeer::CommitOverlayList(
+      panel, unchanged_input, &project::DungeonOverlaySettings::track_tiles);
+  ASSERT_TRUE(unchanged.ok()) << unchanged.status();
+  EXPECT_FALSE(*unchanged);
+  EXPECT_EQ(unchanged_input, "0xB0, 0xB1");
   EXPECT_EQ(changed_calls, 0);
 
-  EXPECT_TRUE(MinecartTrackEditorPanelTestPeer::CommitOverlayList(
-      panel, "$00C0, 0xC1", project_ptr->dungeon_overlay.track_tiles));
+  std::string changed_input = "$00C0, 0xC1";
+  auto changed = MinecartTrackEditorPanelTestPeer::CommitOverlayList(
+      panel, changed_input, &project::DungeonOverlaySettings::track_tiles);
+  ASSERT_TRUE(changed.ok()) << changed.status();
+  EXPECT_TRUE(*changed);
+  EXPECT_EQ(changed_input, "0xC0, 0xC1");
   EXPECT_EQ(changed_calls, 1);
   EXPECT_EQ(project_ptr->dungeon_overlay.track_tiles,
             (std::vector<uint16_t>{0xC0, 0xC1}));
@@ -220,15 +269,152 @@ TEST(MinecartTrackEditorPanelTest,
   EXPECT_EQ(reported_overlay.track_stop_tiles,
             project_ptr->dungeon_overlay.track_stop_tiles);
 
-  EXPECT_TRUE(MinecartTrackEditorPanelTestPeer::ResetOverlaySettings(panel));
+  auto reset = MinecartTrackEditorPanelTestPeer::ResetOverlaySettings(panel);
+  ASSERT_TRUE(reset.ok()) << reset.status();
+  EXPECT_TRUE(*reset);
   EXPECT_EQ(changed_calls, 2);
   EXPECT_TRUE(project_ptr->dungeon_overlay.track_tiles.empty());
   EXPECT_TRUE(project_ptr->dungeon_overlay.track_stop_tiles.empty());
   EXPECT_TRUE(reported_overlay.track_tiles.empty());
   EXPECT_TRUE(reported_overlay.track_stop_tiles.empty());
 
-  EXPECT_FALSE(MinecartTrackEditorPanelTestPeer::ResetOverlaySettings(panel));
+  auto unchanged_reset =
+      MinecartTrackEditorPanelTestPeer::ResetOverlaySettings(panel);
+  ASSERT_TRUE(unchanged_reset.ok()) << unchanged_reset.status();
+  EXPECT_FALSE(*unchanged_reset);
   EXPECT_EQ(changed_calls, 2);
+}
+
+TEST(MinecartTrackEditorPanelTest,
+     OverlayParserRejectsWholeInvalidInputAndNormalizesAcceptedValues) {
+  ScopedTestProject fixture;
+  fixture.project()->dungeon_overlay.track_tiles = {0xB0, 0xB1};
+
+  MinecartTrackEditorPanel panel;
+  ASSERT_TRUE(panel.SetProject(fixture.project()).ok());
+  int changed_calls = 0;
+  panel.SetProjectChangedCallback(
+      [&](const project::DungeonOverlaySettings&) -> absl::Status {
+        ++changed_calls;
+        return absl::OkStatus();
+      });
+  MinecartTrackEditorPanelTestPeer::SetAuditDirty(panel, false);
+
+  for (const std::string& invalid :
+       {"0x1G, 0x2", "65536", "0x10000", "0x1junk", "$", "0x1,", "0x1,,0x2",
+        "999999999999999999999999999999"}) {
+    std::string input = invalid;
+    const auto result = MinecartTrackEditorPanelTestPeer::CommitOverlayList(
+        panel, input, &project::DungeonOverlaySettings::track_tiles);
+    EXPECT_FALSE(result.ok()) << invalid;
+    EXPECT_EQ(input, invalid);
+    EXPECT_EQ(fixture.project()->dungeon_overlay.track_tiles,
+              (std::vector<uint16_t>{0xB0, 0xB1}));
+    EXPECT_EQ(changed_calls, 0);
+    EXPECT_FALSE(MinecartTrackEditorPanelTestPeer::AuditDirty(panel));
+    EXPECT_FALSE(MinecartTrackEditorPanelTestPeer::ShowSuccess(panel));
+    EXPECT_NE(MinecartTrackEditorPanelTestPeer::StatusMessage(panel).find(
+                  "Overlay update rejected"),
+              std::string::npos);
+  }
+
+  std::string accepted = " $00C0  0x00C1 ";
+  auto changed = MinecartTrackEditorPanelTestPeer::CommitOverlayList(
+      panel, accepted, &project::DungeonOverlaySettings::track_tiles);
+  ASSERT_TRUE(changed.ok()) << changed.status();
+  EXPECT_TRUE(*changed);
+  EXPECT_EQ(accepted, "0xC0, 0xC1");
+  EXPECT_EQ(fixture.project()->dungeon_overlay.track_tiles,
+            (std::vector<uint16_t>{0xC0, 0xC1}));
+  EXPECT_EQ(changed_calls, 1);
+  EXPECT_TRUE(MinecartTrackEditorPanelTestPeer::AuditDirty(panel));
+
+  std::string equivalent = "192, 193";
+  auto unchanged = MinecartTrackEditorPanelTestPeer::CommitOverlayList(
+      panel, equivalent, &project::DungeonOverlaySettings::track_tiles);
+  ASSERT_TRUE(unchanged.ok()) << unchanged.status();
+  EXPECT_FALSE(*unchanged);
+  EXPECT_EQ(equivalent, "0xC0, 0xC1");
+  EXPECT_EQ(changed_calls, 1);
+}
+
+TEST(MinecartTrackEditorPanelTest,
+     RejectedOverlayCallbackRollsBackInputModelAndDirtyState) {
+  ScopedTestProject fixture;
+  fixture.project()->dungeon_overlay.track_tiles = {0xB0};
+
+  MinecartTrackEditorPanel panel;
+  ASSERT_TRUE(panel.SetProject(fixture.project()).ok());
+  MinecartTrackEditorPanelTestPeer::InitializeOverlayInputs(panel);
+  MinecartTrackEditorPanelTestPeer::SetTrackTilesInput(panel, "$00C0");
+  MinecartTrackEditorPanelTestPeer::SetAuditDirty(panel, false);
+  bool session_active = false;
+  bool project_dirty = false;
+  panel.SetProjectChangedCallback(
+      [&](const project::DungeonOverlaySettings&) -> absl::Status {
+        if (!session_active) {
+          return absl::FailedPreconditionError(
+              "minecart overlay session is not active");
+        }
+        project_dirty = true;
+        return absl::OkStatus();
+      });
+
+  const auto result =
+      MinecartTrackEditorPanelTestPeer::CommitTrackTilesInput(panel);
+  EXPECT_FALSE(result.ok());
+  EXPECT_TRUE(absl::IsFailedPrecondition(result.status())) << result.status();
+  EXPECT_EQ(fixture.project()->dungeon_overlay.track_tiles,
+            (std::vector<uint16_t>{0xB0}));
+  EXPECT_EQ(MinecartTrackEditorPanelTestPeer::TrackTilesInput(panel), "0xB0");
+  EXPECT_FALSE(project_dirty);
+  EXPECT_FALSE(MinecartTrackEditorPanelTestPeer::AuditDirty(panel));
+  EXPECT_FALSE(MinecartTrackEditorPanelTestPeer::ShowSuccess(panel));
+  EXPECT_NE(MinecartTrackEditorPanelTestPeer::StatusMessage(panel).find(
+                "session is not active"),
+            std::string::npos);
+
+  const auto reset =
+      MinecartTrackEditorPanelTestPeer::ResetOverlaySettings(panel);
+  EXPECT_FALSE(reset.ok());
+  EXPECT_TRUE(absl::IsFailedPrecondition(reset.status())) << reset.status();
+  EXPECT_EQ(fixture.project()->dungeon_overlay.track_tiles,
+            (std::vector<uint16_t>{0xB0}));
+  EXPECT_EQ(MinecartTrackEditorPanelTestPeer::TrackTilesInput(panel), "0xB0");
+  EXPECT_FALSE(project_dirty);
+  EXPECT_FALSE(MinecartTrackEditorPanelTestPeer::AuditDirty(panel));
+}
+
+TEST(MinecartTrackEditorPanelTest,
+     DependencyReapplyRefreshesSamePointerProjectOverlayInputs) {
+  ScopedTestProject fixture;
+  fixture.WriteSource(MakeFlatSource(32));
+  fixture.project()->dungeon_overlay.track_tiles = {0xB0};
+
+  MinecartTrackEditorPanel panel;
+  ASSERT_TRUE(panel.SetProject(fixture.project()).ok());
+  ASSERT_TRUE(panel.ReloadTracks().ok());
+  MinecartTrack draft = panel.GetTracks().front();
+  draft.room_id = 0x0777;
+  ASSERT_TRUE(panel.UpdateTrack(0, draft).ok());
+  ASSERT_TRUE(panel.HasUnpublishedChanges());
+  MinecartTrackEditorPanelTestPeer::InitializeOverlayInputs(panel);
+  ASSERT_EQ(MinecartTrackEditorPanelTestPeer::TrackTilesInput(panel), "0xB0");
+
+  DungeonEditorV2 editor;
+  DungeonEditorV2MinecartTrackTestPeer::SetMinecartTrackEditorPanel(editor,
+                                                                    &panel);
+  EditorDependencies dependencies;
+  dependencies.project = fixture.project();
+
+  fixture.project()->dungeon_overlay.track_tiles = {0xD0, 0xD1};
+  ASSERT_EQ(MinecartTrackEditorPanelTestPeer::TrackTilesInput(panel), "0xB0");
+  editor.SetDependencies(dependencies);
+
+  EXPECT_EQ(MinecartTrackEditorPanelTestPeer::TrackTilesInput(panel),
+            "0xD0, 0xD1");
+  EXPECT_TRUE(panel.HasUnpublishedChanges());
+  EXPECT_EQ(panel.GetTracks().front().room_id, 0x0777);
 }
 
 TEST(MinecartTrackEditorPanelTest,
@@ -239,10 +425,17 @@ TEST(MinecartTrackEditorPanelTest,
 
   bool project_dirty = false;
   panel.SetProjectChangedCallback(
-      [&](const project::DungeonOverlaySettings&) { project_dirty = true; });
-  ASSERT_TRUE(MinecartTrackEditorPanelTestPeer::CommitOverlayList(
-      panel, "$00D0, $00D1",
-      fixture.project()->dungeon_overlay.track_switch_tiles));
+      [&](const project::DungeonOverlaySettings&) -> absl::Status {
+        project_dirty = true;
+        return absl::OkStatus();
+      });
+  std::string switch_input = "$00D0, $00D1";
+  const auto switch_changed =
+      MinecartTrackEditorPanelTestPeer::CommitOverlayList(
+          panel, switch_input,
+          &project::DungeonOverlaySettings::track_switch_tiles);
+  ASSERT_TRUE(switch_changed.ok()) << switch_changed.status();
+  ASSERT_TRUE(*switch_changed);
   ASSERT_TRUE(project_dirty);
 
   int save_calls = 0;

--- a/test/unit/editor/minecart_track_editor_panel_test.cc
+++ b/test/unit/editor/minecart_track_editor_panel_test.cc
@@ -1,5 +1,6 @@
 #include "app/editor/dungeon/ui/window/minecart_track_editor_panel.h"
 
+#include <array>
 #include <chrono>
 #include <filesystem>
 #include <fstream>
@@ -57,6 +58,24 @@ class MinecartTrackEditorPanelTestPeer {
   static void SetTrackTilesInput(MinecartTrackEditorPanel& panel,
                                  std::string input) {
     panel.overlay_track_tiles_input_ = std::move(input);
+  }
+
+  static void SetOverlayInputs(MinecartTrackEditorPanel& panel,
+                               std::array<std::string, 5> inputs) {
+    panel.overlay_track_tiles_input_ = std::move(inputs[0]);
+    panel.overlay_track_stop_tiles_input_ = std::move(inputs[1]);
+    panel.overlay_track_switch_tiles_input_ = std::move(inputs[2]);
+    panel.overlay_track_object_ids_input_ = std::move(inputs[3]);
+    panel.overlay_minecart_sprite_ids_input_ = std::move(inputs[4]);
+  }
+
+  static std::array<std::string, 5> OverlayInputs(
+      const MinecartTrackEditorPanel& panel) {
+    return {panel.overlay_track_tiles_input_,
+            panel.overlay_track_stop_tiles_input_,
+            panel.overlay_track_switch_tiles_input_,
+            panel.overlay_track_object_ids_input_,
+            panel.overlay_minecart_sprite_ids_input_};
   }
 
   static const std::string& TrackTilesInput(
@@ -383,6 +402,45 @@ TEST(MinecartTrackEditorPanelTest,
   EXPECT_EQ(MinecartTrackEditorPanelTestPeer::TrackTilesInput(panel), "0xB0");
   EXPECT_FALSE(project_dirty);
   EXPECT_FALSE(MinecartTrackEditorPanelTestPeer::AuditDirty(panel));
+}
+
+TEST(MinecartTrackEditorPanelTest,
+     NoOpResetClearsRejectedOverlayInputsWithoutDirtyingProject) {
+  ScopedTestProject fixture;
+
+  MinecartTrackEditorPanel panel;
+  ASSERT_TRUE(panel.SetProject(fixture.project()).ok());
+  int changed_calls = 0;
+  panel.SetProjectChangedCallback(
+      [&](const project::DungeonOverlaySettings&) -> absl::Status {
+        ++changed_calls;
+        return absl::OkStatus();
+      });
+  MinecartTrackEditorPanelTestPeer::SetAuditDirty(panel, false);
+  MinecartTrackEditorPanelTestPeer::SetOverlayInputs(
+      panel, {"0x1G", "rejected-stop", "rejected-switch", "rejected-object",
+              "rejected-sprite"});
+
+  const auto rejected =
+      MinecartTrackEditorPanelTestPeer::CommitTrackTilesInput(panel);
+  ASSERT_FALSE(rejected.ok());
+  ASSERT_FALSE(MinecartTrackEditorPanelTestPeer::StatusMessage(panel).empty());
+
+  const auto reset =
+      MinecartTrackEditorPanelTestPeer::ResetOverlaySettings(panel);
+  ASSERT_TRUE(reset.ok()) << reset.status();
+  EXPECT_FALSE(*reset);
+  EXPECT_EQ(MinecartTrackEditorPanelTestPeer::OverlayInputs(panel),
+            (std::array<std::string, 5>{"", "", "", "", ""}));
+  EXPECT_TRUE(MinecartTrackEditorPanelTestPeer::StatusMessage(panel).empty());
+  EXPECT_FALSE(MinecartTrackEditorPanelTestPeer::ShowSuccess(panel));
+  EXPECT_FALSE(MinecartTrackEditorPanelTestPeer::AuditDirty(panel));
+  EXPECT_EQ(changed_calls, 0);
+  EXPECT_TRUE(fixture.project()->dungeon_overlay.track_tiles.empty());
+  EXPECT_TRUE(fixture.project()->dungeon_overlay.track_stop_tiles.empty());
+  EXPECT_TRUE(fixture.project()->dungeon_overlay.track_switch_tiles.empty());
+  EXPECT_TRUE(fixture.project()->dungeon_overlay.track_object_ids.empty());
+  EXPECT_TRUE(fixture.project()->dungeon_overlay.minecart_sprite_ids.empty());
 }
 
 TEST(MinecartTrackEditorPanelTest,

--- a/test/unit/editor/minecart_track_editor_panel_test.cc
+++ b/test/unit/editor/minecart_track_editor_panel_test.cc
@@ -55,6 +55,16 @@ class MinecartTrackEditorPanelTestPeer {
     return panel.SaveProjectSettings();
   }
 
+  static absl::Status NotifyProjectDraftChanged(
+      MinecartTrackEditorPanel& panel) {
+    return panel.NotifyProjectDraftChanged();
+  }
+
+  static bool HasPendingProjectDraftChanges(
+      const MinecartTrackEditorPanel& panel) {
+    return panel.HasPendingProjectDraftChanges();
+  }
+
   static void InitializeOverlayInputs(MinecartTrackEditorPanel& panel) {
     panel.InitializeOverlayInputs();
   }
@@ -273,10 +283,18 @@ class ScopedManagerProject {
   }
 
   const std::filesystem::path& project_path() const { return project_path_; }
+  std::filesystem::path Path(const std::string& filename) const {
+    return root_ / filename;
+  }
 
   project::YazeProject ReadProject() const {
+    return ReadProject(project_path_);
+  }
+
+  project::YazeProject ReadProject(
+      const std::filesystem::path& project_path) const {
     project::YazeProject project;
-    const absl::Status status = project.Open(project_path_.string());
+    const absl::Status status = project.Open(project_path.string());
     if (!status.ok()) {
       throw std::runtime_error(std::string(status.message()));
     }
@@ -287,6 +305,31 @@ class ScopedManagerProject {
   std::filesystem::path root_;
   std::filesystem::path rom_path_;
   std::filesystem::path project_path_;
+};
+
+class ScopedBoundMinecartPanel {
+ public:
+  ScopedBoundMinecartPanel(EditorManager* manager, RomSession* session) {
+    dungeon_ =
+        session->editors.GetEditorAs<DungeonEditorV2>(EditorType::kDungeon);
+    if (dungeon_ == nullptr) {
+      throw std::runtime_error("Dungeon editor was not created");
+    }
+    DungeonEditorV2MinecartTrackTestPeer::SetMinecartTrackEditorPanel(*dungeon_,
+                                                                      &panel_);
+    manager->ConfigureSession(session);
+  }
+
+  ~ScopedBoundMinecartPanel() {
+    DungeonEditorV2MinecartTrackTestPeer::SetMinecartTrackEditorPanel(*dungeon_,
+                                                                      nullptr);
+  }
+
+  MinecartTrackEditorPanel* panel() { return &panel_; }
+
+ private:
+  DungeonEditorV2* dungeon_ = nullptr;
+  MinecartTrackEditorPanel panel_;
 };
 
 void AppendDwValues(std::stringstream& stream, int first_value, int count) {
@@ -740,8 +783,227 @@ TEST(MinecartTrackEditorPanelTest,
   EXPECT_EQ(fixture.ReadProject().dungeon_overlay.track_tiles,
             (std::vector<uint16_t>{0xC0}));
 
+  MinecartTrackEditorPanelTestPeer::SetTrackTilesInput(panel, "$00C1");
+  ASSERT_TRUE(
+      MinecartTrackEditorPanelTestPeer::NotifyProjectDraftChanged(panel).ok());
+  ASSERT_TRUE(manager->AutosaveActiveSession().ok());
+  EXPECT_FALSE(session->project_dirty);
+  EXPECT_EQ(fixture.ReadProject().dungeon_overlay.track_tiles,
+            (std::vector<uint16_t>{0xC1}));
+
   DungeonEditorV2MinecartTrackTestPeer::SetMinecartTrackEditorPanel(*dungeon,
                                                                     nullptr);
+}
+
+TEST(MinecartTrackEditorPanelTest,
+     GlobalProjectSaveCommitsFocusedOverlayDraftAndReadsBack) {
+  FeatureFlagsGuard flags_guard;
+  ScopedImGuiContext imgui;
+  ScopedManagerProject fixture("global_save", "Global Save", 0xB0);
+
+  auto renderer = std::make_unique<gfx::NullRenderer>();
+  auto manager = std::make_unique<EditorManager>();
+  manager->Initialize(renderer.get(), "");
+  manager->SetAssetLoadMode(AssetLoadMode::kLazy);
+  ASSERT_TRUE(manager->OpenRomOrProject(fixture.project_path().string()).ok());
+  auto* session =
+      static_cast<RomSession*>(manager->session_coordinator()->GetSession(0));
+  ASSERT_NE(session, nullptr);
+  ScopedBoundMinecartPanel binding(manager.get(), session);
+  auto* panel = binding.panel();
+
+  MinecartTrackEditorPanelTestPeer::SetTrackTilesInput(*panel, "$00C0");
+  EXPECT_TRUE(
+      MinecartTrackEditorPanelTestPeer::HasPendingProjectDraftChanges(*panel));
+  ASSERT_TRUE(
+      MinecartTrackEditorPanelTestPeer::NotifyProjectDraftChanged(*panel).ok());
+  EXPECT_TRUE(session->project_dirty);
+  EXPECT_TRUE(manager->IsCurrentProjectDirty());
+
+  ASSERT_TRUE(manager->SaveProject().ok());
+  EXPECT_FALSE(session->project_dirty);
+  EXPECT_FALSE(
+      MinecartTrackEditorPanelTestPeer::HasPendingProjectDraftChanges(*panel));
+  EXPECT_EQ(manager->GetCurrentProject()->dungeon_overlay.track_tiles,
+            (std::vector<uint16_t>{0xC0}));
+  ASSERT_TRUE(session->project_context.has_value());
+  EXPECT_EQ(session->project_context->dungeon_overlay.track_tiles,
+            (std::vector<uint16_t>{0xC0}));
+  EXPECT_EQ(fixture.ReadProject().dungeon_overlay.track_tiles,
+            (std::vector<uint16_t>{0xC0}));
+}
+
+TEST(MinecartTrackEditorPanelTest,
+     InvalidGlobalSaveAndSaveAsPreserveDraftAndGuardDestructiveActions) {
+  FeatureFlagsGuard flags_guard;
+  ScopedImGuiContext imgui;
+  ScopedManagerProject fixture_a("invalid_a", "Invalid A", 0xA0);
+  ScopedManagerProject fixture_b("invalid_b", "Invalid B", 0xB0);
+
+  auto renderer = std::make_unique<gfx::NullRenderer>();
+  auto manager = std::make_unique<EditorManager>();
+  manager->Initialize(renderer.get(), "");
+  manager->SetAssetLoadMode(AssetLoadMode::kLazy);
+  ASSERT_TRUE(
+      manager->OpenRomOrProject(fixture_a.project_path().string()).ok());
+  ASSERT_TRUE(
+      manager->OpenRomOrProject(fixture_b.project_path().string()).ok());
+  manager->SwitchToSession(0);
+
+  auto* session =
+      static_cast<RomSession*>(manager->session_coordinator()->GetSession(0));
+  ASSERT_NE(session, nullptr);
+  ScopedBoundMinecartPanel binding(manager.get(), session);
+  auto* panel = binding.panel();
+  const project::DungeonOverlaySettings original_model =
+      manager->GetCurrentProject()->dungeon_overlay;
+  const std::string original_filepath = manager->GetCurrentProject()->filepath;
+  auto invalid_inputs = MinecartTrackEditorPanelTestPeer::OverlayInputs(*panel);
+  invalid_inputs[0] = "$00C0";
+  invalid_inputs[1] = "not-hex";
+  MinecartTrackEditorPanelTestPeer::SetOverlayInputs(*panel, invalid_inputs);
+  ASSERT_TRUE(
+      MinecartTrackEditorPanelTestPeer::NotifyProjectDraftChanged(*panel).ok());
+  ASSERT_TRUE(session->project_dirty);
+
+  const absl::Status save_status = manager->SaveProject();
+  EXPECT_TRUE(absl::IsInvalidArgument(save_status)) << save_status;
+  EXPECT_EQ(manager->GetCurrentProject()->dungeon_overlay.track_tiles,
+            original_model.track_tiles);
+  EXPECT_EQ(manager->GetCurrentProject()->dungeon_overlay.track_stop_tiles,
+            original_model.track_stop_tiles);
+  EXPECT_EQ(manager->GetCurrentProject()->dungeon_overlay.track_switch_tiles,
+            original_model.track_switch_tiles);
+  EXPECT_EQ(manager->GetCurrentProject()->dungeon_overlay.track_object_ids,
+            original_model.track_object_ids);
+  EXPECT_EQ(manager->GetCurrentProject()->dungeon_overlay.minecart_sprite_ids,
+            original_model.minecart_sprite_ids);
+  EXPECT_EQ(MinecartTrackEditorPanelTestPeer::OverlayInputs(*panel),
+            invalid_inputs);
+  EXPECT_TRUE(session->project_dirty);
+  EXPECT_TRUE(
+      MinecartTrackEditorPanelTestPeer::HasPendingProjectDraftChanges(*panel));
+  const project::DungeonOverlaySettings disk_model =
+      fixture_a.ReadProject().dungeon_overlay;
+  EXPECT_EQ(disk_model.track_tiles, original_model.track_tiles);
+  EXPECT_EQ(disk_model.track_stop_tiles, original_model.track_stop_tiles);
+  EXPECT_EQ(disk_model.track_switch_tiles, original_model.track_switch_tiles);
+  EXPECT_EQ(disk_model.track_object_ids, original_model.track_object_ids);
+  EXPECT_EQ(disk_model.minecart_sprite_ids, original_model.minecart_sprite_ids);
+
+  const std::filesystem::path save_as_path =
+      fixture_a.Path("blocked-copy.yaze");
+  const absl::Status save_as_status =
+      manager->SaveProjectAs(save_as_path.string());
+  EXPECT_TRUE(absl::IsInvalidArgument(save_as_status)) << save_as_status;
+  EXPECT_FALSE(std::filesystem::exists(save_as_path));
+  EXPECT_EQ(manager->GetCurrentProject()->filepath, original_filepath);
+  EXPECT_EQ(MinecartTrackEditorPanelTestPeer::OverlayInputs(*panel),
+            invalid_inputs);
+  EXPECT_TRUE(session->project_dirty);
+
+  manager->SwitchToSession(1);
+  EXPECT_TRUE(manager->HasPendingUnsavedSessionAction());
+  EXPECT_EQ(manager->GetCurrentSessionId(), session->session_id());
+  EXPECT_NE(manager->GetPendingUnsavedSessionActionPrompt().find(
+                "uncommitted project editor draft"),
+            std::string::npos);
+  manager->ConfirmPendingUnsavedSessionActionSaveAndContinue();
+  EXPECT_FALSE(manager->HasPendingUnsavedSessionAction());
+  EXPECT_EQ(manager->GetCurrentSessionId(), session->session_id());
+  EXPECT_EQ(MinecartTrackEditorPanelTestPeer::OverlayInputs(*panel),
+            invalid_inputs);
+  EXPECT_TRUE(session->project_dirty);
+
+  manager->RemoveSession(0);
+  EXPECT_TRUE(manager->HasPendingUnsavedSessionAction());
+  EXPECT_EQ(manager->session_coordinator()->GetTotalSessionCount(), 2u);
+  manager->CancelPendingUnsavedSessionAction();
+
+  manager->Quit();
+  EXPECT_TRUE(manager->HasPendingUnsavedSessionAction());
+  EXPECT_FALSE(manager->quit());
+  manager->CancelPendingUnsavedSessionAction();
+}
+
+TEST(MinecartTrackEditorPanelTest,
+     GlobalProjectSaveAsCommitsFocusedOverlayDraftAndReadsBack) {
+  FeatureFlagsGuard flags_guard;
+  ScopedImGuiContext imgui;
+  ScopedManagerProject fixture("global_save_as", "Global Save As", 0xB0);
+
+  auto renderer = std::make_unique<gfx::NullRenderer>();
+  auto manager = std::make_unique<EditorManager>();
+  manager->Initialize(renderer.get(), "");
+  manager->SetAssetLoadMode(AssetLoadMode::kLazy);
+  ASSERT_TRUE(manager->OpenRomOrProject(fixture.project_path().string()).ok());
+  auto* session =
+      static_cast<RomSession*>(manager->session_coordinator()->GetSession(0));
+  ASSERT_NE(session, nullptr);
+  ScopedBoundMinecartPanel binding(manager.get(), session);
+  auto* panel = binding.panel();
+
+  MinecartTrackEditorPanelTestPeer::SetTrackTilesInput(*panel, "$00C1");
+  ASSERT_TRUE(
+      MinecartTrackEditorPanelTestPeer::NotifyProjectDraftChanged(*panel).ok());
+  const std::filesystem::path save_as_path = fixture.Path("saved-copy.yaze");
+  ASSERT_TRUE(manager->SaveProjectAs(save_as_path.string()).ok());
+
+  EXPECT_EQ(manager->GetCurrentProject()->filepath, save_as_path.string());
+  ASSERT_TRUE(session->project_context.has_value());
+  EXPECT_EQ(session->project_context->filepath, save_as_path.string());
+  EXPECT_FALSE(session->project_dirty);
+  EXPECT_FALSE(
+      MinecartTrackEditorPanelTestPeer::HasPendingProjectDraftChanges(*panel));
+  EXPECT_EQ(fixture.ReadProject(save_as_path).dungeon_overlay.track_tiles,
+            (std::vector<uint16_t>{0xC1}));
+  EXPECT_EQ(fixture.ReadProject().dungeon_overlay.track_tiles,
+            (std::vector<uint16_t>{0xB0}));
+}
+
+TEST(MinecartTrackEditorPanelTest,
+     FailedGlobalProjectWriteKeepsCommittedOverlayDirtyForRetry) {
+  FeatureFlagsGuard flags_guard;
+  ScopedImGuiContext imgui;
+  ScopedManagerProject fixture("failed_write", "Failed Write", 0xB0);
+
+  auto renderer = std::make_unique<gfx::NullRenderer>();
+  auto manager = std::make_unique<EditorManager>();
+  manager->Initialize(renderer.get(), "");
+  manager->SetAssetLoadMode(AssetLoadMode::kLazy);
+  ASSERT_TRUE(manager->OpenRomOrProject(fixture.project_path().string()).ok());
+  auto* session =
+      static_cast<RomSession*>(manager->session_coordinator()->GetSession(0));
+  ASSERT_NE(session, nullptr);
+  ScopedBoundMinecartPanel binding(manager.get(), session);
+  auto* panel = binding.panel();
+
+  const std::filesystem::path failed_path =
+      fixture.Path("missing-parent/retry.yaze");
+  manager->GetCurrentProject()->filepath = failed_path.string();
+  MinecartTrackEditorPanelTestPeer::SetTrackTilesInput(*panel, "$00C2");
+  ASSERT_TRUE(
+      MinecartTrackEditorPanelTestPeer::NotifyProjectDraftChanged(*panel).ok());
+
+  const absl::Status failed_save = manager->SaveProject();
+  EXPECT_FALSE(failed_save.ok());
+  EXPECT_FALSE(std::filesystem::exists(failed_path));
+  EXPECT_EQ(fixture.ReadProject().dungeon_overlay.track_tiles,
+            (std::vector<uint16_t>{0xB0}));
+  EXPECT_EQ(manager->GetCurrentProject()->dungeon_overlay.track_tiles,
+            (std::vector<uint16_t>{0xC2}));
+  ASSERT_TRUE(session->project_context.has_value());
+  EXPECT_EQ(session->project_context->dungeon_overlay.track_tiles,
+            (std::vector<uint16_t>{0xC2}));
+  EXPECT_TRUE(session->project_dirty);
+  EXPECT_FALSE(
+      MinecartTrackEditorPanelTestPeer::HasPendingProjectDraftChanges(*panel));
+
+  ASSERT_TRUE(std::filesystem::create_directories(failed_path.parent_path()));
+  ASSERT_TRUE(manager->SaveProject().ok());
+  EXPECT_FALSE(session->project_dirty);
+  EXPECT_EQ(fixture.ReadProject(failed_path).dungeon_overlay.track_tiles,
+            (std::vector<uint16_t>{0xC2}));
 }
 
 TEST(MinecartTrackEditorPanelTest,
@@ -782,8 +1044,11 @@ TEST(MinecartTrackEditorPanelTest,
   MinecartTrackEditorPanelTestPeer::SetTrackTilesInput(panel_b, "$00C0");
 
   absl::Status edit_status = absl::UnknownError("callback did not run");
+  absl::Status draft_status = absl::UnknownError("callback did not run");
   absl::Status save_status = absl::UnknownError("callback did not run");
   CallbackEditor transient_editor([&]() -> absl::Status {
+    draft_status =
+        MinecartTrackEditorPanelTestPeer::NotifyProjectDraftChanged(panel_b);
     edit_status =
         MinecartTrackEditorPanelTestPeer::SaveProjectSettings(panel_b);
     MinecartTrackEditorPanelTestPeer::SetTrackTilesInput(panel_b, "0xB0");
@@ -807,6 +1072,7 @@ TEST(MinecartTrackEditorPanelTest,
   DungeonEditorV2MinecartTrackTestPeer::SetMinecartTrackEditorPanel(*dungeon_b,
                                                                     nullptr);
 
+  EXPECT_TRUE(absl::IsFailedPrecondition(draft_status)) << draft_status;
   EXPECT_TRUE(absl::IsFailedPrecondition(edit_status)) << edit_status;
   EXPECT_TRUE(absl::IsFailedPrecondition(save_status)) << save_status;
   EXPECT_EQ(manager->GetCurrentSessionId(), session_a->session_id());


### PR DESCRIPTION
## Summary
- treat minecart overlay text drafts as session-scoped project work, including while a field remains focused or invalid
- atomically validate and commit all five overlay lists before global Save Project, Save As, autosave, and save-and-continue
- gate overlay mutation and saving on the stable project-context owner so transient multi-session rendering cannot write the wrong descriptor
- preserve live drafts across same-revision dependency rebinding while refreshing genuine external project revisions

## Safety behavior
- invalid overlay input blocks saving without changing the model, descriptor bytes, buffers, or dirty state
- failed descriptor writes keep the committed model dirty for retry
- switch, close, and quit guards include focused overlay drafts
- inactive-session overlay callbacks fail closed and roll back the UI edit

## Verification
- `MinecartTrackEditorPanelTest.*` — 23/23 passed
- focused EditorManager project/session/quit/save-and-close regressions — 7/7 passed
- `scripts/pre-push.sh` — passed: build, 13 smoke tests, formatting, and 40 change-aware UI tests
- independent final review found no blocking/high/medium issues

## Integration
- built on merged minecart source publishing PR #193 and graphics save stop-loss PR #194
- no ROM, emulator state, or Oracle source file is modified
