### PR TITLE
Correct fixed-payload dungeon object parity

### DIFF
--- a/src/zelda3/dungeon/draw_routines/draw_routine_registry.cc
+++ b/src/zelda3/dungeon/draw_routines/draw_routine_registry.cc
@@ -504,7 +504,7 @@ void DrawRoutineRegistry::BuildObjectMapping() {
   object_to_routine_map_[0xFF8] = 109;
   object_to_routine_map_[0xFF9] = 30;
   object_to_routine_map_[0xFFA] = 16;
-  object_to_routine_map_[0xFFB] = 106;
+  object_to_routine_map_[0xFFB] = DrawRoutineIds::kVitreousGooDamage;
   for (int id = 0xFFC; id <= 0xFFE; id++) {
     object_to_routine_map_[id] = 110;
   }

--- a/src/zelda3/dungeon/draw_routines/draw_routine_registry.cc
+++ b/src/zelda3/dungeon/draw_routines/draw_routine_registry.cc
@@ -397,7 +397,7 @@ void DrawRoutineRegistry::BuildObjectMapping() {
   object_to_routine_map_[0x13C] = 16;
   object_to_routine_map_[0x13D] = 30;
   object_to_routine_map_[0x13E] = 100;
-  object_to_routine_map_[0x13F] = 16;
+  object_to_routine_map_[0x13F] = DrawRoutineIds::kMagicBatAltar;
 
   // Subtype 3 Object Mappings (0xF80-0xFFF)
   object_to_routine_map_[0xF80] = 94;

--- a/src/zelda3/dungeon/draw_routines/draw_routine_registry.h
+++ b/src/zelda3/dungeon/draw_routines/draw_routine_registry.h
@@ -90,6 +90,7 @@ constexpr int kSmithyFurnace = 127;
 constexpr int kBigGrayRock = 128;
 constexpr int kAgahnimsAltar = 129;
 constexpr int kFortuneTellerRoom = 131;
+constexpr int kMagicBatAltar = 132;
 
 // Corner routines (19, 35-37, 75-78)
 constexpr int kCorner4x4 = 19;

--- a/src/zelda3/dungeon/draw_routines/draw_routine_registry.h
+++ b/src/zelda3/dungeon/draw_routines/draw_routine_registry.h
@@ -91,6 +91,7 @@ constexpr int kBigGrayRock = 128;
 constexpr int kAgahnimsAltar = 129;
 constexpr int kFortuneTellerRoom = 131;
 constexpr int kMagicBatAltar = 132;
+constexpr int kVitreousGooDamage = 133;
 
 // Corner routines (19, 35-37, 75-78)
 constexpr int kCorner4x4 = 19;

--- a/src/zelda3/dungeon/draw_routines/special_routines.cc
+++ b/src/zelda3/dungeon/draw_routines/special_routines.cc
@@ -655,6 +655,22 @@ void DrawBossShell4x4(const DrawContext& ctx) {
   Draw4x4ColumnMajor(ctx, /*x_offset=*/0, /*y_offset=*/0, /*start_index=*/0);
 }
 
+void DrawVitreousGooDamage(const DrawContext& ctx) {
+  // USDASM RoomDraw_VitreousGooDamage ($01A809) invokes
+  // RoomDraw_A_Many32x32Blocks twice with A=5, moving the second call four
+  // tile rows down. The routine reads neither object size nor room state and
+  // writes through the currently selected layer's tilemap pointers.
+  if (ctx.tiles.size() < 8)
+    return;
+
+  for (int block_y = 0; block_y < 2; ++block_y) {
+    for (int block_x = 0; block_x < 5; ++block_x) {
+      DrawMany32x32Block(ctx.target_bg, ctx.object.x_ + block_x * 4,
+                         ctx.object.y_ + block_y * 4, ctx.tiles);
+    }
+  }
+}
+
 void DrawSolidWallDecor3x4(const DrawContext& ctx) {
   // ASM: RoomDraw_SolidWallDecor3x4 ($0199EC) -> RoomDraw_Nx4 with A=3.
   DrawNx4(ctx, /*columns=*/3, /*start_index=*/0);
@@ -1970,6 +1986,17 @@ void RegisterSpecialRoutines(std::vector<DrawRoutineInfo>& registry) {
       .draws_to_both_bgs = false,
       .base_width = 4,
       .base_height = 4,
+      .category = DrawRoutineInfo::Category::Special,
+  });
+
+  registry.push_back(DrawRoutineInfo{
+      .id = DrawRoutineIds::kVitreousGooDamage,  // 133
+      .name = "VitreousGooDamage",
+      .function = DrawVitreousGooDamage,
+      .draws_to_both_bgs = false,
+      .base_width = 20,
+      .base_height = 8,
+      .min_tiles = 8,
       .category = DrawRoutineInfo::Category::Special,
   });
 

--- a/src/zelda3/dungeon/draw_routines/special_routines.cc
+++ b/src/zelda3/dungeon/draw_routines/special_routines.cc
@@ -564,6 +564,16 @@ void DrawFortuneTellerRoom(const DrawContext& ctx) {
   }
 }
 
+void DrawMagicBatAltar(const DrawContext& ctx) {
+  // USDASM's final subtype-2 entry is object 0x13F (table index 0x3F), not a
+  // subtype-3 0x2xx object. RoomDraw_MagicBatAltar ($019A12) advances through
+  // eight source columns, reading seven words down each column from obj2086.
+  if (ctx.tiles.size() < 56)
+    return;
+
+  DrawColumnMajor(ctx.target_bg, ctx.object.x_, ctx.object.y_, 8, 7, ctx.tiles);
+}
+
 void DrawUtility3x5(const DrawContext& ctx) {
   // ASM: RoomDraw_Utility3x5 ($01A194) uses:
   // - top row: tiles 0..2
@@ -2111,6 +2121,17 @@ void RegisterSpecialRoutines(std::vector<DrawRoutineInfo>& registry) {
       .base_width = 14,
       .base_height = 14,
       .min_tiles = 26,
+      .category = DrawRoutineInfo::Category::Special,
+  });
+
+  registry.push_back(DrawRoutineInfo{
+      .id = DrawRoutineIds::kMagicBatAltar,  // 132
+      .name = "MagicBatAltar",
+      .function = DrawMagicBatAltar,
+      .draws_to_both_bgs = false,
+      .base_width = 8,
+      .base_height = 7,
+      .min_tiles = 56,
       .category = DrawRoutineInfo::Category::Special,
   });
 

--- a/src/zelda3/dungeon/draw_routines/special_routines.h
+++ b/src/zelda3/dungeon/draw_routines/special_routines.h
@@ -151,6 +151,13 @@ void DrawAgahnimsAltar(const DrawContext& ctx);
 void DrawFortuneTellerRoom(const DrawContext& ctx);
 
 /**
+ * @brief Draw the fixed 8x7 Magic Bat altar in column-major order
+ *
+ * ASM: subtype-2 object 0x13F, RoomDraw_MagicBatAltar ($019A12)
+ */
+void DrawMagicBatAltar(const DrawContext& ctx);
+
+/**
  * @brief Draw utility 3x5 pattern (special row pattern)
  *
  * ASM: RoomDraw_Utility3x5 ($01A194)

--- a/src/zelda3/dungeon/draw_routines/special_routines.h
+++ b/src/zelda3/dungeon/draw_routines/special_routines.h
@@ -207,6 +207,13 @@ void DrawFloorLight(const DrawContext& ctx);
 void DrawBossShell4x4(const DrawContext& ctx);
 
 /**
+ * @brief Draw the fixed 5x2 grid of repeated 4x4 Vitreous goo stamps
+ *
+ * ASM: subtype-3 object 0x27B, RoomDraw_VitreousGooDamage ($01A809)
+ */
+void DrawVitreousGooDamage(const DrawContext& ctx);
+
+/**
  * @brief Draw solid wall decor 3x4
  *
  * ASM: RoomDraw_SolidWallDecor3x4 ($0199EC)

--- a/src/zelda3/dungeon/object_dimensions.cc
+++ b/src/zelda3/dungeon/object_dimensions.cc
@@ -918,7 +918,8 @@ void ObjectDimensionTable::InitializeDefaults() {
   // Boss shells (single 4x4)
   dimensions_[0xF95] = {4, 4, Dir::None, 0, false};
   dimensions_[0xFF2] = {4, 4, Dir::None, 0, false};
-  dimensions_[0xFFB] = {4, 4, Dir::None, 0, false};
+  // Vitreous goo damage (fixed 5x2 grid of repeated 4x4 stamps)
+  dimensions_[0xFFB] = {20, 8, Dir::None, 0, false};
   // Auto/straight stairs (fixed 4x4)
   for (int id = 0xF9B; id <= 0xFA1; id++) {
     dimensions_[id] = {4, 4, Dir::None, 0, false};

--- a/src/zelda3/dungeon/object_dimensions.cc
+++ b/src/zelda3/dungeon/object_dimensions.cc
@@ -876,8 +876,8 @@ void ObjectDimensionTable::InitializeDefaults() {
   // 0x13D: Table 4x3 (repeatable with 8-tile spacing)
   dimensions_[0x13D] = {4, 3, Dir::Horizontal, 8, false};
   dimensions_[0x13E] = {6, 3, Dir::None, 0, false};  // Utility 6x3
-  // 0x13F: Magic Bat Altar (repeatable 4x4)
-  dimensions_[0x13F] = {4, 4, Dir::Horizontal, 4, false};
+  // 0x13F: Magic Bat altar (fixed 8x7; subtype 2 has no size nibble)
+  dimensions_[0x13F] = {8, 7, Dir::None, 0, false};
 
   // ============================================================================
   // Subtype 3 objects (0xF80-0xFFF)

--- a/src/zelda3/dungeon/object_drawer.cc
+++ b/src/zelda3/dungeon/object_drawer.cc
@@ -1245,7 +1245,7 @@ void ObjectDrawer::InitializeDrawRoutines() {
                                        tiles, state);
       });
 
-  // Routine 106 - Boss Shell 4x4 (Type 3 objects 0x272, 0x27B, 0xF95)
+  // Routine 106 - Boss Shell 4x4 (Yaze 0xF95/0xFF2; ASM 0x215/0x272)
   draw_routines_.push_back(
       [](ObjectDrawer* self, const RoomObject& obj, gfx::BackgroundBuffer& bg,
          std::span<const gfx::TileInfo> tiles, const DungeonState* state) {
@@ -1476,6 +1476,14 @@ void ObjectDrawer::InitializeDrawRoutines() {
          std::span<const gfx::TileInfo> tiles, const DungeonState* state) {
         self->DrawUsingRegistryRoutine(DrawRoutineIds::kMagicBatAltar, obj, bg,
                                        tiles, state);
+      };
+
+  ensure_index(DrawRoutineIds::kVitreousGooDamage);
+  draw_routines_[DrawRoutineIds::kVitreousGooDamage] =
+      [](ObjectDrawer* self, const RoomObject& obj, gfx::BackgroundBuffer& bg,
+         std::span<const gfx::TileInfo> tiles, const DungeonState* state) {
+        self->DrawUsingRegistryRoutine(DrawRoutineIds::kVitreousGooDamage, obj,
+                                       bg, tiles, state);
       };
 
   // Routine 130 - Custom Object (Oracle of Secrets 0x31, 0x32)
@@ -3189,6 +3197,11 @@ std::pair<int, int> yaze::zelda3::ObjectDrawer::CalculateObjectDimensions(
     case 106:  // BossShell4x4
       width = 32;
       height = 32;
+      break;
+
+    case DrawRoutineIds::kVitreousGooDamage:
+      width = 160;
+      height = 64;
       break;
 
     case 107:  // SolidWallDecor3x4

--- a/src/zelda3/dungeon/object_drawer.cc
+++ b/src/zelda3/dungeon/object_drawer.cc
@@ -1470,6 +1470,14 @@ void ObjectDrawer::InitializeDrawRoutines() {
                                        bg, tiles, state);
       };
 
+  ensure_index(DrawRoutineIds::kMagicBatAltar);
+  draw_routines_[DrawRoutineIds::kMagicBatAltar] =
+      [](ObjectDrawer* self, const RoomObject& obj, gfx::BackgroundBuffer& bg,
+         std::span<const gfx::TileInfo> tiles, const DungeonState* state) {
+        self->DrawUsingRegistryRoutine(DrawRoutineIds::kMagicBatAltar, obj, bg,
+                                       tiles, state);
+      };
+
   // Routine 130 - Custom Object (Oracle of Secrets 0x31, 0x32)
   // Uses external binary files instead of ROM tile data.
   // Requires CustomObjectManager initialization and enable_custom_objects flag.
@@ -3276,6 +3284,11 @@ std::pair<int, int> yaze::zelda3::ObjectDrawer::CalculateObjectDimensions(
     case DrawRoutineIds::kFortuneTellerRoom:
       width = 112;
       height = 112;
+      break;
+
+    case DrawRoutineIds::kMagicBatAltar:
+      width = 64;
+      height = 56;
       break;
 
     default:

--- a/src/zelda3/dungeon/object_parser.cc
+++ b/src/zelda3/dungeon/object_parser.cc
@@ -709,8 +709,13 @@ int ObjectParser::GetSubtype3TileCount(int16_t object_id) const {
     return 16;
   }
   // Boss shells (4x4)
-  if (object_id == 0xF95 || object_id == 0xFF2 || object_id == 0xFFB) {
+  if (object_id == 0xF95 || object_id == 0xFF2) {
     return 16;
+  }
+  // Vitreous goo damage reuses one 8-word 4x2 source stamp across a fixed
+  // 5x2 grid of 4x4 destinations.
+  if (object_id == 0xFFB) {
+    return 8;
   }
   // Auto stairs (4x4)
   if ((object_id >= 0xF9B && object_id <= 0xF9D) || object_id == 0xFB3) {

--- a/src/zelda3/dungeon/object_parser.cc
+++ b/src/zelda3/dungeon/object_parser.cc
@@ -585,11 +585,16 @@ int ObjectParser::GetSubtype2TileCount(int16_t object_id) const {
   if (object_id == 0x11F || object_id == 0x120) {
     return 4;
   }
-  // 4x4 fixed patterns (stairs/altars/walls)
+  // 4x4 fixed patterns (stairs/walls)
   if (object_id == 0x11C || object_id == 0x124 || object_id == 0x125 ||
       object_id == 0x129 || (object_id >= 0x12D && object_id <= 0x133) ||
-      object_id == 0x13C || object_id == 0x13F) {
+      object_id == 0x13C) {
     return 16;
+  }
+  // Magic Bat altar is subtype-2 object 0x13F (table index 0x3F).
+  // RoomDraw_MagicBatAltar consumes eight columns of seven words from obj2086.
+  if (object_id == 0x13F) {
+    return 56;
   }
   // Water hop stairs use a fixed 4x2 pattern.
   if (object_id == 0x135 || object_id == 0x136) {

--- a/test/unit/zelda3/dungeon/object_dimensions_test.cc
+++ b/test/unit/zelda3/dungeon/object_dimensions_test.cc
@@ -496,6 +496,40 @@ TEST_F(ObjectDimensionTableTest,
   }
 }
 
+TEST_F(ObjectDimensionTableTest, MagicBatAltarUsesFixedEightBySevenBounds) {
+  auto& table = ObjectDimensionTable::Get();
+  ASSERT_TRUE(table.LoadFromRom(rom_.get()).ok());
+  EXPECT_EQ(table.GetBaseDimensions(0x13F), std::make_pair(8, 7));
+
+  for (uint8_t size : {uint8_t{0x00}, uint8_t{0x03}, uint8_t{0x0F},
+                       uint8_t{0xF0}, uint8_t{0xFF}}) {
+    SCOPED_TRACE(::testing::Message() << "size=" << static_cast<int>(size));
+
+    const auto [width, height] = table.GetDimensions(0x13F, size);
+    EXPECT_EQ(width, 8);
+    EXPECT_EQ(height, 7);
+
+    const auto selection = table.GetSelectionBounds(0x13F, size);
+    EXPECT_EQ(selection.offset_x, 0);
+    EXPECT_EQ(selection.offset_y, 0);
+    EXPECT_EQ(selection.width, 8);
+    EXPECT_EQ(selection.height, 7);
+
+    const RoomObject object(0x13F, 0, 0, size, 0);
+    const auto geometry = ObjectGeometry::Get().MeasureByObjectId(object);
+    ASSERT_TRUE(geometry.ok());
+    EXPECT_EQ(geometry->min_x_tiles, 0);
+    EXPECT_EQ(geometry->min_y_tiles, 0);
+    EXPECT_EQ(geometry->width_tiles, 8);
+    EXPECT_EQ(geometry->height_tiles, 7);
+
+    const auto [legacy_width, legacy_height] =
+        ObjectDrawer(rom_.get(), 0).CalculateObjectDimensions(object);
+    EXPECT_EQ(legacy_width, 64);
+    EXPECT_EQ(legacy_height, 56);
+  }
+}
+
 TEST_F(ObjectDimensionTableTest,
        BigWallDecorAliasesUseFixedEightByThreeBounds) {
   auto& table = ObjectDimensionTable::Get();

--- a/test/unit/zelda3/dungeon/object_dimensions_test.cc
+++ b/test/unit/zelda3/dungeon/object_dimensions_test.cc
@@ -531,6 +531,41 @@ TEST_F(ObjectDimensionTableTest, MagicBatAltarUsesFixedEightBySevenBounds) {
 }
 
 TEST_F(ObjectDimensionTableTest,
+       VitreousGooDamageUsesFixedTwentyByEightBounds) {
+  auto& table = ObjectDimensionTable::Get();
+  ASSERT_TRUE(table.LoadFromRom(rom_.get()).ok());
+  EXPECT_EQ(table.GetBaseDimensions(0xFFB), std::make_pair(20, 8));
+
+  for (uint8_t size : {uint8_t{0x00}, uint8_t{0x03}, uint8_t{0x0E},
+                       uint8_t{0x0F}, uint8_t{0xF0}, uint8_t{0xFF}}) {
+    SCOPED_TRACE(::testing::Message() << "size=" << static_cast<int>(size));
+
+    const auto [width, height] = table.GetDimensions(0xFFB, size);
+    EXPECT_EQ(width, 20);
+    EXPECT_EQ(height, 8);
+
+    const auto selection = table.GetSelectionBounds(0xFFB, size);
+    EXPECT_EQ(selection.offset_x, 0);
+    EXPECT_EQ(selection.offset_y, 0);
+    EXPECT_EQ(selection.width, 20);
+    EXPECT_EQ(selection.height, 8);
+
+    const RoomObject object(0xFFB, 0, 0, size, 0);
+    const auto geometry = ObjectGeometry::Get().MeasureByObjectId(object);
+    ASSERT_TRUE(geometry.ok());
+    EXPECT_EQ(geometry->min_x_tiles, 0);
+    EXPECT_EQ(geometry->min_y_tiles, 0);
+    EXPECT_EQ(geometry->width_tiles, 20);
+    EXPECT_EQ(geometry->height_tiles, 8);
+
+    const auto [legacy_width, legacy_height] =
+        ObjectDrawer(rom_.get(), 0).CalculateObjectDimensions(object);
+    EXPECT_EQ(legacy_width, 160);
+    EXPECT_EQ(legacy_height, 64);
+  }
+}
+
+TEST_F(ObjectDimensionTableTest,
        BigWallDecorAliasesUseFixedEightByThreeBounds) {
   auto& table = ObjectDimensionTable::Get();
   ASSERT_TRUE(table.LoadFromRom(rom_.get()).ok());

--- a/test/unit/zelda3/dungeon/object_drawer_registry_replay_test.cc
+++ b/test/unit/zelda3/dungeon/object_drawer_registry_replay_test.cc
@@ -363,6 +363,37 @@ TEST(ObjectDrawerRegistryReplayTest,
   EXPECT_TRUE(FilterTraceByLayer(trace, RoomObject::LayerType::BG2).empty());
 }
 
+TEST(ObjectDrawerRegistryReplayTest,
+     MagicBatAltarDrawsFixedEightBySevenColumnMajorOnSelectedLayer) {
+  ScopedCustomObjectsFlag disable_custom(false);
+
+  constexpr int kX = 10;
+  constexpr int kY = 12;
+  constexpr uint16_t kFirstTile = 0x0200;
+
+  for (uint8_t size : {uint8_t{0}, uint8_t{0xFF}}) {
+    for (const auto layer :
+         {RoomObject::LayerType::BG1, RoomObject::LayerType::BG2}) {
+      SCOPED_TRACE(::testing::Message()
+                   << "size=" << static_cast<int>(size)
+                   << " layer=" << static_cast<int>(layer));
+
+      const auto trace = ReplayObjectTrace(
+          /*object_id=*/0x013F, kX, kY, size, layer,
+          MakeSequentialTiles(/*count=*/56, /*start_tile_id=*/kFirstTile));
+      const auto bg1 = FilterTraceByLayer(trace, RoomObject::LayerType::BG1);
+      const auto bg2 = FilterTraceByLayer(trace, RoomObject::LayerType::BG2);
+      const auto& selected = layer == RoomObject::LayerType::BG1 ? bg1 : bg2;
+      const auto& other = layer == RoomObject::LayerType::BG1 ? bg2 : bg1;
+
+      ExpectTraceMatchesSnapshot(
+          selected, MakeColumnMajorSnapshot(kX, kY, /*width=*/8, /*height=*/7,
+                                            /*start_tile_id=*/kFirstTile));
+      EXPECT_TRUE(other.empty());
+    }
+  }
+}
+
 std::array<uint8_t, 0x10000> MakeOpaqueDoorGfx() {
   std::array<uint8_t, 0x10000> gfx{};
   gfx.fill(1);

--- a/test/unit/zelda3/dungeon/object_drawer_registry_replay_test.cc
+++ b/test/unit/zelda3/dungeon/object_drawer_registry_replay_test.cc
@@ -16,6 +16,7 @@
 #include "core/features.h"
 #include "rom/rom.h"
 #include "zelda3/dungeon/custom_object.h"
+#include "zelda3/dungeon/draw_routines/draw_routine_registry.h"
 #include "zelda3/dungeon/dungeon_state.h"
 #include "zelda3/dungeon/moving_wall_semantics.h"
 #include "zelda3/dungeon/object_dimensions.h"
@@ -211,6 +212,27 @@ std::vector<SnapshotTileWrite> MakeBigGrayRockSnapshot(int x, int y,
   return out;
 }
 
+std::vector<SnapshotTileWrite> MakeMany32x32BlockGridSnapshot(
+    int x, int y, int block_columns, int block_rows, uint16_t start_tile_id) {
+  std::vector<SnapshotTileWrite> out;
+  out.reserve(block_columns * block_rows * 16);
+  for (int block_y = 0; block_y < block_rows; ++block_y) {
+    for (int block_x = 0; block_x < block_columns; ++block_x) {
+      for (int repeated_rows = 0; repeated_rows < 2; ++repeated_rows) {
+        for (int row = 0; row < 2; ++row) {
+          for (int column = 0; column < 4; ++column) {
+            out.push_back(
+                {x + block_x * 4 + column,
+                 y + block_y * 4 + repeated_rows * 2 + row,
+                 static_cast<uint16_t>(start_tile_id + row * 4 + column)});
+          }
+        }
+      }
+    }
+  }
+  return out;
+}
+
 void ExpectTraceMatchesSnapshot(
     const std::vector<ObjectDrawer::TileTrace>& trace,
     const std::vector<SnapshotTileWrite>& expected) {
@@ -390,6 +412,49 @@ TEST(ObjectDrawerRegistryReplayTest,
           selected, MakeColumnMajorSnapshot(kX, kY, /*width=*/8, /*height=*/7,
                                             /*start_tile_id=*/kFirstTile));
       EXPECT_TRUE(other.empty());
+    }
+  }
+}
+
+TEST(ObjectDrawerRegistryReplayTest,
+     VitreousGooDamageDrawsFixedFiveByTwoStampGridOnSelectedLayer) {
+  ScopedCustomObjectsFlag disable_custom(false);
+
+  constexpr int kX = 6;
+  constexpr int kY = 8;
+  constexpr uint16_t kFirstTile = 0x0300;
+  FakeDungeonState inactive_state;
+
+  const auto* routine = DrawRoutineRegistry::Get().GetRoutineInfo(
+      DrawRoutineIds::kVitreousGooDamage);
+  ASSERT_NE(routine, nullptr);
+  EXPECT_EQ(routine->base_width, 20);
+  EXPECT_EQ(routine->base_height, 8);
+  EXPECT_EQ(routine->min_tiles, 8);
+  EXPECT_FALSE(routine->draws_to_both_bgs);
+
+  const auto expected = MakeMany32x32BlockGridSnapshot(
+      kX, kY, /*block_columns=*/5, /*block_rows=*/2, kFirstTile);
+  for (uint8_t size : {uint8_t{0}, uint8_t{0x0E}, uint8_t{0xFF}}) {
+    for (const auto layer :
+         {RoomObject::LayerType::BG1, RoomObject::LayerType::BG2}) {
+      for (const bool use_state : {false, true}) {
+        SCOPED_TRACE(::testing::Message()
+                     << "size=" << static_cast<int>(size) << " layer="
+                     << static_cast<int>(layer) << " use_state=" << use_state);
+
+        const auto trace = ReplayObjectTrace(
+            /*object_id=*/0x0FFB, kX, kY, size, layer,
+            MakeSequentialTiles(/*count=*/8, /*start_tile_id=*/kFirstTile),
+            use_state ? &inactive_state : nullptr);
+        const auto bg1 = FilterTraceByLayer(trace, RoomObject::LayerType::BG1);
+        const auto bg2 = FilterTraceByLayer(trace, RoomObject::LayerType::BG2);
+        const auto& selected = layer == RoomObject::LayerType::BG1 ? bg1 : bg2;
+        const auto& other = layer == RoomObject::LayerType::BG1 ? bg2 : bg1;
+
+        ExpectTraceMatchesSnapshot(selected, expected);
+        EXPECT_TRUE(other.empty());
+      }
     }
   }
 }

