### PR TITLE
Block unsafe Screen Editor saves

### DIFF
--- a/src/app/editor/editor_manager.cc
+++ b/src/app/editor/editor_manager.cc
@@ -4090,10 +4090,10 @@ absl::Status EditorManager::SaveRomInternal(
   // state instead of reporting a partial save as successful.
   if (current_editor_set->HasPendingScreenChanges()) {
     return absl::FailedPreconditionError(absl::StrFormat(
-        "Save blocked: Screen Editor dungeon-map edits are pending, but "
-        "dungeon-map ROM persistence is not safely available (Save Dungeon "
-        "Maps is %s). Discard the Screen Editor dungeon-map edits before "
-        "saving the ROM.",
+        "Save blocked: Screen Editor edits are pending, but they cannot all "
+        "participate safely in the coordinated ROM save (Save Dungeon Maps is "
+        "%s). Use the title-screen or world-map Save control where applicable, "
+        "or discard the pending Screen Editor edits before saving the ROM.",
         core::FeatureFlags::get().kSaveDungeonMaps ? "enabled" : "disabled"));
   }
 
@@ -6562,7 +6562,7 @@ std::string EditorManager::DescribePendingUnsavedWork(
     work.emplace_back("unapplied graphics sheet edits");
   }
   if (pending_screen_changes) {
-    work.emplace_back("unapplied Screen Editor dungeon-map edits");
+    work.emplace_back("unapplied Screen Editor edits");
   }
   if (rom_dirty) {
     work.emplace_back("unsaved ROM-buffer changes");

--- a/src/app/editor/editor_manager.cc
+++ b/src/app/editor/editor_manager.cc
@@ -4084,16 +4084,17 @@ absl::Status EditorManager::SaveRomInternal(
         core::FeatureFlags::get().kSaveGraphicsSheet ? "enabled" : "disabled"));
   }
 
-  // ScreenEditor keeps dungeon-map and dungeon-map Tile16 edits in its model.
-  // Neither domain can safely participate in the coordinated ROM transaction
-  // yet, so fail before any serializer mutates the ROM for either feature-flag
-  // state instead of reporting a partial save as successful.
+  // ScreenEditor keeps dungeon-map, Tile16, title-screen, and pause-map edits
+  // in editor-owned models. Not every domain can safely participate in the
+  // coordinated ROM transaction yet, so fail before any serializer mutates
+  // the ROM instead of reporting a partial save as successful.
   if (current_editor_set->HasPendingScreenChanges()) {
     return absl::FailedPreconditionError(absl::StrFormat(
         "Save blocked: Screen Editor edits are pending, but they cannot all "
         "participate safely in the coordinated ROM save (Save Dungeon Maps is "
-        "%s). Use the title-screen or world-map Save control where applicable, "
-        "or discard the pending Screen Editor edits before saving the ROM.",
+        "%s). Title-screen and pause-map ROM writes remain disabled until "
+        "write/reopen/readback verification exists; discard the pending Screen "
+        "Editor edits before saving the ROM.",
         core::FeatureFlags::get().kSaveDungeonMaps ? "enabled" : "disabled"));
   }
 
@@ -5156,6 +5157,7 @@ absl::Status EditorManager::ReplaceActiveSessionRom(
     }
   };
 
+  session->editors.InvalidateScreenRomBackedState();
   gfx::PaletteManager::Get().ReleaseSession(&session->game_data);
   session->rom = std::move(rom);
   session->filepath = filepath;
@@ -5180,6 +5182,7 @@ absl::Status EditorManager::ReplaceActiveSessionRom(
   if (!load_status.ok()) {
     // Loading editors is fallible. Restore the prior ROM and rebuild its
     // assets so a failed reload never leaves a half-initialized live session.
+    session->editors.InvalidateScreenRomBackedState();
     gfx::PaletteManager::Get().ReleaseSession(&session->game_data);
     session->rom = std::move(previous_rom);
     session->filepath = previous_filepath;

--- a/src/app/editor/editor_manager.cc
+++ b/src/app/editor/editor_manager.cc
@@ -4084,6 +4084,19 @@ absl::Status EditorManager::SaveRomInternal(
         core::FeatureFlags::get().kSaveGraphicsSheet ? "enabled" : "disabled"));
   }
 
