### PR TITLE
Report project-only session changes

### DIFF
--- a/src/app/editor/system/session/session_coordinator.cc
+++ b/src/app/editor/system/session/session_coordinator.cc
@@ -1283,8 +1283,15 @@ bool SessionCoordinator::IsSessionModified(size_t index) const {
     return true;
   }
 
-  if (auto* dungeon_editor =
-          session->editors.GetEditorAs<DungeonEditorV2>(EditorType::kDungeon)) {
+  if (session->project_dirty ||
+      session->editors.HasPendingProjectDraftChanges() ||
+      (session->project_file_editor_state.initialized &&
+       session->project_file_editor_state.modified)) {
+    return true;
+  }
+
+  if (auto* dungeon_editor = static_cast<DungeonEditorV2*>(
+          session->editors.GetExistingEditor(EditorType::kDungeon))) {
     return dungeon_editor->HasPendingDungeonChanges();
   }
 

--- a/test/unit/editor/minecart_track_editor_panel_test.cc
+++ b/test/unit/editor/minecart_track_editor_panel_test.cc
@@ -834,6 +834,48 @@ TEST(MinecartTrackEditorPanelTest,
 }
 
 TEST(MinecartTrackEditorPanelTest,
+     SessionModifiedIncludesProjectWorkWithoutMaterializingCleanDungeon) {
+  FeatureFlagsGuard flags_guard;
+  ScopedImGuiContext imgui;
+  ScopedManagerProject fixture("session_status", "Session Status", 0xB0);
+
+  auto renderer = std::make_unique<gfx::NullRenderer>();
+  auto manager = std::make_unique<EditorManager>();
+  manager->Initialize(renderer.get(), "");
+  manager->SetAssetLoadMode(AssetLoadMode::kLazy);
+  ASSERT_TRUE(manager->OpenRomOrProject(fixture.project_path().string()).ok());
+
+  auto* session =
+      static_cast<RomSession*>(manager->session_coordinator()->GetSession(0));
+  ASSERT_NE(session, nullptr);
+  EXPECT_EQ(session->editors.GetExistingEditor(EditorType::kDungeon), nullptr);
+  EXPECT_FALSE(manager->session_coordinator()->IsSessionModified(0));
+  EXPECT_EQ(session->editors.GetExistingEditor(EditorType::kDungeon), nullptr);
+
+  ScopedBoundMinecartPanel binding(manager.get(), session);
+  auto* panel = binding.panel();
+  MinecartTrackEditorPanelTestPeer::SetTrackTilesInput(*panel, "$00C0");
+  ASSERT_FALSE(session->project_dirty);
+  ASSERT_TRUE(
+      MinecartTrackEditorPanelTestPeer::HasPendingProjectDraftChanges(*panel));
+  EXPECT_TRUE(manager->session_coordinator()->IsSessionModified(0));
+
+  MinecartTrackEditorPanelTestPeer::SetTrackTilesInput(*panel, "0xB0");
+  ASSERT_FALSE(
+      MinecartTrackEditorPanelTestPeer::HasPendingProjectDraftChanges(*panel));
+  session->project_dirty = true;
+  EXPECT_TRUE(manager->session_coordinator()->IsSessionModified(0));
+
+  session->project_dirty = false;
+  session->project_file_editor_state.initialized = true;
+  session->project_file_editor_state.modified = true;
+  EXPECT_TRUE(manager->session_coordinator()->IsSessionModified(0));
+
+  session->project_file_editor_state.modified = false;
+  EXPECT_FALSE(manager->session_coordinator()->IsSessionModified(0));
+}
+
+TEST(MinecartTrackEditorPanelTest,
      InvalidGlobalSaveAndSaveAsPreserveDraftAndGuardDestructiveActions) {
   FeatureFlagsGuard flags_guard;
   ScopedImGuiContext imgui;


### PR DESCRIPTION
## Summary
- include project, editor-owned project draft, and raw project-file draft state in Session Manager modified reporting
- avoid materializing a lazy Dungeon Editor while polling clean session status
- cover each project-only state and the clean non-materializing path

## Stack
- depends on #197 (which depends on #195)
- retarget to `master` after #197 merges

## Verification
- focused session/minecart tests: 3/3 passed
- combined Screen/Gfx/session-status stack tests: 26/26 passed
- independent reviews: no blocking findings
- pre-push validation passed (build, 13/13 smoke tests, formatting)
