### PR TITLE
Unblock Oracle D6 qualification gates

### DIFF
--- a/src/zelda3/dungeon/track_collision_generator.cc
+++ b/src/zelda3/dungeon/track_collision_generator.cc
@@ -9,6 +9,7 @@
 
 #include "absl/status/status.h"
 #include "absl/strings/str_format.h"
+#include "core/features.h"
 #include "rom/snes.h"
 #include "rom/write_fence.h"
 #include "util/macro.h"
@@ -214,13 +215,30 @@ DimensionService::DimensionResult ResolveTrackObjectDimensions(
     const DimensionService& dimension_service) {
   auto dims = dimension_service.GetDimensions(obj);
 
-  // In CLI-only contexts, custom object feature flags are often disabled.
-  // Object 0x31 may then map through DrawNothing and collapse to a 1x1
-  // footprint. Track assets are authored as 2x2 pieces, so recover a stable
-  // fallback here to avoid sparse/gapped collision generation.
-  if (obj.id_ == static_cast<int16_t>(options.track_object_id) &&
-      dims.offset_x_tiles == 0 && dims.offset_y_tiles == 0 &&
-      dims.width_tiles == 1 && dims.height_tiles == 1) {
+  // Object 0x31's size byte selects a custom-object subtype; it is not a
+  // vanilla width/height nibble. Without project custom-object geometry,
+  // DimensionService falls through to that vanilla interpretation and gives
+  // non-zero subtypes incorrect variable-width footprints. Oracle's track
+  // assets are all authored as 2x2 pieces, so use that canonical footprint in
+  // the project-free CLI path. Configured non-0x31 track IDs continue to use
+  // DimensionService normally.
+  const bool is_canonical_oos_track =
+      obj.id_ == 0x31 &&
+      obj.id_ == static_cast<int16_t>(options.track_object_id);
+  if (is_canonical_oos_track &&
+      !core::FeatureFlags::get().kEnableCustomObjects) {
+    dims.offset_x_tiles = 0;
+    dims.offset_y_tiles = 0;
+    dims.width_tiles = kFallbackTrackFootprintWidthTiles;
+    dims.height_tiles = kFallbackTrackFootprintHeightTiles;
+    return dims;
+  }
+
+  // Also recover when custom objects are enabled but a configured subtype has
+  // no loaded payload and therefore measures as the 1x1 fallback.
+  if (is_canonical_oos_track && dims.offset_x_tiles == 0 &&
+      dims.offset_y_tiles == 0 && dims.width_tiles == 1 &&
+      dims.height_tiles == 1) {
     dims.width_tiles = kFallbackTrackFootprintWidthTiles;
     dims.height_tiles = kFallbackTrackFootprintHeightTiles;
   }

--- a/test/integration/zelda3/oracle_smoke_check_integration_test.cc
+++ b/test/integration/zelda3/oracle_smoke_check_integration_test.cc
@@ -115,21 +115,28 @@ TEST_F(OracleSmokeCheckIntegrationTest, StrictReadinessReportsD4D3Readiness) {
   EXPECT_TRUE(checks.value("d3_kalyxo_castle", json::object()).contains("ok"));
 }
 
-TEST_F(OracleSmokeCheckIntegrationTest, D6GoronMinesAuditAlwaysOk) {
-  // The D6 minecart audit never exits non-zero (issues are informational).
-  // Verify d6.ok=true and the command exit status is ok.
+TEST_F(OracleSmokeCheckIntegrationTest,
+       D6GoronMinesAuditReportsOkIndependently) {
+  // Aggregate smoke status can fail for an unrelated D4 structural gap or a
+  // strict-readiness gap. The formatter still returns the complete JSON
+  // report, so qualify the D6 audit from its own result instead.
   cli::handlers::OracleSmokeCheckCommandHandler handler;
   std::string out;
   const auto status = handler.Run({"--format=json"}, &rom_, &out);
-  ASSERT_TRUE(status.ok()) << out;
+  ASSERT_TRUE(status.ok() ||
+              status.code() == absl::StatusCode::kFailedPrecondition)
+      << "Unexpected smoke handler status: " << status << "\n"
+      << out;
 
   const auto doc = json::parse(out, nullptr, false);
-  ASSERT_FALSE(doc.is_discarded());
-  EXPECT_TRUE(GetSmoke(doc)
-                  .value("checks", json::object())
-                  .value("d6_goron_mines", json::object())
-                  .value("ok", false))
+  ASSERT_FALSE(doc.is_discarded()) << out;
+  const auto& d6 = GetSmoke(doc)
+                       .value("checks", json::object())
+                       .value("d6_goron_mines", json::object());
+  ASSERT_TRUE(d6.contains("ok")) << out;
+  EXPECT_TRUE(d6.value("ok", false))
       << "D6 minecart audit reported ok=false on real ROM: " << out;
+  EXPECT_EQ(d6.value("track_rooms_found", -1), 4) << out;
 }
 
 TEST_F(OracleSmokeCheckIntegrationTest, ReportFileContainsAllCheckKeys) {

--- a/test/unit/zelda3/dungeon/track_collision_generator_test.cc
+++ b/test/unit/zelda3/dungeon/track_collision_generator_test.cc
@@ -1,6 +1,7 @@
 #include "zelda3/dungeon/track_collision_generator.h"
 
 #include <algorithm>
+#include <array>
 #include <cstdint>
 #include <initializer_list>
 #include <utility>
@@ -8,13 +9,32 @@
 
 #include <gtest/gtest.h>
 
+#include "core/features.h"
 #include "rom/snes.h"
 #include "zelda3/dungeon/dimension_service.h"
+#include "zelda3/dungeon/draw_routines/draw_routine_registry.h"
 #include "zelda3/dungeon/dungeon_rom_addresses.h"
 #include "zelda3/dungeon/room.h"
 
 namespace yaze::zelda3 {
 namespace {
+
+class ScopedCustomObjectsFlag {
+ public:
+  explicit ScopedCustomObjectsFlag(bool enabled)
+      : previous_(core::FeatureFlags::get().kEnableCustomObjects) {
+    core::FeatureFlags::get().kEnableCustomObjects = enabled;
+    DrawRoutineRegistry::Get().RefreshFeatureFlagMappings();
+  }
+
+  ~ScopedCustomObjectsFlag() {
+    core::FeatureFlags::get().kEnableCustomObjects = previous_;
+    DrawRoutineRegistry::Get().RefreshFeatureFlagMappings();
+  }
+
+ private:
+  bool previous_;
+};
 
 int CountExpectedTilesInBounds(const RoomObject& obj) {
   const auto dims = DimensionService::Get().GetDimensions(obj);
@@ -88,24 +108,50 @@ TEST(TrackCollisionGeneratorTest, UsesDimensionServiceNotLegacyWidthHeight) {
   EXPECT_EQ(result.tiles_generated, expected);
 }
 
-TEST(TrackCollisionGeneratorTest, DegenerateTrackDimensionsFallbackToTwoByTwo) {
-  Room room;
-  RoomObject track_obj(0x31, 10, 10, 0, 0);
-  room.AddTileObject(track_obj);
-
-  auto result_or = GenerateTrackCollision(&room, GeneratorOptions{});
-  ASSERT_TRUE(result_or.ok()) << result_or.status();
-
-  const auto& result = result_or.value();
-  EXPECT_EQ(result.tiles_generated, 4);
+TEST(TrackCollisionGeneratorTest,
+     CanonicalTrackSubtypesFallbackToTwoByTwoWithoutCustomGeometry) {
+  ScopedCustomObjectsFlag custom_objects(/*enabled=*/false);
+  constexpr std::array<uint8_t, 16> kTrackSubtypes = {
+      0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15};
 
   const auto idx = [](int x, int y) {
     return static_cast<size_t>(y * 64 + x);
   };
+  for (const uint8_t subtype : kTrackSubtypes) {
+    SCOPED_TRACE(::testing::Message() << "subtype=" << +subtype);
+    Room room;
+    room.AddTileObject(RoomObject(0x31, 10, 10, subtype, 0));
+
+    auto result_or = GenerateTrackCollision(&room, GeneratorOptions{});
+    ASSERT_TRUE(result_or.ok()) << result_or.status();
+
+    const auto& result = result_or.value();
+    EXPECT_EQ(result.tiles_generated, 4);
+    EXPECT_NE(result.collision_map.tiles[idx(10, 10)], 0);
+    EXPECT_NE(result.collision_map.tiles[idx(11, 10)], 0);
+    EXPECT_NE(result.collision_map.tiles[idx(10, 11)], 0);
+    EXPECT_NE(result.collision_map.tiles[idx(11, 11)], 0);
+  }
+}
+
+TEST(TrackCollisionGeneratorTest,
+     ConfiguredSingleTileTrackIdPreservesOneByOneGeometry) {
+  Room room;
+  room.AddTileObject(RoomObject(0x35, 10, 10, 0, 0));
+
+  GeneratorOptions options;
+  options.track_object_id = 0x35;
+  auto result_or = GenerateTrackCollision(&room, options);
+  ASSERT_TRUE(result_or.ok()) << result_or.status();
+
+  const auto& result = result_or.value();
+  const auto idx = [](int x, int y) {
+    return static_cast<size_t>(y * 64 + x);
+  };
+  EXPECT_EQ(result.tiles_generated, 1);
   EXPECT_NE(result.collision_map.tiles[idx(10, 10)], 0);
-  EXPECT_NE(result.collision_map.tiles[idx(11, 10)], 0);
-  EXPECT_NE(result.collision_map.tiles[idx(10, 11)], 0);
-  EXPECT_NE(result.collision_map.tiles[idx(11, 11)], 0);
+  EXPECT_EQ(result.collision_map.tiles[idx(11, 10)], 0);
+  EXPECT_EQ(result.collision_map.tiles[idx(10, 11)], 0);
 }
 
 TEST(TrackCollisionGeneratorTest, LegacyWidthHeightDoesNotChangeOutput) {


### PR DESCRIPTION
## Summary

- keep Oracle's canonical minecart object `0x31` at its real 2x2 footprint when z3ed runs without loaded custom-object geometry
- preserve DimensionService geometry for configured non-`0x31` track IDs, including legitimate 1x1 objects
- make the D6 smoke integration assertion report D6 independently while still rejecting unexpected handler status classes

## Root cause

Without Oracle project context, custom objects are disabled and object `0x31` falls through to vanilla size-byte interpretation. Oracle uses that byte as a track subtype, not width/height geometry, so nonzero subtypes generated the wrong collision footprint. Room `0xB8` consequently collapsed to 132 generated tiles instead of the project-backed 202.

The D6-specific smoke test also required the aggregate Oracle smoke command to pass, so unrelated D4 structural readiness on the editable base ROM could fail a healthy D6 audit.

## Verification

- `TrackCollisionGeneratorTest.*`: 8/8 passed, including all `0x31` subtypes `0..15` and configured `0x35` 1x1 preservation
- `OracleWorkflowTest.D6*` plus the independent D6 smoke test: 4/4 passed on editable `oos168.sfc`
- independent D6 smoke test passed on patched `oos168x.sfc`
- project-free real-ROM generation now matches project-backed geometry exactly:
  - A8: 40
  - B8: 202
  - D8: 288
  - DA: 196
- current pre-push gate passed
- touched-file clang-format and `git diff --check` passed

## Scope

This is one bounded issue #115 qualification-blocker batch. It does not claim the pending GUI save/reopen or Mesen traversal proof, and it changes no workflow files.