+  // ScreenEditor keeps dungeon-map and dungeon-map Tile16 edits in its model.
+  // Neither domain can safely participate in the coordinated ROM transaction
+  // yet, so fail before any serializer mutates the ROM for either feature-flag
+  // state instead of reporting a partial save as successful.
+  if (current_editor_set->HasPendingScreenChanges()) {
+    return absl::FailedPreconditionError(absl::StrFormat(
+        "Save blocked: Screen Editor dungeon-map edits are pending, but "
+        "dungeon-map ROM persistence is not safely available (Save Dungeon "
+        "Maps is %s). Discard the Screen Editor dungeon-map edits before "
+        "saving the ROM.",
+        core::FeatureFlags::get().kSaveDungeonMaps ? "enabled" : "disabled"));
+  }
+
   // --- State machine checks (delegated to RomLifecycleManager) ---
   if (rom_lifecycle_.IsRomWriteConfirmPending()) {
     return absl::CancelledError("Save pending confirmation");
@@ -5968,10 +5981,11 @@ absl::Status EditorManager::DiscardPendingRomBackupRestore() {
 
   const size_t session_index = GetCurrentSessionIndex();
   if (session->editors.HasPendingGraphicsChanges() ||
+      session->editors.HasPendingScreenChanges() ||
       HasPendingDungeonChangesForSession(session_index) ||
       gfx::PaletteManager::Get().HasUnsavedChanges(&session->game_data)) {
     return absl::FailedPreconditionError(
-        "Resolve pending graphics, dungeon, or palette edits before "
+        "Resolve pending graphics, screen, dungeon, or palette edits before "
         "discarding the restored backup");
   }
 
@@ -6430,6 +6444,7 @@ bool EditorManager::SessionHasPendingRomWork(size_t session_index) const {
   return session != nullptr &&
          ((session->rom.is_loaded() && session->rom.dirty()) ||
           session->editors.HasPendingGraphicsChanges() ||
+          session->editors.HasPendingScreenChanges() ||
           HasPendingDungeonChangesForSession(session_index) ||
           gfx::PaletteManager::Get().HasUnsavedChanges(&session->game_data));
 }
@@ -6521,6 +6536,8 @@ std::string EditorManager::DescribePendingUnsavedWork(
       HasPendingDungeonChangesForSession(session_index);
   const bool pending_graphics_changes =
       session != nullptr && session->editors.HasPendingGraphicsChanges();
+  const bool pending_screen_changes =
+      session != nullptr && session->editors.HasPendingScreenChanges();
   const int pending_rooms = PendingDungeonRoomCountForSession(session_index);
   const size_t pending_palette_colors =
       PendingPaletteColorCountForSession(session_index);
@@ -6543,6 +6560,9 @@ std::string EditorManager::DescribePendingUnsavedWork(
   }
   if (pending_graphics_changes) {
     work.emplace_back("unapplied graphics sheet edits");
+  }
+  if (pending_screen_changes) {
+    work.emplace_back("unapplied Screen Editor dungeon-map edits");
   }
   if (rom_dirty) {
     work.emplace_back("unsaved ROM-buffer changes");
@@ -6573,8 +6593,8 @@ std::string EditorManager::DescribeAllPendingUnsavedWork() const {
   }
 
   return absl::StrFormat(
-      "%d sessions have unsaved ROM, graphics, dungeon, palette, or project "
-      "work.",
+      "%d sessions have unsaved ROM, graphics, screen, dungeon, palette, or "
+      "project work.",
       modified_sessions);
 }
 

--- a/src/app/editor/editor_manager.cc
+++ b/src/app/editor/editor_manager.cc
@@ -45,6 +45,7 @@
 #include "app/application.h"
 #include "app/editor/dungeon/dungeon_editor_v2.h"
 #include "app/editor/editor.h"
+#include "app/editor/graphics/screen_editor.h"
 #include "app/editor/hack/workflow/hack_workflow_backend.h"
 #include "app/editor/hack/workflow/hack_workflow_backend_factory.h"
 #include "app/editor/hack/workflow/project_workflow_output_panel.h"
@@ -4189,7 +4190,7 @@ absl::Status EditorManager::SaveRomInternal(
 
   // --- Save editor-specific data ---
   RETURN_IF_ERROR(
-      save_editor(current_editor_set->GetEditor(EditorType::kScreen)));
+      save_editor(current_editor_set->GetExistingEditor(EditorType::kScreen)));
   RETURN_IF_ERROR(
       save_editor(current_editor_set->GetEditor(EditorType::kDungeon)));
   RETURN_IF_ERROR(
@@ -5147,6 +5148,12 @@ absl::Status EditorManager::ReplaceActiveSessionRom(
       session->editor_initialized[dungeon_index];
   const bool dungeon_assets_were_loaded =
       session->editor_assets_loaded[dungeon_index];
+  auto* screen_editor = static_cast<ScreenEditor*>(
+      session->editors.GetExistingEditor(EditorType::kScreen));
+  const size_t screen_index = EditorTypeIndex(EditorType::kScreen);
+  const bool screen_was_initialized = session->editor_initialized[screen_index];
+  const bool screen_assets_were_loaded =
+      session->editor_assets_loaded[screen_index];
   auto restore_dungeon_asset_state = [&]() {
     if (dungeon_editor) {
       session->editor_initialized[dungeon_index] =
@@ -5154,6 +5161,15 @@ absl::Status EditorManager::ReplaceActiveSessionRom(
       session->editor_assets_loaded[dungeon_index] =
           session->editor_assets_loaded[dungeon_index] ||
           dungeon_assets_were_loaded;
+    }
+  };
+  auto restore_screen_asset_state = [&]() {
+    if (screen_editor) {
+      session->editor_initialized[screen_index] =
+          session->editor_initialized[screen_index] || screen_was_initialized;
+      session->editor_assets_loaded[screen_index] =
+          session->editor_assets_loaded[screen_index] ||
+          screen_assets_were_loaded;
     }
   };
 
@@ -5172,6 +5188,12 @@ absl::Status EditorManager::ReplaceActiveSessionRom(
   auto load_status = LoadAssetsForMode();
   if (load_status.ok() && game_data_was_loaded && !session->game_data_loaded) {
     load_status = EnsureGameDataLoaded();
+  }
+  if (load_status.ok() && screen_editor && screen_assets_were_loaded) {
+    load_status = screen_editor->RefreshRomBackedState();
+  }
+  if (load_status.ok()) {
+    restore_screen_asset_state();
   }
   if (load_status.ok() && dungeon_editor) {
     load_status = dungeon_editor->RefreshRomBackedState();
@@ -5200,6 +5222,17 @@ absl::Status EditorManager::ReplaceActiveSessionRom(
       if (rollback_status.ok()) {
         rollback_status = game_data_status;
       }
+    }
+    if (screen_editor && screen_assets_were_loaded) {
+      auto screen_status = screen_editor->RefreshRomBackedState();
+      if (screen_status.ok()) {
+        restore_screen_asset_state();
+      }
+      if (rollback_status.ok()) {
+        rollback_status = screen_status;
+      }
+    } else {
+      restore_screen_asset_state();
     }
     if (dungeon_editor) {
       auto dungeon_status = dungeon_editor->RefreshRomBackedState();

--- a/src/app/editor/editor_manager.cc
+++ b/src/app/editor/editor_manager.cc
@@ -4204,8 +4204,14 @@ absl::Status EditorManager::SaveRomInternal(
   };
 
   // --- Save editor-specific data ---
-  RETURN_IF_ERROR(
-      save_editor(current_editor_set->GetExistingEditor(EditorType::kScreen)));
+  auto* screen_editor = static_cast<ScreenEditor*>(
+      current_editor_set->GetExistingEditor(EditorType::kScreen));
+  // A failed lazy Screen load leaves an invalid, clean editor behind. It has
+  // nothing to serialize and must not poison unrelated ROM saves.
+  if (screen_editor != nullptr && (screen_editor->IsRomBackedStateValid() ||
+                                   screen_editor->HasPendingScreenChanges())) {
+    RETURN_IF_ERROR(save_editor(screen_editor));
+  }
   RETURN_IF_ERROR(
       save_editor(current_editor_set->GetEditor(EditorType::kDungeon)));
   RETURN_IF_ERROR(

--- a/src/app/editor/graphics/screen_editor.cc
+++ b/src/app/editor/graphics/screen_editor.cc
@@ -1,6 +1,7 @@
 #include "screen_editor.h"
 #include "util/i18n/tr.h"
 
+#include <algorithm>
 #include <fstream>
 #include <iostream>
 #include <memory>
@@ -103,6 +104,14 @@ void ScreenEditor::Initialize() {
 absl::Status ScreenEditor::Load() {
   gfx::ScopedTimer timer("ScreenEditor::Load");
   ResetRomBackedStateForLoad();
+  if (!rom_ || !rom_->is_loaded() || !game_data()) {
+    return absl::FailedPreconditionError(
+        "Screen Editor requires a loaded ROM and GameData");
+  }
+  if (game_data()->palette_groups.dungeon_main.size() <= 3) {
+    return absl::FailedPreconditionError(
+        "Screen Editor requires dungeon palette 3");
+  }
 
   ASSIGN_OR_RETURN(dungeon_maps_,
                    zelda3::LoadDungeonMaps(*rom(), dungeon_map_labels_));
@@ -111,21 +120,18 @@ absl::Status ScreenEditor::Load() {
                                    game_data()->graphics_buffer, false));
 
   // Load graphics sheets and apply dungeon palette
-  sheets_[0] =
-      std::make_unique<gfx::Bitmap>(gfx::Arena::Get().gfx_sheets()[212]);
-  sheets_[1] =
-      std::make_unique<gfx::Bitmap>(gfx::Arena::Get().gfx_sheets()[213]);
-  sheets_[2] =
-      std::make_unique<gfx::Bitmap>(gfx::Arena::Get().gfx_sheets()[214]);
-  sheets_[3] =
-      std::make_unique<gfx::Bitmap>(gfx::Arena::Get().gfx_sheets()[215]);
-
-  // Apply dungeon palette to all sheets
+  // Recreate sheet contents in place. Arena commands retain Bitmap*, so the
+  // unique_ptr owners must remain stable across reloads.
   for (int i = 0; i < 4; i++) {
-    sheets_[i]->SetPalette(
+    const auto& source = gfx::Arena::Get().gfx_sheets()[212 + i];
+    auto* sheet = GetOrCreateSheet(i);
+    sheet->Create(source.width(), source.height(), source.depth(),
+                  source.vector());
+    sheet->metadata() = source.metadata();
+    sheet->SetPalette(
         *game_data()->palette_groups.dungeon_main.mutable_palette(3));
     gfx::Arena::Get().QueueTextureCommand(
-        gfx::Arena::TextureCommandType::CREATE, sheets_[i].get());
+        gfx::Arena::TextureCommandType::CREATE, sheet);
   }
 
   // Create a single tilemap for tile8 graphics with on-demand texture creation
@@ -162,10 +168,18 @@ absl::Status ScreenEditor::Load() {
   // Queue single texture creation for the atlas (not individual tiles)
   gfx::Arena::Get().QueueTextureCommand(gfx::Arena::TextureCommandType::CREATE,
                                         &tile8_tilemap_.atlas);
+  RefreshTileCacheForReload(tile16_blockset_);
+  RefreshTileCacheForReload(tile8_tilemap_);
+  rom_backed_state_valid_ = true;
   return absl::OkStatus();
 }
 
 absl::Status ScreenEditor::Save() {
+  if (!rom_backed_state_valid_) {
+    return absl::FailedPreconditionError(
+        "Screen Editor ROM-backed state is invalid; reload Screen assets "
+        "before saving");
+  }
   if (HasPendingScreenChanges()) {
     return absl::FailedPreconditionError(
         "Screen Editor edits cannot all participate safely in the coordinated "
@@ -194,6 +208,12 @@ void ScreenEditor::DrawToolset() {
 }
 
 void ScreenEditor::DrawInventoryMenuEditor() {
+  if (!rom_backed_state_valid_) {
+    ImGui::TextWrapped(
+        tr("Screen assets are unavailable. Reload the active ROM before "
+           "drawing or editing the inventory screen."));
+    return;
+  }
   if (!inventory_loaded_ && rom()->is_loaded() && game_data()) {
     status_ = inventory_->Create(rom(), game_data());
     if (status_.ok()) {
@@ -366,6 +386,11 @@ void ScreenEditor::DrawInventoryItemIcons() {
 void ScreenEditor::DrawDungeonMapScreen(int i) {
   gfx::ScopedTimer timer("screen_editor_draw_dungeon_map_screen");
 
+  if (!rom_backed_state_valid_ || !HasValidDungeonFloorSelection(i)) {
+    ImGui::TextWrapped(tr("No valid dungeon-map floor is loaded."));
+    return;
+  }
+
   const auto& theme = AgentUI::GetTheme();
   auto& current_dungeon = dungeon_maps_[selected_dungeon];
 
@@ -403,6 +428,11 @@ void ScreenEditor::DrawDungeonMapScreen(int i) {
 
     // Extract tile data from the atlas directly
     const int tiles_per_row = tile16_blockset_.atlas.width() / 16;
+    const int tiles_per_column = tile16_blockset_.atlas.height() / 16;
+    if (tiles_per_row <= 0 || tiles_per_column <= 0 || tile16_id < 0 ||
+        tile16_id >= tiles_per_row * tiles_per_column) {
+      continue;
+    }
     const int tile_x = (tile16_id % tiles_per_row) * 16;
     const int tile_y = (tile16_id / tiles_per_row) * 16;
 
@@ -461,16 +491,37 @@ void ScreenEditor::DrawDungeonMapScreen(int i) {
   if (!screen_canvas_.points().empty()) {
     int x = screen_canvas_.points().front().x / 64;
     int y = screen_canvas_.points().front().y / 64;
-    selected_room = x + (y * 5);
+    const int room = x + (y * 5);
+    if (room >= 0 && room < zelda3::kNumRooms) {
+      selected_room = static_cast<uint8_t>(room);
+    }
   }
 }
 
 void ScreenEditor::DrawDungeonMapsTabs() {
+  if (!rom_backed_state_valid_ || !HasValidDungeonSelection()) {
+    ImGui::TextWrapped(tr("No valid dungeon map is loaded."));
+    return;
+  }
   auto& current_dungeon = dungeon_maps_[selected_dungeon];
+  const int floor_count =
+      current_dungeon.nbr_of_floor + current_dungeon.nbr_of_basement;
+  if (floor_count <= 0 ||
+      floor_count > static_cast<int>(current_dungeon.floor_rooms.size()) ||
+      floor_count > static_cast<int>(current_dungeon.floor_gfx.size()) ||
+      floor_count >
+          static_cast<int>(dungeon_map_labels_[selected_dungeon].size())) {
+    ImGui::TextWrapped(tr("This dungeon has no drawable map floors."));
+    return;
+  }
+  if (!HasValidDungeonFloorSelection(floor_number)) {
+    floor_number = 0;
+  }
+  if (selected_room >= zelda3::kNumRooms) {
+    selected_room = 0;
+  }
   if (gui::BeginThemedTabBar("##DungeonMapTabs")) {
-    auto nbr_floors =
-        current_dungeon.nbr_of_floor + current_dungeon.nbr_of_basement;
-    for (int i = 0; i < nbr_floors; i++) {
+    for (int i = 0; i < floor_count; i++) {
       int basement_num = current_dungeon.nbr_of_basement - i;
       std::string tab_name = absl::StrFormat("Basement %d", basement_num);
       if (i >= current_dungeon.nbr_of_basement) {
@@ -573,6 +624,17 @@ void ScreenEditor::DrawDungeonMapsTabs() {
 void ScreenEditor::DrawDungeonMapsRoomGfx() {
   gfx::ScopedTimer timer("screen_editor_draw_dungeon_maps_room_gfx");
 
+  if (!rom_backed_state_valid_ ||
+      !HasValidDungeonFloorSelection(floor_number) ||
+      selected_room >= zelda3::kNumRooms ||
+      tile16_blockset_.atlas.width() < 16 ||
+      tile16_blockset_.atlas.height() < 16 ||
+      tile16_blockset_.tile_info.empty() || tile8_tilemap_.atlas.width() < 8 ||
+      tile8_tilemap_.atlas.height() < 8) {
+    ImGui::TextWrapped(tr("Dungeon-map graphics are not ready to draw."));
+    return;
+  }
+
   if (ImGui::BeginChild("##DungeonMapTiles", ImVec2(0, 0), true)) {
     // Enhanced tilesheet canvas with BeginCanvas/EndCanvas pattern
     {
@@ -595,14 +657,19 @@ void ScreenEditor::DrawDungeonMapsRoomGfx() {
       if (tilesheet_canvas_.IsMouseHovering() &&
           ImGui::IsMouseClicked(ImGuiMouseButton_Left)) {
         if (!tilesheet_canvas_.points().empty()) {
-          selected_tile16_ = static_cast<int>(
+          const int selected_tile16 = static_cast<int>(
               tilesheet_canvas_.points().front().x / 32 +
               (tilesheet_canvas_.points().front().y / 32) * 16);
 
-          // Render selected tile16 and cache tile metadata
-          gfx::RenderTile16(nullptr, tile16_blockset_, selected_tile16_);
-          std::ranges::copy(tile16_blockset_.tile_info[selected_tile16_],
-                            current_tile16_info.begin());
+          if (selected_tile16 >= 0 &&
+              selected_tile16 <
+                  static_cast<int>(tile16_blockset_.tile_info.size())) {
+            selected_tile16_ = selected_tile16;
+            // Render selected tile16 and cache tile metadata
+            gfx::RenderTile16(nullptr, tile16_blockset_, selected_tile16_);
+            std::ranges::copy(tile16_blockset_.tile_info[selected_tile16_],
+                              current_tile16_info.begin());
+          }
         }
       }
 
@@ -712,7 +779,9 @@ void ScreenEditor::DrawDungeonMapsRoomGfx() {
     ImGui::SameLine();
     gui::InputTileInfo("BR", &current_tile16_info[3]);
 
-    if (ImGui::Button(tr("Modify Tile16"))) {
+    if (ImGui::Button(tr("Modify Tile16")) && selected_tile16_ >= 0 &&
+        selected_tile16_ <
+            static_cast<int>(tile16_blockset_.tile_info.size())) {
       SaveTile16CompUndoState(
           absl::StrFormat("Modify tile16 #%d", selected_tile16_));
       gfx::ModifyTile16(tile16_blockset_, game_data()->graphics_buffer,
@@ -743,6 +812,17 @@ void ScreenEditor::DrawDungeonMapsRoomGfx() {
  * - Efficient memory management for large dungeons
  */
 void ScreenEditor::DrawDungeonMapsEditor() {
+  if (!rom_backed_state_valid_) {
+    ImGui::TextWrapped(
+        tr("Screen assets are unavailable. Reload the active ROM before "
+           "drawing or editing dungeon maps."));
+    return;
+  }
+  if (!HasValidDungeonSelection()) {
+    ImGui::TextWrapped(tr("No valid dungeon-map model is loaded."));
+    return;
+  }
+
   // Enhanced editing mode controls with visual feedback
   if (gui::ToolbarIconButton(ICON_MD_DRAW, "Draw Mode")) {
     current_mode_ = EditingMode::DRAW;
@@ -779,12 +859,14 @@ void ScreenEditor::DrawDungeonMapsEditor() {
     ImGui::TableHeadersRow();
 
     ImGui::TableNextColumn();
-    for (int i = 0; i < dungeon_names.size(); i++) {
+    const size_t dungeon_count =
+        std::min(dungeon_names.size(), dungeon_maps_.size());
+    for (size_t i = 0; i < dungeon_count; i++) {
       rom()->resource_label()->SelectableLabelWithNameEdit(
-          selected_dungeon == i, "Dungeon Names", absl::StrFormat("%d", i),
-          dungeon_names[i]);
+          selected_dungeon == static_cast<int>(i), "Dungeon Names",
+          absl::StrFormat("%d", i), dungeon_names[i]);
       if (ImGui::IsItemClicked()) {
-        selected_dungeon = i;
+        selected_dungeon = static_cast<int>(i);
       }
     }
 
@@ -828,18 +910,19 @@ void ScreenEditor::LoadBinaryGfx() {
           zelda3::LoadDungeonMapTile16(tile16_blockset_, *rom(), game_data(),
                                        converted_bin, true)
               .ok()) {
-        sheets_.clear();
         std::vector<std::vector<uint8_t>> gfx_sheets;
         for (int i = 0; i < 4; i++) {
           gfx_sheets.emplace_back(converted_bin.begin() + (i * 0x1000),
                                   converted_bin.begin() + ((i + 1) * 0x1000));
-          sheets_[i] = std::make_unique<gfx::Bitmap>(128, 32, 8, gfx_sheets[i]);
-          sheets_[i]->SetPalette(
+          auto* sheet = GetOrCreateSheet(i);
+          sheet->Create(128, 32, 8, gfx_sheets[i]);
+          sheet->SetPalette(
               *game_data()->palette_groups.dungeon_main.mutable_palette(3));
           // Queue texture creation via Arena's deferred system
           gfx::Arena::Get().QueueTextureCommand(
-              gfx::Arena::TextureCommandType::CREATE, sheets_[i].get());
+              gfx::Arena::TextureCommandType::CREATE, sheet);
         }
+        RefreshTileCacheForReload(tile16_blockset_);
         binary_gfx_loaded_ = true;
         MarkDungeonMapTile16Modified();
       } else {
@@ -851,6 +934,12 @@ void ScreenEditor::LoadBinaryGfx() {
 }
 
 void ScreenEditor::DrawTitleScreenEditor() {
+  if (!rom_backed_state_valid_) {
+    ImGui::TextWrapped(
+        tr("Screen assets are unavailable. Reload the active ROM before "
+           "drawing or editing the title screen."));
+    return;
+  }
   // Initialize title screen on first draw
   if (!title_screen_loaded_ && rom()->is_loaded() && game_data()) {
     status_ = title_screen_.Create(rom(), game_data());
@@ -1129,6 +1218,12 @@ void ScreenEditor::DrawTitleScreenBlocksetSelector() {
 void ScreenEditor::DrawNamingScreenEditor() {}
 
 void ScreenEditor::DrawOverworldMapEditor() {
+  if (!rom_backed_state_valid_) {
+    ImGui::TextWrapped(
+        tr("Screen assets are unavailable. Reload the active ROM before "
+           "drawing or editing the pause-map screen."));
+    return;
+  }
   // Initialize overworld map on first draw
   if (!ow_map_loaded_ && rom()->is_loaded()) {
     status_ = ow_map_screen_.Create(rom());
@@ -1445,7 +1540,52 @@ void ScreenEditor::InvalidateRomBackedState() {
   ResetRomBackedStateForLoad();
 }
 
+absl::Status ScreenEditor::RefreshRomBackedState() {
+  return Load();
+}
+
+gfx::Bitmap* ScreenEditor::GetOrCreateSheet(int index) {
+  auto& sheet = sheets_[index];
+  if (!sheet) {
+    sheet = std::make_unique<gfx::Bitmap>();
+  }
+  return sheet.get();
+}
+
+void ScreenEditor::RefreshTileCacheForReload(gfx::Tilemap& tilemap) {
+  if (tilemap.tile_size.x <= 0 || tilemap.tile_size.y <= 0) {
+    return;
+  }
+  for (auto& [tile_id, bitmap] : tilemap.tile_cache.cache_) {
+    if (!bitmap) {
+      continue;
+    }
+    auto data = gfx::GetTilemapData(tilemap, tile_id);
+    bitmap->Create(tilemap.tile_size.x, tilemap.tile_size.y, 8, data);
+    bitmap->SetPalette(tilemap.atlas.palette());
+    gfx::Arena::Get().QueueTextureCommand(
+        gfx::Arena::TextureCommandType::CREATE, bitmap.get());
+  }
+}
+
+bool ScreenEditor::HasValidDungeonSelection() const {
+  return selected_dungeon >= 0 &&
+         selected_dungeon < static_cast<int>(dungeon_maps_.size()) &&
+         selected_dungeon < static_cast<int>(dungeon_map_labels_.size());
+}
+
+bool ScreenEditor::HasValidDungeonFloorSelection(int floor) const {
+  if (!HasValidDungeonSelection() || floor < 0) {
+    return false;
+  }
+  const auto& dungeon = dungeon_maps_[selected_dungeon];
+  return floor < static_cast<int>(dungeon.floor_rooms.size()) &&
+         floor < static_cast<int>(dungeon.floor_gfx.size()) &&
+         floor < static_cast<int>(dungeon_map_labels_[selected_dungeon].size());
+}
+
 void ScreenEditor::ResetRomBackedStateForLoad() {
+  rom_backed_state_valid_ = false;
   dungeon_maps_.clear();
   for (auto& labels : dungeon_map_labels_) {
     labels.clear();
@@ -1468,15 +1608,16 @@ void ScreenEditor::ResetRomBackedStateForLoad() {
   inventory_loaded_ = false;
   title_screen_loaded_ = false;
   ow_map_loaded_ = false;
-  // Inventory owns a non-assignable Canvas, so reconstruct the complete model
-  // rather than retaining its ROM-backed buffers across a session ROM reload.
-  inventory_ = std::make_unique<zelda3::Inventory>();
-  title_screen_ = zelda3::TitleScreen{};
-  ow_map_screen_ = zelda3::OverworldMapScreen{};
-  palette_ = gfx::SnesPalette{};
-  sheets_.clear();
-  tile16_blockset_ = gfx::Tilemap{};
-  tile8_tilemap_ = gfx::Tilemap{};
+  inventory_->ResetForReload();
+  title_screen_.ResetForReload();
+  ow_map_screen_.ResetForReload();
+  palette_.clear();
+  tile16_blockset_.tile_info.clear();
+  tile16_blockset_.tile_size = {0, 0};
+  tile16_blockset_.map_size = {0, 0};
+  tile8_tilemap_.tile_info.clear();
+  tile8_tilemap_.tile_size = {0, 0};
+  tile8_tilemap_.map_size = {0, 0};
 
   selected_room = 0;
   selected_tile16_ = 0;

--- a/src/app/editor/graphics/screen_editor.cc
+++ b/src/app/editor/graphics/screen_editor.cc
@@ -102,7 +102,7 @@ void ScreenEditor::Initialize() {
 
 absl::Status ScreenEditor::Load() {
   gfx::ScopedTimer timer("ScreenEditor::Load");
-  inventory_loaded_ = false;
+  ResetRomBackedStateForLoad();
 
   ASSIGN_OR_RETURN(dungeon_maps_,
                    zelda3::LoadDungeonMaps(*rom(), dungeon_map_labels_));
@@ -166,6 +166,11 @@ absl::Status ScreenEditor::Load() {
 }
 
 absl::Status ScreenEditor::Save() {
+  if (HasPendingScreenChanges()) {
+    return absl::FailedPreconditionError(
+        "Screen Editor dungeon-map edits cannot be saved safely yet; discard "
+        "them before saving the ROM");
+  }
   if (core::FeatureFlags::get().kSaveDungeonMaps) {
     RETURN_IF_ERROR(zelda3::SaveDungeonMaps(*rom(), dungeon_maps_));
   }
@@ -489,6 +494,7 @@ void ScreenEditor::DrawDungeonMapsTabs() {
           room_before, after,
           [this](const ScreenSnapshot& s) { RestoreFromSnapshot(s); },
           "Edit room assignment"));
+      MarkDungeonMapModified();
     }
   }
 
@@ -500,6 +506,7 @@ void ScreenEditor::DrawDungeonMapsTabs() {
           boss_before, after,
           [this](const ScreenSnapshot& s) { RestoreFromSnapshot(s); },
           "Edit boss room"));
+      MarkDungeonMapModified();
     }
   }
 
@@ -744,8 +751,13 @@ void ScreenEditor::DrawDungeonMapsEditor() {
     current_mode_ = EditingMode::EDIT;
   }
   ImGui::SameLine();
-  if (gui::ToolbarIconButton(ICON_MD_SAVE, "Save dungeon map tiles")) {
-    PRINT_IF_ERROR(zelda3::SaveDungeonMapTile16(tile16_blockset_, *rom()));
+  ImGui::BeginDisabled();
+  gui::ToolbarIconButton(ICON_MD_SAVE, "Save dungeon map tiles");
+  ImGui::EndDisabled();
+  if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled)) {
+    ImGui::SetTooltip(
+        tr("Dungeon-map Tile16 saving is disabled until it can participate in "
+           "the coordinated ROM save transaction."));
   }
 
   static std::vector<std::string> dungeon_names = {
@@ -828,6 +840,7 @@ void ScreenEditor::LoadBinaryGfx() {
               gfx::Arena::TextureCommandType::CREATE, sheets_[i].get());
         }
         binary_gfx_loaded_ = true;
+        MarkDungeonMapTile16Modified();
       } else {
         status_ = absl::InternalError("Failed to load dungeon map tile16");
       }
@@ -1364,6 +1377,7 @@ void ScreenEditor::CommitDungeonMapUndo() {
       pending_dungeon_before_, after,
       [this](const ScreenSnapshot& snap) { RestoreFromSnapshot(snap); },
       pending_dungeon_desc_));
+  MarkDungeonMapModified();
 }
 
 void ScreenEditor::CommitTile16CompUndo() {
@@ -1376,6 +1390,7 @@ void ScreenEditor::CommitTile16CompUndo() {
       pending_tile16_before_, after,
       [this](const ScreenSnapshot& snap) { RestoreFromSnapshot(snap); },
       pending_tile16_desc_));
+  MarkDungeonMapTile16Modified();
 }
 
 void ScreenEditor::RestoreFromSnapshot(const ScreenSnapshot& snapshot) {
@@ -1386,6 +1401,7 @@ void ScreenEditor::RestoreFromSnapshot(const ScreenSnapshot& snapshot) {
         dungeon_maps_[idx] = snapshot.dungeon_map.map_data;
         dungeon_map_labels_[idx] = snapshot.dungeon_map.labels;
         selected_dungeon = idx;
+        MarkDungeonMapModified();
       }
       break;
     }
@@ -1400,9 +1416,45 @@ void ScreenEditor::RestoreFromSnapshot(const ScreenSnapshot& snapshot) {
                           selected_tile16_);
         gfx::UpdateTile16(nullptr, tile16_blockset_, selected_tile16_);
       }
+      MarkDungeonMapTile16Modified();
       break;
     }
   }
+}
+
+void ScreenEditor::ResetRomBackedStateForLoad() {
+  dungeon_maps_.clear();
+  for (auto& labels : dungeon_map_labels_) {
+    labels.clear();
+  }
+
+  undo_manager_.Clear();
+  has_pending_dungeon_undo_ = false;
+  has_pending_tile16_undo_ = false;
+  pending_dungeon_before_ = ScreenSnapshot{};
+  pending_tile16_before_ = ScreenSnapshot{};
+  pending_dungeon_desc_.clear();
+  pending_tile16_desc_.clear();
+  pending_dungeon_map_changes_ = false;
+  pending_dungeon_map_tile16_changes_ = false;
+
+  binary_gfx_loaded_ = false;
+  inventory_loaded_ = false;
+  title_screen_loaded_ = false;
+  ow_map_loaded_ = false;
+  sheets_.clear();
+  tile16_blockset_ = gfx::Tilemap{};
+  tile8_tilemap_ = gfx::Tilemap{};
+
+  selected_room = 0;
+  selected_tile16_ = 0;
+  selected_tile8_ = 0;
+  selected_dungeon = 0;
+  floor_number = 0;
+  copy_button_pressed = false;
+  paste_button_pressed = false;
+  current_tile16_info = {};
+  status_ = absl::OkStatus();
 }
 
 }  // namespace editor

--- a/src/app/editor/graphics/screen_editor.cc
+++ b/src/app/editor/graphics/screen_editor.cc
@@ -169,15 +169,15 @@ absl::Status ScreenEditor::Save() {
   if (HasPendingScreenChanges()) {
     return absl::FailedPreconditionError(
         "Screen Editor edits cannot all participate safely in the coordinated "
-        "ROM save; use the title-screen or world-map Save control where "
-        "applicable, or discard the pending edits before saving the ROM");
+        "ROM save; title-screen and pause-map ROM writes remain disabled until "
+        "write/reopen/readback verification exists, so discard the pending "
+        "edits before saving the ROM");
   }
   if (core::FeatureFlags::get().kSaveDungeonMaps) {
     RETURN_IF_ERROR(zelda3::SaveDungeonMaps(*rom(), dungeon_maps_));
   }
-  // Title screen and overworld maps are currently saved via their respective
-  // 'Save' buttons in the UI, but we could also trigger them here for a full
-  // save.
+  // Title-screen and pause-map controls remain fail-closed until their writers
+  // have write/reopen/readback coverage.
   return absl::OkStatus();
 }
 
@@ -195,9 +195,9 @@ void ScreenEditor::DrawToolset() {
 
 void ScreenEditor::DrawInventoryMenuEditor() {
   if (!inventory_loaded_ && rom()->is_loaded() && game_data()) {
-    status_ = inventory_.Create(rom(), game_data());
+    status_ = inventory_->Create(rom(), game_data());
     if (status_.ok()) {
-      palette_ = inventory_.palette();
+      palette_ = inventory_->palette();
       inventory_loaded_ = true;
     } else {
       const auto& theme = AgentUI::GetTheme();
@@ -224,7 +224,7 @@ void ScreenEditor::DrawInventoryMenuEditor() {
       frame_opts.grid_step = 32.0f;
       frame_opts.render_popups = true;
       auto runtime = gui::BeginCanvas(screen_canvas_, frame_opts);
-      gui::DrawBitmap(runtime, inventory_.bitmap(), 2,
+      gui::DrawBitmap(runtime, inventory_->bitmap(), 2,
                       inventory_loaded_ ? 1.0f : 0.0f);
       gui::EndCanvas(screen_canvas_, runtime, frame_opts);
     }
@@ -237,7 +237,7 @@ void ScreenEditor::DrawInventoryMenuEditor() {
       frame_opts.grid_step = 16.0f;
       frame_opts.render_popups = true;
       auto runtime = gui::BeginCanvas(tilesheet_canvas_, frame_opts);
-      gui::DrawBitmap(runtime, inventory_.tilesheet(), 2,
+      gui::DrawBitmap(runtime, inventory_->tilesheet(), 2,
                       inventory_loaded_ ? 1.0f : 0.0f);
       gui::EndCanvas(tilesheet_canvas_, runtime, frame_opts);
     }
@@ -315,7 +315,7 @@ void ScreenEditor::DrawInventoryItemIcons() {
     ImGui::Text(tr("Item Icons (2x2 tiles each)"));
     ImGui::Separator();
 
-    auto& icons = inventory_.item_icons();
+    auto& icons = inventory_->item_icons();
     if (icons.empty()) {
       ImGui::TextWrapped(
           tr("No item icons loaded. Icons will be loaded when the "
@@ -874,20 +874,18 @@ void ScreenEditor::DrawTitleScreenEditor() {
     current_mode_ = EditingMode::DRAW;
   }
   ImGui::SameLine();
+  ImGui::BeginDisabled();
   if (ImGui::Button(ICON_MD_SAVE)) {
     status_ = SaveTitleScreenToRom();
-    if (status_.ok()) {
-      ImGui::OpenPopup("SaveSuccess");
-    }
+  }
+  ImGui::EndDisabled();
+  if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled)) {
+    ImGui::SetTooltip(
+        tr("Title-screen ROM saving is disabled until write/reopen/readback "
+           "verification exists."));
   }
   ImGui::SameLine();
   ImGui::Text(tr("Selected Tile: %d"), selected_title_tile16_);
-
-  // Save success popup
-  if (ImGui::BeginPopup("SaveSuccess")) {
-    ImGui::Text(tr("Title screen saved successfully!"));
-    ImGui::EndPopup();
-  }
 
   // Layer visibility controls
   bool prev_bg1 = show_title_bg1_;
@@ -1161,11 +1159,15 @@ void ScreenEditor::DrawOverworldMapEditor() {
         "click Map Canvas."));
   }
   ImGui::SameLine();
+  ImGui::BeginDisabled();
   if (ImGui::Button(tr("Save World Map"))) {
     status_ = SaveOverworldMapToRom();
-    if (status_.ok()) {
-      ImGui::OpenPopup("OWSaveSuccess");
-    }
+  }
+  ImGui::EndDisabled();
+  if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled)) {
+    ImGui::SetTooltip(tr(
+        "Pause-map ROM saving is disabled until Light World, Dark World, and "
+        "palette writes pass write/reopen/readback verification."));
   }
   ImGui::SameLine();
 
@@ -1222,12 +1224,6 @@ void ScreenEditor::DrawOverworldMapEditor() {
   }
   if (ImGui::BeginPopup("CustomMapSaveSuccess")) {
     ImGui::Text(tr("Custom map saved successfully!"));
-    ImGui::EndPopup();
-  }
-
-  // Save success popup
-  if (ImGui::BeginPopup("OWSaveSuccess")) {
-    ImGui::Text(tr("Overworld map saved successfully!"));
     ImGui::EndPopup();
   }
 
@@ -1434,17 +1430,19 @@ void ScreenEditor::RestoreFromSnapshot(const ScreenSnapshot& snapshot) {
 }
 
 absl::Status ScreenEditor::SaveTitleScreenToRom() {
-  RETURN_IF_ERROR(title_screen_.Save(rom()));
-  pending_title_screen_changes_ = false;
-  return absl::OkStatus();
+  return absl::FailedPreconditionError(
+      "Title-screen ROM saving is disabled until write/reopen/readback "
+      "verification exists");
 }
 
 absl::Status ScreenEditor::SaveOverworldMapToRom() {
-  RETURN_IF_ERROR(ow_map_screen_.Save(rom()));
-  // The pause-map writer persists tile placement only. Palette edits remain
-  // pending until that separate persistence path exists.
-  pending_overworld_map_changes_ = false;
-  return absl::OkStatus();
+  return absl::FailedPreconditionError(
+      "Pause-map ROM saving is disabled until Light World, Dark World, and "
+      "palette writes pass write/reopen/readback verification");
+}
+
+void ScreenEditor::InvalidateRomBackedState() {
+  ResetRomBackedStateForLoad();
 }
 
 void ScreenEditor::ResetRomBackedStateForLoad() {
@@ -1470,6 +1468,9 @@ void ScreenEditor::ResetRomBackedStateForLoad() {
   inventory_loaded_ = false;
   title_screen_loaded_ = false;
   ow_map_loaded_ = false;
+  // Inventory owns a non-assignable Canvas, so reconstruct the complete model
+  // rather than retaining its ROM-backed buffers across a session ROM reload.
+  inventory_ = std::make_unique<zelda3::Inventory>();
   title_screen_ = zelda3::TitleScreen{};
   ow_map_screen_ = zelda3::OverworldMapScreen{};
   palette_ = gfx::SnesPalette{};
@@ -1484,8 +1485,21 @@ void ScreenEditor::ResetRomBackedStateForLoad() {
   floor_number = 0;
   copy_button_pressed = false;
   paste_button_pressed = false;
-  screen_canvas_.mutable_points()->clear();
-  tilesheet_canvas_.mutable_points()->clear();
+  current_mode_ = EditingMode::DRAW;
+  selected_title_tile16_ = 0;
+  title_h_flip_ = false;
+  title_v_flip_ = false;
+  title_palette_ = 0;
+  show_title_bg1_ = true;
+  show_title_bg2_ = true;
+  selected_ow_tile_ = 0;
+  ow_show_dark_world_ = false;
+  for (auto* canvas :
+       {&current_tile_canvas_, &screen_canvas_, &tilesheet_canvas_,
+        &tilemap_canvas_, &title_bg1_canvas_, &title_bg2_canvas_,
+        &title_blockset_canvas_, &ow_map_canvas_, &ow_tileset_canvas_}) {
+    canvas->ClearSelection();
+  }
   current_tile16_info = {};
   status_ = absl::OkStatus();
 }

--- a/src/app/editor/graphics/screen_editor.cc
+++ b/src/app/editor/graphics/screen_editor.cc
@@ -168,8 +168,9 @@ absl::Status ScreenEditor::Load() {
 absl::Status ScreenEditor::Save() {
   if (HasPendingScreenChanges()) {
     return absl::FailedPreconditionError(
-        "Screen Editor dungeon-map edits cannot be saved safely yet; discard "
-        "them before saving the ROM");
+        "Screen Editor edits cannot all participate safely in the coordinated "
+        "ROM save; use the title-screen or world-map Save control where "
+        "applicable, or discard the pending edits before saving the ROM");
   }
   if (core::FeatureFlags::get().kSaveDungeonMaps) {
     RETURN_IF_ERROR(zelda3::SaveDungeonMaps(*rom(), dungeon_maps_));
@@ -874,7 +875,7 @@ void ScreenEditor::DrawTitleScreenEditor() {
   }
   ImGui::SameLine();
   if (ImGui::Button(ICON_MD_SAVE)) {
-    status_ = title_screen_.Save(rom());
+    status_ = SaveTitleScreenToRom();
     if (status_.ok()) {
       ImGui::OpenPopup("SaveSuccess");
     }
@@ -968,6 +969,7 @@ void ScreenEditor::DrawTitleScreenCompositeCanvas() {
 
           // Update BG1 buffer and re-render both layers and composite
           title_screen_.mutable_bg1_buffer()[tilemap_index] = tile_word;
+          MarkTitleScreenModified();
           status_ = title_screen_.RenderBG1Layer();
           if (status_.ok()) {
             // Update BG1 texture
@@ -1023,6 +1025,7 @@ void ScreenEditor::DrawTitleScreenBG1Canvas() {
 
           // Update buffer and re-render
           title_screen_.mutable_bg1_buffer()[tilemap_index] = tile_word;
+          MarkTitleScreenModified();
           status_ = title_screen_.RenderBG1Layer();
           if (status_.ok()) {
             gfx::Arena::Get().QueueTextureCommand(
@@ -1069,6 +1072,7 @@ void ScreenEditor::DrawTitleScreenBG2Canvas() {
 
           // Update buffer and re-render
           title_screen_.mutable_bg2_buffer()[tilemap_index] = tile_word;
+          MarkTitleScreenModified();
           status_ = title_screen_.RenderBG2Layer();
           if (status_.ok()) {
             gfx::Arena::Get().QueueTextureCommand(
@@ -1158,7 +1162,7 @@ void ScreenEditor::DrawOverworldMapEditor() {
   }
   ImGui::SameLine();
   if (ImGui::Button(tr("Save World Map"))) {
-    status_ = ow_map_screen_.Save(rom());
+    status_ = SaveOverworldMapToRom();
     if (status_.ok()) {
       ImGui::OpenPopup("OWSaveSuccess");
     }
@@ -1184,6 +1188,8 @@ void ScreenEditor::DrawOverworldMapEditor() {
       status_ = ow_map_screen_.LoadCustomMap(path);
       if (!status_.ok()) {
         ImGui::OpenPopup("CustomMapLoadError");
+      } else {
+        MarkOverworldMapModified();
       }
     }
   }
@@ -1261,6 +1267,7 @@ void ScreenEditor::DrawOverworldMapEditor() {
             } else {
               ow_map_screen_.mutable_lw_tiles()[tile_index] = selected_ow_tile_;
             }
+            MarkOverworldMapModified();
 
             // Re-render map
             status_ = ow_map_screen_.RenderMapLayer(ow_show_dark_world_);
@@ -1305,7 +1312,11 @@ void ScreenEditor::DrawOverworldMapEditor() {
     auto& palette = ow_show_dark_world_ ? ow_map_screen_.dw_palette()
                                         : ow_map_screen_.lw_palette();
     // Use inline palette editor for full 128-color palette
+    const auto palette_before = palette;
     gui::InlinePaletteEditor(palette, "Overworld Map Palette");
+    if (palette != palette_before) {
+      MarkOverworldMapPaletteModified();
+    }
 
     ImGui::EndTable();
   }
@@ -1422,6 +1433,20 @@ void ScreenEditor::RestoreFromSnapshot(const ScreenSnapshot& snapshot) {
   }
 }
 
+absl::Status ScreenEditor::SaveTitleScreenToRom() {
+  RETURN_IF_ERROR(title_screen_.Save(rom()));
+  pending_title_screen_changes_ = false;
+  return absl::OkStatus();
+}
+
+absl::Status ScreenEditor::SaveOverworldMapToRom() {
+  RETURN_IF_ERROR(ow_map_screen_.Save(rom()));
+  // The pause-map writer persists tile placement only. Palette edits remain
+  // pending until that separate persistence path exists.
+  pending_overworld_map_changes_ = false;
+  return absl::OkStatus();
+}
+
 void ScreenEditor::ResetRomBackedStateForLoad() {
   dungeon_maps_.clear();
   for (auto& labels : dungeon_map_labels_) {
@@ -1437,11 +1462,17 @@ void ScreenEditor::ResetRomBackedStateForLoad() {
   pending_tile16_desc_.clear();
   pending_dungeon_map_changes_ = false;
   pending_dungeon_map_tile16_changes_ = false;
+  pending_title_screen_changes_ = false;
+  pending_overworld_map_changes_ = false;
+  pending_overworld_map_palette_changes_ = false;
 
   binary_gfx_loaded_ = false;
   inventory_loaded_ = false;
   title_screen_loaded_ = false;
   ow_map_loaded_ = false;
+  title_screen_ = zelda3::TitleScreen{};
+  ow_map_screen_ = zelda3::OverworldMapScreen{};
+  palette_ = gfx::SnesPalette{};
   sheets_.clear();
   tile16_blockset_ = gfx::Tilemap{};
   tile8_tilemap_ = gfx::Tilemap{};
@@ -1453,6 +1484,8 @@ void ScreenEditor::ResetRomBackedStateForLoad() {
   floor_number = 0;
   copy_button_pressed = false;
   paste_button_pressed = false;
+  screen_canvas_.mutable_points()->clear();
+  tilesheet_canvas_.mutable_points()->clear();
   current_tile16_info = {};
   status_ = absl::OkStatus();
 }

--- a/src/app/editor/graphics/screen_editor.h
+++ b/src/app/editor/graphics/screen_editor.h
@@ -74,6 +74,8 @@ class ScreenEditor : public Editor {
            HasPendingTitleScreenChanges() || HasPendingOverworldMapChanges();
   }
   void InvalidateRomBackedState();
+  absl::Status RefreshRomBackedState();
+  bool IsRomBackedStateValid() const { return rom_backed_state_valid_; }
 
   std::vector<zelda3::DungeonMap> dungeon_maps_;
 
@@ -105,6 +107,10 @@ class ScreenEditor : public Editor {
   void DrawDungeonMapsRoomGfx();
 
   void LoadBinaryGfx();
+  gfx::Bitmap* GetOrCreateSheet(int index);
+  void RefreshTileCacheForReload(gfx::Tilemap& tilemap);
+  bool HasValidDungeonSelection() const;
+  bool HasValidDungeonFloorSelection(int floor) const;
 
   // Undo/redo helpers
   ScreenSnapshot CaptureDungeonMapSnapshot() const;
@@ -202,6 +208,7 @@ class ScreenEditor : public Editor {
   bool pending_title_screen_changes_ = false;
   bool pending_overworld_map_changes_ = false;
   bool pending_overworld_map_palette_changes_ = false;
+  bool rom_backed_state_valid_ = false;
   ScreenSnapshot pending_dungeon_before_;
   ScreenSnapshot pending_tile16_before_;
   std::string pending_dungeon_desc_;

--- a/src/app/editor/graphics/screen_editor.h
+++ b/src/app/editor/graphics/screen_editor.h
@@ -2,6 +2,7 @@
 #define YAZE_APP_EDITOR_SCREEN_EDITOR_H
 
 #include <array>
+#include <memory>
 
 #include "absl/status/status.h"
 #include "app/editor/editor.h"
@@ -72,6 +73,7 @@ class ScreenEditor : public Editor {
            HasPendingDungeonMapTile16Changes() ||
            HasPendingTitleScreenChanges() || HasPendingOverworldMapChanges();
   }
+  void InvalidateRomBackedState();
 
   std::vector<zelda3::DungeonMap> dungeon_maps_;
 
@@ -166,7 +168,8 @@ class ScreenEditor : public Editor {
   gui::Canvas title_blockset_canvas_{"##TitleBlocksetCanvas", ImVec2(128, 512),
                                      gui::CanvasGridSize::k8x8, 2.0f};
 
-  zelda3::Inventory inventory_;
+  std::unique_ptr<zelda3::Inventory> inventory_ =
+      std::make_unique<zelda3::Inventory>();
   bool inventory_loaded_ = false;
   zelda3::TitleScreen title_screen_;
   zelda3::OverworldMapScreen ow_map_screen_;

--- a/src/app/editor/graphics/screen_editor.h
+++ b/src/app/editor/graphics/screen_editor.h
@@ -54,9 +54,21 @@ class ScreenEditor : public Editor {
   void set_rom(Rom* rom) { rom_ = rom; }
   Rom* rom() const { return rom_; }
 
+  bool HasPendingDungeonMapChanges() const {
+    return pending_dungeon_map_changes_;
+  }
+  bool HasPendingDungeonMapTile16Changes() const {
+    return pending_dungeon_map_tile16_changes_;
+  }
+  bool HasPendingScreenChanges() const {
+    return HasPendingDungeonMapChanges() || HasPendingDungeonMapTile16Changes();
+  }
+
   std::vector<zelda3::DungeonMap> dungeon_maps_;
 
  private:
+  friend class ScreenEditorSaveStoplossTestPeer;
+
   void DrawTitleScreenEditor();
   void DrawNamingScreenEditor();
   void DrawOverworldMapEditor();
@@ -75,7 +87,6 @@ class ScreenEditor : public Editor {
 
   absl::Status LoadDungeonMapTile16(const std::vector<uint8_t>& gfx_data,
                                     bool bin_mode = false);
-  absl::Status SaveDungeonMapTile16();
 
   void DrawDungeonMapScreen(int i);
   void DrawDungeonMapsTabs();
@@ -92,6 +103,11 @@ class ScreenEditor : public Editor {
   void CommitDungeonMapUndo();
   void CommitTile16CompUndo();
   void RestoreFromSnapshot(const ScreenSnapshot& snapshot);
+  void ResetRomBackedStateForLoad();
+  void MarkDungeonMapModified() { pending_dungeon_map_changes_ = true; }
+  void MarkDungeonMapTile16Modified() {
+    pending_dungeon_map_tile16_changes_ = true;
+  }
 
   enum class EditingMode { DRAW, EDIT };
 
@@ -162,6 +178,8 @@ class ScreenEditor : public Editor {
   // Undo/redo pending state
   bool has_pending_dungeon_undo_ = false;
   bool has_pending_tile16_undo_ = false;
+  bool pending_dungeon_map_changes_ = false;
+  bool pending_dungeon_map_tile16_changes_ = false;
   ScreenSnapshot pending_dungeon_before_;
   ScreenSnapshot pending_tile16_before_;
   std::string pending_dungeon_desc_;

--- a/src/app/editor/graphics/screen_editor.h
+++ b/src/app/editor/graphics/screen_editor.h
@@ -60,8 +60,17 @@ class ScreenEditor : public Editor {
   bool HasPendingDungeonMapTile16Changes() const {
     return pending_dungeon_map_tile16_changes_;
   }
+  bool HasPendingTitleScreenChanges() const {
+    return pending_title_screen_changes_;
+  }
+  bool HasPendingOverworldMapChanges() const {
+    return pending_overworld_map_changes_ ||
+           pending_overworld_map_palette_changes_;
+  }
   bool HasPendingScreenChanges() const {
-    return HasPendingDungeonMapChanges() || HasPendingDungeonMapTile16Changes();
+    return HasPendingDungeonMapChanges() ||
+           HasPendingDungeonMapTile16Changes() ||
+           HasPendingTitleScreenChanges() || HasPendingOverworldMapChanges();
   }
 
   std::vector<zelda3::DungeonMap> dungeon_maps_;
@@ -108,6 +117,13 @@ class ScreenEditor : public Editor {
   void MarkDungeonMapTile16Modified() {
     pending_dungeon_map_tile16_changes_ = true;
   }
+  void MarkTitleScreenModified() { pending_title_screen_changes_ = true; }
+  void MarkOverworldMapModified() { pending_overworld_map_changes_ = true; }
+  void MarkOverworldMapPaletteModified() {
+    pending_overworld_map_palette_changes_ = true;
+  }
+  absl::Status SaveTitleScreenToRom();
+  absl::Status SaveOverworldMapToRom();
 
   enum class EditingMode { DRAW, EDIT };
 
@@ -180,6 +196,9 @@ class ScreenEditor : public Editor {
   bool has_pending_tile16_undo_ = false;
   bool pending_dungeon_map_changes_ = false;
   bool pending_dungeon_map_tile16_changes_ = false;
+  bool pending_title_screen_changes_ = false;
+  bool pending_overworld_map_changes_ = false;
+  bool pending_overworld_map_palette_changes_ = false;
   ScreenSnapshot pending_dungeon_before_;
   ScreenSnapshot pending_tile16_before_;
   std::string pending_dungeon_desc_;

--- a/src/app/editor/session_types.cc
+++ b/src/app/editor/session_types.cc
@@ -249,6 +249,13 @@ bool EditorSet::HasPendingScreenChanges() const {
   return false;
 }
 
+void EditorSet::InvalidateScreenRomBackedState() {
+  if (auto* editor =
+          static_cast<ScreenEditor*>(FindEditor(EditorType::kScreen))) {
+    editor->InvalidateRomBackedState();
+  }
+}
+
 zelda3::Overworld* EditorSet::GetOverworldData() const {
   if (auto* editor =
           static_cast<OverworldEditor*>(FindEditor(EditorType::kOverworld))) {

--- a/src/app/editor/session_types.cc
+++ b/src/app/editor/session_types.cc
@@ -241,6 +241,14 @@ bool EditorSet::HasPendingGraphicsChanges() const {
   return false;
 }
 
+bool EditorSet::HasPendingScreenChanges() const {
+  if (auto* editor =
+          static_cast<ScreenEditor*>(FindEditor(EditorType::kScreen))) {
+    return editor->HasPendingScreenChanges();
+  }
+  return false;
+}
+
 zelda3::Overworld* EditorSet::GetOverworldData() const {
   if (auto* editor =
           static_cast<OverworldEditor*>(FindEditor(EditorType::kOverworld))) {

--- a/src/app/editor/session_types.h
+++ b/src/app/editor/session_types.h
@@ -95,6 +95,9 @@ class EditorSet {
   std::vector<std::pair<uint32_t, uint32_t>> CollectDungeonWriteRanges() const;
   bool HasPendingGraphicsChanges() const;
   bool HasPendingScreenChanges() const;
+  // Reset cached Screen Editor models only when that lazy editor already
+  // exists. ROM replacement must not materialize an otherwise-unused editor.
+  void InvalidateScreenRomBackedState();
   zelda3::Overworld* GetOverworldData() const;
 
   // Deprecated named accessors (legacy compatibility)

--- a/src/app/editor/session_types.h
+++ b/src/app/editor/session_types.h
@@ -94,6 +94,7 @@ class EditorSet {
   int TotalDungeonRoomCount() const;
   std::vector<std::pair<uint32_t, uint32_t>> CollectDungeonWriteRanges() const;
   bool HasPendingGraphicsChanges() const;
+  bool HasPendingScreenChanges() const;
   zelda3::Overworld* GetOverworldData() const;
 
   // Deprecated named accessors (legacy compatibility)

--- a/src/app/editor/system/session/session_coordinator.cc
+++ b/src/app/editor/system/session/session_coordinator.cc
@@ -1279,6 +1279,10 @@ bool SessionCoordinator::IsSessionModified(size_t index) const {
     return true;
   }
 
+  if (session->editors.HasPendingScreenChanges()) {
+    return true;
+  }
+
   if (gfx::PaletteManager::Get().HasUnsavedChanges(&session->game_data)) {
     return true;
   }

--- a/src/app/gfx/core/bitmap.cc
+++ b/src/app/gfx/core/bitmap.cc
@@ -92,7 +92,8 @@ Bitmap& Bitmap::operator=(const Bitmap& other) {
     // CRITICAL: Release old resources before replacing to prevent leaks
     // Queue texture destruction if we have one
     if (texture_) {
-      Arena::Get().QueueTextureCommand(Arena::TextureCommandType::DESTROY, this);
+      Arena::Get().QueueTextureCommand(Arena::TextureCommandType::DESTROY,
+                                       this);
     }
     // Free old surface through Arena
     if (surface_) {
@@ -269,7 +270,8 @@ void Bitmap::Create(int width, int height, int depth, int format,
   // malloc errors on shutdown
   if (surface_ && data_.size() > 0) {
     SDL_LockSurface(surface_);
-    size_t copy_size = std::min(data_.size(), static_cast<size_t>(surface_->pitch * surface_->h));
+    size_t copy_size = std::min(
+        data_.size(), static_cast<size_t>(surface_->pitch * surface_->h));
     memcpy(surface_->pixels, pixel_data_, copy_size);
     SDL_UnlockSurface(surface_);
   }
@@ -289,7 +291,8 @@ void Bitmap::Reformat(int format) {
   // assignment
   if (surface_ && data_.size() > 0) {
     SDL_LockSurface(surface_);
-    size_t copy_size = std::min(data_.size(), static_cast<size_t>(surface_->pitch * surface_->h));
+    size_t copy_size = std::min(
+        data_.size(), static_cast<size_t>(surface_->pitch * surface_->h));
     memcpy(surface_->pixels, pixel_data_, copy_size);
     SDL_UnlockSurface(surface_);
   }
@@ -492,9 +495,8 @@ void Bitmap::SetPaletteWithTransparent(const SnesPalette& palette, size_t index,
 
   // Colors 1-15: Extract from source palette
   // NOTE: palette[i].rgb() returns 0-255 values in ImVec4 (unconventional!)
-  for (size_t i = 0; i < static_cast<size_t>(length) &&
-                     (index + i) < palette.size();
-       ++i) {
+  for (size_t i = 0;
+       i < static_cast<size_t>(length) && (index + i) < palette.size(); ++i) {
     const auto& pal_color = palette[index + i];
     ImVec4 rgb_255 = pal_color.rgb();  // 0-255 range (unconventional storage)
 
@@ -555,23 +557,25 @@ void Bitmap::SetPalette(const std::vector<SDL_Color>& palette) {
     SDL_Log("Warning: SetPalette - surface has no palette!");
     return;
   }
-  
+
   int max_colors = sdl_palette->ncolors;
   int colors_to_set = static_cast<int>(palette.size());
-  
+
   // Debug: Check if palette capacity is sufficient (should be 256 after EnsureSurfacePalette256)
   if (max_colors < colors_to_set) {
-    SDL_Log("Warning: SetPalette - SDL palette has %d colors, trying to set %d. "
-            "Colors above %d may not display correctly.",
-            max_colors, colors_to_set, max_colors);
+    SDL_Log(
+        "Warning: SetPalette - SDL palette has %d colors, trying to set %d. "
+        "Colors above %d may not display correctly.",
+        max_colors, colors_to_set, max_colors);
     colors_to_set = max_colors;  // Clamp to available space
   }
 
   SDL_UnlockSurface(surface_);
-  
+
   // Use SDL_SetPaletteColors for proper palette setting
   // This is more reliable than direct array access
-  if (SDL_SetPaletteColors(sdl_palette, palette.data(), 0, colors_to_set) != 0) {
+  if (SDL_SetPaletteColors(sdl_palette, palette.data(), 0, colors_to_set) !=
+      0) {
     SDL_Log("Warning: SDL_SetPaletteColors failed: %s", SDL_GetError());
     // Fall back to manual setting
     for (int i = 0; i < colors_to_set; ++i) {
@@ -581,7 +585,7 @@ void Bitmap::SetPalette(const std::vector<SDL_Color>& palette) {
       sdl_palette->colors[i].a = palette[i].a;
     }
   }
-  
+
   SDL_LockSurface(surface_);
 }
 

--- a/src/app/gfx/core/bitmap.cc
+++ b/src/app/gfx/core/bitmap.cc
@@ -224,24 +224,34 @@ void Bitmap::Create(int width, int height, int depth,
  */
 void Bitmap::Create(int width, int height, int depth, int format,
                     const std::vector<uint8_t>& data) {
-  if (data.empty()) {
-    SDL_Log("Bitmap data is empty\n");
-    active_ = false;
-    return;
-  }
-  active_ = true;
-  // Assign new generation for staleness detection in deferred texture commands
+  // Treat recreation as a new resource generation before touching either
+  // deferred commands or the current resources. Commands queued for the old
+  // surface/texture will then be discarded as stale by Arena.
   generation_ = next_generation_++;
+
+  // Keep the texture handle alive until the deferred DESTROY command runs.
+  // Callers queue the replacement CREATE after this method returns, so both
+  // commands share the new generation and execute in DESTROY -> CREATE order.
+  if (texture_) {
+    Arena::Get().QueueTextureCommand(Arena::TextureCommandType::DESTROY, this);
+  }
+  if (surface_) {
+    Arena::Get().FreeSurface(surface_);
+    surface_ = nullptr;
+  }
+
   width_ = width;
   height_ = height;
   depth_ = depth;
-  if (data.empty()) {
-    SDL_Log("Data provided to Bitmap is empty.\n");
-    return;
-  }
-  data_.reserve(data.size());
   data_ = data;
   pixel_data_ = data_.data();
+  active_ = false;
+
+  if (data.empty()) {
+    SDL_Log("Bitmap data is empty\n");
+    return;
+  }
+
   surface_ = Arena::Get().AllocateSurface(width_, height_, depth_,
                                           GetSnesPixelFormat(format));
   if (surface_ == nullptr) {

--- a/src/app/gfx/core/bitmap.cc
+++ b/src/app/gfx/core/bitmap.cc
@@ -712,8 +712,8 @@ void Bitmap::Get16x16Tile(int tile_x, int tile_y,
       uint8_t pixel_value = data_[pixel_offset];
 
       // Store the pixel value in the tile data
-      tile_data_offset++;
       tile_data[tile_data_offset] = pixel_value;
+      tile_data_offset++;
     }
   }
 }

--- a/src/app/gfx/core/bitmap.cc
+++ b/src/app/gfx/core/bitmap.cc
@@ -229,12 +229,9 @@ void Bitmap::Create(int width, int height, int depth, int format,
   // surface/texture will then be discarded as stale by Arena.
   generation_ = next_generation_++;
 
-  // Keep the texture handle alive until the deferred DESTROY command runs.
-  // Callers queue the replacement CREATE after this method returns, so both
-  // commands share the new generation and execute in DESTROY -> CREATE order.
-  if (texture_) {
-    Arena::Get().QueueTextureCommand(Arena::TextureCommandType::DESTROY, this);
-  }
+  // Preserve an existing texture handle. A caller can queue UPDATE to reuse it
+  // with the new surface. If the caller instead queues CREATE, Arena owns
+  // destroying the old texture immediately before creating its replacement.
   if (surface_) {
     Arena::Get().FreeSurface(surface_);
     surface_ = nullptr;

--- a/src/app/gfx/resource/arena.cc
+++ b/src/app/gfx/resource/arena.cc
@@ -67,6 +67,10 @@ bool Arena::ProcessSingleTexture(IRenderer* renderer) {
           command.bitmap->surface()->format && command.bitmap->is_active() &&
           command.bitmap->width() > 0 && command.bitmap->height() > 0) {
         try {
+          if (auto existing_texture = command.bitmap->texture()) {
+            active_renderer->DestroyTexture(existing_texture);
+            command.bitmap->set_texture(nullptr);
+          }
           auto texture = active_renderer->CreateTexture(
               command.bitmap->width(), command.bitmap->height());
           if (texture) {
@@ -194,6 +198,10 @@ void Arena::ProcessTextureQueue(IRenderer* renderer) {
                 "Arena::ProcessTextureQueue", 0, true,
                 "Calling CreateTexture...");
 
+            if (auto existing_texture = command.bitmap->texture()) {
+              active_renderer->DestroyTexture(existing_texture);
+              command.bitmap->set_texture(nullptr);
+            }
             auto texture = active_renderer->CreateTexture(
                 command.bitmap->width(), command.bitmap->height());
 

--- a/src/app/gfx/resource/arena.cc
+++ b/src/app/gfx/resource/arena.cc
@@ -52,6 +52,7 @@ bool Arena::ProcessSingleTexture(IRenderer* renderer) {
   auto it = texture_command_queue_.begin();
   const auto& command = *it;
   bool processed = false;
+  bool should_remove = true;
 
   // Skip stale commands where bitmap was reallocated since queuing
   if (command.bitmap && command.bitmap->generation() != command.generation) {
@@ -66,21 +67,44 @@ bool Arena::ProcessSingleTexture(IRenderer* renderer) {
       if (command.bitmap && command.bitmap->surface() &&
           command.bitmap->surface()->format && command.bitmap->is_active() &&
           command.bitmap->width() > 0 && command.bitmap->height() > 0) {
+        const auto old_texture = command.bitmap->texture();
+        TextureHandle replacement = nullptr;
         try {
-          if (auto existing_texture = command.bitmap->texture()) {
-            active_renderer->DestroyTexture(existing_texture);
-            command.bitmap->set_texture(nullptr);
-          }
-          auto texture = active_renderer->CreateTexture(
+          replacement = active_renderer->CreateTexture(
               command.bitmap->width(), command.bitmap->height());
-          if (texture) {
-            command.bitmap->set_texture(texture);
-            active_renderer->UpdateTexture(texture, *command.bitmap);
-            processed = true;
-          }
         } catch (...) {
           LOG_ERROR("Arena", "Exception during single texture creation");
+          should_remove = false;
+          break;
         }
+        if (!replacement) {
+          should_remove = false;
+          break;
+        }
+        try {
+          active_renderer->UpdateTexture(replacement, *command.bitmap);
+        } catch (...) {
+          LOG_ERROR("Arena", "Exception updating new single texture");
+          if (replacement != old_texture) {
+            try {
+              active_renderer->DestroyTexture(replacement);
+            } catch (...) {
+              LOG_ERROR("Arena", "Exception cleaning up failed single texture");
+            }
+          }
+          should_remove = false;
+          break;
+        }
+
+        command.bitmap->set_texture(replacement);
+        if (old_texture && old_texture != replacement) {
+          try {
+            active_renderer->DestroyTexture(old_texture);
+          } catch (...) {
+            LOG_ERROR("Arena", "Exception destroying replaced single texture");
+          }
+        }
+        processed = true;
       }
       break;
     }
@@ -112,8 +136,9 @@ bool Arena::ProcessSingleTexture(IRenderer* renderer) {
     }
   }
 
-  // Always remove the command after attempting (whether successful or not)
-  texture_command_queue_.erase(it);
+  if (should_remove) {
+    texture_command_queue_.erase(it);
+  }
   return processed;
 }
 
@@ -193,39 +218,57 @@ void Arena::ProcessTextureQueue(IRenderer* renderer) {
                 absl::StrFormat("Low color count: %d", color_count));
           }
 
+          zelda3::PaletteDebugger::Get().LogPaletteApplication(
+              "Arena::ProcessTextureQueue", 0, true,
+              "Calling CreateTexture...");
+          const auto old_texture = command.bitmap->texture();
+          TextureHandle replacement = nullptr;
           try {
-            zelda3::PaletteDebugger::Get().LogPaletteApplication(
-                "Arena::ProcessTextureQueue", 0, true,
-                "Calling CreateTexture...");
-
-            if (auto existing_texture = command.bitmap->texture()) {
-              active_renderer->DestroyTexture(existing_texture);
-              command.bitmap->set_texture(nullptr);
-            }
-            auto texture = active_renderer->CreateTexture(
+            replacement = active_renderer->CreateTexture(
                 command.bitmap->width(), command.bitmap->height());
-
-            if (texture) {
-              zelda3::PaletteDebugger::Get().LogPaletteApplication(
-                  "Arena::ProcessTextureQueue", 0, true,
-                  "CreateTexture SUCCESS");
-
-              command.bitmap->set_texture(texture);
-              active_renderer->UpdateTexture(texture, *command.bitmap);
-              processed++;
-            } else {
-              zelda3::PaletteDebugger::Get().LogPaletteApplication(
-                  "Arena::ProcessTextureQueue", 0, false,
-                  "CreateTexture returned NULL");
-              should_remove = false;  // Retry next frame
-            }
           } catch (...) {
             LOG_ERROR("Arena", "Exception during texture creation");
             zelda3::PaletteDebugger::Get().LogPaletteApplication(
                 "Arena::ProcessTextureQueue", 0, false,
                 "EXCEPTION during texture creation");
-            should_remove = true;  // Remove bad command
+            should_remove = false;
+            break;
           }
+
+          if (!replacement) {
+            zelda3::PaletteDebugger::Get().LogPaletteApplication(
+                "Arena::ProcessTextureQueue", 0, false,
+                "CreateTexture returned NULL");
+            should_remove = false;
+            break;
+          }
+
+          try {
+            active_renderer->UpdateTexture(replacement, *command.bitmap);
+          } catch (...) {
+            LOG_ERROR("Arena", "Exception updating new texture");
+            if (replacement != old_texture) {
+              try {
+                active_renderer->DestroyTexture(replacement);
+              } catch (...) {
+                LOG_ERROR("Arena", "Exception cleaning up failed texture");
+              }
+            }
+            should_remove = false;
+            break;
+          }
+
+          command.bitmap->set_texture(replacement);
+          if (old_texture && old_texture != replacement) {
+            try {
+              active_renderer->DestroyTexture(old_texture);
+            } catch (...) {
+              LOG_ERROR("Arena", "Exception destroying replaced texture");
+            }
+          }
+          zelda3::PaletteDebugger::Get().LogPaletteApplication(
+              "Arena::ProcessTextureQueue", 0, true, "CreateTexture SUCCESS");
+          processed++;
         }
         break;
       }
@@ -302,9 +345,14 @@ bool Arena::ProcessTextureQueueWithBudget(IRenderer* renderer,
       }
     }
 
-    // Process one texture
+    // A failed CREATE remains queued for a later frame. Stop this budget pass
+    // when no command was removed so a retry cannot spin on the same front
+    // entry indefinitely.
+    const size_t queue_size_before = texture_command_queue_.size();
     if (ProcessSingleTexture(active_renderer)) {
       textures_this_call++;
+    } else if (texture_command_queue_.size() == queue_size_before) {
+      break;
     }
   }
 

--- a/src/app/gfx/resource/arena.cc
+++ b/src/app/gfx/resource/arena.cc
@@ -267,7 +267,7 @@ void Arena::ProcessTextureQueue(IRenderer* renderer) {
 }
 
 bool Arena::ProcessTextureQueueWithBudget(IRenderer* renderer,
-                                           float budget_ms) {
+                                          float budget_ms) {
   using Clock = std::chrono::high_resolution_clock;
   using Microseconds = std::chrono::microseconds;
 
@@ -290,8 +290,8 @@ bool Arena::ProcessTextureQueueWithBudget(IRenderer* renderer,
   while (!texture_command_queue_.empty()) {
     // Check time budget before each texture (not after, to avoid overshoot)
     if (textures_this_call > 0) {  // Always process at least one
-      auto elapsed = std::chrono::duration_cast<Microseconds>(
-          Clock::now() - start_time);
+      auto elapsed =
+          std::chrono::duration_cast<Microseconds>(Clock::now() - start_time);
       if (elapsed.count() >= budget_us) {
         LOG_DEBUG("Arena",
                   "Budget exhausted: processed %zu textures in %.2fms, "
@@ -310,8 +310,8 @@ bool Arena::ProcessTextureQueueWithBudget(IRenderer* renderer,
 
   // Update statistics
   if (textures_this_call > 0) {
-    auto total_elapsed = std::chrono::duration_cast<Microseconds>(
-        Clock::now() - start_time);
+    auto total_elapsed =
+        std::chrono::duration_cast<Microseconds>(Clock::now() - start_time);
     float elapsed_ms = total_elapsed.count() / 1000.0f;
 
     texture_queue_stats_.textures_processed += textures_this_call;
@@ -556,8 +556,8 @@ size_t Arena::EvictLRUSheets(size_t count) {
   sheet_cache_stats_.current_size = sheet_lru_map_.size();
 
   if (evicted > 0) {
-    LOG_DEBUG("Arena", "Evicted %zu LRU sheet textures, %zu remaining",
-              evicted, sheet_lru_map_.size());
+    LOG_DEBUG("Arena", "Evicted %zu LRU sheet textures, %zu remaining", evicted,
+              sheet_lru_map_.size());
   }
 
   return evicted;

--- a/src/app/gui/canvas/canvas.cc
+++ b/src/app/gui/canvas/canvas.cc
@@ -257,7 +257,7 @@ void Canvas::Cleanup() {
   }
   extensions_.reset();
 
-  selection_.Clear();
+  ClearSelection();
 
   // Stop performance monitoring before cleanup to prevent segfault
   if (performance_integration_) {
@@ -268,6 +268,17 @@ void Canvas::Cleanup() {
   context_menu_.reset();
   usage_tracker_.reset();
   performance_integration_.reset();
+}
+
+void Canvas::ClearSelection() {
+  selection_.Clear();
+  interaction_handler_.ClearState();
+  points_.clear();
+  selected_tiles_.clear();
+  selected_points_.clear();
+  selected_tile_pos_ = ImVec2(-1, -1);
+  select_rect_active_ = false;
+  drawn_tile_pos_ = ImVec2(-1, -1);
 }
 
 void Canvas::InitializeEnhancedComponents() {

--- a/src/app/gui/canvas/canvas.h
+++ b/src/app/gui/canvas/canvas.h
@@ -230,6 +230,8 @@ class Canvas {
   const CanvasConfig& GetConfig() const { return config_; }
   CanvasSelection& GetSelection() { return selection_; }
   const CanvasSelection& GetSelection() const { return selection_; }
+  // Clear modern, interaction-handler, and legacy selection state together.
+  void ClearSelection();
 
   // Enhanced palette management
   void InitializePaletteEditor(Rom* rom);

--- a/src/zelda3/screen/inventory.cc
+++ b/src/zelda3/screen/inventory.cc
@@ -15,6 +15,7 @@ absl::Status Inventory::Create(Rom* rom, GameData* game_data) {
   if (!rom || !rom->is_loaded()) {
     return absl::InvalidArgumentError("ROM is not loaded");
   }
+  ResetForReload();
   game_data_ = game_data;
 
   // Build the tileset first (loads 2BPP graphics)
@@ -38,6 +39,17 @@ absl::Status Inventory::Create(Rom* rom, GameData* game_data) {
                                         &bitmap_);
 
   return absl::OkStatus();
+}
+
+void Inventory::ResetForReload() {
+  data_.clear();
+  tilesheets_.clear();
+  test_.clear();
+  palette_.clear();
+  tiles_.clear();
+  item_icons_.clear();
+  canvas_.ClearSelection();
+  game_data_ = nullptr;
 }
 
 absl::Status Inventory::BuildTileset(Rom* rom) {

--- a/src/zelda3/screen/inventory.cc
+++ b/src/zelda3/screen/inventory.cc
@@ -145,51 +145,54 @@ absl::Status Inventory::LoadItemIcons(Rom* rom) {
   RETURN_IF_ERROR(load_icons(fire_rod_icons));
 
   // Ice rod (.ices)
-  std::vector<IconDef> ice_rod_icons = {{0x90, "No ice rod"}, {0x98, "Ice rod"}};
+  std::vector<IconDef> ice_rod_icons = {{0x90, "No ice rod"},
+                                        {0x98, "Ice rod"}};
   RETURN_IF_ERROR(load_icons(ice_rod_icons));
 
   // Medallions
-  std::vector<IconDef> medal_icons = {
-      {0xA0, "No Bombos"}, {0xA8, "Bombos"}, {0xB0, "No Ether"},
-      {0xB8, "Ether"},     {0xC0, "No Quake"},  {0xC8, "Quake"}};
+  std::vector<IconDef> medal_icons = {{0xA0, "No Bombos"}, {0xA8, "Bombos"},
+                                      {0xB0, "No Ether"},  {0xB8, "Ether"},
+                                      {0xC0, "No Quake"},  {0xC8, "Quake"}};
   RETURN_IF_ERROR(load_icons(medal_icons));
 
   // Utilities
-  std::vector<IconDef> util_icons = {
-      {0xD0, "No lantern"}, {0xD8, "Lantern"},    {0xE0, "No hammer"},
-      {0xE8, "Hammer"},     {0xF0, "No flute"},     {0xF8, "Flute"},
-      {0x100, "No net"},    {0x108, "Bug net"},   {0x110, "No book"},
-      {0x118, "Book"}};
+  std::vector<IconDef> util_icons = {{0xD0, "No lantern"}, {0xD8, "Lantern"},
+                                     {0xE0, "No hammer"},  {0xE8, "Hammer"},
+                                     {0xF0, "No flute"},   {0xF8, "Flute"},
+                                     {0x100, "No net"},    {0x108, "Bug net"},
+                                     {0x110, "No book"},   {0x118, "Book"}};
   RETURN_IF_ERROR(load_icons(util_icons));
 
   // Bottles
   std::vector<IconDef> bottle_icons = {
-      {0x120, "No bottle"},        {0x128, "Empty bottle"},
-      {0x130, "Red potion"},       {0x138, "Green potion"},
-      {0x140, "Blue potion"},      {0x148, "Fairy"},
-      {0x150, "Bee"},              {0x158, "Good bee"}};
+      {0x120, "No bottle"},    {0x128, "Empty bottle"}, {0x130, "Red potion"},
+      {0x138, "Green potion"}, {0x140, "Blue potion"},  {0x148, "Fairy"},
+      {0x150, "Bee"},          {0x158, "Good bee"}};
   RETURN_IF_ERROR(load_icons(bottle_icons));
 
   // Canes and Mirror
   std::vector<IconDef> magic_icons = {
-      {0x160, "No Somaria"}, {0x168, "Cane of Somaria"}, {0x170, "No Byrna"},
-      {0x178, "Cane of Byrna"}, {0x180, "No Cape"},     {0x188, "Magic cape"},
+      {0x160, "No Somaria"}, {0x168, "Cane of Somaria"},
+      {0x170, "No Byrna"},   {0x178, "Cane of Byrna"},
+      {0x180, "No Cape"},    {0x188, "Magic cape"},
       {0x190, "No mirror"},  {0x198, "Magic mirror"}};
   RETURN_IF_ERROR(load_icons(magic_icons));
 
   // Passive equipment
   std::vector<IconDef> equip_icons = {
-      {0x1A0, "No gloves"},  {0x1A8, "Power glove"}, {0x1B0, "Titan mitts"},
-      {0x1B8, "No boots"},   {0x1C0, "Pegasus boots"}, {0x1C8, "No flippers"},
-      {0x1D0, "Flippers"},   {0x1D8, "No pearl"},    {0x1E0, "Moon pearl"}};
+      {0x1A0, "No gloves"}, {0x1A8, "Power glove"},   {0x1B0, "Titan mitts"},
+      {0x1B8, "No boots"},  {0x1C0, "Pegasus boots"}, {0x1C8, "No flippers"},
+      {0x1D0, "Flippers"},  {0x1D8, "No pearl"},      {0x1E0, "Moon pearl"}};
   RETURN_IF_ERROR(load_icons(equip_icons));
 
   // Combat
   std::vector<IconDef> combat_icons = {
-      {0x1E8, "No sword"},   {0x1F0, "Fighter sword"}, {0x1F8, "Master sword"},
-      {0x200, "Tempered sword"}, {0x208, "Golden sword"}, {0x210, "No shield"},
-      {0x218, "Blue shield"}, {0x220, "Red shield"}, {0x228, "Mirror shield"},
-      {0x230, "Green mail"}, {0x238, "Blue mail"}, {0x240, "Red mail"}};
+      {0x1E8, "No sword"},      {0x1F0, "Fighter sword"},
+      {0x1F8, "Master sword"},  {0x200, "Tempered sword"},
+      {0x208, "Golden sword"},  {0x210, "No shield"},
+      {0x218, "Blue shield"},   {0x220, "Red shield"},
+      {0x228, "Mirror shield"}, {0x230, "Green mail"},
+      {0x238, "Blue mail"},     {0x240, "Red mail"}};
   RETURN_IF_ERROR(load_icons(combat_icons));
 
   return absl::OkStatus();

--- a/src/zelda3/screen/inventory.h
+++ b/src/zelda3/screen/inventory.h
@@ -42,6 +42,9 @@ class Inventory {
    */
   absl::Status Create(Rom* rom, GameData* game_data = nullptr);
 
+  // Clear ROM-derived logical state without moving queued Bitmap owners.
+  void ResetForReload();
+
   auto& bitmap() { return bitmap_; }
   auto& tilesheet() { return tilesheets_bmp_; }
   auto& palette() { return palette_; }

--- a/src/zelda3/screen/overworld_map_screen.cc
+++ b/src/zelda3/screen/overworld_map_screen.cc
@@ -14,6 +14,7 @@ absl::Status OverworldMapScreen::Create(Rom* rom) {
   if (!rom || !rom->is_loaded()) {
     return absl::InvalidArgumentError("ROM is not loaded");
   }
+  ResetForReload();
 
   // Set metadata for overworld map bitmaps
   // Mode 7 graphics use full 128-color palettes
@@ -93,6 +94,13 @@ absl::Status OverworldMapScreen::Create(Rom* rom) {
                                         &map_bitmap_);
 
   return absl::OkStatus();
+}
+
+void OverworldMapScreen::ResetForReload() {
+  lw_map_tiles_.fill(0);
+  dw_map_tiles_.fill(0);
+  lw_palette_.clear();
+  dw_palette_.clear();
 }
 
 absl::Status OverworldMapScreen::LoadMapData(Rom* rom) {

--- a/src/zelda3/screen/overworld_map_screen.h
+++ b/src/zelda3/screen/overworld_map_screen.h
@@ -29,6 +29,9 @@ class OverworldMapScreen {
    */
   absl::Status Create(Rom* rom);
 
+  // Clear ROM-derived logical state without moving queued Bitmap owners.
+  void ResetForReload();
+
   /**
    * @brief Save changes back to ROM
    * @param rom ROM instance to write data to

--- a/src/zelda3/screen/title_screen.cc
+++ b/src/zelda3/screen/title_screen.cc
@@ -15,6 +15,7 @@ absl::Status TitleScreen::Create(Rom* rom, GameData* game_data) {
   if (!rom || !rom->is_loaded()) {
     return absl::InvalidArgumentError("ROM is not loaded");
   }
+  ResetForReload();
   game_data_ = game_data;
 
   // Initialize bitmaps for each layer
@@ -178,6 +179,20 @@ absl::Status TitleScreen::Create(Rom* rom, GameData* game_data) {
   RETURN_IF_ERROR(LoadTitleScreen(rom));
 
   return absl::OkStatus();
+}
+
+void TitleScreen::ResetForReload() {
+  tiles_bg1_buffer_.fill(0x492);
+  tiles_bg2_buffer_.fill(0x492);
+  for (auto& tile : oam_data_) {
+    tile = {};
+  }
+  tile16_blockset_.tile_info.clear();
+  tile16_blockset_.tile_size = {0, 0};
+  tile16_blockset_.map_size = {0, 0};
+  palette_.clear();
+  pal_selected_ = 2;
+  game_data_ = nullptr;
 }
 
 absl::Status TitleScreen::BuildTileset(Rom* rom) {

--- a/src/zelda3/screen/title_screen.h
+++ b/src/zelda3/screen/title_screen.h
@@ -31,6 +31,9 @@ class TitleScreen {
    */
   absl::Status Create(Rom* rom, GameData* game_data = nullptr);
 
+  // Clear ROM-derived logical state without moving queued Bitmap owners.
+  void ResetForReload();
+
   // Accessors for layer data
   auto& bg1_buffer() { return tiles_bg1_buffer_; }
   auto& bg2_buffer() { return tiles_bg2_buffer_; }

--- a/src/zelda3/screen/title_screen.h
+++ b/src/zelda3/screen/title_screen.h
@@ -102,9 +102,9 @@ class TitleScreen {
   gfx::Bitmap tiles8_bitmap_;           // 8x8 tile graphics
   gfx::Bitmap title_composite_bitmap_;  // Composite BG1+BG2 with transparency
 
-  gfx::Tilemap tile16_blockset_;  // 16x16 tile blockset
-  gfx::SnesPalette palette_;      // Title screen palette
-  GameData* game_data_ = nullptr; // GameData for palette access
+  gfx::Tilemap tile16_blockset_;   // 16x16 tile blockset
+  gfx::SnesPalette palette_;       // Title screen palette
+  GameData* game_data_ = nullptr;  // GameData for palette access
 };
 
 }  // namespace zelda3

--- a/test/unit/editor/editor_manager_rom_write_policy_test.cc
+++ b/test/unit/editor/editor_manager_rom_write_policy_test.cc
@@ -1,5 +1,6 @@
 #include <gtest/gtest.h>
 
+#include <algorithm>
 #include <chrono>
 #include <cstdint>
 #include <filesystem>
@@ -18,6 +19,7 @@
 #include "app/editor/editor_manager.h"
 #include "app/editor/graphics/graphics_editor.h"
 #include "app/editor/graphics/graphics_undo_actions.h"
+#include "app/editor/graphics/screen_editor.h"
 #include "app/gfx/backend/null_renderer.h"
 #include "app/gfx/resource/arena.h"
 #include "app/gfx/types/snes_palette.h"
@@ -36,6 +38,103 @@ class GraphicsEditorSaveStoplossTestPeer {
  public:
   static void MarkSheetModified(GraphicsEditor* editor, uint16_t sheet_id) {
     editor->state_.MarkSheetModified(sheet_id);
+  }
+};
+
+class ScreenEditorSaveStoplossTestPeer {
+ public:
+  static void MarkDungeonMapModified(ScreenEditor* editor) {
+    editor->MarkDungeonMapModified();
+  }
+
+  static void MarkDungeonMapTile16Modified(ScreenEditor* editor) {
+    editor->MarkDungeonMapTile16Modified();
+  }
+
+  static void ClearPendingChanges(ScreenEditor* editor) {
+    editor->pending_dungeon_map_changes_ = false;
+    editor->pending_dungeon_map_tile16_changes_ = false;
+  }
+
+  static void CommitDungeonMapEdit(ScreenEditor* editor) {
+    std::array<uint8_t, zelda3::kNumRooms> rooms{};
+    rooms.fill(0x0F);
+    std::array<uint8_t, zelda3::kNumRooms> graphics{};
+    graphics.fill(0xFF);
+    editor->dungeon_maps_.emplace_back(
+        0xFFFF, 1, 0,
+        std::vector<std::array<uint8_t, zelda3::kNumRooms>>{rooms},
+        std::vector<std::array<uint8_t, zelda3::kNumRooms>>{graphics});
+    editor->dungeon_map_labels_[0].emplace_back();
+    editor->selected_dungeon = 0;
+    editor->SaveDungeonMapUndoState("Edit dungeon map");
+    editor->dungeon_maps_[0].boss_room = 0x0123;
+    editor->CommitDungeonMapUndo();
+  }
+
+  static void CommitDungeonMapTile16Edit(ScreenEditor* editor) {
+    editor->selected_tile16_ = 4;
+    editor->current_tile16_info = {};
+    editor->SaveTile16CompUndoState("Edit dungeon-map Tile16");
+    editor->current_tile16_info[0] = gfx::TileInfo(1, 0, false, false, false);
+    editor->CommitTile16CompUndo();
+  }
+
+  static void PrimeRomBackedState(ScreenEditor* editor) {
+    editor->dungeon_maps_.emplace_back(
+        0xFFFF, 0, 0, std::vector<std::array<uint8_t, zelda3::kNumRooms>>{},
+        std::vector<std::array<uint8_t, zelda3::kNumRooms>>{});
+    MarkDungeonMapModified(editor);
+    MarkDungeonMapTile16Modified(editor);
+    editor->has_pending_dungeon_undo_ = true;
+    editor->has_pending_tile16_undo_ = true;
+    editor->pending_dungeon_desc_ = "pending dungeon edit";
+    editor->pending_tile16_desc_ = "pending Tile16 edit";
+    editor->dungeon_map_labels_[0].emplace_back();
+    editor->binary_gfx_loaded_ = true;
+    editor->inventory_loaded_ = true;
+    editor->title_screen_loaded_ = true;
+    editor->ow_map_loaded_ = true;
+    editor->selected_room = 7;
+    editor->selected_tile16_ = 8;
+    editor->selected_tile8_ = 9;
+    editor->selected_dungeon = 10;
+    editor->floor_number = 11;
+    editor->sheets_[0] = std::make_unique<gfx::Bitmap>();
+    editor->tile16_blockset_.tile_cache.CacheTile(1, gfx::Bitmap{});
+    editor->tile8_tilemap_.tile_cache.CacheTile(2, gfx::Bitmap{});
+
+    ScreenSnapshot before;
+    ScreenSnapshot after;
+    editor->undo_manager_.Push(std::make_unique<ScreenEditAction>(
+        before, after, [](const ScreenSnapshot&) {}, "older screen edit"));
+    editor->undo_manager_.Push(std::make_unique<ScreenEditAction>(
+        before, after, [](const ScreenSnapshot&) {}, "newer screen edit"));
+    editor->undo_manager_.Undo().IgnoreError();
+  }
+
+  static void ResetRomBackedStateForLoad(ScreenEditor* editor) {
+    editor->ResetRomBackedStateForLoad();
+  }
+
+  static bool HasReloadResidue(const ScreenEditor& editor) {
+    const bool has_labels =
+        std::ranges::any_of(editor.dungeon_map_labels_,
+                            [](const auto& labels) { return !labels.empty(); });
+    return !editor.dungeon_maps_.empty() || has_labels ||
+           editor.undo_manager_.CanUndo() || editor.undo_manager_.CanRedo() ||
+           editor.has_pending_dungeon_undo_ ||
+           editor.has_pending_tile16_undo_ ||
+           !editor.pending_dungeon_desc_.empty() ||
+           !editor.pending_tile16_desc_.empty() || editor.binary_gfx_loaded_ ||
+           editor.inventory_loaded_ || editor.title_screen_loaded_ ||
+           editor.ow_map_loaded_ || editor.selected_room != 0 ||
+           editor.selected_tile16_ != 0 || editor.selected_tile8_ != 0 ||
+           editor.selected_dungeon != 0 || editor.floor_number != 0 ||
+           !editor.sheets_.empty() ||
+           editor.tile16_blockset_.tile_cache.Size() != 0 ||
+           editor.tile8_tilemap_.tile_cache.Size() != 0 ||
+           editor.HasPendingScreenChanges();
   }
 };
 
@@ -991,7 +1090,7 @@ TEST(EditorManagerBackupRestoreTest,
   EXPECT_EQ(discard_status.code(), absl::StatusCode::kFailedPrecondition)
       << discard_status;
   EXPECT_NE(std::string(discard_status.message())
-                .find("pending graphics, dungeon, or palette edits"),
+                .find("pending graphics, screen, dungeon, or palette edits"),
             std::string::npos);
   EXPECT_EQ(manager->GetCurrentRom(), active_rom);
   ASSERT_TRUE(active_rom->ReadByte(kPcOffset).ok());
@@ -1061,7 +1160,7 @@ TEST(EditorManagerBackupRestoreTest,
   EXPECT_EQ(discard_status.code(), absl::StatusCode::kFailedPrecondition)
       << discard_status;
   EXPECT_NE(std::string(discard_status.message())
-                .find("pending graphics, dungeon, or palette edits"),
+                .find("pending graphics, screen, dungeon, or palette edits"),
             std::string::npos);
   EXPECT_EQ(manager->GetCurrentRom(), active_rom);
   ASSERT_TRUE(active_rom->ReadByte(kPcOffset).ok());
@@ -1776,6 +1875,161 @@ TEST(GraphicsSaveStoplossTest, PixelUndoAndRedoRemarkTheSheetDirty) {
   EXPECT_EQ(sheet.vector(), after_data);
   EXPECT_TRUE(state.HasUnsavedChanges());
   EXPECT_TRUE(state.modified_sheets.contains(kSheetId));
+}
+
+TEST(ScreenSaveStoplossTest,
+     PendingQueryDoesNotMaterializeTheLazyScreenEditor) {
+  EditorSet editor_set;
+
+  EXPECT_EQ(editor_set.GetExistingEditor(EditorType::kScreen), nullptr);
+  EXPECT_FALSE(editor_set.HasPendingScreenChanges());
+  EXPECT_EQ(editor_set.GetExistingEditor(EditorType::kScreen), nullptr);
+}
+
+TEST(ScreenSaveStoplossTest,
+     PendingMapAndTile16EditsBlockLifecycleForBothScopeStates) {
+  FeatureFlagsGuard guard;
+  ScopedImGuiContext imgui;
+
+  auto renderer = std::make_unique<gfx::NullRenderer>();
+  auto manager = std::make_unique<EditorManager>();
+  manager->Initialize(renderer.get(), "");
+  manager->SetAssetLoadMode(AssetLoadMode::kLazy);
+  manager->user_settings().prefs().backup_before_save = false;
+
+  const auto rom_path = MakeTempFilePath("yaze_pending_screen_save.sfc");
+  ScopedFileCleanup cleanup{rom_path};
+  WriteTestRom(rom_path, "PENDING SCREEN");
+
+  ASSERT_OK(manager->OpenRomOrProject(rom_path.string()));
+  DisableRomWritesForTest();
+
+  auto* project = manager->GetCurrentProject();
+  ASSERT_NE(project, nullptr);
+  project->workspace_settings.backup_on_save = false;
+  project->rom_metadata.expected_hash.clear();
+
+  auto* editor_set = manager->GetCurrentEditorSet();
+  ASSERT_NE(editor_set, nullptr);
+  auto* screen = editor_set->GetEditorAs<ScreenEditor>(EditorType::kScreen);
+  ASSERT_NE(screen, nullptr);
+
+  Rom* rom = manager->GetCurrentRom();
+  ASSERT_NE(rom, nullptr);
+  EXPECT_FALSE(rom->dirty());
+
+  constexpr uint32_t kPcOffset = 0x1234;
+  constexpr uint8_t kPendingRomByte = 0xA5;
+
+  for (const bool tile16_domain : {false, true}) {
+    SCOPED_TRACE(tile16_domain ? "dungeon-map Tile16" : "dungeon map");
+    ScreenEditorSaveStoplossTestPeer::ClearPendingChanges(screen);
+    if (tile16_domain) {
+      ScreenEditorSaveStoplossTestPeer::MarkDungeonMapTile16Modified(screen);
+    } else {
+      ScreenEditorSaveStoplossTestPeer::MarkDungeonMapModified(screen);
+    }
+
+    ASSERT_TRUE(editor_set->HasPendingScreenChanges());
+    EXPECT_EQ(screen->HasPendingDungeonMapChanges(), !tile16_domain);
+    EXPECT_EQ(screen->HasPendingDungeonMapTile16Changes(), tile16_domain);
+    EXPECT_TRUE(manager->session_coordinator()->IsSessionModified(
+        manager->GetCurrentSessionIndex()));
+
+    manager->Quit();
+    ASSERT_TRUE(manager->HasPendingUnsavedSessionAction());
+    EXPECT_NE(manager->GetPendingUnsavedSessionActionPrompt().find(
+                  "unapplied Screen Editor dungeon-map edits"),
+              std::string::npos);
+    manager->CancelPendingUnsavedSessionAction();
+
+    const auto autosave_status = manager->AutosaveActiveSession();
+    EXPECT_EQ(autosave_status.code(), absl::StatusCode::kFailedPrecondition)
+        << autosave_status;
+    EXPECT_NE(std::string(autosave_status.message())
+                  .find("Screen Editor dungeon-map edits are pending"),
+              std::string::npos);
+
+    auto* session = manager->session_coordinator()->GetActiveRomSession();
+    ASSERT_NE(session, nullptr);
+    session->backup_restore_pending = true;
+    const auto discard_status = manager->DiscardPendingRomBackupRestore();
+    EXPECT_EQ(discard_status.code(), absl::StatusCode::kFailedPrecondition)
+        << discard_status;
+    EXPECT_NE(std::string(discard_status.message())
+                  .find("pending graphics, screen, dungeon, or palette edits"),
+              std::string::npos);
+    EXPECT_TRUE(session->backup_restore_pending);
+    session->backup_restore_pending = false;
+
+    ASSERT_OK(rom->WriteByte(kPcOffset, kPendingRomByte));
+    for (const bool screen_scope_enabled : {false, true}) {
+      core::FeatureFlags::get().kSaveDungeonMaps = screen_scope_enabled;
+      const auto save_status = manager->SaveRom();
+
+      EXPECT_EQ(save_status.code(), absl::StatusCode::kFailedPrecondition)
+          << save_status;
+      EXPECT_NE(std::string(save_status.message())
+                    .find("Screen Editor dungeon-map edits are pending"),
+                std::string::npos);
+      EXPECT_NE(std::string(save_status.message())
+                    .find(screen_scope_enabled ? "enabled" : "disabled"),
+                std::string::npos);
+      EXPECT_EQ(ReadByteAt(rom_path, kPcOffset), 0x00);
+      ASSERT_TRUE(rom->ReadByte(kPcOffset).ok());
+      EXPECT_EQ(*rom->ReadByte(kPcOffset), kPendingRomByte);
+      EXPECT_TRUE(editor_set->HasPendingScreenChanges());
+    }
+  }
+}
+
+TEST(ScreenSaveStoplossTest, DirectEditorSaveFailsClosedForEitherDomain) {
+  ScreenEditor editor;
+
+  ScreenEditorSaveStoplossTestPeer::MarkDungeonMapModified(&editor);
+  auto status = editor.Save();
+  EXPECT_EQ(status.code(), absl::StatusCode::kFailedPrecondition) << status;
+
+  ScreenEditorSaveStoplossTestPeer::ClearPendingChanges(&editor);
+  ScreenEditorSaveStoplossTestPeer::MarkDungeonMapTile16Modified(&editor);
+  status = editor.Save();
+  EXPECT_EQ(status.code(), absl::StatusCode::kFailedPrecondition) << status;
+}
+
+TEST(ScreenSaveStoplossTest, MutationUndoAndRedoRemarkEachDomainPending) {
+  ScreenEditor dungeon_map_editor;
+  ScreenEditorSaveStoplossTestPeer::CommitDungeonMapEdit(&dungeon_map_editor);
+  ASSERT_TRUE(dungeon_map_editor.HasPendingDungeonMapChanges());
+
+  ScreenEditorSaveStoplossTestPeer::ClearPendingChanges(&dungeon_map_editor);
+  ASSERT_OK(dungeon_map_editor.Undo());
+  EXPECT_TRUE(dungeon_map_editor.HasPendingDungeonMapChanges());
+
+  ScreenEditorSaveStoplossTestPeer::ClearPendingChanges(&dungeon_map_editor);
+  ASSERT_OK(dungeon_map_editor.Redo());
+  EXPECT_TRUE(dungeon_map_editor.HasPendingDungeonMapChanges());
+
+  ScreenEditor tile16_editor;
+  ScreenEditorSaveStoplossTestPeer::CommitDungeonMapTile16Edit(&tile16_editor);
+  ASSERT_TRUE(tile16_editor.HasPendingDungeonMapTile16Changes());
+
+  ScreenEditorSaveStoplossTestPeer::ClearPendingChanges(&tile16_editor);
+  ASSERT_OK(tile16_editor.Undo());
+  EXPECT_TRUE(tile16_editor.HasPendingDungeonMapTile16Changes());
+
+  ScreenEditorSaveStoplossTestPeer::ClearPendingChanges(&tile16_editor);
+  ASSERT_OK(tile16_editor.Redo());
+  EXPECT_TRUE(tile16_editor.HasPendingDungeonMapTile16Changes());
+}
+
+TEST(ScreenSaveStoplossTest, ReloadResetClearsRomBackedStateAndHistory) {
+  ScreenEditor editor;
+  ScreenEditorSaveStoplossTestPeer::PrimeRomBackedState(&editor);
+  ASSERT_TRUE(ScreenEditorSaveStoplossTestPeer::HasReloadResidue(editor));
+
+  ScreenEditorSaveStoplossTestPeer::ResetRomBackedStateForLoad(&editor);
+
+  EXPECT_FALSE(ScreenEditorSaveStoplossTestPeer::HasReloadResidue(editor));
 }
 
 }  // namespace

--- a/test/unit/editor/editor_manager_rom_write_policy_test.cc
+++ b/test/unit/editor/editor_manager_rom_write_policy_test.cc
@@ -2190,6 +2190,61 @@ TEST(ScreenSaveStoplossTest,
 }
 
 TEST(ScreenSaveStoplossTest,
+     CleanFailedScreenLoadDoesNotBlockUnrelatedRomSave) {
+  FeatureFlagsGuard guard;
+  ScopedImGuiContext imgui;
+
+  auto renderer = std::make_unique<gfx::NullRenderer>();
+  auto manager = std::make_unique<EditorManager>();
+  manager->Initialize(renderer.get(), "");
+  manager->SetAssetLoadMode(AssetLoadMode::kLazy);
+  manager->user_settings().prefs().backup_before_save = false;
+
+  const auto rom_path =
+      MakeTempFilePath("yaze_clean_failed_screen_load_save.sfc");
+  ScopedFileCleanup cleanup{rom_path};
+  WriteScreenModelTestRom(rom_path, "FAILED SCREEN LOAD SAVE");
+
+  ASSERT_OK(manager->OpenRomOrProject(rom_path.string()));
+  DisableRomWritesForTest();
+
+  auto* project = manager->GetCurrentProject();
+  ASSERT_NE(project, nullptr);
+  project->workspace_settings.backup_on_save = false;
+  project->rom_metadata.expected_hash.clear();
+
+  // Load GameData through a different editor, then make ScreenEditor::Load()
+  // fail its palette precondition after it has reset its ROM-backed state.
+  ASSERT_OK(manager->EnsureEditorAssetsLoaded(EditorType::kPalette));
+  auto* game_data = manager->GetCurrentGameData();
+  ASSERT_NE(game_data, nullptr);
+  game_data->palette_groups.dungeon_main.clear();
+
+  const auto load_status =
+      manager->EnsureEditorAssetsLoaded(EditorType::kScreen);
+  EXPECT_EQ(load_status.code(), absl::StatusCode::kFailedPrecondition)
+      << load_status;
+  EXPECT_NE(std::string(load_status.message()).find("dungeon palette 3"),
+            std::string::npos)
+      << load_status;
+
+  auto* editor_set = manager->GetCurrentEditorSet();
+  ASSERT_NE(editor_set, nullptr);
+  auto* screen = static_cast<ScreenEditor*>(
+      editor_set->GetExistingEditor(EditorType::kScreen));
+  ASSERT_NE(screen, nullptr);
+  EXPECT_FALSE(screen->IsRomBackedStateValid());
+  EXPECT_FALSE(screen->HasPendingScreenChanges());
+
+  constexpr uint32_t kUnrelatedOffset = 0x1234;
+  constexpr uint8_t kUnrelatedValue = 0x5A;
+  ASSERT_OK(
+      manager->GetCurrentRom()->WriteByte(kUnrelatedOffset, kUnrelatedValue));
+  ASSERT_OK(manager->SaveRom());
+  EXPECT_EQ(ReadByteAt(rom_path, kUnrelatedOffset), kUnrelatedValue);
+}
+
+TEST(ScreenSaveStoplossTest,
      RomReplacementRefreshesLoadedScreenInPlaceBeforeEnabledGlobalSave) {
   FeatureFlagsGuard guard;
   ScopedImGuiContext imgui;

--- a/test/unit/editor/editor_manager_rom_write_policy_test.cc
+++ b/test/unit/editor/editor_manager_rom_write_policy_test.cc
@@ -25,6 +25,8 @@
 #include "app/gfx/types/snes_palette.h"
 #include "app/gfx/util/palette_manager.h"
 #include "core/features.h"
+#include "framework/mock_renderer.h"
+#include "gmock/gmock.h"
 #include "rom/snes.h"
 #include "testing.h"
 #include "zelda3/dungeon/dungeon_rom_addresses.h"
@@ -43,6 +45,24 @@ class GraphicsEditorSaveStoplossTestPeer {
 
 class ScreenEditorSaveStoplossTestPeer {
  public:
+  struct BitmapOwners {
+    zelda3::Inventory* inventory = nullptr;
+    gfx::Bitmap* inventory_bitmap = nullptr;
+    gfx::Bitmap* inventory_tilesheet = nullptr;
+    gfx::Bitmap* title_bg1 = nullptr;
+    gfx::Bitmap* title_bg2 = nullptr;
+    gfx::Bitmap* title_oam = nullptr;
+    gfx::Bitmap* title_tiles8 = nullptr;
+    gfx::Bitmap* title_composite = nullptr;
+    gfx::Bitmap* overworld_tiles8 = nullptr;
+    gfx::Bitmap* overworld_map = nullptr;
+    gfx::Bitmap* sheet0 = nullptr;
+    gfx::Bitmap* tile16_atlas = nullptr;
+    gfx::Bitmap* tile8_atlas = nullptr;
+    gfx::Bitmap* tile16_cached = nullptr;
+    gfx::Bitmap* tile8_cached = nullptr;
+  };
+
   static std::array<gui::Canvas*, 9> AllCanvases(ScreenEditor* editor) {
     return {&editor->current_tile_canvas_,   &editor->screen_canvas_,
             &editor->tilesheet_canvas_,      &editor->tilemap_canvas_,
@@ -132,6 +152,7 @@ class ScreenEditorSaveStoplossTestPeer {
   }
 
   static void PrimeRomBackedState(ScreenEditor* editor) {
+    const std::vector<uint8_t> pixel{1};
     editor->dungeon_maps_.emplace_back(
         0xFFFF, 0, 0, std::vector<std::array<uint8_t, zelda3::kNumRooms>>{},
         std::vector<std::array<uint8_t, zelda3::kNumRooms>>{});
@@ -154,14 +175,27 @@ class ScreenEditorSaveStoplossTestPeer {
     editor->selected_tile8_ = 9;
     editor->selected_dungeon = 10;
     editor->floor_number = 11;
-    editor->sheets_[0] = std::make_unique<gfx::Bitmap>();
-    editor->tile16_blockset_.tile_cache.CacheTile(1, gfx::Bitmap{});
-    editor->tile8_tilemap_.tile_cache.CacheTile(2, gfx::Bitmap{});
+    editor->sheets_[0] = std::make_unique<gfx::Bitmap>(1, 1, 8, pixel);
+    gfx::Bitmap tile16_cached(1, 1, 8, pixel);
+    gfx::Bitmap tile8_cached(1, 1, 8, pixel);
+    editor->tile16_blockset_.atlas.Create(1, 1, 8, pixel);
+    editor->tile8_tilemap_.atlas.Create(1, 1, 8, pixel);
+    editor->tile16_blockset_.tile_info.push_back({});
+    editor->tile8_tilemap_.tile_info.push_back({});
+    editor->tile16_blockset_.tile_cache.CacheTile(1, tile16_cached);
+    editor->tile8_tilemap_.tile_cache.CacheTile(2, tile8_cached);
     editor->inventory_->item_icons().push_back(
         zelda3::ItemIcon{1, 2, 3, 4, "stale item"});
     editor->inventory_->palette().AddColor(gfx::SnesColor(1));
     editor->inventory_->bitmap().Create(1, 1, 8, std::vector<uint8_t>{1});
     editor->inventory_->tilesheet().Create(1, 1, 8, std::vector<uint8_t>{1});
+    editor->title_screen_.bg1_bitmap().Create(1, 1, 8, pixel);
+    editor->title_screen_.bg2_bitmap().Create(1, 1, 8, pixel);
+    editor->title_screen_.oam_bitmap().Create(1, 1, 8, pixel);
+    editor->title_screen_.tiles8_bitmap().Create(1, 1, 8, pixel);
+    editor->title_screen_.composite_bitmap().Create(1, 1, 8, pixel);
+    editor->ow_map_screen_.tiles8_bitmap().Create(1, 1, 8, pixel);
+    editor->ow_map_screen_.map_bitmap().Create(1, 1, 8, pixel);
     editor->current_mode_ = ScreenEditor::EditingMode::EDIT;
     editor->selected_title_tile16_ = 12;
     editor->title_h_flip_ = true;
@@ -171,6 +205,7 @@ class ScreenEditorSaveStoplossTestPeer {
     editor->show_title_bg2_ = false;
     editor->selected_ow_tile_ = 13;
     editor->ow_show_dark_world_ = true;
+    editor->rom_backed_state_valid_ = true;
     float canvas_seed = 1.0f;
     for (auto* canvas : AllCanvases(editor)) {
       PrimeCanvasSelection(canvas, canvas_seed++);
@@ -206,35 +241,92 @@ class ScreenEditorSaveStoplossTestPeer {
            editor.ow_map_loaded_ || editor.selected_room != 0 ||
            editor.selected_tile16_ != 0 || editor.selected_tile8_ != 0 ||
            editor.selected_dungeon != 0 || editor.floor_number != 0 ||
-           !editor.sheets_.empty() ||
-           editor.tile16_blockset_.tile_cache.Size() != 0 ||
-           editor.tile8_tilemap_.tile_cache.Size() != 0 ||
+           !editor.tile16_blockset_.tile_info.empty() ||
+           !editor.tile8_tilemap_.tile_info.empty() ||
            !editor.inventory_->item_icons().empty() ||
            editor.inventory_->palette().size() != 0 ||
-           editor.inventory_->bitmap().size() != 0 ||
-           editor.inventory_->tilesheet().size() != 0 ||
+           editor.title_screen_.palette().size() != 0 ||
+           editor.ow_map_screen_.lw_palette().size() != 0 ||
+           editor.ow_map_screen_.dw_palette().size() != 0 ||
            editor.current_mode_ != ScreenEditor::EditingMode::DRAW ||
            editor.selected_title_tile16_ != 0 || editor.title_h_flip_ ||
            editor.title_v_flip_ || editor.title_palette_ != 0 ||
            !editor.show_title_bg1_ || !editor.show_title_bg2_ ||
            editor.selected_ow_tile_ != 0 || editor.ow_show_dark_world_ ||
-           has_canvas_selection || editor.HasPendingScreenChanges();
+           has_canvas_selection || editor.HasPendingScreenChanges() ||
+           editor.rom_backed_state_valid_;
   }
 
-  static void SeedCachedDungeonMapWithoutPending(ScreenEditor* editor) {
-    std::array<uint8_t, zelda3::kNumRooms> rooms{};
-    rooms.fill(0x0F);
-    std::array<uint8_t, zelda3::kNumRooms> graphics{};
-    graphics.fill(0xFF);
-    editor->dungeon_maps_.emplace_back(
-        0x1234, 1, 0,
-        std::vector<std::array<uint8_t, zelda3::kNumRooms>>{rooms},
-        std::vector<std::array<uint8_t, zelda3::kNumRooms>>{graphics});
-    ClearPendingChanges(editor);
+  static BitmapOwners CaptureBitmapOwners(ScreenEditor* editor) {
+    return {
+        .inventory = editor->inventory_.get(),
+        .inventory_bitmap = &editor->inventory_->bitmap(),
+        .inventory_tilesheet = &editor->inventory_->tilesheet(),
+        .title_bg1 = &editor->title_screen_.bg1_bitmap(),
+        .title_bg2 = &editor->title_screen_.bg2_bitmap(),
+        .title_oam = &editor->title_screen_.oam_bitmap(),
+        .title_tiles8 = &editor->title_screen_.tiles8_bitmap(),
+        .title_composite = &editor->title_screen_.composite_bitmap(),
+        .overworld_tiles8 = &editor->ow_map_screen_.tiles8_bitmap(),
+        .overworld_map = &editor->ow_map_screen_.map_bitmap(),
+        .sheet0 = editor->sheets_.at(0).get(),
+        .tile16_atlas = &editor->tile16_blockset_.atlas,
+        .tile8_atlas = &editor->tile8_tilemap_.atlas,
+        .tile16_cached = editor->tile16_blockset_.tile_cache.GetTile(1),
+        .tile8_cached = editor->tile8_tilemap_.tile_cache.GetTile(2),
+    };
+  }
+
+  static void QueueBitmapOwners(const BitmapOwners& owners) {
+    for (auto* bitmap :
+         {owners.inventory_bitmap, owners.inventory_tilesheet, owners.title_bg1,
+          owners.title_bg2, owners.title_oam, owners.title_tiles8,
+          owners.title_composite, owners.overworld_tiles8, owners.overworld_map,
+          owners.sheet0, owners.tile16_atlas, owners.tile8_atlas,
+          owners.tile16_cached, owners.tile8_cached}) {
+      gfx::Arena::Get().QueueTextureCommand(
+          gfx::Arena::TextureCommandType::CREATE, bitmap);
+    }
+  }
+
+  static void ExpectSameBitmapOwners(const BitmapOwners& expected,
+                                     const BitmapOwners& actual) {
+    EXPECT_EQ(actual.inventory, expected.inventory);
+    EXPECT_EQ(actual.inventory_bitmap, expected.inventory_bitmap);
+    EXPECT_EQ(actual.inventory_tilesheet, expected.inventory_tilesheet);
+    EXPECT_EQ(actual.title_bg1, expected.title_bg1);
+    EXPECT_EQ(actual.title_bg2, expected.title_bg2);
+    EXPECT_EQ(actual.title_oam, expected.title_oam);
+    EXPECT_EQ(actual.title_tiles8, expected.title_tiles8);
+    EXPECT_EQ(actual.title_composite, expected.title_composite);
+    EXPECT_EQ(actual.overworld_tiles8, expected.overworld_tiles8);
+    EXPECT_EQ(actual.overworld_map, expected.overworld_map);
+    EXPECT_EQ(actual.sheet0, expected.sheet0);
+    EXPECT_EQ(actual.tile16_atlas, expected.tile16_atlas);
+    EXPECT_EQ(actual.tile8_atlas, expected.tile8_atlas);
+    EXPECT_EQ(actual.tile16_cached, expected.tile16_cached);
+    EXPECT_EQ(actual.tile8_cached, expected.tile8_cached);
   }
 
   static size_t DungeonMapCount(const ScreenEditor& editor) {
     return editor.dungeon_maps_.size();
+  }
+
+  static int DungeonFloorCount(const ScreenEditor& editor, size_t dungeon) {
+    const auto& map = editor.dungeon_maps_.at(dungeon);
+    return map.nbr_of_floor + map.nbr_of_basement;
+  }
+
+  static void DrawDungeonMapsEditor(ScreenEditor* editor) {
+    editor->DrawDungeonMapsEditor();
+  }
+
+  static void DrawEmptyDungeonMapMethods(ScreenEditor* editor) {
+    editor->rom_backed_state_valid_ = true;
+    editor->DrawDungeonMapScreen(0);
+    editor->DrawDungeonMapsTabs();
+    editor->DrawDungeonMapsRoomGfx();
+    editor->DrawDungeonMapsEditor();
   }
 
   static absl::Status CreateTitleScreenModel(ScreenEditor* editor, Rom* rom,
@@ -368,6 +460,8 @@ struct ScopedImGuiContext {
     ctx = ImGui::CreateContext();
     ImGui::SetCurrentContext(ctx);
     ImGuiIO& io = ImGui::GetIO();
+    io.DisplaySize = ImVec2(1280, 720);
+    io.DeltaTime = 1.0f / 60.0f;
     unsigned char* pixels = nullptr;
     int width = 0;
     int height = 0;
@@ -407,6 +501,12 @@ void WriteByteAt(const std::filesystem::path& path, std::streamoff offset,
   ASSERT_TRUE(file.good());
 }
 
+void WriteWordAt(const std::filesystem::path& path, std::streamoff offset,
+                 uint16_t value) {
+  WriteByteAt(path, offset, static_cast<uint8_t>(value & 0xFF));
+  WriteByteAt(path, offset + 1, static_cast<uint8_t>(value >> 8));
+}
+
 void WriteTestRom(const std::filesystem::path& path,
                   const std::string& title = "YAZE TEST ROM") {
   std::vector<uint8_t> rom_data(512 * 1024, 0x00);
@@ -420,11 +520,24 @@ void WriteTestRom(const std::filesystem::path& path,
   ASSERT_TRUE(out.good());
 }
 
-void WriteScreenModelTestRom(const std::filesystem::path& path) {
+void WriteScreenModelTestRom(const std::filesystem::path& path,
+                             const std::string& title = "SCREEN MODEL TEST") {
   std::vector<uint8_t> rom_data(1024 * 1024, 0x00);
-  const std::string kTitle = "SCREEN MODEL TEST";
-  for (size_t i = 0; i < kTitle.size(); ++i) {
-    rom_data[0x7FC0 + i] = static_cast<uint8_t>(kTitle[i]);
+  for (size_t i = 0; i < title.size() && i < 20; ++i) {
+    rom_data[0x7FC0 + i] = static_cast<uint8_t>(title[i]);
+  }
+  std::ofstream out(path, std::ios::binary | std::ios::trunc);
+  ASSERT_TRUE(out.is_open());
+  out.write(reinterpret_cast<const char*>(rom_data.data()),
+            static_cast<std::streamsize>(rom_data.size()));
+  ASSERT_TRUE(out.good());
+}
+
+void WriteTooSmallForAssetsTestRom(const std::filesystem::path& path) {
+  std::vector<uint8_t> rom_data(512 * 1024, 0x00);
+  const std::string title = "INVALID ASSET ROM";
+  for (size_t i = 0; i < title.size() && i < 20; ++i) {
+    rom_data[0x7FC0 + i] = static_cast<uint8_t>(title[i]);
   }
   std::ofstream out(path, std::ios::binary | std::ios::trunc);
   ASSERT_TRUE(out.is_open());
@@ -2077,7 +2190,7 @@ TEST(ScreenSaveStoplossTest,
 }
 
 TEST(ScreenSaveStoplossTest,
-     RomReplacementInvalidatesCachedScreenBeforeEnabledGlobalSave) {
+     RomReplacementRefreshesLoadedScreenInPlaceBeforeEnabledGlobalSave) {
   FeatureFlagsGuard guard;
   ScopedImGuiContext imgui;
 
@@ -2091,7 +2204,7 @@ TEST(ScreenSaveStoplossTest,
   ScopedDirectoryCleanup cleanup{temp_dir};
   const auto rom_path = temp_dir / "game.sfc";
   const auto project_path = temp_dir / "game.yaze";
-  WriteTestRom(rom_path, "BEFORE SCREEN RELOAD");
+  WriteScreenModelTestRom(rom_path, "BEFORE SCREEN RELOAD");
   WriteTestProject(project_path, rom_path);
   ASSERT_OK(manager->OpenRomOrProject(project_path.string()));
 
@@ -2108,19 +2221,42 @@ TEST(ScreenSaveStoplossTest,
 
   auto* editor_set = manager->GetCurrentEditorSet();
   ASSERT_NE(editor_set, nullptr);
+  ASSERT_OK(manager->EnsureEditorAssetsLoaded(EditorType::kScreen));
   auto* screen = editor_set->GetEditorAs<ScreenEditor>(EditorType::kScreen);
   ASSERT_NE(screen, nullptr);
-  ScreenEditorSaveStoplossTestPeer::SeedCachedDungeonMapWithoutPending(screen);
-  ASSERT_EQ(ScreenEditorSaveStoplossTestPeer::DungeonMapCount(*screen), 1u);
+  ASSERT_TRUE(screen->IsRomBackedStateValid());
+  ASSERT_EQ(ScreenEditorSaveStoplossTestPeer::DungeonMapCount(*screen), 14u);
   ASSERT_FALSE(screen->HasPendingScreenChanges());
+  auto* const sheet0_before =
+      ScreenEditorSaveStoplossTestPeer::CaptureBitmapOwners(screen).sheet0;
 
-  constexpr uint8_t kReplacementFloorByte = 0xA6;
-  WriteTestRom(rom_path, "AFTER SCREEN RELOAD");
+  constexpr uint8_t kReplacementFloorByte = 0x10;
+  WriteScreenModelTestRom(rom_path, "AFTER SCREEN RELOAD");
   WriteByteAt(rom_path, zelda3::kDungeonMapFloors, kReplacementFloorByte);
+  for (int dungeon = 0; dungeon < zelda3::kNumDungeons; ++dungeon) {
+    WriteWordAt(rom_path, zelda3::kDungeonMapBossRooms + (dungeon * 2), 0xFFFF);
+  }
   ASSERT_OK(manager->ReloadProjectRom());
 
   EXPECT_EQ(editor_set->GetExistingEditor(EditorType::kScreen), screen);
-  EXPECT_EQ(ScreenEditorSaveStoplossTestPeer::DungeonMapCount(*screen), 0u);
+  EXPECT_TRUE(screen->IsRomBackedStateValid());
+  EXPECT_EQ(ScreenEditorSaveStoplossTestPeer::DungeonMapCount(*screen), 14u);
+  EXPECT_EQ(ScreenEditorSaveStoplossTestPeer::DungeonFloorCount(*screen, 0), 1);
+  EXPECT_EQ(
+      ScreenEditorSaveStoplossTestPeer::CaptureBitmapOwners(screen).sheet0,
+      sheet0_before);
+  const auto screen_index = static_cast<size_t>(EditorType::kScreen);
+  EXPECT_TRUE(session->editor_initialized[screen_index]);
+  EXPECT_TRUE(session->editor_assets_loaded[screen_index]);
+
+  // Exercise the visible panel after replacement, including the populated
+  // first floor and guarded empty states for the other synthetic dungeons.
+  ImGui::NewFrame();
+  ImGui::Begin("ScreenReloadDrawSafety");
+  ScreenEditorSaveStoplossTestPeer::DrawDungeonMapsEditor(screen);
+  ImGui::End();
+  ImGui::Render();
+
   EXPECT_TRUE(core::FeatureFlags::get().kSaveDungeonMaps);
   ASSERT_NE(manager->GetCurrentRom(), nullptr);
   ASSERT_OK(manager->GetCurrentRom()->WriteByte(0x1234, 0x5A));
@@ -2129,6 +2265,71 @@ TEST(ScreenSaveStoplossTest,
   EXPECT_EQ(ReadByteAt(rom_path, zelda3::kDungeonMapFloors),
             kReplacementFloorByte);
   EXPECT_EQ(ReadByteAt(rom_path, 0x1234), 0x5A);
+}
+
+TEST(ScreenSaveStoplossTest,
+     FailedRomReplacementRefreshesLoadedScreenAfterRollback) {
+  FeatureFlagsGuard guard;
+  ScopedImGuiContext imgui;
+
+  auto renderer = std::make_unique<gfx::NullRenderer>();
+  auto manager = std::make_unique<EditorManager>();
+  manager->Initialize(renderer.get(), "");
+  manager->SetAssetLoadMode(AssetLoadMode::kLazy);
+
+  const auto temp_dir = MakeTempFilePath("yaze_screen_replace_rollback");
+  ASSERT_TRUE(std::filesystem::create_directories(temp_dir));
+  ScopedDirectoryCleanup cleanup{temp_dir};
+  const auto rom_path = temp_dir / "game.sfc";
+  const auto project_path = temp_dir / "game.yaze";
+  WriteScreenModelTestRom(rom_path, "SCREEN ROLLBACK OLD");
+  WriteTestProject(project_path, rom_path);
+  ASSERT_OK(manager->OpenRomOrProject(project_path.string()));
+  ASSERT_OK(manager->EnsureEditorAssetsLoaded(EditorType::kScreen));
+
+  auto* session = manager->session_coordinator()->GetActiveRomSession();
+  ASSERT_NE(session, nullptr);
+  ASSERT_TRUE(session->game_data_loaded);
+  auto* editor_set = manager->GetCurrentEditorSet();
+  ASSERT_NE(editor_set, nullptr);
+  auto* screen = editor_set->GetEditorAs<ScreenEditor>(EditorType::kScreen);
+  ASSERT_NE(screen, nullptr);
+  ASSERT_TRUE(screen->IsRomBackedStateValid());
+  auto* const sheet0_before =
+      ScreenEditorSaveStoplossTestPeer::CaptureBitmapOwners(screen).sheet0;
+  Rom* const rom_before = manager->GetCurrentRom();
+
+  // This ROM passes the 512 KiB file gate but cannot load palettes,
+  // forcing ReplaceActiveSessionRom through its in-place rollback path.
+  WriteTooSmallForAssetsTestRom(rom_path);
+  const auto reload_status = manager->ReloadProjectRom();
+  EXPECT_EQ(reload_status.code(), absl::StatusCode::kOutOfRange)
+      << reload_status;
+  EXPECT_NE(std::string(reload_status.message()).find("palette"),
+            std::string::npos)
+      << reload_status;
+
+  EXPECT_EQ(manager->GetCurrentRom(), rom_before);
+  ASSERT_NE(manager->GetCurrentRom(), nullptr);
+  EXPECT_NE(manager->GetCurrentRom()->title().find("SCREEN ROLLBACK OLD"),
+            std::string::npos);
+  EXPECT_EQ(editor_set->GetExistingEditor(EditorType::kScreen), screen);
+  EXPECT_TRUE(screen->IsRomBackedStateValid());
+  EXPECT_EQ(ScreenEditorSaveStoplossTestPeer::DungeonMapCount(*screen), 14u);
+  EXPECT_EQ(
+      ScreenEditorSaveStoplossTestPeer::CaptureBitmapOwners(screen).sheet0,
+      sheet0_before);
+  const size_t screen_index = EditorTypeIndex(EditorType::kScreen);
+  EXPECT_TRUE(session->editor_initialized[screen_index]);
+  EXPECT_TRUE(session->editor_assets_loaded[screen_index]);
+  core::FeatureFlags::get().kSaveDungeonMaps = false;
+  EXPECT_TRUE(screen->Save().ok());
+
+  ImGui::NewFrame();
+  ImGui::Begin("ScreenRollbackDrawSafety");
+  ScreenEditorSaveStoplossTestPeer::DrawDungeonMapsEditor(screen);
+  ImGui::End();
+  ImGui::Render();
 }
 
 TEST(ScreenSaveStoplossTest,
@@ -2277,6 +2478,24 @@ TEST(ScreenSaveStoplossTest, DirectEditorSaveFailsClosedForEveryDomain) {
 }
 
 TEST(ScreenSaveStoplossTest,
+     InvalidStateSaveAndEmptyDungeonDrawMethodsFailClosed) {
+  ScopedImGuiContext imgui;
+  ScreenEditor editor;
+
+  const auto save_status = editor.Save();
+  EXPECT_EQ(save_status.code(), absl::StatusCode::kFailedPrecondition)
+      << save_status;
+  EXPECT_NE(std::string(save_status.message()).find("ROM-backed state"),
+            std::string::npos);
+
+  ImGui::NewFrame();
+  ImGui::Begin("EmptyDungeonMapDrawSafety");
+  ScreenEditorSaveStoplossTestPeer::DrawEmptyDungeonMapMethods(&editor);
+  ImGui::End();
+  ImGui::Render();
+}
+
+TEST(ScreenSaveStoplossTest,
      DirectTitleAndPauseMapSavesFailWithoutClearingPendingDomains) {
   ScreenEditor editor;
 
@@ -2329,13 +2548,28 @@ TEST(ScreenSaveStoplossTest, MutationUndoAndRedoRemarkEachDomainPending) {
 }
 
 TEST(ScreenSaveStoplossTest, ReloadResetClearsRomBackedStateAndHistory) {
+  ScopedTextureQueueClear texture_queue;
+  ::testing::NiceMock<yaze::test::MockRenderer> renderer;
   ScreenEditor editor;
   ScreenEditorSaveStoplossTestPeer::PrimeRomBackedState(&editor);
   ASSERT_TRUE(ScreenEditorSaveStoplossTestPeer::HasReloadResidue(editor));
+  const auto owners_before =
+      ScreenEditorSaveStoplossTestPeer::CaptureBitmapOwners(&editor);
+  ScreenEditorSaveStoplossTestPeer::QueueBitmapOwners(owners_before);
 
   ScreenEditorSaveStoplossTestPeer::ResetRomBackedStateForLoad(&editor);
 
   EXPECT_FALSE(ScreenEditorSaveStoplossTestPeer::HasReloadResidue(editor));
+  const auto owners_after =
+      ScreenEditorSaveStoplossTestPeer::CaptureBitmapOwners(&editor);
+  ScreenEditorSaveStoplossTestPeer::ExpectSameBitmapOwners(owners_before,
+                                                           owners_after);
+
+  // Process the actual queue after reset. Under ASan this catches any future
+  // reset that frees a Bitmap owner still referenced by Arena.
+  while (gfx::Arena::Get().HasPendingTextures()) {
+    gfx::Arena::Get().ProcessTextureQueue(&renderer);
+  }
 }
 
 TEST(ScreenSaveStoplossTest,

--- a/test/unit/editor/editor_manager_rom_write_policy_test.cc
+++ b/test/unit/editor/editor_manager_rom_write_policy_test.cc
@@ -43,6 +43,42 @@ class GraphicsEditorSaveStoplossTestPeer {
 
 class ScreenEditorSaveStoplossTestPeer {
  public:
+  static std::array<gui::Canvas*, 9> AllCanvases(ScreenEditor* editor) {
+    return {&editor->current_tile_canvas_,   &editor->screen_canvas_,
+            &editor->tilesheet_canvas_,      &editor->tilemap_canvas_,
+            &editor->title_bg1_canvas_,      &editor->title_bg2_canvas_,
+            &editor->title_blockset_canvas_, &editor->ow_map_canvas_,
+            &editor->ow_tileset_canvas_};
+  }
+
+  static void PrimeCanvasSelection(gui::Canvas* canvas, float seed) {
+    const ImVec2 point(seed, seed + 1.0f);
+    canvas->mutable_points()->push_back(point);
+    canvas->mutable_selected_points()->push_back(point);
+    canvas->mutable_selected_tiles()->push_back(point);
+    canvas->GetSelection().selected_points.push_back(point);
+    canvas->GetSelection().selected_tiles.push_back(point);
+    canvas->GetSelection().selected_tile_pos = point;
+    canvas->GetSelection().select_rect_active = true;
+    canvas->GetInteractionHandler().SetSelectedTilePosition(point);
+    canvas->SetSelectedTilePos(point);
+  }
+
+  static bool HasCanvasSelectionResidue(const gui::Canvas& canvas) {
+    const auto& selection = canvas.GetSelection();
+    const auto& interaction = canvas.GetInteractionHandler();
+    return !canvas.points().empty() || !canvas.selected_points().empty() ||
+           !canvas.selected_tiles().empty() ||
+           canvas.selected_tile_pos().x != -1.0f ||
+           !selection.selected_points.empty() ||
+           !selection.selected_tiles.empty() ||
+           selection.selected_tile_pos.x != -1.0f ||
+           selection.select_rect_active ||
+           interaction.GetSelectedTilePosition().x != -1.0f ||
+           !interaction.GetSelectedPoints().empty() ||
+           !interaction.GetSelectedTiles().empty();
+  }
+
   static void MarkDungeonMapModified(ScreenEditor* editor) {
     editor->MarkDungeonMapModified();
   }
@@ -121,8 +157,24 @@ class ScreenEditorSaveStoplossTestPeer {
     editor->sheets_[0] = std::make_unique<gfx::Bitmap>();
     editor->tile16_blockset_.tile_cache.CacheTile(1, gfx::Bitmap{});
     editor->tile8_tilemap_.tile_cache.CacheTile(2, gfx::Bitmap{});
-    editor->screen_canvas_.mutable_points()->push_back(ImVec2(1, 2));
-    editor->tilesheet_canvas_.mutable_points()->push_back(ImVec2(3, 4));
+    editor->inventory_->item_icons().push_back(
+        zelda3::ItemIcon{1, 2, 3, 4, "stale item"});
+    editor->inventory_->palette().AddColor(gfx::SnesColor(1));
+    editor->inventory_->bitmap().Create(1, 1, 8, std::vector<uint8_t>{1});
+    editor->inventory_->tilesheet().Create(1, 1, 8, std::vector<uint8_t>{1});
+    editor->current_mode_ = ScreenEditor::EditingMode::EDIT;
+    editor->selected_title_tile16_ = 12;
+    editor->title_h_flip_ = true;
+    editor->title_v_flip_ = true;
+    editor->title_palette_ = 3;
+    editor->show_title_bg1_ = false;
+    editor->show_title_bg2_ = false;
+    editor->selected_ow_tile_ = 13;
+    editor->ow_show_dark_world_ = true;
+    float canvas_seed = 1.0f;
+    for (auto* canvas : AllCanvases(editor)) {
+      PrimeCanvasSelection(canvas, canvas_seed++);
+    }
 
     ScreenSnapshot before;
     ScreenSnapshot after;
@@ -137,10 +189,13 @@ class ScreenEditorSaveStoplossTestPeer {
     editor->ResetRomBackedStateForLoad();
   }
 
-  static bool HasReloadResidue(const ScreenEditor& editor) {
+  static bool HasReloadResidue(ScreenEditor& editor) {
     const bool has_labels =
         std::ranges::any_of(editor.dungeon_map_labels_,
                             [](const auto& labels) { return !labels.empty(); });
+    const bool has_canvas_selection = std::ranges::any_of(
+        AllCanvases(&editor),
+        [](const auto* canvas) { return HasCanvasSelectionResidue(*canvas); });
     return !editor.dungeon_maps_.empty() || has_labels ||
            editor.undo_manager_.CanUndo() || editor.undo_manager_.CanRedo() ||
            editor.has_pending_dungeon_undo_ ||
@@ -154,9 +209,32 @@ class ScreenEditorSaveStoplossTestPeer {
            !editor.sheets_.empty() ||
            editor.tile16_blockset_.tile_cache.Size() != 0 ||
            editor.tile8_tilemap_.tile_cache.Size() != 0 ||
-           !editor.screen_canvas_.points().empty() ||
-           !editor.tilesheet_canvas_.points().empty() ||
-           editor.HasPendingScreenChanges();
+           !editor.inventory_->item_icons().empty() ||
+           editor.inventory_->palette().size() != 0 ||
+           editor.inventory_->bitmap().size() != 0 ||
+           editor.inventory_->tilesheet().size() != 0 ||
+           editor.current_mode_ != ScreenEditor::EditingMode::DRAW ||
+           editor.selected_title_tile16_ != 0 || editor.title_h_flip_ ||
+           editor.title_v_flip_ || editor.title_palette_ != 0 ||
+           !editor.show_title_bg1_ || !editor.show_title_bg2_ ||
+           editor.selected_ow_tile_ != 0 || editor.ow_show_dark_world_ ||
+           has_canvas_selection || editor.HasPendingScreenChanges();
+  }
+
+  static void SeedCachedDungeonMapWithoutPending(ScreenEditor* editor) {
+    std::array<uint8_t, zelda3::kNumRooms> rooms{};
+    rooms.fill(0x0F);
+    std::array<uint8_t, zelda3::kNumRooms> graphics{};
+    graphics.fill(0xFF);
+    editor->dungeon_maps_.emplace_back(
+        0x1234, 1, 0,
+        std::vector<std::array<uint8_t, zelda3::kNumRooms>>{rooms},
+        std::vector<std::array<uint8_t, zelda3::kNumRooms>>{graphics});
+    ClearPendingChanges(editor);
+  }
+
+  static size_t DungeonMapCount(const ScreenEditor& editor) {
+    return editor.dungeon_maps_.size();
   }
 
   static absl::Status CreateTitleScreenModel(ScreenEditor* editor, Rom* rom,
@@ -318,6 +396,15 @@ uint8_t ReadByteAt(const std::filesystem::path& path, std::streamoff offset) {
   file.read(&b, 1);
   EXPECT_TRUE(file.good());
   return static_cast<uint8_t>(b);
+}
+
+void WriteByteAt(const std::filesystem::path& path, std::streamoff offset,
+                 uint8_t value) {
+  std::fstream file(path, std::ios::binary | std::ios::in | std::ios::out);
+  ASSERT_TRUE(file.is_open());
+  file.seekp(offset, std::ios::beg);
+  file.put(static_cast<char>(value));
+  ASSERT_TRUE(file.good());
 }
 
 void WriteTestRom(const std::filesystem::path& path,
@@ -1985,7 +2072,63 @@ TEST(ScreenSaveStoplossTest,
 
   EXPECT_EQ(editor_set.GetExistingEditor(EditorType::kScreen), nullptr);
   EXPECT_FALSE(editor_set.HasPendingScreenChanges());
+  editor_set.InvalidateScreenRomBackedState();
   EXPECT_EQ(editor_set.GetExistingEditor(EditorType::kScreen), nullptr);
+}
+
+TEST(ScreenSaveStoplossTest,
+     RomReplacementInvalidatesCachedScreenBeforeEnabledGlobalSave) {
+  FeatureFlagsGuard guard;
+  ScopedImGuiContext imgui;
+
+  auto renderer = std::make_unique<gfx::NullRenderer>();
+  auto manager = std::make_unique<EditorManager>();
+  manager->Initialize(renderer.get(), "");
+  manager->SetAssetLoadMode(AssetLoadMode::kLazy);
+
+  const auto temp_dir = MakeTempFilePath("yaze_screen_replace_save");
+  ASSERT_TRUE(std::filesystem::create_directories(temp_dir));
+  ScopedDirectoryCleanup cleanup{temp_dir};
+  const auto rom_path = temp_dir / "game.sfc";
+  const auto project_path = temp_dir / "game.yaze";
+  WriteTestRom(rom_path, "BEFORE SCREEN RELOAD");
+  WriteTestProject(project_path, rom_path);
+  ASSERT_OK(manager->OpenRomOrProject(project_path.string()));
+
+  DisableRomWritesForTest();
+  core::FeatureFlags::get().kSaveDungeonMaps = true;
+  auto* project = manager->GetCurrentProject();
+  ASSERT_NE(project, nullptr);
+  project->feature_flags = core::FeatureFlags::get();
+  project->workspace_settings.backup_on_save = false;
+  project->rom_metadata.expected_hash.clear();
+  auto* session = manager->session_coordinator()->GetActiveRomSession();
+  ASSERT_NE(session, nullptr);
+  session->feature_flags = core::FeatureFlags::get();
+
+  auto* editor_set = manager->GetCurrentEditorSet();
+  ASSERT_NE(editor_set, nullptr);
+  auto* screen = editor_set->GetEditorAs<ScreenEditor>(EditorType::kScreen);
+  ASSERT_NE(screen, nullptr);
+  ScreenEditorSaveStoplossTestPeer::SeedCachedDungeonMapWithoutPending(screen);
+  ASSERT_EQ(ScreenEditorSaveStoplossTestPeer::DungeonMapCount(*screen), 1u);
+  ASSERT_FALSE(screen->HasPendingScreenChanges());
+
+  constexpr uint8_t kReplacementFloorByte = 0xA6;
+  WriteTestRom(rom_path, "AFTER SCREEN RELOAD");
+  WriteByteAt(rom_path, zelda3::kDungeonMapFloors, kReplacementFloorByte);
+  ASSERT_OK(manager->ReloadProjectRom());
+
+  EXPECT_EQ(editor_set->GetExistingEditor(EditorType::kScreen), screen);
+  EXPECT_EQ(ScreenEditorSaveStoplossTestPeer::DungeonMapCount(*screen), 0u);
+  EXPECT_TRUE(core::FeatureFlags::get().kSaveDungeonMaps);
+  ASSERT_NE(manager->GetCurrentRom(), nullptr);
+  ASSERT_OK(manager->GetCurrentRom()->WriteByte(0x1234, 0x5A));
+  ASSERT_OK(manager->SaveRom());
+
+  EXPECT_EQ(ReadByteAt(rom_path, zelda3::kDungeonMapFloors),
+            kReplacementFloorByte);
+  EXPECT_EQ(ReadByteAt(rom_path, 0x1234), 0x5A);
 }
 
 TEST(ScreenSaveStoplossTest,
@@ -2133,6 +2276,32 @@ TEST(ScreenSaveStoplossTest, DirectEditorSaveFailsClosedForEveryDomain) {
   }
 }
 
+TEST(ScreenSaveStoplossTest,
+     DirectTitleAndPauseMapSavesFailWithoutClearingPendingDomains) {
+  ScreenEditor editor;
+
+  ScreenEditorSaveStoplossTestPeer::MarkTitleScreenModified(&editor);
+  const auto title_status =
+      ScreenEditorSaveStoplossTestPeer::SaveTitleScreenToRom(&editor);
+  EXPECT_EQ(title_status.code(), absl::StatusCode::kFailedPrecondition)
+      << title_status;
+  EXPECT_TRUE(editor.HasPendingTitleScreenChanges());
+
+  ScreenEditorSaveStoplossTestPeer::MarkOverworldMapModified(&editor);
+  ScreenEditorSaveStoplossTestPeer::MarkOverworldMapPaletteModified(&editor);
+  const auto map_status =
+      ScreenEditorSaveStoplossTestPeer::SaveOverworldMapToRom(&editor);
+  EXPECT_EQ(map_status.code(), absl::StatusCode::kFailedPrecondition)
+      << map_status;
+  EXPECT_TRUE(
+      ScreenEditorSaveStoplossTestPeer::HasPendingOverworldMapTileChanges(
+          editor));
+  EXPECT_TRUE(
+      ScreenEditorSaveStoplossTestPeer::HasPendingOverworldMapPaletteChanges(
+          editor));
+  EXPECT_TRUE(editor.HasPendingOverworldMapChanges());
+}
+
 TEST(ScreenSaveStoplossTest, MutationUndoAndRedoRemarkEachDomainPending) {
   ScreenEditor dungeon_map_editor;
   ScreenEditorSaveStoplossTestPeer::CommitDungeonMapEdit(&dungeon_map_editor);
@@ -2199,21 +2368,6 @@ TEST(ScreenSaveStoplossTest,
     EXPECT_EQ(ScreenEditorSaveStoplossTestPeer::DarkWorldPaletteSize(editor),
               128u);
   }
-
-  ScreenEditorSaveStoplossTestPeer::MarkTitleScreenModified(&editor);
-  ASSERT_OK(ScreenEditorSaveStoplossTestPeer::SaveTitleScreenToRom(&editor));
-  EXPECT_FALSE(editor.HasPendingTitleScreenChanges());
-
-  ScreenEditorSaveStoplossTestPeer::MarkOverworldMapModified(&editor);
-  ScreenEditorSaveStoplossTestPeer::MarkOverworldMapPaletteModified(&editor);
-  ASSERT_OK(ScreenEditorSaveStoplossTestPeer::SaveOverworldMapToRom(&editor));
-  EXPECT_FALSE(
-      ScreenEditorSaveStoplossTestPeer::HasPendingOverworldMapTileChanges(
-          editor));
-  EXPECT_TRUE(
-      ScreenEditorSaveStoplossTestPeer::HasPendingOverworldMapPaletteChanges(
-          editor));
-  EXPECT_TRUE(editor.HasPendingOverworldMapChanges());
 }
 
 }  // namespace

--- a/test/unit/editor/editor_manager_rom_write_policy_test.cc
+++ b/test/unit/editor/editor_manager_rom_write_policy_test.cc
@@ -51,9 +51,24 @@ class ScreenEditorSaveStoplossTestPeer {
     editor->MarkDungeonMapTile16Modified();
   }
 
+  static void MarkTitleScreenModified(ScreenEditor* editor) {
+    editor->MarkTitleScreenModified();
+  }
+
+  static void MarkOverworldMapModified(ScreenEditor* editor) {
+    editor->MarkOverworldMapModified();
+  }
+
+  static void MarkOverworldMapPaletteModified(ScreenEditor* editor) {
+    editor->MarkOverworldMapPaletteModified();
+  }
+
   static void ClearPendingChanges(ScreenEditor* editor) {
     editor->pending_dungeon_map_changes_ = false;
     editor->pending_dungeon_map_tile16_changes_ = false;
+    editor->pending_title_screen_changes_ = false;
+    editor->pending_overworld_map_changes_ = false;
+    editor->pending_overworld_map_palette_changes_ = false;
   }
 
   static void CommitDungeonMapEdit(ScreenEditor* editor) {
@@ -86,6 +101,9 @@ class ScreenEditorSaveStoplossTestPeer {
         std::vector<std::array<uint8_t, zelda3::kNumRooms>>{});
     MarkDungeonMapModified(editor);
     MarkDungeonMapTile16Modified(editor);
+    MarkTitleScreenModified(editor);
+    MarkOverworldMapModified(editor);
+    MarkOverworldMapPaletteModified(editor);
     editor->has_pending_dungeon_undo_ = true;
     editor->has_pending_tile16_undo_ = true;
     editor->pending_dungeon_desc_ = "pending dungeon edit";
@@ -103,6 +121,8 @@ class ScreenEditorSaveStoplossTestPeer {
     editor->sheets_[0] = std::make_unique<gfx::Bitmap>();
     editor->tile16_blockset_.tile_cache.CacheTile(1, gfx::Bitmap{});
     editor->tile8_tilemap_.tile_cache.CacheTile(2, gfx::Bitmap{});
+    editor->screen_canvas_.mutable_points()->push_back(ImVec2(1, 2));
+    editor->tilesheet_canvas_.mutable_points()->push_back(ImVec2(3, 4));
 
     ScreenSnapshot before;
     ScreenSnapshot after;
@@ -134,7 +154,50 @@ class ScreenEditorSaveStoplossTestPeer {
            !editor.sheets_.empty() ||
            editor.tile16_blockset_.tile_cache.Size() != 0 ||
            editor.tile8_tilemap_.tile_cache.Size() != 0 ||
+           !editor.screen_canvas_.points().empty() ||
+           !editor.tilesheet_canvas_.points().empty() ||
            editor.HasPendingScreenChanges();
+  }
+
+  static absl::Status CreateTitleScreenModel(ScreenEditor* editor, Rom* rom,
+                                             zelda3::GameData* game_data) {
+    auto status = editor->title_screen_.Create(rom, game_data);
+    editor->title_screen_loaded_ = status.ok();
+    return status;
+  }
+
+  static absl::Status CreateOverworldMapModel(ScreenEditor* editor, Rom* rom) {
+    auto status = editor->ow_map_screen_.Create(rom);
+    editor->ow_map_loaded_ = status.ok();
+    return status;
+  }
+
+  static size_t TitleScreenPaletteSize(ScreenEditor& editor) {
+    return editor.title_screen_.palette().size();
+  }
+
+  static size_t LightWorldPaletteSize(ScreenEditor& editor) {
+    return editor.ow_map_screen_.lw_palette().size();
+  }
+
+  static size_t DarkWorldPaletteSize(ScreenEditor& editor) {
+    return editor.ow_map_screen_.dw_palette().size();
+  }
+
+  static absl::Status SaveTitleScreenToRom(ScreenEditor* editor) {
+    return editor->SaveTitleScreenToRom();
+  }
+
+  static absl::Status SaveOverworldMapToRom(ScreenEditor* editor) {
+    return editor->SaveOverworldMapToRom();
+  }
+
+  static bool HasPendingOverworldMapTileChanges(ScreenEditor& editor) {
+    return editor.pending_overworld_map_changes_;
+  }
+
+  static bool HasPendingOverworldMapPaletteChanges(ScreenEditor& editor) {
+    return editor.pending_overworld_map_palette_changes_;
   }
 };
 
@@ -216,6 +279,11 @@ struct ScopedGraphicsSheetRestore {
   gfx::Bitmap original;
 };
 
+struct ScopedTextureQueueClear {
+  ScopedTextureQueueClear() { gfx::Arena::Get().ClearTextureQueue(); }
+  ~ScopedTextureQueueClear() { gfx::Arena::Get().ClearTextureQueue(); }
+};
+
 struct ScopedImGuiContext {
   ImGuiContext* ctx = nullptr;
   ScopedImGuiContext() {
@@ -263,6 +331,40 @@ void WriteTestRom(const std::filesystem::path& path,
   out.write(reinterpret_cast<const char*>(rom_data.data()),
             static_cast<std::streamsize>(rom_data.size()));
   ASSERT_TRUE(out.good());
+}
+
+void WriteScreenModelTestRom(const std::filesystem::path& path) {
+  std::vector<uint8_t> rom_data(1024 * 1024, 0x00);
+  const std::string kTitle = "SCREEN MODEL TEST";
+  for (size_t i = 0; i < kTitle.size(); ++i) {
+    rom_data[0x7FC0 + i] = static_cast<uint8_t>(kTitle[i]);
+  }
+  std::ofstream out(path, std::ios::binary | std::ios::trunc);
+  ASSERT_TRUE(out.is_open());
+  out.write(reinterpret_cast<const char*>(rom_data.data()),
+            static_cast<std::streamsize>(rom_data.size()));
+  ASSERT_TRUE(out.good());
+}
+
+void PopulateTitleScreenTestGameData(zelda3::GameData* game_data) {
+  ASSERT_NE(game_data, nullptr);
+  game_data->graphics_buffer.resize(zelda3::kNumGfxSheets * 0x1000, 0x00);
+
+  gfx::SnesPalette palette;
+  for (uint16_t color = 0; color < 8; ++color) {
+    palette.AddColor(gfx::SnesColor(color));
+  }
+  auto add_palettes = [&palette](gfx::PaletteGroup* group, size_t count) {
+    ASSERT_NE(group, nullptr);
+    for (size_t i = 0; i < count; ++i) {
+      group->AddPalette(palette);
+    }
+  };
+  add_palettes(&game_data->palette_groups.overworld_main, 6);
+  add_palettes(&game_data->palette_groups.overworld_animated, 1);
+  add_palettes(&game_data->palette_groups.overworld_aux, 4);
+  add_palettes(&game_data->palette_groups.hud, 1);
+  add_palettes(&game_data->palette_groups.sprites_aux1, 2);
 }
 
 constexpr int kDungeonHeaderTablePc = 0x0F6000;
@@ -1887,7 +1989,7 @@ TEST(ScreenSaveStoplossTest,
 }
 
 TEST(ScreenSaveStoplossTest,
-     PendingMapAndTile16EditsBlockLifecycleForBothScopeStates) {
+     EveryPendingDomainBlocksLifecycleForBothScopeStates) {
   FeatureFlagsGuard guard;
   ScopedImGuiContext imgui;
 
@@ -1921,25 +2023,55 @@ TEST(ScreenSaveStoplossTest,
   constexpr uint32_t kPcOffset = 0x1234;
   constexpr uint8_t kPendingRomByte = 0xA5;
 
-  for (const bool tile16_domain : {false, true}) {
-    SCOPED_TRACE(tile16_domain ? "dungeon-map Tile16" : "dungeon map");
+  enum class PendingDomain {
+    kDungeonMap,
+    kDungeonMapTile16,
+    kTitle,
+    kOverworld,
+    kOverworldPalette
+  };
+  for (const PendingDomain domain :
+       {PendingDomain::kDungeonMap, PendingDomain::kDungeonMapTile16,
+        PendingDomain::kTitle, PendingDomain::kOverworld,
+        PendingDomain::kOverworldPalette}) {
+    SCOPED_TRACE(static_cast<int>(domain));
     ScreenEditorSaveStoplossTestPeer::ClearPendingChanges(screen);
-    if (tile16_domain) {
-      ScreenEditorSaveStoplossTestPeer::MarkDungeonMapTile16Modified(screen);
-    } else {
-      ScreenEditorSaveStoplossTestPeer::MarkDungeonMapModified(screen);
+    switch (domain) {
+      case PendingDomain::kDungeonMap:
+        ScreenEditorSaveStoplossTestPeer::MarkDungeonMapModified(screen);
+        break;
+      case PendingDomain::kDungeonMapTile16:
+        ScreenEditorSaveStoplossTestPeer::MarkDungeonMapTile16Modified(screen);
+        break;
+      case PendingDomain::kTitle:
+        ScreenEditorSaveStoplossTestPeer::MarkTitleScreenModified(screen);
+        break;
+      case PendingDomain::kOverworld:
+        ScreenEditorSaveStoplossTestPeer::MarkOverworldMapModified(screen);
+        break;
+      case PendingDomain::kOverworldPalette:
+        ScreenEditorSaveStoplossTestPeer::MarkOverworldMapPaletteModified(
+            screen);
+        break;
     }
 
     ASSERT_TRUE(editor_set->HasPendingScreenChanges());
-    EXPECT_EQ(screen->HasPendingDungeonMapChanges(), !tile16_domain);
-    EXPECT_EQ(screen->HasPendingDungeonMapTile16Changes(), tile16_domain);
+    EXPECT_EQ(screen->HasPendingDungeonMapChanges(),
+              domain == PendingDomain::kDungeonMap);
+    EXPECT_EQ(screen->HasPendingDungeonMapTile16Changes(),
+              domain == PendingDomain::kDungeonMapTile16);
+    EXPECT_EQ(screen->HasPendingTitleScreenChanges(),
+              domain == PendingDomain::kTitle);
+    EXPECT_EQ(screen->HasPendingOverworldMapChanges(),
+              domain == PendingDomain::kOverworld ||
+                  domain == PendingDomain::kOverworldPalette);
     EXPECT_TRUE(manager->session_coordinator()->IsSessionModified(
         manager->GetCurrentSessionIndex()));
 
     manager->Quit();
     ASSERT_TRUE(manager->HasPendingUnsavedSessionAction());
     EXPECT_NE(manager->GetPendingUnsavedSessionActionPrompt().find(
-                  "unapplied Screen Editor dungeon-map edits"),
+                  "unapplied Screen Editor edits"),
               std::string::npos);
     manager->CancelPendingUnsavedSessionAction();
 
@@ -1947,7 +2079,7 @@ TEST(ScreenSaveStoplossTest,
     EXPECT_EQ(autosave_status.code(), absl::StatusCode::kFailedPrecondition)
         << autosave_status;
     EXPECT_NE(std::string(autosave_status.message())
-                  .find("Screen Editor dungeon-map edits are pending"),
+                  .find("Screen Editor edits are pending"),
               std::string::npos);
 
     auto* session = manager->session_coordinator()->GetActiveRomSession();
@@ -1970,7 +2102,7 @@ TEST(ScreenSaveStoplossTest,
       EXPECT_EQ(save_status.code(), absl::StatusCode::kFailedPrecondition)
           << save_status;
       EXPECT_NE(std::string(save_status.message())
-                    .find("Screen Editor dungeon-map edits are pending"),
+                    .find("Screen Editor edits are pending"),
                 std::string::npos);
       EXPECT_NE(std::string(save_status.message())
                     .find(screen_scope_enabled ? "enabled" : "disabled"),
@@ -1983,17 +2115,22 @@ TEST(ScreenSaveStoplossTest,
   }
 }
 
-TEST(ScreenSaveStoplossTest, DirectEditorSaveFailsClosedForEitherDomain) {
+TEST(ScreenSaveStoplossTest, DirectEditorSaveFailsClosedForEveryDomain) {
   ScreenEditor editor;
 
-  ScreenEditorSaveStoplossTestPeer::MarkDungeonMapModified(&editor);
-  auto status = editor.Save();
-  EXPECT_EQ(status.code(), absl::StatusCode::kFailedPrecondition) << status;
-
-  ScreenEditorSaveStoplossTestPeer::ClearPendingChanges(&editor);
-  ScreenEditorSaveStoplossTestPeer::MarkDungeonMapTile16Modified(&editor);
-  status = editor.Save();
-  EXPECT_EQ(status.code(), absl::StatusCode::kFailedPrecondition) << status;
+  const std::array mark_pending = {
+      &ScreenEditorSaveStoplossTestPeer::MarkDungeonMapModified,
+      &ScreenEditorSaveStoplossTestPeer::MarkDungeonMapTile16Modified,
+      &ScreenEditorSaveStoplossTestPeer::MarkTitleScreenModified,
+      &ScreenEditorSaveStoplossTestPeer::MarkOverworldMapModified,
+      &ScreenEditorSaveStoplossTestPeer::MarkOverworldMapPaletteModified,
+  };
+  for (const auto mark : mark_pending) {
+    ScreenEditorSaveStoplossTestPeer::ClearPendingChanges(&editor);
+    mark(&editor);
+    const auto status = editor.Save();
+    EXPECT_EQ(status.code(), absl::StatusCode::kFailedPrecondition) << status;
+  }
 }
 
 TEST(ScreenSaveStoplossTest, MutationUndoAndRedoRemarkEachDomainPending) {
@@ -2030,6 +2167,53 @@ TEST(ScreenSaveStoplossTest, ReloadResetClearsRomBackedStateAndHistory) {
   ScreenEditorSaveStoplossTestPeer::ResetRomBackedStateForLoad(&editor);
 
   EXPECT_FALSE(ScreenEditorSaveStoplossTestPeer::HasReloadResidue(editor));
+}
+
+TEST(ScreenSaveStoplossTest,
+     RepeatedScreenModelCreateDoesNotAccumulatePaletteState) {
+  ScopedImGuiContext imgui;
+  ScopedTextureQueueClear texture_queue;
+
+  const auto rom_path = MakeTempFilePath("yaze_screen_model_reload.sfc");
+  ScopedFileCleanup cleanup{rom_path};
+  WriteScreenModelTestRom(rom_path);
+
+  Rom rom;
+  ASSERT_OK(rom.LoadFromFile(rom_path.string()));
+  zelda3::GameData game_data(&rom);
+  PopulateTitleScreenTestGameData(&game_data);
+  ScreenEditor editor(&rom);
+
+  for (int load = 0; load < 2; ++load) {
+    if (load != 0) {
+      ScreenEditorSaveStoplossTestPeer::ResetRomBackedStateForLoad(&editor);
+    }
+    ASSERT_OK(ScreenEditorSaveStoplossTestPeer::CreateTitleScreenModel(
+        &editor, &rom, &game_data));
+    ASSERT_OK(ScreenEditorSaveStoplossTestPeer::CreateOverworldMapModel(&editor,
+                                                                        &rom));
+    EXPECT_EQ(ScreenEditorSaveStoplossTestPeer::TitleScreenPaletteSize(editor),
+              64u);
+    EXPECT_EQ(ScreenEditorSaveStoplossTestPeer::LightWorldPaletteSize(editor),
+              128u);
+    EXPECT_EQ(ScreenEditorSaveStoplossTestPeer::DarkWorldPaletteSize(editor),
+              128u);
+  }
+
+  ScreenEditorSaveStoplossTestPeer::MarkTitleScreenModified(&editor);
+  ASSERT_OK(ScreenEditorSaveStoplossTestPeer::SaveTitleScreenToRom(&editor));
+  EXPECT_FALSE(editor.HasPendingTitleScreenChanges());
+
+  ScreenEditorSaveStoplossTestPeer::MarkOverworldMapModified(&editor);
+  ScreenEditorSaveStoplossTestPeer::MarkOverworldMapPaletteModified(&editor);
+  ASSERT_OK(ScreenEditorSaveStoplossTestPeer::SaveOverworldMapToRom(&editor));
+  EXPECT_FALSE(
+      ScreenEditorSaveStoplossTestPeer::HasPendingOverworldMapTileChanges(
+          editor));
+  EXPECT_TRUE(
+      ScreenEditorSaveStoplossTestPeer::HasPendingOverworldMapPaletteChanges(
+          editor));
+  EXPECT_TRUE(editor.HasPendingOverworldMapChanges());
 }
 
 }  // namespace

--- a/test/unit/editor/editor_manager_rom_write_policy_test.cc
+++ b/test/unit/editor/editor_manager_rom_write_policy_test.cc
@@ -2231,23 +2231,30 @@ TEST(ScreenSaveStoplossTest,
       ScreenEditorSaveStoplossTestPeer::CaptureBitmapOwners(screen).sheet0;
 
   constexpr uint8_t kReplacementFloorByte = 0x10;
-  WriteScreenModelTestRom(rom_path, "AFTER SCREEN RELOAD");
-  WriteByteAt(rom_path, zelda3::kDungeonMapFloors, kReplacementFloorByte);
-  for (int dungeon = 0; dungeon < zelda3::kNumDungeons; ++dungeon) {
-    WriteWordAt(rom_path, zelda3::kDungeonMapBossRooms + (dungeon * 2), 0xFFFF);
-  }
-  ASSERT_OK(manager->ReloadProjectRom());
-
-  EXPECT_EQ(editor_set->GetExistingEditor(EditorType::kScreen), screen);
-  EXPECT_TRUE(screen->IsRomBackedStateValid());
-  EXPECT_EQ(ScreenEditorSaveStoplossTestPeer::DungeonMapCount(*screen), 14u);
-  EXPECT_EQ(ScreenEditorSaveStoplossTestPeer::DungeonFloorCount(*screen, 0), 1);
-  EXPECT_EQ(
-      ScreenEditorSaveStoplossTestPeer::CaptureBitmapOwners(screen).sheet0,
-      sheet0_before);
   const auto screen_index = static_cast<size_t>(EditorType::kScreen);
-  EXPECT_TRUE(session->editor_initialized[screen_index]);
-  EXPECT_TRUE(session->editor_assets_loaded[screen_index]);
+  for (const auto mode : {AssetLoadMode::kLazy, AssetLoadMode::kFull}) {
+    SCOPED_TRACE(mode == AssetLoadMode::kLazy ? "lazy replacement"
+                                              : "full replacement");
+    manager->SetAssetLoadMode(mode);
+    WriteScreenModelTestRom(rom_path, "AFTER SCREEN RELOAD");
+    WriteByteAt(rom_path, zelda3::kDungeonMapFloors, kReplacementFloorByte);
+    for (int dungeon = 0; dungeon < zelda3::kNumDungeons; ++dungeon) {
+      WriteWordAt(rom_path, zelda3::kDungeonMapBossRooms + (dungeon * 2),
+                  0xFFFF);
+    }
+    ASSERT_OK(manager->ReloadProjectRom());
+
+    EXPECT_EQ(editor_set->GetExistingEditor(EditorType::kScreen), screen);
+    EXPECT_TRUE(screen->IsRomBackedStateValid());
+    EXPECT_EQ(ScreenEditorSaveStoplossTestPeer::DungeonMapCount(*screen), 14u);
+    EXPECT_EQ(ScreenEditorSaveStoplossTestPeer::DungeonFloorCount(*screen, 0),
+              1);
+    EXPECT_EQ(
+        ScreenEditorSaveStoplossTestPeer::CaptureBitmapOwners(screen).sheet0,
+        sheet0_before);
+    EXPECT_TRUE(session->editor_initialized[screen_index]);
+    EXPECT_TRUE(session->editor_assets_loaded[screen_index]);
+  }
 
   // Exercise the visible panel after replacement, including the populated
   // first floor and guarded empty states for the other synthetic dungeons.

--- a/test/unit/editor/gfx_group_editor_render_test.cc
+++ b/test/unit/editor/gfx_group_editor_render_test.cc
@@ -6,6 +6,8 @@
 #include "app/editor/graphics/screen_editor_internal.h"
 #include "app/gfx/core/bitmap.h"
 #include "app/gfx/resource/arena.h"
+#include "framework/mock_renderer.h"
+#include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
 namespace yaze::editor {
@@ -79,6 +81,52 @@ TEST_F(GfxGroupEditorRenderTest, InactiveButSurfacedSheetGetsActivated) {
 
   EXPECT_TRUE(sheet.is_active());
   EXPECT_EQ(gfx::Arena::Get().texture_command_queue_size(), 1u);
+}
+
+TEST_F(GfxGroupEditorRenderTest,
+       BitmapRecreationInvalidatesOldCommandsAndReplacesTextureInOrder) {
+  ::testing::NiceMock<yaze::test::MockRenderer> renderer;
+  gfx::Bitmap bitmap = MakeSheetBitmap();
+  int old_texture_storage = 0;
+  int new_texture_storage = 0;
+  auto old_texture = reinterpret_cast<gfx::TextureHandle>(&old_texture_storage);
+  auto new_texture = reinterpret_cast<gfx::TextureHandle>(&new_texture_storage);
+
+  EXPECT_CALL(renderer, CreateTexture(kSheetWidth, kSheetHeight))
+      .WillOnce(::testing::Return(old_texture));
+  EXPECT_CALL(renderer, UpdateTexture(old_texture, ::testing::Ref(bitmap)));
+  bitmap.CreateTexture();
+  gfx::Arena::Get().ProcessTextureQueue(&renderer);
+  ASSERT_EQ(bitmap.texture(), old_texture);
+  ASSERT_FALSE(gfx::Arena::Get().HasPendingTextures());
+  ASSERT_TRUE(::testing::Mock::VerifyAndClearExpectations(&renderer));
+
+  const uint32_t old_generation = bitmap.generation();
+  bitmap.UpdateTexture();  // Must become stale when Create() replaces data.
+  std::vector<uint8_t> replacement_pixels(kSheetWidth * kSheetHeight, 7);
+  bitmap.Create(kSheetWidth, kSheetHeight, kSheetDepth, replacement_pixels);
+  bitmap.CreateTexture();
+
+  EXPECT_NE(bitmap.generation(), old_generation);
+  ASSERT_EQ(bitmap.texture(), old_texture)
+      << "The old handle must remain available to deferred DESTROY";
+
+  {
+    ::testing::InSequence sequence;
+    EXPECT_CALL(renderer, DestroyTexture(old_texture));
+    EXPECT_CALL(renderer, CreateTexture(kSheetWidth, kSheetHeight))
+        .WillOnce(::testing::Return(new_texture));
+    EXPECT_CALL(renderer, UpdateTexture(new_texture, ::testing::Ref(bitmap)));
+  }
+
+  // Processing the real deferred queue (rather than inspecting it) makes this
+  // an ASan-friendly lifetime regression: stale UPDATE is discarded, then the
+  // retained Bitmap owner receives DESTROY followed by replacement CREATE.
+  gfx::Arena::Get().ProcessTextureQueue(&renderer);
+
+  EXPECT_FALSE(gfx::Arena::Get().HasPendingTextures());
+  EXPECT_EQ(bitmap.texture(), new_texture);
+  EXPECT_EQ(bitmap.vector().front(), 7);
 }
 
 // EnsureCompositeBitmapTextureQueued mirrors EnsureSheetTextureQueued but

--- a/test/unit/editor/gfx_group_editor_render_test.cc
+++ b/test/unit/editor/gfx_group_editor_render_test.cc
@@ -25,6 +25,27 @@ gfx::Bitmap MakeSheetBitmap() {
   return bmp;
 }
 
+TEST(BitmapTileExtractionTest,
+     Get16x16TileWritesCurrentOffsetAndAdvancesByTileSize) {
+  std::vector<uint8_t> pixels(16 * 16);
+  for (size_t i = 0; i < pixels.size(); ++i) {
+    pixels[i] = static_cast<uint8_t>(i);
+  }
+  gfx::Bitmap bitmap(16, 16, 8, pixels);
+
+  constexpr int kInitialOffset = 3;
+  std::vector<uint8_t> tile_data(kInitialOffset + pixels.size() + 1, 0xEE);
+  int tile_data_offset = kInitialOffset;
+
+  bitmap.Get16x16Tile(0, 0, tile_data, tile_data_offset);
+
+  EXPECT_EQ(tile_data[kInitialOffset], pixels.front());
+  EXPECT_EQ(tile_data[kInitialOffset + pixels.size() - 1], pixels.back());
+  EXPECT_EQ(tile_data[kInitialOffset - 1], 0xEE);
+  EXPECT_EQ(tile_data[kInitialOffset + pixels.size()], 0xEE);
+  EXPECT_EQ(tile_data_offset, kInitialOffset + static_cast<int>(pixels.size()));
+}
+
 class GfxGroupEditorRenderTest : public ::testing::Test {
  protected:
   void SetUp() override { gfx::Arena::Get().ClearTextureQueue(); }

--- a/test/unit/editor/gfx_group_editor_render_test.cc
+++ b/test/unit/editor/gfx_group_editor_render_test.cc
@@ -1,6 +1,7 @@
 #include "app/editor/graphics/gfx_group_editor_internal.h"
 
 #include <cstdint>
+#include <stdexcept>
 #include <vector>
 
 #include "app/editor/graphics/screen_editor_internal.h"
@@ -134,10 +135,10 @@ TEST_F(GfxGroupEditorRenderTest,
 
   {
     ::testing::InSequence sequence;
-    EXPECT_CALL(renderer, DestroyTexture(old_texture));
     EXPECT_CALL(renderer, CreateTexture(kSheetWidth, kSheetHeight))
         .WillOnce(::testing::Return(new_texture));
     EXPECT_CALL(renderer, UpdateTexture(new_texture, ::testing::Ref(bitmap)));
+    EXPECT_CALL(renderer, DestroyTexture(old_texture));
   }
 
   EXPECT_TRUE(gfx::Arena::Get().ProcessSingleTexture(&renderer));
@@ -165,21 +166,181 @@ TEST_F(GfxGroupEditorRenderTest,
 
   {
     ::testing::InSequence sequence;
-    EXPECT_CALL(renderer, DestroyTexture(old_texture));
     EXPECT_CALL(renderer, CreateTexture(kSheetWidth, kSheetHeight))
         .WillOnce(::testing::Return(intermediate_texture));
     EXPECT_CALL(renderer,
                 UpdateTexture(intermediate_texture, ::testing::Ref(bitmap)));
-    EXPECT_CALL(renderer, DestroyTexture(intermediate_texture));
+    EXPECT_CALL(renderer, DestroyTexture(old_texture));
     EXPECT_CALL(renderer, CreateTexture(kSheetWidth, kSheetHeight))
         .WillOnce(::testing::Return(final_texture));
     EXPECT_CALL(renderer, UpdateTexture(final_texture, ::testing::Ref(bitmap)));
+    EXPECT_CALL(renderer, DestroyTexture(intermediate_texture));
   }
 
   gfx::Arena::Get().ProcessTextureQueue(&renderer);
 
   EXPECT_FALSE(gfx::Arena::Get().HasPendingTextures());
   EXPECT_EQ(bitmap.texture(), final_texture);
+}
+
+TEST_F(GfxGroupEditorRenderTest,
+       SingleCreateNullRetainsOldTextureAndRetriesThroughBudgetPath) {
+  ::testing::StrictMock<yaze::test::MockRenderer> renderer;
+  gfx::Bitmap bitmap = MakeSheetBitmap();
+  int old_texture_storage = 0;
+  int new_texture_storage = 0;
+  auto old_texture = reinterpret_cast<gfx::TextureHandle>(&old_texture_storage);
+  auto new_texture = reinterpret_cast<gfx::TextureHandle>(&new_texture_storage);
+  bitmap.set_texture(old_texture);
+  bitmap.CreateTexture();
+
+  EXPECT_CALL(renderer, CreateTexture(kSheetWidth, kSheetHeight))
+      .WillOnce(::testing::Return(nullptr));
+  EXPECT_FALSE(
+      gfx::Arena::Get().ProcessTextureQueueWithBudget(&renderer, 100.0f));
+  EXPECT_EQ(bitmap.texture(), old_texture);
+  EXPECT_EQ(gfx::Arena::Get().texture_command_queue_size(), 1u);
+  ASSERT_TRUE(::testing::Mock::VerifyAndClearExpectations(&renderer));
+
+  {
+    ::testing::InSequence sequence;
+    EXPECT_CALL(renderer, CreateTexture(kSheetWidth, kSheetHeight))
+        .WillOnce(::testing::Return(new_texture));
+    EXPECT_CALL(renderer, UpdateTexture(new_texture, ::testing::Ref(bitmap)));
+    EXPECT_CALL(renderer, DestroyTexture(old_texture));
+  }
+  EXPECT_TRUE(
+      gfx::Arena::Get().ProcessTextureQueueWithBudget(&renderer, 100.0f));
+  EXPECT_FALSE(gfx::Arena::Get().HasPendingTextures());
+  EXPECT_EQ(bitmap.texture(), new_texture);
+}
+
+TEST_F(GfxGroupEditorRenderTest,
+       SingleCreateExceptionsCleanReplacementAndRetryThroughBudgetPath) {
+  ::testing::StrictMock<yaze::test::MockRenderer> renderer;
+  gfx::Bitmap bitmap = MakeSheetBitmap();
+  int old_texture_storage = 0;
+  int failed_texture_storage = 0;
+  int new_texture_storage = 0;
+  auto old_texture = reinterpret_cast<gfx::TextureHandle>(&old_texture_storage);
+  auto failed_texture =
+      reinterpret_cast<gfx::TextureHandle>(&failed_texture_storage);
+  auto new_texture = reinterpret_cast<gfx::TextureHandle>(&new_texture_storage);
+  bitmap.set_texture(old_texture);
+  bitmap.CreateTexture();
+
+  EXPECT_CALL(renderer, CreateTexture(kSheetWidth, kSheetHeight))
+      .WillOnce(::testing::Throw(std::runtime_error("create failed")));
+  EXPECT_FALSE(
+      gfx::Arena::Get().ProcessTextureQueueWithBudget(&renderer, 100.0f));
+  EXPECT_EQ(bitmap.texture(), old_texture);
+  EXPECT_EQ(gfx::Arena::Get().texture_command_queue_size(), 1u);
+  ASSERT_TRUE(::testing::Mock::VerifyAndClearExpectations(&renderer));
+
+  {
+    ::testing::InSequence sequence;
+    EXPECT_CALL(renderer, CreateTexture(kSheetWidth, kSheetHeight))
+        .WillOnce(::testing::Return(failed_texture));
+    EXPECT_CALL(renderer, UpdateTexture(failed_texture, ::testing::Ref(bitmap)))
+        .WillOnce(::testing::Throw(std::runtime_error("update failed")));
+    EXPECT_CALL(renderer, DestroyTexture(failed_texture));
+  }
+  EXPECT_FALSE(
+      gfx::Arena::Get().ProcessTextureQueueWithBudget(&renderer, 100.0f));
+  EXPECT_EQ(bitmap.texture(), old_texture);
+  EXPECT_EQ(gfx::Arena::Get().texture_command_queue_size(), 1u);
+  ASSERT_TRUE(::testing::Mock::VerifyAndClearExpectations(&renderer));
+
+  {
+    ::testing::InSequence sequence;
+    EXPECT_CALL(renderer, CreateTexture(kSheetWidth, kSheetHeight))
+        .WillOnce(::testing::Return(new_texture));
+    EXPECT_CALL(renderer, UpdateTexture(new_texture, ::testing::Ref(bitmap)));
+    EXPECT_CALL(renderer, DestroyTexture(old_texture))
+        .WillOnce(::testing::Throw(std::runtime_error("destroy failed")));
+  }
+  EXPECT_TRUE(
+      gfx::Arena::Get().ProcessTextureQueueWithBudget(&renderer, 100.0f));
+  EXPECT_FALSE(gfx::Arena::Get().HasPendingTextures());
+  EXPECT_EQ(bitmap.texture(), new_texture)
+      << "Failure to destroy the old handle must not blank the replacement";
+}
+
+TEST_F(GfxGroupEditorRenderTest, BatchCreateNullRetainsOldTextureAndRetries) {
+  ::testing::StrictMock<yaze::test::MockRenderer> renderer;
+  gfx::Bitmap bitmap = MakeSheetBitmap();
+  int old_texture_storage = 0;
+  int new_texture_storage = 0;
+  auto old_texture = reinterpret_cast<gfx::TextureHandle>(&old_texture_storage);
+  auto new_texture = reinterpret_cast<gfx::TextureHandle>(&new_texture_storage);
+  bitmap.set_texture(old_texture);
+  bitmap.CreateTexture();
+
+  EXPECT_CALL(renderer, CreateTexture(kSheetWidth, kSheetHeight))
+      .WillOnce(::testing::Return(nullptr));
+  gfx::Arena::Get().ProcessTextureQueue(&renderer);
+  EXPECT_EQ(bitmap.texture(), old_texture);
+  EXPECT_EQ(gfx::Arena::Get().texture_command_queue_size(), 1u);
+  ASSERT_TRUE(::testing::Mock::VerifyAndClearExpectations(&renderer));
+
+  {
+    ::testing::InSequence sequence;
+    EXPECT_CALL(renderer, CreateTexture(kSheetWidth, kSheetHeight))
+        .WillOnce(::testing::Return(new_texture));
+    EXPECT_CALL(renderer, UpdateTexture(new_texture, ::testing::Ref(bitmap)));
+    EXPECT_CALL(renderer, DestroyTexture(old_texture));
+  }
+  gfx::Arena::Get().ProcessTextureQueue(&renderer);
+  EXPECT_FALSE(gfx::Arena::Get().HasPendingTextures());
+  EXPECT_EQ(bitmap.texture(), new_texture);
+}
+
+TEST_F(GfxGroupEditorRenderTest,
+       BatchCreateExceptionsCleanReplacementAndRetry) {
+  ::testing::StrictMock<yaze::test::MockRenderer> renderer;
+  gfx::Bitmap bitmap = MakeSheetBitmap();
+  int old_texture_storage = 0;
+  int failed_texture_storage = 0;
+  int new_texture_storage = 0;
+  auto old_texture = reinterpret_cast<gfx::TextureHandle>(&old_texture_storage);
+  auto failed_texture =
+      reinterpret_cast<gfx::TextureHandle>(&failed_texture_storage);
+  auto new_texture = reinterpret_cast<gfx::TextureHandle>(&new_texture_storage);
+  bitmap.set_texture(old_texture);
+  bitmap.CreateTexture();
+
+  EXPECT_CALL(renderer, CreateTexture(kSheetWidth, kSheetHeight))
+      .WillOnce(::testing::Throw(std::runtime_error("create failed")));
+  gfx::Arena::Get().ProcessTextureQueue(&renderer);
+  EXPECT_EQ(bitmap.texture(), old_texture);
+  EXPECT_EQ(gfx::Arena::Get().texture_command_queue_size(), 1u);
+  ASSERT_TRUE(::testing::Mock::VerifyAndClearExpectations(&renderer));
+
+  {
+    ::testing::InSequence sequence;
+    EXPECT_CALL(renderer, CreateTexture(kSheetWidth, kSheetHeight))
+        .WillOnce(::testing::Return(failed_texture));
+    EXPECT_CALL(renderer, UpdateTexture(failed_texture, ::testing::Ref(bitmap)))
+        .WillOnce(::testing::Throw(std::runtime_error("update failed")));
+    EXPECT_CALL(renderer, DestroyTexture(failed_texture));
+  }
+  gfx::Arena::Get().ProcessTextureQueue(&renderer);
+  EXPECT_EQ(bitmap.texture(), old_texture);
+  EXPECT_EQ(gfx::Arena::Get().texture_command_queue_size(), 1u);
+  ASSERT_TRUE(::testing::Mock::VerifyAndClearExpectations(&renderer));
+
+  {
+    ::testing::InSequence sequence;
+    EXPECT_CALL(renderer, CreateTexture(kSheetWidth, kSheetHeight))
+        .WillOnce(::testing::Return(new_texture));
+    EXPECT_CALL(renderer, UpdateTexture(new_texture, ::testing::Ref(bitmap)));
+    EXPECT_CALL(renderer, DestroyTexture(old_texture))
+        .WillOnce(::testing::Throw(std::runtime_error("destroy failed")));
+  }
+  gfx::Arena::Get().ProcessTextureQueue(&renderer);
+  EXPECT_FALSE(gfx::Arena::Get().HasPendingTextures());
+  EXPECT_EQ(bitmap.texture(), new_texture)
+      << "Failure to destroy the old handle must not blank the replacement";
 }
 
 // EnsureCompositeBitmapTextureQueued mirrors EnsureSheetTextureQueued but

--- a/test/unit/editor/gfx_group_editor_render_test.cc
+++ b/test/unit/editor/gfx_group_editor_render_test.cc
@@ -59,11 +59,12 @@ TEST_F(GfxGroupEditorRenderTest, TexturelessSheetGetsCreateQueued) {
          "ones without consulting the caller.";
 }
 
-TEST_F(GfxGroupEditorRenderTest, RepeatedCallsKeepQueuingWhileTextureMissing) {
+TEST_F(GfxGroupEditorRenderTest,
+       RepeatedCallsQueueReplacementSafeCreatesWhileTextureMissing) {
   // The Arena drains commands in ProcessTextureQueue; until that runs the
   // sheet still has no texture, so calling the helper again still queues.
-  // This is acceptable: ProcessTextureQueue is idempotent on duplicate
-  // CREATE entries for the same bitmap.
+  // This is safe but not free: each CREATE replaces any texture installed by
+  // an earlier CREATE, destroying that texture before allocating another.
   gfx::Bitmap sheet = MakeSheetBitmap();
 
   internal::EnsureSheetTextureQueued(sheet);
@@ -84,32 +85,52 @@ TEST_F(GfxGroupEditorRenderTest, InactiveButSurfacedSheetGetsActivated) {
 }
 
 TEST_F(GfxGroupEditorRenderTest,
-       BitmapRecreationInvalidatesOldCommandsAndReplacesTextureInOrder) {
-  ::testing::NiceMock<yaze::test::MockRenderer> renderer;
+       BitmapRecreationInvalidatesOldCommandsAndPreservesTextureForUpdate) {
+  ::testing::StrictMock<yaze::test::MockRenderer> renderer;
   gfx::Bitmap bitmap = MakeSheetBitmap();
   int old_texture_storage = 0;
-  int new_texture_storage = 0;
   auto old_texture = reinterpret_cast<gfx::TextureHandle>(&old_texture_storage);
-  auto new_texture = reinterpret_cast<gfx::TextureHandle>(&new_texture_storage);
-
-  EXPECT_CALL(renderer, CreateTexture(kSheetWidth, kSheetHeight))
-      .WillOnce(::testing::Return(old_texture));
-  EXPECT_CALL(renderer, UpdateTexture(old_texture, ::testing::Ref(bitmap)));
-  bitmap.CreateTexture();
-  gfx::Arena::Get().ProcessTextureQueue(&renderer);
-  ASSERT_EQ(bitmap.texture(), old_texture);
-  ASSERT_FALSE(gfx::Arena::Get().HasPendingTextures());
-  ASSERT_TRUE(::testing::Mock::VerifyAndClearExpectations(&renderer));
+  bitmap.set_texture(old_texture);
 
   const uint32_t old_generation = bitmap.generation();
   bitmap.UpdateTexture();  // Must become stale when Create() replaces data.
   std::vector<uint8_t> replacement_pixels(kSheetWidth * kSheetHeight, 7);
   bitmap.Create(kSheetWidth, kSheetHeight, kSheetDepth, replacement_pixels);
-  bitmap.CreateTexture();
+  bitmap.UpdateTexture();
 
   EXPECT_NE(bitmap.generation(), old_generation);
   ASSERT_EQ(bitmap.texture(), old_texture)
-      << "The old handle must remain available to deferred DESTROY";
+      << "Recreation must retain the texture so UPDATE can reuse it";
+  EXPECT_CALL(renderer, DestroyTexture(::testing::_)).Times(0);
+  EXPECT_CALL(renderer, CreateTexture(::testing::_, ::testing::_)).Times(0);
+  EXPECT_CALL(renderer, UpdateTexture(old_texture, ::testing::Ref(bitmap)))
+      .Times(1);
+
+  // The pre-recreation UPDATE is stale; only the UPDATE stamped with the new
+  // generation reaches the retained texture.
+  gfx::Arena::Get().ProcessTextureQueue(&renderer);
+
+  EXPECT_FALSE(gfx::Arena::Get().HasPendingTextures());
+  EXPECT_EQ(bitmap.texture(), old_texture);
+  EXPECT_EQ(bitmap.vector().front(), 7);
+}
+
+TEST_F(GfxGroupEditorRenderTest,
+       BitmapRecreationCreateReplacesTextureInSingleQueuePath) {
+  ::testing::StrictMock<yaze::test::MockRenderer> renderer;
+  gfx::Bitmap bitmap = MakeSheetBitmap();
+  int old_texture_storage = 0;
+  int new_texture_storage = 0;
+  auto old_texture = reinterpret_cast<gfx::TextureHandle>(&old_texture_storage);
+  auto new_texture = reinterpret_cast<gfx::TextureHandle>(&new_texture_storage);
+  bitmap.set_texture(old_texture);
+
+  std::vector<uint8_t> replacement_pixels(kSheetWidth * kSheetHeight, 7);
+  bitmap.Create(kSheetWidth, kSheetHeight, kSheetDepth, replacement_pixels);
+  bitmap.CreateTexture();
+
+  ASSERT_EQ(bitmap.texture(), old_texture)
+      << "CREATE processing, not Bitmap::Create, owns texture replacement";
 
   {
     ::testing::InSequence sequence;
@@ -119,14 +140,46 @@ TEST_F(GfxGroupEditorRenderTest,
     EXPECT_CALL(renderer, UpdateTexture(new_texture, ::testing::Ref(bitmap)));
   }
 
-  // Processing the real deferred queue (rather than inspecting it) makes this
-  // an ASan-friendly lifetime regression: stale UPDATE is discarded, then the
-  // retained Bitmap owner receives DESTROY followed by replacement CREATE.
-  gfx::Arena::Get().ProcessTextureQueue(&renderer);
+  EXPECT_TRUE(gfx::Arena::Get().ProcessSingleTexture(&renderer));
 
   EXPECT_FALSE(gfx::Arena::Get().HasPendingTextures());
   EXPECT_EQ(bitmap.texture(), new_texture);
   EXPECT_EQ(bitmap.vector().front(), 7);
+}
+
+TEST_F(GfxGroupEditorRenderTest,
+       DuplicateCreateCommandsDestroyEachReplacedTextureInBatchPath) {
+  ::testing::StrictMock<yaze::test::MockRenderer> renderer;
+  gfx::Bitmap bitmap = MakeSheetBitmap();
+  int old_texture_storage = 0;
+  int intermediate_texture_storage = 0;
+  int final_texture_storage = 0;
+  auto old_texture = reinterpret_cast<gfx::TextureHandle>(&old_texture_storage);
+  auto intermediate_texture =
+      reinterpret_cast<gfx::TextureHandle>(&intermediate_texture_storage);
+  auto final_texture =
+      reinterpret_cast<gfx::TextureHandle>(&final_texture_storage);
+  bitmap.set_texture(old_texture);
+  bitmap.CreateTexture();
+  bitmap.CreateTexture();
+
+  {
+    ::testing::InSequence sequence;
+    EXPECT_CALL(renderer, DestroyTexture(old_texture));
+    EXPECT_CALL(renderer, CreateTexture(kSheetWidth, kSheetHeight))
+        .WillOnce(::testing::Return(intermediate_texture));
+    EXPECT_CALL(renderer,
+                UpdateTexture(intermediate_texture, ::testing::Ref(bitmap)));
+    EXPECT_CALL(renderer, DestroyTexture(intermediate_texture));
+    EXPECT_CALL(renderer, CreateTexture(kSheetWidth, kSheetHeight))
+        .WillOnce(::testing::Return(final_texture));
+    EXPECT_CALL(renderer, UpdateTexture(final_texture, ::testing::Ref(bitmap)));
+  }
+
+  gfx::Arena::Get().ProcessTextureQueue(&renderer);
+
+  EXPECT_FALSE(gfx::Arena::Get().HasPendingTextures());
+  EXPECT_EQ(bitmap.texture(), final_texture);
 }
 
 // EnsureCompositeBitmapTextureQueued mirrors EnsureSheetTextureQueued but
@@ -187,10 +240,10 @@ TEST_F(GfxGroupEditorRenderTest,
 }
 
 TEST_F(GfxGroupEditorRenderTest,
-       EnsureCompositeBitmapPinsPurposeWithoutQueueingTwice) {
-  // Repeated calls before the queue drains keep queueing CREATE (the Arena's
-  // CREATE branch is idempotent on duplicates), but each call still stamps
-  // purpose. This is the slice-1 contract; slice-7 inherits it.
+       EnsureCompositeBitmapPinsPurposeAcrossReplacementSafeCreates) {
+  // Repeated calls before the queue drains keep queueing CREATE. Arena safely
+  // replaces the texture for each command, though callers should avoid the
+  // duplicate allocation work when they can. Each call still stamps purpose.
   gfx::Bitmap composite = MakeCompositeBitmap();
 
   internal::EnsureCompositeBitmapTextureQueued(composite);


### PR DESCRIPTION
## Summary
- fail closed when Screen Editor-owned ROM domains are pending across save, autosave, close/switch/quit, backup restore, and ROM reload paths
- keep pending-state queries lazy/non-materializing and disable direct Title/Pause-map/Tile16 write bypasses until those serializers can participate safely
- preserve Screen asset owners across ROM replacement and rehydrate them on both success and rollback
- make Bitmap/Arena texture recreation queue-safe and transactional so failed replacement attempts retain the installed texture for retry

## Stack
- depends on #195
- currently targets `codex/minecart-overlay-project-dirty`; retarget to `master` after #195 merges

## Verification
- Screen stop-loss tests: 10/10 passed
- Gfx replacement/render tests: 15/15 passed
- combined Screen/Gfx/Minecart merge suite: 52/52 passed
- focused EditorManager lifecycle tests: 7/7 passed
- repository pre-push: build, 13/13 smoke tests, formatting, and 40/40 UI regressions passed
- independent merge and texture-lifecycle reviews found no blocking issues

## Intentional follow-ups
- direct Title and Pause/Overworld-map ROM writes remain disabled until write/reopen/readback serializers are complete
- floor/basement map model validity remains deferred
- the pre-existing global raw queued `Bitmap*` owner-lifetime risk and unobservable non-throwing renderer upload failures are not expanded by this change

## Sanitizer note
The local `mac-asan` executable could not link because that preset currently omits required Abseil libraries after compiling 973 objects; focused and normal Debug verification above passed, with no source-specific sanitizer compiler failure.
