### PR TITLE
Load the full Turtle Rock pipe tile payload

### DIFF
--- a/src/zelda3/dungeon/object_parser.cc
+++ b/src/zelda3/dungeon/object_parser.cc
@@ -747,15 +747,15 @@ int ObjectParser::GetSubtype3TileCount(int16_t object_id) const {
     return 24;
   }
   // Turtle Rock pipes: 24 tiles (proven from routine bodies, not just
-  // dimensions table). DrawVerticalTurtleRockPipe (0xFBA, 0xFBB at
-  // special_routines.cc:430-437) draws two stacked 4x3 sections, reading
-  // tiles[0..11] then tiles[12..23]. DrawHorizontalTurtleRockPipe
-  // (0xFBC, 0xFBD at special_routines.cc:439-441) calls DrawNx4 with
-  // columns=6, which reads a 6x4 column-major block (tiles[0..23]).
+  // dimensions table). DrawVerticalTurtleRockPipe (0xFBA, 0xFBB) draws two
+  // stacked 4x3 sections, reading tiles[0..11] then tiles[12..23].
+  // DrawHorizontalTurtleRockPipe (0xFBC, 0xFBD, 0xFDC / ASM 0x25C) calls
+  // DrawNx4 with columns=6, which reads a 6x4 column-major block
+  // (tiles[0..23]).
   // Without this case the parser fell through to the default 8 and
   // TileAtWrapped substituted tiles[0..7] for indices 8..23 -- same
   // failure mode Waterfall47/48 had before e9938002.
-  if (object_id >= 0xFBA && object_id <= 0xFBD) {
+  if ((object_id >= 0xFBA && object_id <= 0xFBD) || object_id == 0xFDC) {
     return 24;
   }
   // Utility 6x3 (18 tiles)

--- a/test/unit/zelda3/dungeon/object_drawer_registry_replay_test.cc
+++ b/test/unit/zelda3/dungeon/object_drawer_registry_replay_test.cc
@@ -2827,6 +2827,24 @@ TEST(ObjectDrawerRegistryReplayTest,
 }
 
 TEST(ObjectDrawerRegistryReplayTest,
+     TurtleRockPipe25CDrawsAllTwentyFourTilesWithoutWrapping) {
+  ScopedCustomObjectsFlag disable_custom(false);
+
+  constexpr int kX = 10;
+  constexpr int kY = 12;
+  constexpr uint16_t kFirstTile = 0x0240;
+  const auto trace = ReplayObjectTrace(
+      /*object_id=*/0x0FDC, kX, kY, /*size=*/0, RoomObject::LayerType::BG1,
+      MakeSequentialTiles(/*count=*/24, /*start_tile_id=*/kFirstTile));
+
+  const auto bg1 = FilterTraceByLayer(trace, RoomObject::LayerType::BG1);
+  ExpectTraceMatchesSnapshot(
+      bg1, MakeColumnMajorSnapshot(kX, kY, /*width=*/6, /*height=*/4,
+                                   /*start_tile_id=*/kFirstTile));
+  EXPECT_TRUE(FilterTraceByLayer(trace, RoomObject::LayerType::BG2).empty());
+}
+
+TEST(ObjectDrawerRegistryReplayTest,
      VerticalJumpLedgesDrawOneTileForSizePlusEightRows) {
   ScopedCustomObjectsFlag disable_custom(false);
 

--- a/test/unit/zelda3/dungeon/object_drawing_comprehensive_test.cc
+++ b/test/unit/zelda3/dungeon/object_drawing_comprehensive_test.cc
@@ -163,9 +163,9 @@ int ExpectedSubtype3TileCount(int id) {
   if (id == 0xFCB || id == 0xFF6 || id == 0xFF7) {
     return 24;
   }
-  // Turtle Rock pipes: 24 tiles (matches GetSubtype3TileCount; routine
-  // bodies at special_routines.cc:430-441 read tiles[0..23]).
-  if (id >= 0xFBA && id <= 0xFBD) {
+  // Turtle Rock pipes: 24 tiles (matches GetSubtype3TileCount; the vertical
+  // and horizontal routine bodies read tiles[0..23]).
+  if ((id >= 0xFBA && id <= 0xFBD) || id == 0xFDC) {
     return 24;
   }
   if (id == 0xFCD || id == 0xFDD) {

--- a/test/unit/zelda3/object_parser_test.cc
+++ b/test/unit/zelda3/object_parser_test.cc
@@ -594,15 +594,15 @@ TEST_F(ObjectParserTest, TurtleRockPipesProvideTwentyFourTiles) {
   // - 0xFBA, 0xFBB -> kVerticalTurtleRockPipe (102):
   //     special_routines.cc:430-437 stacks two 4x3 sections, reading
   //     tiles[0..11] then tiles[12..23] -> 24 tiles.
-  // - 0xFBC, 0xFBD -> kHorizontalTurtleRockPipe (103):
-  //     special_routines.cc:439-441 calls DrawNx4(columns=6, start=0)
+  // - 0xFBC, 0xFBD, 0xFDC (ASM 0x25C) -> kHorizontalTurtleRockPipe (103):
+  //     DrawHorizontalTurtleRockPipe calls DrawNx4(columns=6, start=0),
   //     which reads a 6x4 column-major block -> 24 tiles.
   // Before the GetSubtype3TileCount special case landed, the parser
   // defaulted to 8 and TileAtWrapped substituted tiles[0..7] for
   // indices 8..23, mis-tiling the pipe sections. Pin the count via
   // both the ParseObject and GetObjectDrawInfo paths so neither
   // surface can regress to the wrap-substitution failure mode.
-  for (int id : {0xFBA, 0xFBB, 0xFBC, 0xFBD}) {
+  for (int id : {0xFBA, 0xFBB, 0xFBC, 0xFBD, 0xFDC}) {
     SCOPED_TRACE(::testing::Message() << "object_id=0x" << std::hex << id);
 
     auto parsed = parser_->ParseObject(id);


### PR DESCRIPTION
## Summary
- load the full 24-word tile payload for Yaze object `0xFDC` (ALTTP/ASM object `0x25C`)
- keep Type 3 count expectations aligned with the parser
- pin the 6x4 column-major draw trace so all 24 tiles are consumed without wrapping

## Root cause
Yaze already routes object `0xFDC` to `kHorizontalTurtleRockPipe`, but `ObjectParser::GetSubtype3TileCount()` only special-cased `0xFBA`-`0xFBD`. FDC therefore fell through to the default eight-word payload. `TileAtWrapped` then recycled words 0-7 for draw indices 8-23, silently corrupting the pipe preview.

USDASM provides both sides of the proof:
- the Type 3 routine table maps ASM object `0x25C` to `RoomDraw_HorizontalTurtleRockPipe` at `$0186A8`
- `RoomDraw_HorizontalTurtleRockPipe` loads six columns and jumps to `RoomDraw_Nx4` at `$019AA3`, consuming a 6x4 / 24-word payload

## Verification
- `ObjectParserTest.TurtleRockPipesProvideTwentyFourTiles`
- `ObjectDrawingComprehensiveTest.DetectsType3Objects`
- `ObjectDrawerRegistryReplayTest.TurtleRockPipe25CDrawsAllTwentyFourTilesWithoutWrapping`
- `git diff --check HEAD^ HEAD`

All three focused tests passed. No GUI or emulator verification was run; coverage is parser plus headless draw trace.