--- a/test/unit/zelda3/dungeon/object_drawing_comprehensive_test.cc
+++ b/test/unit/zelda3/dungeon/object_drawing_comprehensive_test.cc
@@ -68,8 +68,11 @@ int ExpectedSubtype2TileCount(int id) {
     return 4;
   }
   if (id == 0x11C || id == 0x124 || id == 0x125 || id == 0x129 ||
-      (id >= 0x12D && id <= 0x133) || id == 0x13C || id == 0x13F) {
+      (id >= 0x12D && id <= 0x133) || id == 0x13C) {
     return 16;
+  }
+  if (id == 0x13F) {
+    return 56;
   }
   if (id == 0x135 || id == 0x136) {
     return 8;

--- a/test/unit/zelda3/dungeon/object_drawing_comprehensive_test.cc
+++ b/test/unit/zelda3/dungeon/object_drawing_comprehensive_test.cc
@@ -133,8 +133,11 @@ int ExpectedSubtype3TileCount(int id) {
   if (id == 0xFC8 || id == 0xFE6 || id == 0xFEB || id == 0xFFA) {
     return 16;
   }
-  if (id == 0xF95 || id == 0xFF2 || id == 0xFFB) {
+  if (id == 0xF95 || id == 0xFF2) {
     return 16;
+  }
+  if (id == 0xFFB) {
+    return 8;
   }
   if ((id >= 0xF9B && id <= 0xF9D) || id == 0xFB3) {
     return 16;

--- a/test/unit/zelda3/object_parser_test.cc
+++ b/test/unit/zelda3/object_parser_test.cc
@@ -892,6 +892,24 @@ TEST_F(ObjectParserTest, MarioPortraitUsesFullFourByTwoPayload) {
   EXPECT_EQ(tiles->size(), 8u);
 }
 
+TEST_F(ObjectParserTest, MagicBatAltarUsesFiftySixTilesAndDedicatedRoutine) {
+  auto& registry = zelda3::DrawRoutineRegistry::Get();
+  EXPECT_EQ(registry.GetRoutineIdForObject(0x13F),
+            zelda3::DrawRoutineIds::kMagicBatAltar);
+
+  const auto subtype = parser_->GetObjectSubtype(0x13F);
+  ASSERT_TRUE(subtype.ok());
+  EXPECT_EQ(subtype->max_tile_count, 56);
+
+  const auto parsed = parser_->ParseObject(0x13F);
+  ASSERT_TRUE(parsed.ok());
+  EXPECT_EQ(parsed->size(), 56u);
+
+  const auto info = parser_->GetObjectDrawInfo(0x13F);
+  EXPECT_EQ(info.tile_count, 56);
+  EXPECT_EQ(info.draw_routine_id, zelda3::DrawRoutineIds::kMagicBatAltar);
+}
+
 TEST_F(ObjectParserTest, EnabledStarSwitchAndLitTorchUseFixedTwoByTwoPayload) {
   auto& registry = zelda3::DrawRoutineRegistry::Get();
 

--- a/test/unit/zelda3/object_parser_test.cc
+++ b/test/unit/zelda3/object_parser_test.cc
@@ -910,6 +910,37 @@ TEST_F(ObjectParserTest, MagicBatAltarUsesFiftySixTilesAndDedicatedRoutine) {
   EXPECT_EQ(info.draw_routine_id, zelda3::DrawRoutineIds::kMagicBatAltar);
 }
 
+TEST_F(ObjectParserTest, VitreousGooDamageUsesEightTilesAndDedicatedRoutine) {
+  constexpr uint16_t kVitreousGooOffset = 0x1060;
+  auto* data = mock_rom_->mutable_data();
+  const int table_address = zelda3::kRoomObjectSubtype3 + (0xFFB - 0xF80) * 2;
+  data[table_address] = static_cast<uint8_t>(kVitreousGooOffset & 0xFF);
+  data[table_address + 1] = static_cast<uint8_t>(kVitreousGooOffset >> 8);
+
+  auto& registry = zelda3::DrawRoutineRegistry::Get();
+  EXPECT_EQ(registry.GetRoutineIdForObject(0xFFB),
+            zelda3::DrawRoutineIds::kVitreousGooDamage);
+
+  const auto subtype = parser_->GetObjectSubtype(0xFFB);
+  ASSERT_TRUE(subtype.ok());
+  EXPECT_EQ(subtype->max_tile_count, 8);
+
+  const auto parsed = parser_->ParseObject(0xFFB);
+  ASSERT_TRUE(parsed.ok());
+  EXPECT_EQ(parsed->size(), 8u);
+
+  const auto ranges = parser_->ResolveTileReadRanges(0xFFB);
+  ASSERT_TRUE(ranges.ok()) << ranges.status();
+  EXPECT_THAT(*ranges, ::testing::ElementsAre(zelda3::ObjectTileReadRange{
+                           zelda3::kRoomObjectTileAddress + kVitreousGooOffset,
+                           zelda3::kRoomObjectTileAddress + kVitreousGooOffset +
+                               8 * 2}));
+
+  const auto info = parser_->GetObjectDrawInfo(0xFFB);
+  EXPECT_EQ(info.tile_count, 8);
+  EXPECT_EQ(info.draw_routine_id, zelda3::DrawRoutineIds::kVitreousGooDamage);
+}
+
 TEST_F(ObjectParserTest, EnabledStarSwitchAndLitTorchUseFixedTwoByTwoPayload) {
   auto& registry = zelda3::DrawRoutineRegistry::Get();
 


### PR DESCRIPTION
## Summary

- give the Magic Bat altar (`0x13F`) a dedicated fixed 8x7 column-major draw routine backed by its complete 56-word payload
- correct Vitreous goo (`0xFFB` / ASM `0x27B`) to read only its 8-word payload and replay the two 5-stamp bands as a fixed 20x8 footprint
- add focused parser, dimension, comprehensive-count, selected-layer, and exact ordered-write replay coverage for both objects

This is one coherent fixed-payload dungeon-object parity batch. It is based directly on `master`, does not depend on the Turtle Rock pipe PR, and contains no `.github/workflows/**` changes.

## Root cause and impact

Both objects were routed through generic approximations instead of their USDASM routines. Magic Bat therefore lacked its exact 56-tile altar layout. Vitreous read 16 words even though its source ends after 8, crossing into the next object payload, and rendered as a generic 4x4 shell instead of two rows of five repeated stamps.

The editor now loads the bounded source payloads, reports fixed selection bounds, and produces deterministic selected-layer output that matches the game routine rather than a size-scaled approximation.

## Evidence matrix

| Yaze ID | ASM identity | Source span | Expected draw | Cross-editor result | Authority used |
|---|---|---|---|---|---|
| `0x13F` Magic Bat altar | type-2 `0x13F`, `RoomDraw_MagicBatAltar` | `obj2086` to `obj20F6`, 56 words | fixed 8x7, column-major, selected layer | ZScream agrees; Hyrule Magic reads 56 tiles but incorrectly collapses them to 1x7 because its destination column does not advance | USDASM pointer/data/routine boundaries |
| `0xFFB` Vitreous goo | subtype-3 index `0x7B`, ASM `0x27B`, `RoomDraw_VitreousGooDamage` | `obj1060` to `obj1070`, 8 words, PC `[0x2BB2,0x2BC2)` | two bands of five repeated 4x4 stamps; fixed 20x8, selected layer | Hyrule Magic agrees; ZScream loops ten stamps per band and incorrectly renders 40x8 | USDASM routine at `$01A809` and helper behavior |

## Validation

- built `yaze_test_unit` from the exact PR branch with `cmake --build --preset mac-ai --target yaze_test_unit -j8`
- 8 focused parser, dimensions, comprehensive-count, and ordered replay tests passed
- repository pre-push gate passed: build, 13 unit smoke tests, formatting; UI regression correctly skipped because no UI/workflow files changed
- `git diff --check origin/master..HEAD` passed
- `clang-format --dry-run --Werror` passed for all 11 changed C/C++ files
- `scripts/validate-yaze.sh` passed a ZScream golden-ROM self-comparison; a negative control reported 17 differences, confirming the comparator is active
- a disposable Hyrule Magic-derived ROM loaded and reopened twice without hash drift (`22559c76fe31bd861805a9f85d9384fda6cfe6ff363a72dd729751b033bf9a6e`)
- isolated Mesen runtime capture hit `$019A12` and `$01A809`; routine-only WRAM diffs matched Magic Bat 8x7/56-word and Vitreous 20x8/160-write output with zero missing, extra, or mismatched tile bytes (full provenance in the PR comment)

## Known validation limits

- current ZScream golden fixtures compare ROM regions and do not contain these two objects, so the exact render proof comes from USDASM plus ordered-write unit replay rather than the golden-ROM harness
- headless Hyrule Magic save/reopen is not available through the current `z3ed` command surface; GUI save/reopen remains a manual compatibility check on a disposable copy
- no ROM-writing path changes in this batch


