### PR TITLE
Qualify D6 dungeon edits through GUI save/reopen

### DIFF
--- a/cmake/dependencies/imgui.cmake
+++ b/cmake/dependencies/imgui.cmake
@@ -72,20 +72,31 @@ if(YAZE_BUILD_TESTS)
       ${IMGUI_TEST_ENGINE_DIR}/imgui_te_utils.cpp
       ${IMGUI_TEST_ENGINE_DIR}/imgui_capture_tool.cpp
     )
-    
-    add_library(ImGuiTestEngine STATIC ${IMGUI_TEST_ENGINE_SOURCES})
-    target_include_directories(ImGuiTestEngine PUBLIC 
+
+    # Compile the hook implementation into ImGui itself. Every executable that
+    # consumes a hook-enabled ImGui archive must also own these symbols; a
+    # separate downstream static library leaves non-gRPC consumers unresolved.
+    target_sources(ImGui PRIVATE ${IMGUI_TEST_ENGINE_SOURCES})
+    target_include_directories(ImGui PRIVATE
+      ${IMGUI_TEST_ENGINE_DIR}
+      ${CMAKE_SOURCE_DIR}/ext
+    )
+    target_compile_definitions(ImGui PUBLIC
+      IMGUI_ENABLE_TEST_ENGINE=1
+      IMGUI_TEST_ENGINE_ENABLE_COROUTINE_STDTHREAD_IMPL=1
+    )
+
+    # Preserve the existing target contract for tests and application
+    # libraries that explicitly link ImGuiTestEngine.
+    add_library(ImGuiTestEngine INTERFACE)
+    target_include_directories(ImGuiTestEngine INTERFACE
       ${IMGUI_DIR}
       ${IMGUI_TEST_ENGINE_DIR}
       ${CMAKE_SOURCE_DIR}/ext
     )
-    target_compile_features(ImGuiTestEngine PUBLIC cxx_std_17)
-    if(YAZE_USE_SDL3)
-      target_link_libraries(ImGuiTestEngine PUBLIC ImGui ${YAZE_SDL3_TARGETS})
-    else()
-      target_link_libraries(ImGuiTestEngine PUBLIC ImGui ${YAZE_SDL2_TARGETS})
-    endif()
-    target_compile_definitions(ImGuiTestEngine PUBLIC
+    target_compile_features(ImGuiTestEngine INTERFACE cxx_std_17)
+    target_link_libraries(ImGuiTestEngine INTERFACE ImGui)
+    target_compile_definitions(ImGuiTestEngine INTERFACE
       IMGUI_ENABLE_TEST_ENGINE=1
       IMGUI_TEST_ENGINE_ENABLE_COROUTINE_STDTHREAD_IMPL=1
     )

--- a/scripts/agents/run-d6-gui-qualification.sh
+++ b/scripts/agents/run-d6-gui-qualification.sh
@@ -15,7 +15,8 @@ Usage:
 
 The disposable project must resolve exactly to --rom. Its ROM must begin as a
 byte-identical, non-hard-linked copy of --canonical-rom. The canonical project
-and ROM are hash-checked throughout and are never passed to Yaze or z3ed.
+and ROM are hash-checked throughout and are never passed to Yaze or z3ed. The
+HTTP API port is isolated and reported, but HTTP is not used by this run.
 EOF
 }
 
@@ -112,7 +113,7 @@ done
 [[ -n "$CANONICAL_PROJECT" ]] || die 64 "--canonical-project is required"
 [[ -n "$CANONICAL_ROM" ]] || die 64 "--canonical-rom is required"
 
-for command_name in awk cp date find git jq lsof mktemp python3 shasum tr; do
+for command_name in awk cp date find git jq lsof mktemp mv python3 shasum tr; do
   command -v "$command_name" >/dev/null 2>&1 ||
     die 69 "required command not found: $command_name"
 done
@@ -904,9 +905,10 @@ wait_for_owned_listener() {
   local label="$1"
   local role="$2"
   local port="$3"
+  local timeout_seconds="${4:-30}"
   local output="$EVIDENCE_DIR/$label-$role-listener.lsof"
   local metadata="$EVIDENCE_DIR/$label-$role-listener.json"
-  local deadline=$((SECONDS + 30))
+  local deadline=$((SECONDS + timeout_seconds))
   while [[ "$SECONDS" -lt "$deadline" ]]; do
     if ! kill -0 "$YAZE_PID" 2>/dev/null; then
       return 1
@@ -934,12 +936,54 @@ wait_for_owned_listener() {
             ownership: "lsof -a -p PID -iTCP:PORT -sTCP:LISTEN",
             lsof_output: $lsof_output
           }
-        ' > "$metadata"
+        ' > "$metadata" || return 1
       return 0
     fi
     sleep 0.2
   done
   return 1
+}
+
+record_optional_api_listener() {
+  local label="$1"
+  local output="$EVIDENCE_DIR/$label-api-listener.lsof"
+  local metadata="$EVIDENCE_DIR/$label-api-listener.json"
+  local all_listeners="$EVIDENCE_DIR/$label-api-port-listeners.lsof"
+
+  if wait_for_owned_listener "$label" api "$API_PORT" 1; then
+    local updated="$metadata.tmp"
+    jq '.required_for_qualification = false' "$metadata" > "$updated" ||
+      return 1
+    mv "$updated" "$metadata" || return 1
+    return 0
+  fi
+
+  kill -0 "$YAZE_PID" 2>/dev/null || return 1
+  if lsof -nP -iTCP:"$API_PORT" -sTCP:LISTEN \
+       > "$all_listeners" 2> "$all_listeners.stderr"; then
+    return 1
+  fi
+  [[ ! -s "$all_listeners" && ! -s "$all_listeners.stderr" ]] || return 1
+  : > "$output" || return 1
+  : > "$output.stderr" || return 1
+  jq -n \
+    --arg captured_at_utc "$(date -u '+%Y-%m-%dT%H:%M:%SZ')" \
+    --arg label "$label" \
+    --arg lsof_output "$output" \
+    --argjson pid "$YAZE_PID" \
+    --argjson port "$API_PORT" '
+      {
+        captured_at_utc: $captured_at_utc,
+        launch: $label,
+        role: "api",
+        pid: $pid,
+        port: $port,
+        state: "NOT_OBSERVED",
+        required_for_qualification: false,
+        reason: "HTTP API is not exercised by the D6 GUI qualification",
+        lsof_output: $lsof_output
+      }
+    ' > "$metadata" || return 1
 }
 
 wait_for_port_free "$HARNESS_PORT" ||
@@ -1850,8 +1894,8 @@ launch_yaze() {
 
   wait_for_owned_listener "$label" harness "$HARNESS_PORT" ||
     die 70 "$label harness listener is not owned by Yaze PID $YAZE_PID"
-  wait_for_owned_listener "$label" api "$API_PORT" ||
-    die 70 "$label API listener is not owned by Yaze PID $YAZE_PID"
+  record_optional_api_listener "$label" ||
+    die 70 "$label optional API listener could not be classified safely"
   wait_for_harness "$label" ||
     die 70 "$label Yaze process did not expose the gRPC harness; see $log_file"
   wait_for_room_widget "$label" ||
@@ -2048,6 +2092,7 @@ jq -n \
     {
       status: "pass",
       completed_at_utc: $completed_at_utc,
+      http_api_required: false,
       disposable: {
         project: {path: $project, sha256: $project_sha256},
         rom: $rom,
@@ -2110,13 +2155,13 @@ jq -n \
           label: "first-launch",
           pid: $first_pid,
           harness_listener: $first_harness_listener,
-          api_listener: $first_api_listener
+          api_listener_observation: $first_api_listener
         },
         {
           label: "second-launch",
           pid: $second_pid,
           harness_listener: $second_harness_listener,
-          api_listener: $second_api_listener
+          api_listener_observation: $second_api_listener
         }
       ],
       ports: {harness: $harness_port, api: $api_port},

--- a/scripts/agents/run-d6-gui-qualification.sh
+++ b/scripts/agents/run-d6-gui-qualification.sh
@@ -1,0 +1,2154 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage:
+  scripts/agents/run-d6-gui-qualification.sh \
+    --project <disposable Oracle-of-Secrets.yaze> \
+    --rom <disposable oos168.sfc> \
+    --canonical-project <protected Oracle-of-Secrets.yaze> \
+    --canonical-rom <protected oos168.sfc> \
+    [--yaze-bin <path>] [--z3ed-bin <path>] \
+    [--harness-port <port>] [--api-port <port>] \
+    [--evidence-dir <new-or-empty-directory>]
+
+The disposable project must resolve exactly to --rom. Its ROM must begin as a
+byte-identical, non-hard-linked copy of --canonical-rom. The canonical project
+and ROM are hash-checked throughout and are never passed to Yaze or z3ed.
+EOF
+}
+
+die() {
+  local code="$1"
+  shift
+  echo "error: $*" >&2
+  exit "$code"
+}
+
+require_value() {
+  [[ $# -ge 2 && -n "$2" ]] || die 64 "missing value for $1"
+}
+
+PROJECT=""
+ROM=""
+CANONICAL_PROJECT=""
+CANONICAL_ROM=""
+YAZE_BIN=""
+Z3ED_BIN=""
+HARNESS_PORT=50052
+API_PORT=51052
+EVIDENCE_DIR=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --project)
+      require_value "$@"
+      PROJECT="$2"
+      shift 2
+      ;;
+    --project=*) PROJECT="${1#*=}"; shift ;;
+    --rom)
+      require_value "$@"
+      ROM="$2"
+      shift 2
+      ;;
+    --rom=*) ROM="${1#*=}"; shift ;;
+    --canonical-project)
+      require_value "$@"
+      CANONICAL_PROJECT="$2"
+      shift 2
+      ;;
+    --canonical-project=*) CANONICAL_PROJECT="${1#*=}"; shift ;;
+    --canonical-rom)
+      require_value "$@"
+      CANONICAL_ROM="$2"
+      shift 2
+      ;;
+    --canonical-rom=*) CANONICAL_ROM="${1#*=}"; shift ;;
+    --yaze-bin)
+      require_value "$@"
+      YAZE_BIN="$2"
+      shift 2
+      ;;
+    --yaze-bin=*) YAZE_BIN="${1#*=}"; shift ;;
+    --z3ed-bin)
+      require_value "$@"
+      Z3ED_BIN="$2"
+      shift 2
+      ;;
+    --z3ed-bin=*) Z3ED_BIN="${1#*=}"; shift ;;
+    --harness-port)
+      require_value "$@"
+      HARNESS_PORT="$2"
+      shift 2
+      ;;
+    --harness-port=*) HARNESS_PORT="${1#*=}"; shift ;;
+    --api-port)
+      require_value "$@"
+      API_PORT="$2"
+      shift 2
+      ;;
+    --api-port=*) API_PORT="${1#*=}"; shift ;;
+    --evidence-dir)
+      require_value "$@"
+      EVIDENCE_DIR="$2"
+      shift 2
+      ;;
+    --evidence-dir=*) EVIDENCE_DIR="${1#*=}"; shift ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      usage >&2
+      die 64 "unknown argument: $1"
+      ;;
+  esac
+done
+
+[[ -n "$PROJECT" ]] || die 64 "--project is required"
+[[ -n "$ROM" ]] || die 64 "--rom is required"
+[[ -n "$CANONICAL_PROJECT" ]] || die 64 "--canonical-project is required"
+[[ -n "$CANONICAL_ROM" ]] || die 64 "--canonical-rom is required"
+
+for command_name in awk cp date find git jq lsof mktemp python3 shasum tr; do
+  command -v "$command_name" >/dev/null 2>&1 ||
+    die 69 "required command not found: $command_name"
+done
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+SCRIPT_PATH="$SCRIPT_DIR/run-d6-gui-qualification.sh"
+EDIT_FIXTURE="$REPO_ROOT/test/fixtures/gui/d6_edit_and_save.json"
+REOPEN_FIXTURE="$REPO_ROOT/test/fixtures/gui/d6_reopen_assert.json"
+
+canonical_path() {
+  python3 - "$1" <<'PY'
+import os
+import sys
+
+path = os.path.realpath(sys.argv[1])
+if not os.path.exists(path):
+    raise SystemExit(1)
+print(path)
+PY
+}
+
+normalized_path() {
+  python3 - "$1" <<'PY'
+import os
+import sys
+
+print(os.path.realpath(sys.argv[1]))
+PY
+}
+
+path_is_within() {
+  python3 - "$1" "$2" <<'PY'
+import os
+import sys
+
+child = os.path.realpath(sys.argv[1])
+parent = os.path.realpath(sys.argv[2])
+try:
+    inside = os.path.commonpath([child, parent]) == parent
+except ValueError:
+    inside = False
+raise SystemExit(0 if inside else 1)
+PY
+}
+
+project_value() {
+  python3 - "$1" "$2" "$3" <<'PY'
+import configparser
+import sys
+
+parser = configparser.ConfigParser(interpolation=None, strict=False)
+parser.read(sys.argv[1])
+section, key = sys.argv[2], sys.argv[3]
+if not parser.has_option(section, key):
+    raise SystemExit(1)
+print(parser.get(section, key).strip())
+PY
+}
+
+resolve_project_path() {
+  python3 - "$1" "$2" <<'PY'
+import os
+import sys
+
+project, value = sys.argv[1], sys.argv[2]
+print(os.path.realpath(os.path.join(os.path.dirname(project), value)))
+PY
+}
+
+sha1_file() {
+  shasum "$1" | awk '{print $1}'
+}
+
+sha256_file() {
+  shasum -a 256 "$1" | awk '{print $1}'
+}
+
+PROJECT="$(canonical_path "$PROJECT")" || die 66 "project not found"
+ROM="$(canonical_path "$ROM")" || die 66 "disposable ROM not found"
+CANONICAL_PROJECT="$(canonical_path "$CANONICAL_PROJECT")" ||
+  die 66 "canonical project not found"
+CANONICAL_ROM="$(canonical_path "$CANONICAL_ROM")" ||
+  die 66 "canonical ROM not found"
+
+for required_file in "$PROJECT" "$ROM" "$CANONICAL_PROJECT" \
+  "$CANONICAL_ROM" "$EDIT_FIXTURE" "$REOPEN_FIXTURE"; do
+  [[ -f "$required_file" ]] || die 66 "required file not found: $required_file"
+done
+
+if [[ -z "$YAZE_BIN" ]]; then
+  YAZE_BIN="$("$REPO_ROOT/scripts/yaze" --which 2>/dev/null || true)"
+fi
+if [[ -z "$Z3ED_BIN" ]]; then
+  Z3ED_BIN="$("$REPO_ROOT/scripts/z3ed" --which 2>/dev/null || true)"
+fi
+[[ -n "$YAZE_BIN" ]] || die 69 "Yaze binary not found; pass --yaze-bin"
+[[ -n "$Z3ED_BIN" ]] || die 69 "z3ed binary not found; pass --z3ed-bin"
+YAZE_BIN="$(canonical_path "$YAZE_BIN")" || die 66 "Yaze binary not found"
+Z3ED_BIN="$(canonical_path "$Z3ED_BIN")" || die 66 "z3ed binary not found"
+[[ -x "$YAZE_BIN" ]] || die 66 "Yaze binary is not executable: $YAZE_BIN"
+[[ -x "$Z3ED_BIN" ]] || die 66 "z3ed binary is not executable: $Z3ED_BIN"
+
+case "$HARNESS_PORT" in
+  ''|*[!0-9]*) die 64 "--harness-port must be numeric" ;;
+esac
+case "$API_PORT" in
+  ''|*[!0-9]*) die 64 "--api-port must be numeric" ;;
+esac
+[[ "$HARNESS_PORT" -ge 1024 && "$HARNESS_PORT" -le 65535 ]] ||
+  die 64 "--harness-port must be between 1024 and 65535"
+[[ "$API_PORT" -ge 1024 && "$API_PORT" -le 65535 ]] ||
+  die 64 "--api-port must be between 1024 and 65535"
+[[ "$HARNESS_PORT" -ne "$API_PORT" ]] ||
+  die 64 "harness and API ports must differ"
+
+PROJECT_DIR="$(dirname "$PROJECT")"
+CANONICAL_PROJECT_DIR="$(dirname "$CANONICAL_PROJECT")"
+[[ "$PROJECT" != "$CANONICAL_PROJECT" ]] ||
+  die 65 "disposable and canonical project paths are identical"
+[[ "$ROM" != "$CANONICAL_ROM" ]] ||
+  die 65 "disposable and canonical ROM paths are identical"
+if [[ "$PROJECT" -ef "$CANONICAL_PROJECT" ]]; then
+  die 65 "disposable project is hard-linked to the canonical project"
+fi
+if [[ "$ROM" -ef "$CANONICAL_ROM" ]]; then
+  die 65 "disposable ROM is hard-linked to the canonical ROM"
+fi
+if path_is_within "$PROJECT_DIR" "$CANONICAL_PROJECT_DIR"; then
+  die 65 "disposable project must not be inside the canonical project tree"
+fi
+if path_is_within "$CANONICAL_PROJECT_DIR" "$PROJECT_DIR"; then
+  die 65 "canonical project must not be inside the disposable project tree"
+fi
+path_is_within "$ROM" "$PROJECT_DIR" ||
+  die 65 "disposable ROM must be inside the disposable project tree"
+path_is_within "$CANONICAL_ROM" "$CANONICAL_PROJECT_DIR" ||
+  die 65 "canonical ROM does not belong to the canonical project tree"
+[[ -w "$ROM" ]] || die 73 "disposable ROM is not writable: $ROM"
+
+TARGET_ROM_REL="$(project_value "$PROJECT" files rom_filename)" ||
+  die 65 "disposable project has no files.rom_filename"
+TARGET_MANIFEST_REL="$(project_value "$PROJECT" files hack_manifest_file)" ||
+  die 65 "disposable project has no files.hack_manifest_file"
+TARGET_BACKUP_REL="$(project_value "$PROJECT" files rom_backup_folder)" ||
+  die 65 "disposable project has no files.rom_backup_folder"
+TARGET_BUILD_REL="$(project_value "$PROJECT" build build_target)" ||
+  die 65 "disposable project has no build.build_target"
+TARGET_EXPECTED_HASH="$(project_value "$PROJECT" rom expected_hash)" ||
+  die 65 "disposable project has no rom.expected_hash"
+TARGET_ROLE="$(project_value "$PROJECT" rom role)" ||
+  die 65 "disposable project has no rom.role"
+TARGET_WRITE_POLICY="$(project_value "$PROJECT" rom write_policy)" ||
+  die 65 "disposable project has no rom.write_policy"
+TARGET_AUTOSAVE="$(project_value "$PROJECT" workspace autosave_enabled)" ||
+  die 65 "disposable project has no workspace.autosave_enabled"
+TARGET_BACKUP="$(project_value "$PROJECT" workspace backup_on_save)" ||
+  die 65 "disposable project has no workspace.backup_on_save"
+
+TARGET_PROJECT_ROM="$(resolve_project_path "$PROJECT" "$TARGET_ROM_REL")"
+TARGET_MANIFEST="$(resolve_project_path "$PROJECT" "$TARGET_MANIFEST_REL")"
+TARGET_BACKUP_DIR="$(resolve_project_path "$PROJECT" "$TARGET_BACKUP_REL")"
+TARGET_BUILD="$(resolve_project_path "$PROJECT" "$TARGET_BUILD_REL")"
+[[ "$TARGET_PROJECT_ROM" == "$ROM" ]] ||
+  die 65 "project resolves ROM to $TARGET_PROJECT_ROM, not --rom $ROM"
+[[ "$TARGET_BUILD" != "$ROM" ]] ||
+  die 65 "project build output aliases its editable ROM"
+[[ -f "$TARGET_MANIFEST" ]] ||
+  die 66 "project Hack Manifest not found: $TARGET_MANIFEST"
+path_is_within "$TARGET_MANIFEST" "$PROJECT_DIR" ||
+  die 65 "project Hack Manifest must be inside the disposable project tree"
+[[ -n "$TARGET_BACKUP_REL" ]] ||
+  die 65 "project rom_backup_folder must not be empty"
+path_is_within "$TARGET_BACKUP_DIR" "$PROJECT_DIR" ||
+  die 65 "project ROM backup folder must be inside the disposable project tree"
+if [[ -e "$TARGET_BACKUP_DIR" ]]; then
+  [[ -d "$TARGET_BACKUP_DIR" ]] ||
+    die 65 "project ROM backup path is not a directory: $TARGET_BACKUP_DIR"
+  [[ -w "$TARGET_BACKUP_DIR" ]] ||
+    die 73 "project ROM backup directory is not writable: $TARGET_BACKUP_DIR"
+else
+  [[ -w "$(dirname "$TARGET_BACKUP_DIR")" ]] ||
+    die 73 "project ROM backup parent is not writable: $TARGET_BACKUP_DIR"
+fi
+path_is_within "$TARGET_BUILD" "$PROJECT_DIR" ||
+  die 65 "project build target must be inside the disposable project tree"
+
+CANONICAL_ROM_REL="$(project_value "$CANONICAL_PROJECT" files rom_filename)" ||
+  die 65 "canonical project has no files.rom_filename"
+CANONICAL_MANIFEST_REL="$(
+  project_value "$CANONICAL_PROJECT" files hack_manifest_file
+)" || die 65 "canonical project has no files.hack_manifest_file"
+CANONICAL_PROJECT_ROM="$(resolve_project_path "$CANONICAL_PROJECT" "$CANONICAL_ROM_REL")"
+CANONICAL_MANIFEST="$(
+  resolve_project_path "$CANONICAL_PROJECT" "$CANONICAL_MANIFEST_REL"
+)"
+[[ "$CANONICAL_PROJECT_ROM" == "$CANONICAL_ROM" ]] ||
+  die 65 "canonical descriptor does not resolve to --canonical-rom"
+[[ -f "$CANONICAL_MANIFEST" ]] ||
+  die 66 "canonical Hack Manifest not found: $CANONICAL_MANIFEST"
+path_is_within "$CANONICAL_MANIFEST" "$CANONICAL_PROJECT_DIR" ||
+  die 65 "canonical Hack Manifest must be inside the canonical project tree"
+[[ "$TARGET_MANIFEST" != "$CANONICAL_MANIFEST" ]] ||
+  die 65 "disposable and canonical Hack Manifest paths are identical"
+if [[ "$TARGET_MANIFEST" -ef "$CANONICAL_MANIFEST" ]]; then
+  die 65 "disposable Hack Manifest is hard-linked to the canonical manifest"
+fi
+
+[[ "$(printf '%s' "$TARGET_ROLE" | tr '[:upper:]' '[:lower:]')" == "dev" ]] ||
+  die 65 "disposable project ROM role must be dev"
+[[ "$(printf '%s' "$TARGET_WRITE_POLICY" | tr '[:upper:]' '[:lower:]')" == "block" ]] ||
+  die 65 "disposable project write policy must be block"
+[[ "$(printf '%s' "$TARGET_AUTOSAVE" | tr '[:upper:]' '[:lower:]')" == "false" ]] ||
+  die 65 "disposable project autosave must be disabled"
+[[ "$(printf '%s' "$TARGET_BACKUP" | tr '[:upper:]' '[:lower:]')" == "true" ]] ||
+  die 65 "disposable project backup_on_save must be enabled"
+
+FEATURE_FLAG_REPORT="$(python3 - "$PROJECT" <<'PY'
+import configparser
+import json
+import sys
+
+parser = configparser.ConfigParser(interpolation=None, strict=False)
+parser.read(sys.argv[1])
+
+def parse_bool(key, *, required, default):
+    if not parser.has_option("feature_flags", key):
+        if required:
+            raise SystemExit(f"missing required feature_flags.{key}")
+        return {"present": False, "value": default, "source": "yaze_default"}
+    raw = parser.get("feature_flags", key).strip().lower()
+    if raw in {"true", "1", "yes", "on"}:
+        value = True
+    elif raw in {"false", "0", "no", "off"}:
+        value = False
+    else:
+        raise SystemExit(f"invalid boolean for feature_flags.{key}: {raw}")
+    return {"present": True, "value": value, "source": "project"}
+
+report = {
+    "save_dungeon_maps": parse_bool(
+        "save_dungeon_maps", required=True, default=False
+    ),
+    "save_graphics_sheet": parse_bool(
+        "save_graphics_sheet", required=True, default=False
+    ),
+}
+for key in (
+    "save_dungeon_objects",
+    "save_dungeon_sprites",
+    "save_dungeon_room_headers",
+    "save_dungeon_torches",
+    "save_dungeon_pits",
+    "save_dungeon_blocks",
+    "save_dungeon_collision",
+    "save_dungeon_chests",
+    "save_dungeon_pot_items",
+    "save_dungeon_entrances",
+    "save_dungeon_palettes",
+):
+    report[key] = parse_bool(key, required=False, default=True)
+
+# The native INI reader in this Yaze revision does not parse a
+# save_dungeon_water_fill_zones key. Record the actual effective default rather
+# than implying a descriptor value can disable it.
+water_fill_raw = None
+if parser.has_option("feature_flags", "save_dungeon_water_fill_zones"):
+    water_fill_raw = parser.get(
+        "feature_flags", "save_dungeon_water_fill_zones"
+    ).strip()
+report["save_dungeon_water_fill_zones"] = {
+    "present": water_fill_raw is not None,
+    "descriptor_value_ignored": water_fill_raw,
+    "value": True,
+    "source": "yaze_default_unconfigurable_in_ini",
+}
+
+if report["save_dungeon_maps"]["value"]:
+    raise SystemExit("feature_flags.save_dungeon_maps must be false")
+if report["save_graphics_sheet"]["value"]:
+    raise SystemExit("feature_flags.save_graphics_sheet must be false")
+for key in (
+    "save_dungeon_objects",
+    "save_dungeon_sprites",
+    "save_dungeon_pot_items",
+    "save_dungeon_palettes",
+):
+    if not report[key]["value"]:
+        raise SystemExit(f"feature_flags.{key} must be true when specified")
+
+unrelated_keys = (
+    "save_dungeon_room_headers",
+    "save_dungeon_torches",
+    "save_dungeon_pits",
+    "save_dungeon_blocks",
+    "save_dungeon_collision",
+    "save_dungeon_water_fill_zones",
+    "save_dungeon_chests",
+    "save_dungeon_entrances",
+    "save_dungeon_maps",
+    "save_graphics_sheet",
+)
+payload = {
+    "effective_flags": report,
+    "edited_domains_required_true": [
+        "save_dungeon_objects",
+        "save_dungeon_sprites",
+        "save_dungeon_pot_items",
+        "save_dungeon_palettes",
+    ],
+    "unrelated_enabled_domains": [
+        key for key in unrelated_keys if report[key]["value"]
+    ],
+    "runtime_override": {
+        "applied": False,
+        "descriptor_modified": False,
+        "policy": (
+            "Record effective defaults; exact ROM byte-diff containment must "
+            "reject writes from unrelated domains."
+        ),
+    },
+}
+print(json.dumps(payload, sort_keys=True))
+PY
+)" || die 65 "disposable project feature-flag save scope is unsafe"
+
+jq -e '
+  .dungeon_stream_regions.objects.strategy == "copy_on_write" and
+  .dungeon_stream_regions.sprites.strategy == "copy_on_write" and
+  .dungeon_stream_regions.pot_items.strategy == "repack_all"
+' "$TARGET_MANIFEST" >/dev/null ||
+  die 65 "Hack Manifest lacks the required dungeon stream write strategies"
+
+CANONICAL_ROM_SHA1_BEFORE="$(sha1_file "$CANONICAL_ROM")"
+CANONICAL_ROM_SHA256_BEFORE="$(sha256_file "$CANONICAL_ROM")"
+CANONICAL_PROJECT_SHA256_BEFORE="$(sha256_file "$CANONICAL_PROJECT")"
+CANONICAL_MANIFEST_SHA256_BEFORE="$(sha256_file "$CANONICAL_MANIFEST")"
+TARGET_ROM_SHA1_BEFORE="$(sha1_file "$ROM")"
+TARGET_ROM_SHA256_BEFORE="$(sha256_file "$ROM")"
+TARGET_PROJECT_SHA256_BEFORE="$(sha256_file "$PROJECT")"
+TARGET_MANIFEST_SHA256_BEFORE="$(sha256_file "$TARGET_MANIFEST")"
+YAZE_BIN_SHA256="$(sha256_file "$YAZE_BIN")"
+Z3ED_BIN_SHA256="$(sha256_file "$Z3ED_BIN")"
+SCRIPT_SHA256="$(sha256_file "$SCRIPT_PATH")"
+EDIT_FIXTURE_SHA256="$(sha256_file "$EDIT_FIXTURE")"
+REOPEN_FIXTURE_SHA256="$(sha256_file "$REOPEN_FIXTURE")"
+QUALIFIED_BASELINE_SHA256="b13ef69ede313756dcf560bf0f993663d68d0365609f2c20dcdec2c17f31f7b9"
+QUALIFIED_SAVED_SHA256="d169961b9b83cddd33f63ce7b4a12c50d11939627c7f04dba8143672a91100e8"
+[[ "$TARGET_MANIFEST_SHA256_BEFORE" == "$CANONICAL_MANIFEST_SHA256_BEFORE" ]] ||
+  die 65 "disposable Hack Manifest is not byte-identical to the canonical manifest"
+MANIFESTS_EQUAL_BEFORE=true
+[[ "$TARGET_ROM_SHA1_BEFORE" == "$CANONICAL_ROM_SHA1_BEFORE" &&
+   "$TARGET_ROM_SHA256_BEFORE" == "$CANONICAL_ROM_SHA256_BEFORE" ]] ||
+  die 65 "disposable ROM is not a byte-identical canonical copy"
+NORMALIZED_TARGET_EXPECTED_HASH="$({
+  printf '%s' "$TARGET_EXPECTED_HASH" | tr '[:upper:]' '[:lower:]'
+})"
+[[ "$NORMALIZED_TARGET_EXPECTED_HASH" == "$TARGET_ROM_SHA1_BEFORE" ]] ||
+  die 65 "disposable descriptor expected_hash does not match its ROM"
+[[ "$TARGET_ROM_SHA256_BEFORE" == "$QUALIFIED_BASELINE_SHA256" ]] ||
+  die 65 "disposable ROM is not the qualified D6 baseline SHA-256"
+
+reject_protected_evidence_path() {
+  local candidate="$1"
+  if path_is_within "$candidate" "$CANONICAL_PROJECT_DIR"; then
+    die 65 "evidence directory must not be inside the canonical project tree"
+  fi
+  if path_is_within "$candidate" "$REPO_ROOT"; then
+    die 65 "evidence directory must not be inside the Yaze source tree"
+  fi
+}
+
+if [[ -z "$EVIDENCE_DIR" ]]; then
+  EVIDENCE_BASE="$(normalized_path "${TMPDIR:-/tmp}")"
+  [[ -d "$EVIDENCE_BASE" ]] ||
+    die 73 "temporary evidence parent does not exist: $EVIDENCE_BASE"
+  reject_protected_evidence_path "$EVIDENCE_BASE"
+  EVIDENCE_DIR="$(mktemp -d "$EVIDENCE_BASE/yaze-d6-gui-qualification.XXXXXX")"
+else
+  EVIDENCE_DIR="$(normalized_path "$EVIDENCE_DIR")"
+  reject_protected_evidence_path "$EVIDENCE_DIR"
+  if [[ -e "$EVIDENCE_DIR" ]]; then
+    [[ -d "$EVIDENCE_DIR" ]] || die 73 "evidence path is not a directory"
+    [[ -z "$(find "$EVIDENCE_DIR" -mindepth 1 -maxdepth 1 -print -quit)" ]] ||
+      die 73 "refusing to overwrite non-empty evidence directory"
+  else
+    mkdir -p "$EVIDENCE_DIR"
+  fi
+fi
+EVIDENCE_DIR="$(canonical_path "$EVIDENCE_DIR")" ||
+  die 73 "could not create evidence directory"
+reject_protected_evidence_path "$EVIDENCE_DIR"
+
+FROZEN_INPUT_DIR="$EVIDENCE_DIR/frozen-inputs"
+FROZEN_EDIT_FIXTURE="$FROZEN_INPUT_DIR/d6_edit_and_save.json"
+FROZEN_REOPEN_FIXTURE="$FROZEN_INPUT_DIR/d6_reopen_assert.json"
+mkdir "$FROZEN_INPUT_DIR"
+cp "$EDIT_FIXTURE" "$FROZEN_EDIT_FIXTURE"
+cp "$REOPEN_FIXTURE" "$FROZEN_REOPEN_FIXTURE"
+[[ "$(sha256_file "$FROZEN_EDIT_FIXTURE")" == "$EDIT_FIXTURE_SHA256" ]] ||
+  die 74 "frozen edit fixture hash mismatch"
+[[ "$(sha256_file "$FROZEN_REOPEN_FIXTURE")" == "$REOPEN_FIXTURE_SHA256" ]] ||
+  die 74 "frozen reopen fixture hash mismatch"
+
+FEATURE_FLAG_EVIDENCE="$EVIDENCE_DIR/feature-flags.json"
+printf '%s\n' "$FEATURE_FLAG_REPORT" | jq . > "$FEATURE_FLAG_EVIDENCE"
+GIT_STATUS_EVIDENCE="$EVIDENCE_DIR/yaze-git-status.txt"
+git -C "$REPO_ROOT" status --porcelain=v1 --untracked-files=all \
+  > "$GIT_STATUS_EVIDENCE" || die 70 "could not record Yaze git status"
+YAZE_GIT_HEAD="$(git -C "$REPO_ROOT" rev-parse HEAD)" ||
+  die 70 "could not resolve Yaze git HEAD"
+if [[ -s "$GIT_STATUS_EVIDENCE" ]]; then
+  YAZE_GIT_DIRTY=true
+else
+  YAZE_GIT_DIRTY=false
+fi
+
+OBJECT_STREAM_INVENTORY="$EVIDENCE_DIR/object-stream-plan.json"
+SPRITE_STREAM_INVENTORY="$EVIDENCE_DIR/sprite-stream-plan.json"
+STREAM_INVENTORY_VALIDATION="$EVIDENCE_DIR/stream-inventory-validation.json"
+
+capture_stream_inventory() {
+  local kind="$1"
+  local output="$2"
+  NO_COLOR=1 TERM=dumb "$Z3ED_BIN" dungeon-stream-plan \
+    --kind="$kind" --manifest="$TARGET_MANIFEST" --rom="$ROM" \
+    --format=json > "$output" ||
+    die 70 "z3ed $kind stream inventory failed"
+}
+
+capture_stream_inventory objects "$OBJECT_STREAM_INVENTORY"
+capture_stream_inventory sprites "$SPRITE_STREAM_INVENTORY"
+[[ "$(sha256_file "$ROM")" == "$TARGET_ROM_SHA256_BEFORE" ]] ||
+  die 74 "read-only stream inventory changed the disposable ROM"
+[[ "$(sha256_file "$TARGET_MANIFEST")" == "$TARGET_MANIFEST_SHA256_BEFORE" ]] ||
+  die 74 "read-only stream inventory changed the disposable manifest"
+
+python3 - "$ROM" "$TARGET_MANIFEST" "$OBJECT_STREAM_INVENTORY" \
+  "$SPRITE_STREAM_INVENTORY" "$STREAM_INVENTORY_VALIDATION" <<'PY'
+import hashlib
+import json
+import os
+import sys
+
+rom_path, manifest_path, object_path, sprite_path, output = sys.argv[1:]
+rom = open(rom_path, "rb").read()
+
+def digest_file(path):
+    digest = hashlib.sha256()
+    with open(path, "rb") as stream:
+        for block in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(block)
+    return digest.hexdigest()
+
+def parse_hex(value, field):
+    if not isinstance(value, str):
+        raise SystemExit(f"{field} must be a hexadecimal string")
+    try:
+        parsed = int(value, 0)
+    except ValueError as error:
+        raise SystemExit(f"{field} is not hexadecimal: {value!r}") from error
+    if parsed < 0:
+        raise SystemExit(f"{field} must not be negative")
+    return parsed
+
+def validate_inventory(path, expected_kind, target_rooms, expected_crc32):
+    with open(path, encoding="utf-8") as stream:
+        inventory = json.load(stream)
+    if inventory.get("status") != "ok":
+        raise SystemExit(f"{expected_kind} stream inventory status is not ok")
+    if inventory.get("kind") != expected_kind:
+        raise SystemExit(f"{expected_kind} stream inventory kind mismatch")
+    if inventory.get("strategy") != "copy_on_write":
+        raise SystemExit(f"{expected_kind} stream inventory is not copy_on_write")
+    if os.path.realpath(inventory.get("manifest", "")) != os.path.realpath(
+        manifest_path
+    ):
+        raise SystemExit(f"{expected_kind} stream inventory manifest mismatch")
+    if inventory.get("source_size") != len(rom):
+        raise SystemExit(f"{expected_kind} stream inventory ROM size mismatch")
+    if inventory.get("source_crc32") != expected_crc32:
+        raise SystemExit(f"{expected_kind} stream inventory ROM CRC32 mismatch")
+    if inventory.get("issue_count") != 0 or inventory.get("issues") != []:
+        raise SystemExit(f"{expected_kind} stream inventory reports issues")
+    if (
+        inventory.get("suffix_overlap_count") != 0
+        or inventory.get("interior_overlap_count") != 0
+        or inventory.get("overlaps") != []
+    ):
+        raise SystemExit(f"{expected_kind} stream inventory reports overlaps")
+
+    unique_streams = inventory.get("unique_streams")
+    exact_aliases = inventory.get("exact_aliases")
+    if not isinstance(unique_streams, list) or not isinstance(exact_aliases, list):
+        raise SystemExit(f"{expected_kind} stream inventory lists are invalid")
+
+    targets = []
+    for room in target_rooms:
+        room_id = f"0x{room:03X}"
+        matches = [
+            entry
+            for entry in unique_streams
+            if isinstance(entry, dict)
+            and isinstance(entry.get("room_ids"), list)
+            and room_id in entry["room_ids"]
+        ]
+        if len(matches) != 1:
+            raise SystemExit(
+                f"{expected_kind} room {room_id} must have one unique stream"
+            )
+        entry = matches[0]
+        if entry.get("room_ids") != [room_id]:
+            raise SystemExit(
+                f"{expected_kind} room {room_id} baseline stream is aliased"
+            )
+        if any(
+            isinstance(alias, dict)
+            and room_id in alias.get("room_ids", [])
+            for alias in exact_aliases
+        ):
+            raise SystemExit(f"{expected_kind} room {room_id} is exactly aliased")
+        start = parse_hex(entry.get("data_pc"), f"{room_id}.data_pc")
+        end = parse_hex(entry.get("end_pc"), f"{room_id}.end_pc")
+        if not (0 <= start < end <= len(rom)):
+            raise SystemExit(f"{expected_kind} room {room_id} span is outside ROM")
+        if entry.get("bytes") != end - start:
+            raise SystemExit(f"{expected_kind} room {room_id} byte count mismatch")
+        targets.append(
+            {
+                "room_id": room_id,
+                "data_pc": f"0x{start:06X}",
+                "end_pc": f"0x{end:06X}",
+                "bytes": end - start,
+                "unique": True,
+                "unaliased": True,
+                "overlap_free": True,
+            }
+        )
+
+    return {
+        "path": os.path.realpath(path),
+        "sha256": digest_file(path),
+        "kind": expected_kind,
+        "status": "ok",
+        "manifest": os.path.realpath(manifest_path),
+        "source_size": len(rom),
+        "source_crc32": expected_crc32,
+        "strategy": "copy_on_write",
+        "targets": targets,
+    }
+
+with open(object_path, encoding="utf-8") as stream:
+    object_crc32 = json.load(stream).get("source_crc32")
+with open(sprite_path, encoding="utf-8") as stream:
+    sprite_crc32 = json.load(stream).get("source_crc32")
+if (
+    not isinstance(object_crc32, str)
+    or object_crc32 != sprite_crc32
+    or not object_crc32.startswith("0x")
+):
+    raise SystemExit("object/sprite stream inventory source CRC32 mismatch")
+
+result = {
+    "status": "pass",
+    "rom": {
+        "path": os.path.realpath(rom_path),
+        "size": len(rom),
+        "sha256": hashlib.sha256(rom).hexdigest(),
+        "inventory_source_crc32": object_crc32,
+        "crc32_proof": (
+            "Matching read-only object/sprite inventories captured between "
+            "unchanged ROM SHA-256 checks"
+        ),
+    },
+    "manifest": {
+        "path": os.path.realpath(manifest_path),
+        "sha256": digest_file(manifest_path),
+    },
+    "inventories": {
+        "objects": validate_inventory(
+            object_path, "objects", (0xA8, 0xB8), object_crc32
+        ),
+        "sprites": validate_inventory(
+            sprite_path, "sprites", (0xD8,), object_crc32
+        ),
+    },
+}
+with open(output, "w", encoding="utf-8") as stream:
+    json.dump(result, stream, indent=2)
+    stream.write("\n")
+PY
+
+OBJECT_STREAM_INVENTORY_SHA256="$(sha256_file "$OBJECT_STREAM_INVENTORY")"
+SPRITE_STREAM_INVENTORY_SHA256="$(sha256_file "$SPRITE_STREAM_INVENTORY")"
+STREAM_INVENTORY_VALIDATION_SHA256="$({
+  sha256_file "$STREAM_INVENTORY_VALIDATION"
+})"
+
+PROVENANCE_EVIDENCE="$EVIDENCE_DIR/provenance.json"
+jq -n \
+  --arg captured_at_utc "$(date -u '+%Y-%m-%dT%H:%M:%SZ')" \
+  --arg yaze_git_head "$YAZE_GIT_HEAD" \
+  --arg git_status "$GIT_STATUS_EVIDENCE" \
+  --arg script_path "$SCRIPT_PATH" \
+  --arg script_sha256 "$SCRIPT_SHA256" \
+  --arg edit_fixture "$EDIT_FIXTURE" \
+  --arg edit_fixture_sha256 "$EDIT_FIXTURE_SHA256" \
+  --arg frozen_edit_fixture "$FROZEN_EDIT_FIXTURE" \
+  --arg reopen_fixture "$REOPEN_FIXTURE" \
+  --arg reopen_fixture_sha256 "$REOPEN_FIXTURE_SHA256" \
+  --arg frozen_reopen_fixture "$FROZEN_REOPEN_FIXTURE" \
+  --arg yaze_bin "$YAZE_BIN" \
+  --arg yaze_bin_sha256 "$YAZE_BIN_SHA256" \
+  --arg z3ed_bin "$Z3ED_BIN" \
+  --arg z3ed_bin_sha256 "$Z3ED_BIN_SHA256" \
+  --arg project "$PROJECT" \
+  --arg project_sha256 "$TARGET_PROJECT_SHA256_BEFORE" \
+  --arg manifest "$TARGET_MANIFEST" \
+  --arg manifest_sha256 "$TARGET_MANIFEST_SHA256_BEFORE" \
+  --arg rom "$ROM" \
+  --arg rom_sha256 "$TARGET_ROM_SHA256_BEFORE" \
+  --arg canonical_project "$CANONICAL_PROJECT" \
+  --arg canonical_project_sha256 "$CANONICAL_PROJECT_SHA256_BEFORE" \
+  --arg canonical_manifest "$CANONICAL_MANIFEST" \
+  --arg canonical_manifest_sha256 "$CANONICAL_MANIFEST_SHA256_BEFORE" \
+  --arg canonical_rom "$CANONICAL_ROM" \
+  --arg canonical_rom_sha256 "$CANONICAL_ROM_SHA256_BEFORE" \
+  --arg feature_flags "$FEATURE_FLAG_EVIDENCE" \
+  --arg object_stream_inventory "$OBJECT_STREAM_INVENTORY" \
+  --arg object_stream_inventory_sha256 "$OBJECT_STREAM_INVENTORY_SHA256" \
+  --arg sprite_stream_inventory "$SPRITE_STREAM_INVENTORY" \
+  --arg sprite_stream_inventory_sha256 "$SPRITE_STREAM_INVENTORY_SHA256" \
+  --arg stream_inventory_validation "$STREAM_INVENTORY_VALIDATION" \
+  --arg stream_inventory_validation_sha256 "$STREAM_INVENTORY_VALIDATION_SHA256" \
+  --argjson yaze_git_dirty "$YAZE_GIT_DIRTY" \
+  --argjson manifests_equal_before "$MANIFESTS_EQUAL_BEFORE" '
+    {
+      captured_at_utc: $captured_at_utc,
+      yaze_git: {
+        head: $yaze_git_head,
+        dirty: $yaze_git_dirty,
+        status_file: $git_status
+      },
+      driver: {path: $script_path, sha256: $script_sha256},
+      fixtures: {
+        edit: {
+          source: $edit_fixture,
+          frozen: $frozen_edit_fixture,
+          sha256: $edit_fixture_sha256
+        },
+        reopen: {
+          source: $reopen_fixture,
+          frozen: $frozen_reopen_fixture,
+          sha256: $reopen_fixture_sha256
+        }
+      },
+      binaries: {
+        yaze: {path: $yaze_bin, sha256: $yaze_bin_sha256},
+        z3ed: {path: $z3ed_bin, sha256: $z3ed_bin_sha256}
+      },
+      disposable: {
+        project: {path: $project, sha256: $project_sha256},
+        manifest: {path: $manifest, sha256: $manifest_sha256},
+        rom: {path: $rom, sha256: $rom_sha256},
+        feature_flags: $feature_flags,
+        baseline_stream_inventory: {
+          objects: {
+            path: $object_stream_inventory,
+            sha256: $object_stream_inventory_sha256
+          },
+          sprites: {
+            path: $sprite_stream_inventory,
+            sha256: $sprite_stream_inventory_sha256
+          },
+          validation: {
+            path: $stream_inventory_validation,
+            sha256: $stream_inventory_validation_sha256
+          }
+        }
+      },
+      canonical: {
+        project: {path: $canonical_project, sha256: $canonical_project_sha256},
+        manifest: {path: $canonical_manifest, sha256: $canonical_manifest_sha256},
+        rom: {path: $canonical_rom, sha256: $canonical_rom_sha256}
+      },
+      manifests_equal_before: $manifests_equal_before
+    }
+  ' > "$PROVENANCE_EVIDENCE"
+
+YAZE_PID=""
+FIRST_PID=""
+SECOND_PID=""
+
+assert_frozen_inputs_unchanged() {
+  [[ -n "${CANONICAL_ROM_SHA256_BEFORE:-}" ]] || return 0
+  [[ -f "$CANONICAL_ROM" && -f "$CANONICAL_PROJECT" &&
+     -f "$CANONICAL_MANIFEST" && -f "$PROJECT" &&
+     -f "$TARGET_MANIFEST" && -f "$SCRIPT_PATH" &&
+     -f "$EDIT_FIXTURE" && -f "$REOPEN_FIXTURE" &&
+     -f "$FROZEN_EDIT_FIXTURE" && -f "$FROZEN_REOPEN_FIXTURE" &&
+     -f "$OBJECT_STREAM_INVENTORY" && -f "$SPRITE_STREAM_INVENTORY" &&
+     -f "$STREAM_INVENTORY_VALIDATION" &&
+     -f "$YAZE_BIN" && -f "$Z3ED_BIN" ]] || return 1
+  [[ "$(sha256_file "$CANONICAL_ROM")" == "$CANONICAL_ROM_SHA256_BEFORE" ]] ||
+    return 1
+  [[ "$(sha256_file "$CANONICAL_PROJECT")" == "$CANONICAL_PROJECT_SHA256_BEFORE" ]] ||
+    return 1
+  [[ "$(sha256_file "$CANONICAL_MANIFEST")" == "$CANONICAL_MANIFEST_SHA256_BEFORE" ]] ||
+    return 1
+  [[ "$(sha256_file "$PROJECT")" == "$TARGET_PROJECT_SHA256_BEFORE" ]] ||
+    return 1
+  [[ "$(sha256_file "$TARGET_MANIFEST")" == "$TARGET_MANIFEST_SHA256_BEFORE" ]] ||
+    return 1
+  [[ "$(sha256_file "$SCRIPT_PATH")" == "$SCRIPT_SHA256" ]] || return 1
+  [[ "$(sha256_file "$EDIT_FIXTURE")" == "$EDIT_FIXTURE_SHA256" ]] ||
+    return 1
+  [[ "$(sha256_file "$REOPEN_FIXTURE")" == "$REOPEN_FIXTURE_SHA256" ]] ||
+    return 1
+  [[ "$(sha256_file "$FROZEN_EDIT_FIXTURE")" == "$EDIT_FIXTURE_SHA256" ]] ||
+    return 1
+  [[ "$(sha256_file "$FROZEN_REOPEN_FIXTURE")" == "$REOPEN_FIXTURE_SHA256" ]] ||
+    return 1
+  [[ "$(sha256_file "$OBJECT_STREAM_INVENTORY")" == \
+     "$OBJECT_STREAM_INVENTORY_SHA256" ]] || return 1
+  [[ "$(sha256_file "$SPRITE_STREAM_INVENTORY")" == \
+     "$SPRITE_STREAM_INVENTORY_SHA256" ]] || return 1
+  [[ "$(sha256_file "$STREAM_INVENTORY_VALIDATION")" == \
+     "$STREAM_INVENTORY_VALIDATION_SHA256" ]] || return 1
+  [[ "$(sha256_file "$YAZE_BIN")" == "$YAZE_BIN_SHA256" ]] || return 1
+  [[ "$(sha256_file "$Z3ED_BIN")" == "$Z3ED_BIN_SHA256" ]] || return 1
+  return 0
+}
+
+cleanup() {
+  local status=$?
+  trap - EXIT
+  set +e
+  if [[ -n "${YAZE_PID:-}" ]] && kill -0 "$YAZE_PID" 2>/dev/null; then
+    kill -TERM "$YAZE_PID" 2>/dev/null
+    local i=0
+    while kill -0 "$YAZE_PID" 2>/dev/null && [[ "$i" -lt 50 ]]; do
+      sleep 0.1
+      i=$((i + 1))
+    done
+    if kill -0 "$YAZE_PID" 2>/dev/null; then
+      kill -KILL "$YAZE_PID" 2>/dev/null
+    fi
+    wait "$YAZE_PID" 2>/dev/null
+  fi
+  if ! assert_frozen_inputs_unchanged; then
+    echo "error: a frozen project, manifest, fixture, script, or binary changed during qualification" >&2
+    status=74
+  fi
+  exit "$status"
+}
+trap cleanup EXIT
+trap 'exit 130' INT
+trap 'exit 143' TERM
+
+port_is_free() {
+  python3 - "$1" <<'PY'
+import socket
+import sys
+
+port = int(sys.argv[1])
+sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+try:
+    sock.bind(("127.0.0.1", port))
+except OSError:
+    raise SystemExit(1)
+finally:
+    sock.close()
+PY
+}
+
+wait_for_port_free() {
+  local port="$1"
+  local deadline=$((SECONDS + 15))
+  while [[ "$SECONDS" -lt "$deadline" ]]; do
+    if port_is_free "$port"; then
+      return 0
+    fi
+    sleep 0.2
+  done
+  return 1
+}
+
+wait_for_owned_listener() {
+  local label="$1"
+  local role="$2"
+  local port="$3"
+  local output="$EVIDENCE_DIR/$label-$role-listener.lsof"
+  local metadata="$EVIDENCE_DIR/$label-$role-listener.json"
+  local deadline=$((SECONDS + 30))
+  while [[ "$SECONDS" -lt "$deadline" ]]; do
+    if ! kill -0 "$YAZE_PID" 2>/dev/null; then
+      return 1
+    fi
+    if lsof -nP -a -p "$YAZE_PID" -iTCP:"$port" -sTCP:LISTEN \
+         > "$output" 2> "$output.stderr" &&
+       awk -v pid="$YAZE_PID" '
+         NR > 1 && $2 == pid && $NF == "(LISTEN)" { found = 1 }
+         END { exit(found ? 0 : 1) }
+       ' "$output"; then
+      jq -n \
+        --arg captured_at_utc "$(date -u '+%Y-%m-%dT%H:%M:%SZ')" \
+        --arg label "$label" \
+        --arg role "$role" \
+        --arg lsof_output "$output" \
+        --argjson pid "$YAZE_PID" \
+        --argjson port "$port" '
+          {
+            captured_at_utc: $captured_at_utc,
+            launch: $label,
+            role: $role,
+            pid: $pid,
+            port: $port,
+            state: "LISTEN",
+            ownership: "lsof -a -p PID -iTCP:PORT -sTCP:LISTEN",
+            lsof_output: $lsof_output
+          }
+        ' > "$metadata"
+      return 0
+    fi
+    sleep 0.2
+  done
+  return 1
+}
+
+wait_for_port_free "$HARNESS_PORT" ||
+  die 69 "harness port is already in use: $HARNESS_PORT"
+wait_for_port_free "$API_PORT" ||
+  die 69 "API port is already in use: $API_PORT"
+
+write_backup_inventory() {
+  local output="$1"
+  python3 - "$TARGET_BACKUP_DIR" "$output" <<'PY'
+import hashlib
+import json
+import os
+import sys
+
+backup_dir, output = sys.argv[1:]
+
+def sha256(path):
+    digest = hashlib.sha256()
+    with open(path, "rb") as stream:
+        for block in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(block)
+    return digest.hexdigest()
+
+entries = []
+if os.path.isdir(backup_dir):
+    for entry in sorted(os.scandir(backup_dir), key=lambda item: item.name):
+        if entry.is_file(follow_symlinks=False):
+            entries.append({
+                "path": os.path.realpath(entry.path),
+                "size": entry.stat(follow_symlinks=False).st_size,
+                "sha256": sha256(entry.path),
+            })
+
+with open(output, "w", encoding="utf-8") as stream:
+    json.dump({"backup_dir": backup_dir, "files": entries}, stream, indent=2)
+    stream.write("\n")
+PY
+}
+
+verify_backup_creation() {
+  local before_inventory="$1"
+  local output="$2"
+  python3 - "$TARGET_BACKUP_DIR" "$before_inventory" \
+    "$TARGET_ROM_SHA256_BEFORE" "$ROM" "$output" <<'PY'
+import hashlib
+import json
+import os
+import sys
+
+backup_dir, before_path, expected_sha256, rom_path, output = sys.argv[1:]
+
+def sha256(path):
+    digest = hashlib.sha256()
+    with open(path, "rb") as stream:
+        for block in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(block)
+    return digest.hexdigest()
+
+with open(before_path, encoding="utf-8") as stream:
+    before = json.load(stream)
+before_paths = {entry["path"] for entry in before.get("files", [])}
+
+current = []
+if os.path.isdir(backup_dir):
+    for entry in sorted(os.scandir(backup_dir), key=lambda item: item.name):
+        if not entry.is_file(follow_symlinks=False):
+            continue
+        path = os.path.realpath(entry.path)
+        if path in before_paths:
+            continue
+        if os.path.samefile(path, rom_path):
+            raise SystemExit("new backup aliases the editable ROM")
+        current.append({
+            "path": path,
+            "size": entry.stat(follow_symlinks=False).st_size,
+            "sha256": sha256(path),
+        })
+
+matches = [entry for entry in current if entry["sha256"] == expected_sha256]
+result = {
+    "backup_dir": backup_dir,
+    "expected_pre_save_sha256": expected_sha256,
+    "new_backups": current,
+    "matching_pre_save_backups": matches,
+}
+with open(output, "w", encoding="utf-8") as stream:
+    json.dump(result, stream, indent=2)
+    stream.write("\n")
+
+if not current:
+    raise SystemExit("Save ROM did not create a new backup file")
+if not matches:
+    raise SystemExit("no new backup matches the pre-save ROM SHA-256")
+PY
+}
+
+generate_bounded_rom_diff() {
+  local before_rom="$1"
+  local after_rom="$2"
+  local manifest="$3"
+  local object_inventory="$4"
+  local sprite_inventory="$5"
+  local expected_before_sha256="$6"
+  local expected_after_sha256="$7"
+  local output="$8"
+  python3 - "$before_rom" "$after_rom" "$manifest" "$object_inventory" \
+    "$sprite_inventory" "$expected_before_sha256" "$expected_after_sha256" \
+    "$output" <<'PY'
+import hashlib
+import json
+import os
+import sys
+
+(
+    before_path,
+    after_path,
+    manifest_path,
+    object_inventory_path,
+    sprite_inventory_path,
+    expected_before_sha256,
+    expected_after_sha256,
+    output,
+) = sys.argv[1:]
+before = open(before_path, "rb").read()
+after = open(after_path, "rb").read()
+manifest_bytes = open(manifest_path, "rb").read()
+manifest = json.loads(manifest_bytes)
+object_inventory_bytes = open(object_inventory_path, "rb").read()
+sprite_inventory_bytes = open(sprite_inventory_path, "rb").read()
+object_inventory = json.loads(object_inventory_bytes)
+sprite_inventory = json.loads(sprite_inventory_bytes)
+
+max_reported_ranges = 4096
+max_differing_bytes = 256 * 1024
+object_rooms = (0xA8, 0xB8)
+sprite_rooms = (0xD8,)
+door_pointer_table_pc = 0x0F83C0
+palette_color_pc = 0x0DDC2E
+
+def digest(data):
+    return hashlib.sha256(data).hexdigest()
+
+def parse_address(value, field):
+    if isinstance(value, int):
+        address = value
+    elif isinstance(value, str):
+        try:
+            address = int(value, 0)
+        except ValueError as error:
+            raise SystemExit(f"invalid manifest address {field}={value!r}") from error
+    else:
+        raise SystemExit(f"manifest address {field} must be an integer or string")
+    if address < 0 or address > 0xFFFFFF:
+        raise SystemExit(f"manifest address {field} is outside SNES address space")
+    return address
+
+def snes_to_pc(address, field):
+    bank = (address >> 16) & 0xFF
+    word = address & 0xFFFF
+    if word < 0x8000:
+        raise SystemExit(
+            f"manifest address {field}=0x{address:06X} is not LoROM-mapped"
+        )
+    if bank in {0x7E, 0x7F, 0xFE, 0xFF}:
+        raise SystemExit(f"manifest address {field} uses a WRAM/mirror bank")
+    return ((bank & 0x7F) * 0x8000) + (word & 0x7FFF)
+
+def parse_pc(value, field):
+    return snes_to_pc(parse_address(value, field), field)
+
+def pointer_width(stream, name):
+    encoding = stream.get("pointer_encoding")
+    widths = {"long24": 3, "bank16": 2, "fixed_bank16": 2}
+    if encoding not in widths:
+        raise SystemExit(
+            f"unsupported dungeon_stream_regions.{name}.pointer_encoding={encoding!r}"
+        )
+    return widths[encoding]
+
+def stream_contract(name, expected_strategy):
+    streams = manifest.get("dungeon_stream_regions")
+    if not isinstance(streams, dict) or not isinstance(streams.get(name), dict):
+        raise SystemExit(f"manifest is missing dungeon_stream_regions.{name}")
+    stream = streams[name]
+    if stream.get("strategy") != expected_strategy:
+        raise SystemExit(
+            f"dungeon_stream_regions.{name}.strategy must be {expected_strategy}"
+        )
+    count = stream.get("pointer_count")
+    if not isinstance(count, int) or count <= 0:
+        raise SystemExit(f"dungeon_stream_regions.{name}.pointer_count is invalid")
+    table_pc = parse_pc(stream.get("pointer_table"), f"{name}.pointer_table")
+    width = pointer_width(stream, name)
+
+    def read_ranges(key):
+        values = stream.get(key)
+        if not isinstance(values, list) or not values:
+            raise SystemExit(f"dungeon_stream_regions.{name}.{key} must be non-empty")
+        parsed = []
+        for index, value in enumerate(values):
+            if not isinstance(value, dict):
+                raise SystemExit(f"{name}.{key}[{index}] must be an object")
+            start = parse_pc(value.get("start"), f"{name}.{key}[{index}].start")
+            end = parse_pc(value.get("end"), f"{name}.{key}[{index}].end")
+            if start >= end:
+                raise SystemExit(f"{name}.{key}[{index}] is empty or reversed")
+            parsed.append((start, end, value.get("start"), value.get("end")))
+        return parsed
+
+    data_ranges = read_ranges("data_regions")
+    allocation_ranges = read_ranges("allocation_regions")
+    for allocation in allocation_ranges:
+        if not any(
+            data_start <= allocation[0] and allocation[1] <= data_end
+            for data_start, data_end, _, _ in data_ranges
+        ):
+            raise SystemExit(
+                f"{name} allocation range 0x{allocation[0]:06X}-"
+                f"0x{allocation[1]:06X} is outside declared data regions"
+            )
+    return {
+        "name": name,
+        "stream": stream,
+        "pointer_count": count,
+        "pointer_table_pc": table_pc,
+        "pointer_width": width,
+        "allocation_ranges": allocation_ranges,
+    }
+
+if len(before) != len(after):
+    result = {
+        "before_path": before_path,
+        "after_path": after_path,
+        "before_size": len(before),
+        "after_size": len(after),
+        "error": "ROM size changed",
+        "within_bounds": False,
+    }
+    with open(output, "w", encoding="utf-8") as stream:
+        json.dump(result, stream, indent=2)
+        stream.write("\n")
+    raise SystemExit("saved ROM size differs from its pre-save backup")
+
+if digest(before) != expected_before_sha256:
+    raise SystemExit("pre-save backup does not match qualified baseline SHA-256")
+
+contracts = {
+    "objects": stream_contract("objects", "copy_on_write"),
+    "sprites": stream_contract("sprites", "copy_on_write"),
+    "pot_items": stream_contract("pot_items", "repack_all"),
+}
+
+def parse_inventory_pc(value, field):
+    if not isinstance(value, str):
+        raise SystemExit(f"stream inventory {field} must be a hexadecimal string")
+    try:
+        address = int(value, 0)
+    except ValueError as error:
+        raise SystemExit(
+            f"invalid stream inventory address {field}={value!r}"
+        ) from error
+    if address < 0:
+        raise SystemExit(f"stream inventory address {field} must not be negative")
+    return address
+
+def validate_baseline_inventory(
+    inventory,
+    inventory_path,
+    inventory_bytes,
+    name,
+    rooms,
+):
+    contract = contracts[name]
+    expected_crc32 = object_inventory.get("source_crc32")
+    if (
+        not isinstance(expected_crc32, str)
+        or sprite_inventory.get("source_crc32") != expected_crc32
+    ):
+        raise SystemExit("pre-save object/sprite inventory CRC32 mismatch")
+    if inventory.get("status") != "ok" or inventory.get("kind") != name:
+        raise SystemExit(f"pre-save {name} stream inventory status/kind mismatch")
+    if inventory.get("strategy") != "copy_on_write":
+        raise SystemExit(f"pre-save {name} stream inventory strategy mismatch")
+    if os.path.realpath(inventory.get("manifest", "")) != os.path.realpath(
+        manifest_path
+    ):
+        raise SystemExit(f"pre-save {name} stream inventory manifest mismatch")
+    if inventory.get("source_size") != len(before):
+        raise SystemExit(f"pre-save {name} stream inventory ROM size mismatch")
+    if inventory.get("source_crc32") != expected_crc32:
+        raise SystemExit(f"pre-save {name} stream inventory ROM CRC32 mismatch")
+    if inventory.get("pointer_encoding") != contract["stream"].get(
+        "pointer_encoding"
+    ):
+        raise SystemExit(f"pre-save {name} stream inventory encoding mismatch")
+    if inventory.get("pointer_count") != contract["pointer_count"]:
+        raise SystemExit(f"pre-save {name} stream inventory pointer count mismatch")
+    inventory_table_pc = parse_inventory_pc(
+        inventory.get("pointer_table_pc"), f"{name}.pointer_table_pc"
+    )
+    if inventory_table_pc != contract["pointer_table_pc"]:
+        raise SystemExit(f"pre-save {name} stream inventory pointer table mismatch")
+    if inventory.get("issue_count") != 0 or inventory.get("issues") != []:
+        raise SystemExit(f"pre-save {name} stream inventory reports issues")
+    if (
+        inventory.get("suffix_overlap_count") != 0
+        or inventory.get("interior_overlap_count") != 0
+        or inventory.get("overlaps") != []
+    ):
+        raise SystemExit(f"pre-save {name} stream inventory reports overlaps")
+
+    unique_streams = inventory.get("unique_streams")
+    exact_aliases = inventory.get("exact_aliases")
+    if not isinstance(unique_streams, list) or not isinstance(exact_aliases, list):
+        raise SystemExit(f"pre-save {name} stream inventory lists are invalid")
+
+    decisions = []
+    for room in rooms:
+        room_id = f"0x{room:03X}"
+        matches = [
+            entry
+            for entry in unique_streams
+            if isinstance(entry, dict)
+            and isinstance(entry.get("room_ids"), list)
+            and room_id in entry["room_ids"]
+        ]
+        if len(matches) != 1:
+            raise SystemExit(
+                f"pre-save {name} room {room_id} must have one unique stream"
+            )
+        entry = matches[0]
+        if entry.get("room_ids") != [room_id]:
+            raise SystemExit(
+                f"pre-save {name} room {room_id} stream is not uniquely owned"
+            )
+        if any(
+            isinstance(alias, dict)
+            and room_id in alias.get("room_ids", [])
+            for alias in exact_aliases
+        ):
+            raise SystemExit(f"pre-save {name} room {room_id} is exactly aliased")
+        start = parse_inventory_pc(entry.get("data_pc"), f"{name}.{room_id}.data_pc")
+        end = parse_inventory_pc(entry.get("end_pc"), f"{name}.{room_id}.end_pc")
+        if not (0 <= start < end <= len(before)):
+            raise SystemExit(f"pre-save {name} room {room_id} span is outside ROM")
+        if entry.get("bytes") != end - start:
+            raise SystemExit(f"pre-save {name} room {room_id} byte count mismatch")
+        decisions.append(
+            {
+                "kind": name,
+                "room_id": room_id,
+                "data_pc": f"0x{start:06X}",
+                "end_pc_exclusive": f"0x{end:06X}",
+                "length": end - start,
+                "unique_owner": True,
+                "exact_alias": False,
+                "overlap": False,
+                "in_place_allowance": not (name == "objects" and room == 0xB8),
+                "relocation_allowance": (
+                    "exact planned PC range 0x148000-0x148196"
+                    if name == "objects" and room == 0xB8
+                    else None
+                ),
+                "inventory_path": inventory_path,
+                "inventory_sha256": digest(inventory_bytes),
+                "_start": start,
+                "_end": end,
+            }
+        )
+    return decisions
+
+baseline_stream_decisions = (
+    validate_baseline_inventory(
+        object_inventory,
+        object_inventory_path,
+        object_inventory_bytes,
+        "objects",
+        object_rooms,
+    )
+    + validate_baseline_inventory(
+        sprite_inventory,
+        sprite_inventory_path,
+        sprite_inventory_bytes,
+        "sprites",
+        sprite_rooms,
+    )
+)
+
+allowed = []
+
+def add_allowed(start, end, reason, source, proof=None):
+    if start < 0 or start >= end or end > len(before):
+        raise SystemExit(
+            f"allowlist range 0x{start:06X}-0x{end:06X} is outside the ROM"
+        )
+    rule = {
+        "start": start,
+        "end": end,
+        "start_pc": f"0x{start:06X}",
+        "end_pc_exclusive": f"0x{end:06X}",
+        "length": end - start,
+        "reason": reason,
+        "source": source,
+    }
+    if proof is not None:
+        rule["proof"] = proof
+    allowed.append(rule)
+
+objects = contracts["objects"]
+if objects["pointer_width"] != 3:
+    raise SystemExit("objects copy-on-write qualification requires long24 pointers")
+sprites = contracts["sprites"]
+if sprites["pointer_width"] != 2:
+    raise SystemExit("sprite copy-on-write qualification requires bank16 pointers")
+pots = contracts["pot_items"]
+
+decision_by_room = {
+    (decision["kind"], decision["room_id"]): decision
+    for decision in baseline_stream_decisions
+}
+expected_baseline_spans = {
+    ("objects", "0x0A8"): (0x0FC169, 0x0FC272),
+    ("objects", "0x0B8"): (0x13861D, 0x1387B1),
+    ("sprites", "0x0D8"): (0x04E59F, 0x04E5B6),
+}
+for key, expected_span in expected_baseline_spans.items():
+    decision = decision_by_room.get(key)
+    if decision is None or (decision["_start"], decision["_end"]) != expected_span:
+        raise SystemExit(f"qualified baseline stream span changed for {key}")
+
+a8_stream = expected_baseline_spans[("objects", "0x0A8")]
+b8_stream = expected_baseline_spans[("objects", "0x0B8")]
+d8_sprite_stream = expected_baseline_spans[("sprites", "0x0D8")]
+a8_door_type_pc = 0x0FC26F
+d8_sprite_x_pc = 0x04E5A7
+d8_pot_item_pc = 0x00E512
+b8_cow_payload = (0x148000, 0x148196)
+b8_main_pointer = (
+    objects["pointer_table_pc"] + 0xB8 * objects["pointer_width"],
+    objects["pointer_table_pc"] + 0xB8 * objects["pointer_width"] + 3,
+)
+b8_door_pointer = (
+    door_pointer_table_pc + 0xB8 * 3,
+    door_pointer_table_pc + 0xB8 * 3 + 3,
+)
+a8_main_pointer = (
+    objects["pointer_table_pc"] + 0xA8 * objects["pointer_width"],
+    objects["pointer_table_pc"] + 0xA8 * objects["pointer_width"] + 3,
+)
+a8_door_pointer = (
+    door_pointer_table_pc + 0xA8 * 3,
+    door_pointer_table_pc + 0xA8 * 3 + 3,
+)
+d8_sprite_pointer = (
+    sprites["pointer_table_pc"] + 0xD8 * sprites["pointer_width"],
+    sprites["pointer_table_pc"] + 0xD8 * sprites["pointer_width"] + 2,
+)
+if not (a8_stream[0] <= a8_door_type_pc < a8_stream[1]):
+    raise SystemExit("A8 door type byte is outside its inventoried stream")
+if not (d8_sprite_stream[0] <= d8_sprite_x_pc < d8_sprite_stream[1]):
+    raise SystemExit("D8 sprite X byte is outside its inventoried stream")
+if not any(
+    start <= b8_cow_payload[0]
+    and b8_cow_payload[1] <= end
+    for start, end, _, _ in objects["allocation_ranges"]
+):
+    raise SystemExit("planned B8 COW payload is outside object allocation")
+if not any(
+    start <= d8_pot_item_pc < end
+    for start, end, _, _ in pots["allocation_ranges"]
+):
+    raise SystemExit("planned D8 pot byte is outside pot allocation")
+
+add_allowed(
+    d8_pot_item_pc,
+    d8_pot_item_pc + 1,
+    "D8 deterministic pot repack item byte",
+    "pot repack golden constrained by full post-save SHA-256",
+)
+add_allowed(
+    d8_sprite_x_pc,
+    d8_sprite_x_pc + 1,
+    "D8 sprite[2] X byte in exact inventoried stream",
+    "pre-save z3ed dungeon-stream-plan",
+)
+add_allowed(
+    palette_color_pc,
+    palette_color_pc + 2,
+    "room 0x0DA palette 7 color 7 BGR555 word",
+    "z3ed baseline color_pc 0x0DDC2E",
+)
+add_allowed(
+    *b8_main_pointer,
+    "B8 object COW main-pointer slot",
+    "dungeon_stream_regions.objects.pointer_table",
+)
+add_allowed(
+    *b8_door_pointer,
+    "B8 object COW auxiliary door-pointer slot",
+    "zelda3::kDoorPointers PC 0x0F83C0",
+)
+add_allowed(
+    a8_door_type_pc,
+    a8_door_type_pc + 1,
+    "A8 door[2] raw type byte in exact inventoried stream",
+    "pre-save z3ed dungeon-stream-plan",
+)
+add_allowed(
+    *b8_cow_payload,
+    "B8 exact planned copy-on-write payload",
+    "manifest allocation first-fit plus 404-byte baseline and F0 FF terminator",
+)
+
+allowed.sort(key=lambda item: (item["start"], item["end"], item["reason"]))
+merged_allowed = []
+for rule in allowed:
+    if not merged_allowed or rule["start"] > merged_allowed[-1][1]:
+        merged_allowed.append([rule["start"], rule["end"]])
+    else:
+        merged_allowed[-1][1] = max(merged_allowed[-1][1], rule["end"])
+
+ranges = []
+start = None
+differing_bytes = 0
+for offset, (old, new) in enumerate(zip(before, after)):
+    if old != new:
+        differing_bytes += 1
+        if start is None:
+            start = offset
+    elif start is not None:
+        ranges.append((start, offset))
+        start = None
+if start is not None:
+    ranges.append((start, len(before)))
+
+outside = []
+for changed_start, changed_end in ranges:
+    cursor = changed_start
+    for allowed_start, allowed_end in merged_allowed:
+        if allowed_end <= cursor:
+            continue
+        if allowed_start >= changed_end:
+            break
+        if allowed_start > cursor:
+            outside.append((cursor, min(allowed_start, changed_end)))
+        cursor = max(cursor, allowed_end)
+        if cursor >= changed_end:
+            break
+    if cursor < changed_end:
+        outside.append((cursor, changed_end))
+
+expected_changed_ranges = [
+    (0x00E512, 0x00E513),
+    (0x04E5A7, 0x04E5A8),
+    (0x0DDC2E, 0x0DDC2F),
+    (0x0F8228, 0x0F822B),
+    (0x0F85E8, 0x0F85EB),
+    (0x0FC26F, 0x0FC270),
+    (0x148000, 0x148196),
+]
+expected_transitions = [
+    (0x00E512, bytes.fromhex("0A"), bytes.fromhex("09"), "D8 pot item"),
+    (0x04E5A7, bytes.fromhex("04"), bytes.fromhex("05"), "D8 sprite X"),
+    (0x0DDC2E, bytes.fromhex("FF"), bytes.fromhex("FE"), "DA palette"),
+    (
+        b8_main_pointer[0],
+        bytes.fromhex("1D86A7"),
+        bytes.fromhex("008029"),
+        "B8 object pointer",
+    ),
+    (
+        b8_door_pointer[0],
+        bytes.fromhex("1F86A7"),
+        bytes.fromhex("948129"),
+        "B8 door pointer",
+    ),
+    (0x0FC26F, bytes.fromhex("18"), bytes.fromhex("00"), "A8 door type"),
+]
+golden_errors = []
+if digest(after) != expected_after_sha256:
+    golden_errors.append("post-save SHA-256 mismatch")
+if differing_bytes != 416:
+    golden_errors.append(f"expected 416 changed bytes, found {differing_bytes}")
+if ranges != expected_changed_ranges:
+    golden_errors.append("changed ranges do not match the seven-range golden")
+for offset, old, new, label in expected_transitions:
+    if before[offset : offset + len(old)] != old:
+        golden_errors.append(f"{label} baseline bytes mismatch")
+    if after[offset : offset + len(new)] != new:
+        golden_errors.append(f"{label} saved bytes mismatch")
+if before[b8_stream[0] : b8_stream[1]] != after[b8_stream[0] : b8_stream[1]]:
+    golden_errors.append("old B8 object stream changed during COW")
+for label, span in (
+    ("A8 object pointer", a8_main_pointer),
+    ("A8 door pointer", a8_door_pointer),
+    ("D8 sprite pointer", d8_sprite_pointer),
+):
+    if before[span[0] : span[1]] != after[span[0] : span[1]]:
+        golden_errors.append(f"{label} unexpectedly changed")
+pot_pointer_span = (
+    pots["pointer_table_pc"],
+    pots["pointer_table_pc"] + pots["pointer_count"] * pots["pointer_width"],
+)
+if before[pot_pointer_span[0] : pot_pointer_span[1]] != after[
+    pot_pointer_span[0] : pot_pointer_span[1]
+]:
+    golden_errors.append("pot repack pointer table unexpectedly changed")
+golden_matches = not golden_errors
+
+reported = []
+for start, end in ranges[:max_reported_ranges]:
+    old = before[start:end]
+    new = after[start:end]
+    matching_rules = [
+        rule["reason"]
+        for rule in allowed
+        if rule["start"] < end and start < rule["end"]
+    ]
+    reported.append({
+        "start_pc": f"0x{start:06X}",
+        "end_pc_exclusive": f"0x{end:06X}",
+        "length": end - start,
+        "before_sha256": digest(old),
+        "after_sha256": digest(new),
+        "before_prefix_hex": old[:16].hex().upper(),
+        "after_prefix_hex": new[:16].hex().upper(),
+        "allowed_by": matching_rules,
+    })
+
+all_changed_bytes_contained = not outside
+magnitude_within_bounds = (
+    differing_bytes > 0
+    and differing_bytes <= max_differing_bytes
+    and len(ranges) <= max_reported_ranges
+)
+within_bounds = (
+    magnitude_within_bounds and all_changed_bytes_contained and golden_matches
+)
+result = {
+    "before_path": before_path,
+    "after_path": after_path,
+    "rom_size": len(before),
+    "before_sha256": digest(before),
+    "after_sha256": digest(after),
+    "differing_byte_count": differing_bytes,
+    "range_count": len(ranges),
+    "limits": {
+        "max_differing_bytes": max_differing_bytes,
+        "max_reported_ranges": max_reported_ranges,
+    },
+    "ranges_truncated": len(ranges) > max_reported_ranges,
+    "magnitude_within_bounds": magnitude_within_bounds,
+    "golden_matches": golden_matches,
+    "within_bounds": within_bounds,
+    "allowlist": {
+        "source_manifest": manifest_path,
+        "source_manifest_sha256": digest(manifest_bytes),
+        "baseline_stream_inventories": {
+            "objects": {
+                "path": object_inventory_path,
+                "sha256": digest(object_inventory_bytes),
+                "source_crc32": object_inventory.get("source_crc32"),
+            },
+            "sprites": {
+                "path": sprite_inventory_path,
+                "sha256": digest(sprite_inventory_bytes),
+                "source_crc32": sprite_inventory.get("source_crc32"),
+            },
+        },
+        "address_conversion": "LoROM SNES address to headerless PC offset",
+        "edited_object_rooms": [f"0x{room:03X}" for room in object_rooms],
+        "edited_sprite_rooms": [f"0x{room:03X}" for room in sprite_rooms],
+        "baseline_stream_decisions": [
+            {
+                key: value
+                for key, value in decision.items()
+                if key not in {"_start", "_end"}
+            }
+            for decision in baseline_stream_decisions
+        ],
+        "rules": [
+            {key: value for key, value in rule.items() if key not in {"start", "end"}}
+            for rule in allowed
+        ],
+        "merged_pc_ranges": [
+            {
+                "start_pc": f"0x{start:06X}",
+                "end_pc_exclusive": f"0x{end:06X}",
+                "length": end - start,
+            }
+            for start, end in merged_allowed
+        ],
+    },
+    "allowlist_proof": {
+        "all_changed_bytes_contained": all_changed_bytes_contained,
+        "outside_range_count": len(outside),
+        "outside_ranges_truncated": len(outside) > max_reported_ranges,
+        "outside_ranges": [
+            {
+                "start_pc": f"0x{start:06X}",
+                "end_pc_exclusive": f"0x{end:06X}",
+                "length": end - start,
+            }
+            for start, end in outside[:max_reported_ranges]
+        ],
+    },
+    "golden_proof": {
+        "expected_before_sha256": expected_before_sha256,
+        "expected_after_sha256": expected_after_sha256,
+        "expected_differing_byte_count": 416,
+        "expected_range_count": 7,
+        "expected_ranges": [
+            {
+                "start_pc": f"0x{start:06X}",
+                "end_pc_exclusive": f"0x{end:06X}",
+                "length": end - start,
+            }
+            for start, end in expected_changed_ranges
+        ],
+        "old_b8_stream_unchanged": (
+            before[b8_stream[0] : b8_stream[1]]
+            == after[b8_stream[0] : b8_stream[1]]
+        ),
+        "a8_main_pointer_unchanged": (
+            before[a8_main_pointer[0] : a8_main_pointer[1]]
+            == after[a8_main_pointer[0] : a8_main_pointer[1]]
+        ),
+        "a8_door_pointer_unchanged": (
+            before[a8_door_pointer[0] : a8_door_pointer[1]]
+            == after[a8_door_pointer[0] : a8_door_pointer[1]]
+        ),
+        "d8_sprite_pointer_unchanged": (
+            before[d8_sprite_pointer[0] : d8_sprite_pointer[1]]
+            == after[d8_sprite_pointer[0] : d8_sprite_pointer[1]]
+        ),
+        "pot_pointer_table_unchanged": (
+            before[pot_pointer_span[0] : pot_pointer_span[1]]
+            == after[pot_pointer_span[0] : pot_pointer_span[1]]
+        ),
+        "errors": golden_errors,
+    },
+    "ranges": reported,
+}
+with open(output, "w", encoding="utf-8") as stream:
+    json.dump(result, stream, indent=2)
+    stream.write("\n")
+
+if not within_bounds:
+    raise SystemExit(
+        "ROM diff rejected: "
+        f"bytes={differing_bytes}, ranges={len(ranges)}, "
+        f"outside_allowlist_ranges={len(outside)}, "
+        f"golden_errors={len(golden_errors)}"
+    )
+PY
+}
+
+capture_readback() {
+  local phase="$1"
+  local door_type="$2"
+  local object_y="$3"
+  local sprite_x="$4"
+  local item_id="$5"
+  local palette_color="$6"
+  local out="$EVIDENCE_DIR/$phase"
+  mkdir "$out"
+
+  NO_COLOR=1 TERM=dumb "$Z3ED_BIN" dungeon-describe-room \
+    --room=0xA8 --rom="$ROM" --format=json > "$out/a8-door.json" ||
+    die 70 "$phase z3ed door readback failed"
+  NO_COLOR=1 TERM=dumb "$Z3ED_BIN" dungeon-list-objects \
+    --room=0xB8 --rom="$ROM" --format=json > "$out/b8-object.json" ||
+    die 70 "$phase z3ed object readback failed"
+  NO_COLOR=1 TERM=dumb "$Z3ED_BIN" dungeon-list-sprites \
+    --room=0xD8 --rom="$ROM" --format=json > "$out/d8-sprites.json" ||
+    die 70 "$phase z3ed sprite readback failed"
+  NO_COLOR=1 TERM=dumb "$Z3ED_BIN" dungeon-list-pot-items \
+    --room=0xD8 --rom="$ROM" --format=json > "$out/d8-pot-items.json" ||
+    die 70 "$phase z3ed pot-item readback failed"
+  NO_COLOR=1 TERM=dumb "$Z3ED_BIN" dungeon-get-palette \
+    --room=0xDA --index=7 --rom="$ROM" --format=json > "$out/da-palette.json" ||
+    die 70 "$phase z3ed palette readback failed"
+
+  jq -e --arg expected "$door_type" '
+    .doors[2] as $door |
+    $door.index == 2 and $door.tile_x == 46 and $door.tile_y == 58 and
+    $door.type_id == $expected
+  ' "$out/a8-door.json" >/dev/null ||
+    die 74 "$phase A8 door[2] readback mismatch"
+  jq -e --argjson expected "$object_y" '
+    .["Dungeon Room Objects"].objects[128] as $object |
+    $object.id_hex == "0x00BC" and $object.x == 28 and
+    $object.size == 0 and $object.layer == 0 and $object.y == $expected
+  ' "$out/b8-object.json" >/dev/null ||
+    die 74 "$phase B8 object[128] readback mismatch"
+  jq -e --argjson expected "$sprite_x" '
+    .["Dungeon Room Sprites"].sprites[2] as $sprite |
+    $sprite.sprite_id == "0x64" and $sprite.y == 5 and
+    $sprite.subtype == 0 and $sprite.layer == 0 and $sprite.x == $expected
+  ' "$out/d8-sprites.json" >/dev/null ||
+    die 74 "$phase D8 sprite[2] readback mismatch"
+  jq -e --arg expected "$item_id" '
+    .["Dungeon Pot Items"].items[5] as $item |
+    $item.position == "0x0C4C" and $item.tile_x == 38 and
+    $item.tile_y == 24 and $item.item_id == $expected
+  ' "$out/d8-pot-items.json" >/dev/null ||
+    die 74 "$phase D8 pot[5] readback mismatch"
+  jq -e --arg expected "$palette_color" '
+    .["Dungeon Palette"] as $palette |
+    $palette.room_id == "0x0DA" and
+    $palette.palette_set_id == "0x07" and
+    $palette.resolved_palette_index == 7 and
+    $palette.color_index == 7 and
+    $palette.color_pc == "0x0DDC2E" and
+    $palette.color_snes == $expected
+  ' "$out/da-palette.json" >/dev/null ||
+    die 74 "$phase DA palette 7 color 7 readback mismatch"
+
+  {
+    echo "phase=$phase"
+    echo "captured_at_utc=$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+    echo "rom_sha1=$(sha1_file "$ROM")"
+    echo "rom_sha256=$(sha256_file "$ROM")"
+    echo "expected_door_type=$door_type"
+    echo "expected_object_y=$object_y"
+    echo "expected_sprite_x=$sprite_x"
+    echo "expected_item_id=$item_id"
+    echo "expected_palette_color=$palette_color"
+  } > "$out/readback.txt"
+}
+
+wait_for_harness() {
+  local label="$1"
+  local deadline=$((SECONDS + 30))
+  local log="$EVIDENCE_DIR/$label-harness-ready.txt"
+  while [[ "$SECONDS" -lt "$deadline" ]]; do
+    if ! kill -0 "$YAZE_PID" 2>/dev/null; then
+      return 1
+    fi
+    if NO_COLOR=1 TERM=dumb "$Z3ED_BIN" agent test list \
+      --host 127.0.0.1 --port "$HARNESS_PORT" > "$log" 2>&1; then
+      return 0
+    fi
+    sleep 0.25
+  done
+  return 1
+}
+
+wait_for_room_widget() {
+  local label="$1"
+  local key="Dungeon/Workbench/input_scalar:room_id"
+  local deadline=$((SECONDS + 30))
+  local output="$EVIDENCE_DIR/$label-room-widget.json"
+  while [[ "$SECONDS" -lt "$deadline" ]]; do
+    if ! kill -0 "$YAZE_PID" 2>/dev/null; then
+      return 1
+    fi
+    if NO_COLOR=1 TERM=dumb "$Z3ED_BIN" gui-assert \
+      --widget-key="$key" \
+      --gui_server_address="127.0.0.1:$HARNESS_PORT" \
+      --format=json > "$output" 2>/dev/null &&
+       jq -e --arg key "$key" '
+         .["GUI Assert Action"].status == "Success" and
+         .["GUI Assert Action"].resolved_widget_key == $key
+       ' "$output" >/dev/null 2>&1; then
+      return 0
+    fi
+    sleep 0.25
+  done
+  return 1
+}
+
+launch_yaze() {
+  local label="$1"
+  local app_data="$EVIDENCE_DIR/$label-yaze-app-data"
+  local runtime_dir="$EVIDENCE_DIR/$label-runtime"
+  local log_file="$EVIDENCE_DIR/$label-yaze.log"
+  mkdir -p "$app_data" "$runtime_dir"
+  chmod 700 "$runtime_dir"
+
+  local command=(
+    "$YAZE_BIN"
+    --service
+    --enable_test_harness
+    "--test_harness_port=$HARNESS_PORT"
+    "--api_port=$API_PORT"
+    "--rom_file=$PROJECT"
+    --editor=Dungeon
+    --open_panels=dungeon.workbench
+    --startup_welcome=hide
+    --startup_dashboard=hide
+    --startup_sidebar=hide
+    "--log_file=$log_file"
+    --log_to_console
+  )
+
+  {
+    printf 'YAZE_APP_DATA_DIR=%q XDG_RUNTIME_DIR=%q ' "$app_data" "$runtime_dir"
+    printf '%q ' "${command[@]}"
+    printf '\n'
+  } > "$EVIDENCE_DIR/$label-command.txt"
+
+  YAZE_APP_DATA_DIR="$app_data" XDG_RUNTIME_DIR="$runtime_dir" \
+    "${command[@]}" > "$EVIDENCE_DIR/$label-stdout-stderr.txt" 2>&1 &
+  YAZE_PID=$!
+  echo "$YAZE_PID" > "$EVIDENCE_DIR/$label.pid"
+
+  wait_for_owned_listener "$label" harness "$HARNESS_PORT" ||
+    die 70 "$label harness listener is not owned by Yaze PID $YAZE_PID"
+  wait_for_owned_listener "$label" api "$API_PORT" ||
+    die 70 "$label API listener is not owned by Yaze PID $YAZE_PID"
+  wait_for_harness "$label" ||
+    die 70 "$label Yaze process did not expose the gRPC harness; see $log_file"
+  wait_for_room_widget "$label" ||
+    die 70 "$label Yaze process did not render the Workbench room selector"
+}
+
+run_replay() {
+  local fixture="$1"
+  local label="$2"
+  NO_COLOR=1 TERM=dumb "$Z3ED_BIN" agent test replay "$fixture" \
+    --host 127.0.0.1 --port "$HARNESS_PORT" --ci \
+    > "$EVIDENCE_DIR/$label-replay.txt" 2>&1
+}
+
+wait_for_process_exit() {
+  local label="$1"
+  local deadline=$((SECONDS + 20))
+  while kill -0 "$YAZE_PID" 2>/dev/null && [[ "$SECONDS" -lt "$deadline" ]]; do
+    sleep 0.1
+  done
+  if kill -0 "$YAZE_PID" 2>/dev/null; then
+    die 70 "$label Yaze process did not exit after the registered Quit action"
+  fi
+  local exited_pid="$YAZE_PID"
+  local process_status=0
+  wait "$exited_pid" || process_status=$?
+  YAZE_PID=""
+  [[ "$process_status" -eq 0 ]] ||
+    die 70 "$label Yaze process exited with status $process_status"
+}
+
+cat > "$EVIDENCE_DIR/quit.json" <<'EOF_QUIT'
+{
+  "schema_version": 1,
+  "name": "Quit the D6 qualification instance",
+  "steps": [
+    {
+      "action": "click",
+      "target": "menu:File",
+      "expect": { "success": true, "status": "passed" }
+    },
+    {
+      "action": "click",
+      "widget_key": "menuitem:Quit",
+      "expect": { "success": true, "status": "passed" }
+    }
+  ]
+}
+EOF_QUIT
+
+BACKUP_INVENTORY_BEFORE="$EVIDENCE_DIR/backups-before.json"
+BACKUP_VERIFICATION="$EVIDENCE_DIR/backups-after-save.json"
+write_backup_inventory "$BACKUP_INVENTORY_BEFORE" ||
+  die 70 "could not inventory the disposable ROM backup directory"
+
+capture_readback baseline 0x18 7 4 0x0A 0x7FFF
+assert_frozen_inputs_unchanged || die 74 "a frozen input changed during baseline"
+
+launch_yaze first-launch
+FIRST_PID="$YAZE_PID"
+run_replay "$FROZEN_EDIT_FIXTURE" edit-and-save
+verify_backup_creation "$BACKUP_INVENTORY_BEFORE" "$BACKUP_VERIFICATION" ||
+  die 74 "Save ROM backup verification failed; see $BACKUP_VERIFICATION"
+BACKUP_MATCH_PATH="$(jq -er '.matching_pre_save_backups[0].path' \
+  "$BACKUP_VERIFICATION")" ||
+  die 74 "backup verification did not record a matching backup path"
+BACKUP_MATCH_SHA256="$(jq -er '.matching_pre_save_backups[0].sha256' \
+  "$BACKUP_VERIFICATION")" ||
+  die 74 "backup verification did not record a matching backup hash"
+NEW_BACKUP_COUNT="$(jq -er '.new_backups | length' "$BACKUP_VERIFICATION")" ||
+  die 74 "backup verification did not record new backup files"
+
+TARGET_ROM_SHA256_AFTER_SAVE="$(sha256_file "$ROM")"
+[[ "$TARGET_ROM_SHA256_AFTER_SAVE" != "$TARGET_ROM_SHA256_BEFORE" ]] ||
+  die 74 "Save ROM reported success but the disposable ROM hash did not change"
+ROM_BYTE_DIFF="$EVIDENCE_DIR/rom-byte-diff.json"
+generate_bounded_rom_diff \
+  "$BACKUP_MATCH_PATH" "$ROM" "$TARGET_MANIFEST" \
+  "$OBJECT_STREAM_INVENTORY" "$SPRITE_STREAM_INVENTORY" \
+  "$QUALIFIED_BASELINE_SHA256" "$QUALIFIED_SAVED_SHA256" \
+  "$ROM_BYTE_DIFF" ||
+  die 74 "saved ROM byte diff exceeded bounds or allowlist; see $ROM_BYTE_DIFF"
+ROM_DIFF_BYTE_COUNT="$(jq -er '.differing_byte_count' "$ROM_BYTE_DIFF")" ||
+  die 74 "ROM byte diff did not record a differing-byte count"
+ROM_DIFF_RANGE_COUNT="$(jq -er '.range_count' "$ROM_BYTE_DIFF")" ||
+  die 74 "ROM byte diff did not record a range count"
+ROM_DIFF_ALLOWLIST_RULE_COUNT="$(jq -er '.allowlist.rules | length' \
+  "$ROM_BYTE_DIFF")" || die 74 "ROM byte diff did not record allowlist rules"
+ROM_DIFF_OUTSIDE_RANGE_COUNT="$(jq -er \
+  '.allowlist_proof.outside_range_count' "$ROM_BYTE_DIFF")" ||
+  die 74 "ROM byte diff did not record outside-allowlist ranges"
+ROM_DIFF_BASELINE_STREAM_COUNT="$(jq -er \
+  '.allowlist.baseline_stream_decisions | length' "$ROM_BYTE_DIFF")" ||
+  die 74 "ROM byte diff did not record baseline stream decisions"
+jq -e '
+  .within_bounds == true and
+  .golden_matches == true and
+  .golden_proof.expected_differing_byte_count == 416 and
+  .golden_proof.expected_range_count == 7 and
+  .golden_proof.old_b8_stream_unchanged == true and
+  .golden_proof.a8_main_pointer_unchanged == true and
+  .golden_proof.a8_door_pointer_unchanged == true and
+  .golden_proof.d8_sprite_pointer_unchanged == true and
+  .golden_proof.pot_pointer_table_unchanged == true and
+  (.golden_proof.errors | length) == 0 and
+  .allowlist_proof.all_changed_bytes_contained == true and
+  .allowlist_proof.outside_range_count == 0 and
+  (.allowlist.baseline_stream_decisions | length) == 3 and
+  ([.allowlist.baseline_stream_decisions[] |
+      select(.unique_owner == true and .exact_alias == false and
+             .overlap == false)] | length) == 3
+' "$ROM_BYTE_DIFF" >/dev/null ||
+  die 74 "ROM byte diff containment proof failed; see $ROM_BYTE_DIFF"
+capture_readback before-quit 0x00 8 5 0x09 0x7FFE
+assert_frozen_inputs_unchanged || die 74 "a frozen input changed before first quit"
+
+run_replay "$EVIDENCE_DIR/quit.json" first-quit
+wait_for_process_exit first-launch
+[[ "$(sha256_file "$ROM")" == "$TARGET_ROM_SHA256_AFTER_SAVE" ]] ||
+  die 74 "disposable ROM changed while quitting the first launch"
+
+wait_for_port_free "$HARNESS_PORT" ||
+  die 70 "harness port did not close after first launch"
+wait_for_port_free "$API_PORT" ||
+  die 70 "API port did not close after first launch"
+
+launch_yaze second-launch
+SECOND_PID="$YAZE_PID"
+run_replay "$FROZEN_REOPEN_FIXTURE" reopen-assert
+capture_readback after-relaunch 0x00 8 5 0x09 0x7FFE
+[[ "$(sha256_file "$ROM")" == "$TARGET_ROM_SHA256_AFTER_SAVE" ]] ||
+  die 74 "reopened ROM hash differs from the post-save hash"
+assert_frozen_inputs_unchanged || die 74 "a frozen input changed after relaunch"
+
+run_replay "$EVIDENCE_DIR/quit.json" second-quit
+wait_for_process_exit second-launch
+[[ "$(sha256_file "$ROM")" == "$TARGET_ROM_SHA256_AFTER_SAVE" ]] ||
+  die 74 "disposable ROM changed while quitting the second launch"
+assert_frozen_inputs_unchanged || die 74 "a frozen input changed at completion"
+
+jq -n \
+  --arg completed_at_utc "$(date -u '+%Y-%m-%dT%H:%M:%SZ')" \
+  --arg project "$PROJECT" \
+  --arg rom "$ROM" \
+  --arg canonical_project "$CANONICAL_PROJECT" \
+  --arg canonical_rom "$CANONICAL_ROM" \
+  --arg manifest "$TARGET_MANIFEST" \
+  --arg canonical_manifest "$CANONICAL_MANIFEST" \
+  --arg yaze_bin "$YAZE_BIN" \
+  --arg z3ed_bin "$Z3ED_BIN" \
+  --arg yaze_bin_sha256 "$YAZE_BIN_SHA256" \
+  --arg z3ed_bin_sha256 "$Z3ED_BIN_SHA256" \
+  --arg project_sha256 "$TARGET_PROJECT_SHA256_BEFORE" \
+  --arg manifest_sha256 "$TARGET_MANIFEST_SHA256_BEFORE" \
+  --arg canonical_project_sha256 "$CANONICAL_PROJECT_SHA256_BEFORE" \
+  --arg canonical_manifest_sha256 "$CANONICAL_MANIFEST_SHA256_BEFORE" \
+  --arg initial_sha256 "$TARGET_ROM_SHA256_BEFORE" \
+  --arg saved_sha256 "$TARGET_ROM_SHA256_AFTER_SAVE" \
+  --arg canonical_sha256 "$CANONICAL_ROM_SHA256_BEFORE" \
+  --arg provenance "$PROVENANCE_EVIDENCE" \
+  --arg feature_flags "$FEATURE_FLAG_EVIDENCE" \
+  --arg object_stream_inventory "$OBJECT_STREAM_INVENTORY" \
+  --arg object_stream_inventory_sha256 "$OBJECT_STREAM_INVENTORY_SHA256" \
+  --arg sprite_stream_inventory "$SPRITE_STREAM_INVENTORY" \
+  --arg sprite_stream_inventory_sha256 "$SPRITE_STREAM_INVENTORY_SHA256" \
+  --arg stream_inventory_validation "$STREAM_INVENTORY_VALIDATION" \
+  --arg stream_inventory_validation_sha256 "$STREAM_INVENTORY_VALIDATION_SHA256" \
+  --arg frozen_edit_fixture "$FROZEN_EDIT_FIXTURE" \
+  --arg frozen_reopen_fixture "$FROZEN_REOPEN_FIXTURE" \
+  --arg yaze_git_head "$YAZE_GIT_HEAD" \
+  --arg git_status "$GIT_STATUS_EVIDENCE" \
+  --arg rom_byte_diff "$ROM_BYTE_DIFF" \
+  --arg first_harness_listener "$EVIDENCE_DIR/first-launch-harness-listener.json" \
+  --arg first_api_listener "$EVIDENCE_DIR/first-launch-api-listener.json" \
+  --arg second_harness_listener "$EVIDENCE_DIR/second-launch-harness-listener.json" \
+  --arg second_api_listener "$EVIDENCE_DIR/second-launch-api-listener.json" \
+  --arg backup_dir "$TARGET_BACKUP_DIR" \
+  --arg backup_path "$BACKUP_MATCH_PATH" \
+  --arg backup_sha256 "$BACKUP_MATCH_SHA256" \
+  --arg backup_inventory_before "$BACKUP_INVENTORY_BEFORE" \
+  --arg backup_verification "$BACKUP_VERIFICATION" \
+  --argjson new_backup_count "$NEW_BACKUP_COUNT" \
+  --argjson yaze_git_dirty "$YAZE_GIT_DIRTY" \
+  --argjson manifests_equal_before "$MANIFESTS_EQUAL_BEFORE" \
+  --argjson rom_diff_byte_count "$ROM_DIFF_BYTE_COUNT" \
+  --argjson rom_diff_range_count "$ROM_DIFF_RANGE_COUNT" \
+  --argjson rom_diff_allowlist_rule_count "$ROM_DIFF_ALLOWLIST_RULE_COUNT" \
+  --argjson rom_diff_outside_range_count "$ROM_DIFF_OUTSIDE_RANGE_COUNT" \
+  --argjson rom_diff_baseline_stream_count "$ROM_DIFF_BASELINE_STREAM_COUNT" \
+  --argjson first_pid "$FIRST_PID" \
+  --argjson second_pid "$SECOND_PID" \
+  --argjson harness_port "$HARNESS_PORT" \
+  --argjson api_port "$API_PORT" '
+    {
+      status: "pass",
+      completed_at_utc: $completed_at_utc,
+      disposable: {
+        project: {path: $project, sha256: $project_sha256},
+        rom: $rom,
+        manifest: {path: $manifest, sha256: $manifest_sha256},
+        initial_sha256: $initial_sha256,
+        saved_sha256: $saved_sha256
+      },
+      canonical: {
+        project: {path: $canonical_project, sha256: $canonical_project_sha256},
+        rom: $canonical_rom,
+        rom_sha256: $canonical_sha256,
+        manifest: {
+          path: $canonical_manifest,
+          sha256: $canonical_manifest_sha256
+        },
+        unchanged: true
+      },
+      manifests_equal_before: $manifests_equal_before,
+      backup: {
+        directory: $backup_dir,
+        matching_pre_save_path: $backup_path,
+        matching_pre_save_sha256: $backup_sha256,
+        new_backup_count: $new_backup_count,
+        inventory_before: $backup_inventory_before,
+        verification: $backup_verification
+      },
+      provenance: {
+        file: $provenance,
+        feature_flags: $feature_flags,
+        yaze_git: {
+          head: $yaze_git_head,
+          dirty: $yaze_git_dirty,
+          status_file: $git_status
+        },
+        frozen_fixtures: {
+          edit: $frozen_edit_fixture,
+          reopen: $frozen_reopen_fixture
+        },
+        baseline_stream_inventory: {
+          objects: {
+            path: $object_stream_inventory,
+            sha256: $object_stream_inventory_sha256
+          },
+          sprites: {
+            path: $sprite_stream_inventory,
+            sha256: $sprite_stream_inventory_sha256
+          },
+          validation: {
+            path: $stream_inventory_validation,
+            sha256: $stream_inventory_validation_sha256
+          }
+        }
+      },
+      binaries: {
+        yaze: {path: $yaze_bin, sha256: $yaze_bin_sha256},
+        z3ed: {path: $z3ed_bin, sha256: $z3ed_bin_sha256}
+      },
+      launches: [
+        {
+          label: "first-launch",
+          pid: $first_pid,
+          harness_listener: $first_harness_listener,
+          api_listener: $first_api_listener
+        },
+        {
+          label: "second-launch",
+          pid: $second_pid,
+          harness_listener: $second_harness_listener,
+          api_listener: $second_api_listener
+        }
+      ],
+      ports: {harness: $harness_port, api: $api_port},
+      gui_replay: {
+        edit_and_save: "pass",
+        reopen_assert: "pass",
+        registered_quit_actions: 2
+      },
+      z3ed_readback: {
+        baseline: "pass",
+        before_quit: "pass",
+        after_relaunch: "pass"
+      },
+      rom_byte_diff: {
+        file: $rom_byte_diff,
+        differing_byte_count: $rom_diff_byte_count,
+        range_count: $rom_diff_range_count,
+        bounded: true,
+        allowlist_rule_count: $rom_diff_allowlist_rule_count,
+        baseline_stream_decision_count: $rom_diff_baseline_stream_count,
+        all_changed_bytes_contained: true,
+        outside_allowlist_range_count: $rom_diff_outside_range_count
+      }
+    }
+  ' > "$EVIDENCE_DIR/qualification-summary.json"
+
+echo "D6 GUI save/reopen qualification passed"
+echo "  evidence: $EVIDENCE_DIR"
+echo "  initial ROM SHA-256: $TARGET_ROM_SHA256_BEFORE"
+echo "  saved ROM SHA-256:   $TARGET_ROM_SHA256_AFTER_SAVE"
+echo "  pre-save backup:      $BACKUP_MATCH_PATH"
+echo "  backup SHA-256:       $BACKUP_MATCH_SHA256"
+echo "  ROM byte diff:        $ROM_BYTE_DIFF ($ROM_DIFF_BYTE_COUNT bytes, $ROM_DIFF_RANGE_COUNT ranges)"
+echo "  diff containment:     $ROM_DIFF_ALLOWLIST_RULE_COUNT allowlist rules, $ROM_DIFF_BASELINE_STREAM_COUNT baseline streams, 0 outside ranges"
+echo "  canonical unchanged: $CANONICAL_ROM_SHA256_BEFORE"

--- a/scripts/agents/run-d6-gui-qualification.sh
+++ b/scripts/agents/run-d6-gui-qualification.sh
@@ -373,28 +373,26 @@ for key in (
     "save_dungeon_pot_items",
     "save_dungeon_entrances",
     "save_dungeon_palettes",
+    "save_overworld_maps",
+    "save_overworld_entrances",
+    "save_overworld_exits",
+    "save_overworld_items",
+    "save_overworld_properties",
 ):
     report[key] = parse_bool(key, required=False, default=True)
 
-# The native INI reader in this Yaze revision does not parse a
-# save_dungeon_water_fill_zones key. Record the actual effective default rather
-# than implying a descriptor value can disable it.
-water_fill_raw = None
-if parser.has_option("feature_flags", "save_dungeon_water_fill_zones"):
-    water_fill_raw = parser.get(
-        "feature_flags", "save_dungeon_water_fill_zones"
-    ).strip()
-report["save_dungeon_water_fill_zones"] = {
-    "present": water_fill_raw is not None,
-    "descriptor_value_ignored": water_fill_raw,
-    "value": True,
-    "source": "yaze_default_unconfigurable_in_ini",
-}
+report["save_dungeon_water_fill_zones"] = parse_bool(
+    "save_dungeon_water_fill_zones", required=True, default=False
+)
 
 if report["save_dungeon_maps"]["value"]:
     raise SystemExit("feature_flags.save_dungeon_maps must be false")
 if report["save_graphics_sheet"]["value"]:
     raise SystemExit("feature_flags.save_graphics_sheet must be false")
+if report["save_dungeon_water_fill_zones"]["value"]:
+    raise SystemExit(
+        "feature_flags.save_dungeon_water_fill_zones must be false"
+    )
 for key in (
     "save_dungeon_objects",
     "save_dungeon_sprites",
@@ -415,6 +413,11 @@ unrelated_keys = (
     "save_dungeon_entrances",
     "save_dungeon_maps",
     "save_graphics_sheet",
+    "save_overworld_maps",
+    "save_overworld_entrances",
+    "save_overworld_exits",
+    "save_overworld_items",
+    "save_overworld_properties",
 )
 payload = {
     "effective_flags": report,
@@ -431,8 +434,9 @@ payload = {
         "applied": False,
         "descriptor_modified": False,
         "policy": (
-            "Record effective defaults; exact ROM byte-diff containment must "
-            "reject writes from unrelated domains."
+            "Record effective defaults; coordinated saves serialize only "
+            "already-loaded editors, and exact ROM byte-diff containment "
+            "must reject writes from unrelated domains."
         ),
     },
 }
@@ -880,12 +884,12 @@ import sys
 
 port = int(sys.argv[1])
 sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+sock.settimeout(0.25)
 try:
-    sock.bind(("127.0.0.1", port))
-except OSError:
-    raise SystemExit(1)
+    listening = sock.connect_ex(("127.0.0.1", port)) == 0
 finally:
     sock.close()
+raise SystemExit(1 if listening else 0)
 PY
 }
 
@@ -1960,12 +1964,7 @@ cat > "$EVIDENCE_DIR/quit.json" <<'EOF_QUIT'
   "steps": [
     {
       "action": "click",
-      "target": "menu:File",
-      "expect": { "success": true, "status": "passed" }
-    },
-    {
-      "action": "click",
-      "widget_key": "menuitem:Quit",
+      "target": "shortcut:Quit",
       "expect": { "success": true, "status": "passed" }
     }
   ]

--- a/scripts/agents/run-d6-gui-qualification.sh
+++ b/scripts/agents/run-d6-gui-qualification.sh
@@ -1844,6 +1844,7 @@ wait_for_room_widget() {
     fi
     if NO_COLOR=1 TERM=dumb "$Z3ED_BIN" gui-assert \
       --widget-key="$key" \
+      --rom="$ROM" \
       --gui_server_address="127.0.0.1:$HARNESS_PORT" \
       --format=json > "$output" 2>/dev/null &&
        jq -e --arg key "$key" '

--- a/scripts/agents/run-d6-gui-qualification.sh
+++ b/scripts/agents/run-d6-gui-qualification.sh
@@ -1833,6 +1833,27 @@ wait_for_harness() {
   return 1
 }
 
+wait_for_rendered_frame() {
+  local label="$1"
+  local deadline=$((SECONDS + 30))
+  local output="$EVIDENCE_DIR/$label-render-ready.json"
+  while [[ "$SECONDS" -lt "$deadline" ]]; do
+    if ! kill -0 "$YAZE_PID" 2>/dev/null; then
+      return 1
+    fi
+    if NO_COLOR=1 TERM=dumb "$Z3ED_BIN" gui-screenshot \
+      --rom="$ROM" \
+      --gui_server_address="127.0.0.1:$HARNESS_PORT" \
+      --format=json > "$output" 2>/dev/null &&
+       jq -e '.["Screenshot Capture"].status == "Success"' \
+         "$output" >/dev/null 2>&1; then
+      return 0
+    fi
+    sleep 0.25
+  done
+  return 1
+}
+
 wait_for_room_widget() {
   local label="$1"
   local key="Dungeon/Workbench/input_scalar:room_id"
@@ -1842,14 +1863,16 @@ wait_for_room_widget() {
     if ! kill -0 "$YAZE_PID" 2>/dev/null; then
       return 1
     fi
-    if NO_COLOR=1 TERM=dumb "$Z3ED_BIN" gui-assert \
-      --widget-key="$key" \
+    if NO_COLOR=1 TERM=dumb "$Z3ED_BIN" gui-discover-tool \
+      --window="Dungeon Workbench" \
       --rom="$ROM" \
       --gui_server_address="127.0.0.1:$HARNESS_PORT" \
       --format=json > "$output" 2>/dev/null &&
        jq -e --arg key "$key" '
-         .["GUI Assert Action"].status == "Success" and
-         .["GUI Assert Action"].resolved_widget_key == $key
+         .["Widget Discovery"].status == "Success" and
+         ([.["Widget Discovery"].windows[].widgets[] |
+             select(. == ("room_id (input_scalar) - " + $key))] |
+          length) == 1
        ' "$output" >/dev/null 2>&1; then
       return 0
     fi
@@ -1899,6 +1922,8 @@ launch_yaze() {
     die 70 "$label optional API listener could not be classified safely"
   wait_for_harness "$label" ||
     die 70 "$label Yaze process did not expose the gRPC harness; see $log_file"
+  wait_for_rendered_frame "$label" ||
+    die 70 "$label Yaze process did not complete a rendered frame"
   wait_for_room_widget "$label" ||
     die 70 "$label Yaze process did not render the Workbench room selector"
 }

--- a/src/app/application.cc
+++ b/src/app/application.cc
@@ -85,6 +85,17 @@ void Application::Initialize(const AppConfig& config) {
     LOG_INFO("App", "Controller initialized successfully. Active: %s",
              controller_->IsActive() ? "Yes" : "No");
 
+#ifdef YAZE_WITH_GRPC
+    test::TestManager::Get().SetFailureScreenshotRequester(
+        [controller = controller_.get()](
+            const std::string& preferred_path,
+            test::TestManager::FailureScreenshotCallback callback) {
+          controller->RequestScreenshot({.preferred_path = preferred_path,
+                                         .reveal_to_user = false,
+                                         .callback = std::move(callback)});
+        });
+#endif
+
     if (controller_->editor_manager()) {
       controller_->editor_manager()->ApplyStartupVisibility(config_);
     }
@@ -358,6 +369,7 @@ void Application::Shutdown() {
     grpc_server_.reset();
   }
   canvas_automation_service_.reset();
+  test::TestManager::Get().SetFailureScreenshotRequester({});
 #endif
 
 #ifndef __EMSCRIPTEN__

--- a/src/app/controller.cc
+++ b/src/app/controller.cc
@@ -80,6 +80,15 @@ absl::Status Controller::OnEntry(std::string filename) {
   // Initialize ImGui via backend (handles SDL2/SDL3 automatically)
   RETURN_IF_ERROR(window_backend_->InitializeImGui(renderer_.get()));
 
+  // The test manager is linked at the controller/executable layer rather than
+  // the platform window library. Initialize its engine here, after ImGui has a
+  // context, so remote harness actions use the real engine. The dedicated GUI
+  // test runner owns a separate engine and initializes it below its OnEntry().
+#if defined(YAZE_ENABLE_IMGUI_TEST_ENGINE) && YAZE_ENABLE_IMGUI_TEST_ENGINE && \
+    !defined(YAZE_GUI_TEST_TARGET)
+  test::TestManager::Get().InitializeUITesting();
+#endif
+
   // Initialize the graphics Arena with the renderer
   gfx::Arena::Get().Initialize(renderer_.get());
 
@@ -350,12 +359,24 @@ void Controller::DoRender() const {
 }
 
 void Controller::OnExit() {
+#if defined(YAZE_ENABLE_IMGUI_TEST_ENGINE) && YAZE_ENABLE_IMGUI_TEST_ENGINE && \
+    !defined(YAZE_GUI_TEST_TARGET)
+  // Stop the test engine while its bound ImGui context is still alive.
+  test::TestManager::Get().StopUITesting();
+#endif
+
   if (renderer_) {
     renderer_->Shutdown();
   }
   if (window_backend_) {
     window_backend_->Shutdown();
   }
+
+#if defined(YAZE_ENABLE_IMGUI_TEST_ENGINE) && YAZE_ENABLE_IMGUI_TEST_ENGINE && \
+    !defined(YAZE_GUI_TEST_TARGET)
+  // The backend owns and destroys ImGui; release the engine context afterward.
+  test::TestManager::Get().DestroyUITestingContext();
+#endif
 }
 
 absl::Status Controller::LoadRomForTesting(const std::string& rom_path) {

--- a/src/app/controller.cc
+++ b/src/app/controller.cc
@@ -405,7 +405,8 @@ void Controller::ProcessScreenshotRequests() const {
     screenshot_requests_.pop();
 
     // Perform capture on main thread
-    auto result = test::CaptureHarnessScreenshot(request.preferred_path);
+    auto result = test::CaptureHarnessScreenshot(request.preferred_path,
+                                                 request.reveal_to_user);
     if (request.callback) {
       request.callback(result);
     }

--- a/src/app/controller.h
+++ b/src/app/controller.h
@@ -34,6 +34,7 @@ class Controller {
  public:
   struct ScreenshotRequest {
     std::string preferred_path;
+    bool reveal_to_user = false;
     std::function<void(absl::StatusOr<test::ScreenshotArtifact>)> callback;
   };
 

--- a/src/app/editor/agent/agent_editor.cc
+++ b/src/app/editor/agent/agent_editor.cc
@@ -109,7 +109,16 @@ AgentEditor::AgentEditor() {
       "Describe the persona, tone, and constraints for this agent.";
 }
 
-AgentEditor::~AgentEditor() = default;
+AgentEditor::~AgentEditor() {
+#ifdef YAZE_WITH_GRPC
+  if (harness_telemetry_bridge_) {
+    harness_telemetry_bridge_->SetAgentChat(nullptr);
+    test::TestManager::Get().ClearHarnessListener(
+        harness_telemetry_bridge_.get());
+    harness_telemetry_bridge_.reset();
+  }
+#endif
+}
 
 void AgentEditor::Initialize() {
   // Base initialization

--- a/src/app/editor/agent/agent_editor.h
+++ b/src/app/editor/agent/agent_editor.h
@@ -320,7 +320,8 @@ class AgentEditor : public Editor {
   std::unique_ptr<SramViewerPanel> sram_viewer_panel_;
 #ifdef YAZE_WITH_GRPC
   std::unique_ptr<NetworkCollaborationCoordinator> network_coordinator_;
-  AutomationBridge harness_telemetry_bridge_;
+  std::shared_ptr<AutomationBridge> harness_telemetry_bridge_ =
+      std::make_shared<AutomationBridge>();
 #endif
 
   ToastManager* toast_manager_ = nullptr;

--- a/src/app/editor/agent/agent_editor_models.cc
+++ b/src/app/editor/agent/agent_editor_models.cc
@@ -519,8 +519,8 @@ void AgentEditor::InitializeWithDependencies(ToastManager* toast_manager,
 
 #ifdef YAZE_WITH_GRPC
   if (agent_chat_) {
-    harness_telemetry_bridge_.SetAgentChat(agent_chat_.get());
-    test::TestManager::Get().SetHarnessListener(&harness_telemetry_bridge_);
+    harness_telemetry_bridge_->SetAgentChat(agent_chat_.get());
+    test::TestManager::Get().SetHarnessListener(harness_telemetry_bridge_);
   }
 #endif
 

--- a/src/app/editor/dungeon/dungeon_editor_v2.cc
+++ b/src/app/editor/dungeon/dungeon_editor_v2.cc
@@ -397,6 +397,8 @@ void DungeonEditorV2::ReloadWaterFillZones() {
   });
 
   bool legacy_imported = false;
+  const bool water_fill_save_enabled =
+      core::FeatureFlags::get().dungeon.kSaveWaterFillZones;
   std::vector<zelda3::WaterFillZoneEntry> zones;
 
   auto zones_or = zelda3::LoadWaterFillTable(rom_);
@@ -442,14 +444,20 @@ void DungeonEditorV2::ReloadWaterFillZones() {
       room.SetWaterFillTile(x, y, true);
     }
 
-    if (!legacy_imported) {
+    // A passive legacy import is pending migration only when this project is
+    // allowed to write the WaterFill table. Otherwise retain the overlay as
+    // read-only reference data without creating unsavable room dirtiness.
+    if (!legacy_imported || !water_fill_save_enabled) {
       room.ClearWaterFillDirty();
     }
   }
 
   if (legacy_imported && dependencies_.toast_manager) {
     dependencies_.toast_manager->Show(
-        "Imported legacy water gate zones (save to write new table)",
+        water_fill_save_enabled
+            ? "Imported legacy water gate zones (save to write new table)"
+            : "Loaded legacy water gate zones read-only (WaterFill saving is "
+              "disabled)",
         ToastType::kInfo);
   }
 }
@@ -1183,15 +1191,15 @@ absl::Status DungeonEditorV2::Update() {
     DrawRoomPanels();
   }
 
-  if (ImGui::IsKeyPressed(ImGuiKey_Delete)) {
-    // Delegate delete to current room viewer
-    if (auto* viewer = GetViewerForRoom(current_room_id_)) {
-      viewer->DeleteSelectedObjects();
-    }
-  }
-
   // Keyboard Shortcuts (only if not typing in a text field)
   if (!ImGui::GetIO().WantTextInput) {
+    if (ImGui::IsKeyPressed(ImGuiKey_Delete)) {
+      // Delegate delete to current room viewer.
+      if (auto* viewer = GetViewerForRoom(current_room_id_)) {
+        viewer->DeleteSelectedObjects();
+      }
+    }
+
     if (ImGui::GetIO().KeyCtrl && ImGui::GetIO().KeyShift &&
         ImGui::IsKeyPressed(ImGuiKey_W, false)) {
       ToggleWorkbenchWorkflowMode();

--- a/src/app/editor/dungeon/dungeon_object_interaction.cc
+++ b/src/app/editor/dungeon/dungeon_object_interaction.cc
@@ -17,6 +17,7 @@
 #include "app/gui/core/agent_theme.h"
 #include "app/gui/core/icons.h"
 #include "app/gui/core/theme_manager.h"
+#include "core/features.h"
 #include "zelda3/dungeon/dimension_service.h"
 #include "zelda3/dungeon/object_layer_semantics.h"
 
@@ -202,6 +203,11 @@ void DungeonObjectInteraction::UpdateCollisionPainting(
 
 void DungeonObjectInteraction::UpdateWaterFillPainting(
     const ImVec2& canvas_mouse_pos) {
+  if (!core::FeatureFlags::get().dungeon.kSaveWaterFillZones) {
+    mode_manager_.SetMode(InteractionMode::Select);
+    return;
+  }
+
   const ImGuiIO& io = ImGui::GetIO();
   const bool erase = io.KeyAlt;
 

--- a/src/app/editor/dungeon/inspectors/door_editor_content.cc
+++ b/src/app/editor/dungeon/inspectors/door_editor_content.cc
@@ -7,6 +7,8 @@
 
 #include "absl/strings/str_format.h"
 #include "app/editor/agent/agent_ui_theme.h"
+#include "app/gui/automation/widget_auto_register.h"
+#include "app/gui/core/input.h"
 #include "app/gui/core/style_guard.h"
 #include "app/gui/core/ui_helpers.h"
 #include "imgui/imgui.h"
@@ -136,6 +138,7 @@ void DoorEditorContent::OnClose() {
 void DoorEditorContent::Draw(bool* p_open) {
   (void)p_open;
   ResolveCanvasViewer();
+  gui::AutoWidgetScope automation_scope("Dungeon/DoorEditor");
 
   const auto& theme = AgentUI::GetTheme();
   static constexpr std::array<zelda3::DoorType, 20> kDoorTypes = {{
@@ -277,7 +280,6 @@ void DoorEditorContent::Draw(bool* p_open) {
     return;
   }
 
-  ImGui::BeginChild("##DoorList", ImVec2(0, 0), true);
   int selected_door_index = -1;
   if (ResolveCanvasViewer() &&
       canvas_viewer_->object_interaction().HasEntitySelection()) {
@@ -287,6 +289,32 @@ void DoorEditorContent::Draw(bool* p_open) {
       selected_door_index = static_cast<int>(selected_entity.index);
     }
   }
+
+  if (selected_door_index >= 0 &&
+      selected_door_index < static_cast<int>(doors.size())) {
+    uint8_t raw_type = static_cast<uint8_t>(doors[selected_door_index].type);
+    ImGui::AlignTextToFramePadding();
+    ImGui::TextUnformatted(tr("Selected raw type"));
+    ImGui::SameLine();
+    ImGui::SetNextItemWidth(72.0f);
+    const bool type_changed = gui::InputScalarDeferred(
+        "##SelectedDoorRawType", ImGuiDataType_U8, &raw_type, "%02X",
+        ImGuiInputTextFlags_CharsHexadecimal,
+        {reinterpret_cast<uintptr_t>(rooms_),
+         static_cast<uint64_t>(current_room_id_),
+         static_cast<uint64_t>(selected_door_index)});
+    gui::AutoRegisterLastItem("input_scalar", "selected_door_raw_type",
+                              "Selected door raw type byte");
+    if (type_changed && canvas_viewer_) {
+      canvas_viewer_->object_interaction()
+          .entity_coordinator()
+          .door_handler()
+          .MutateDoorType(selected_door_index,
+                          static_cast<zelda3::DoorType>(raw_type));
+    }
+  }
+
+  ImGui::BeginChild("##DoorList", ImVec2(0, 0), true);
   for (size_t i = 0; i < doors.size(); ++i) {
     const auto& door = doors[i];
     const auto [tile_x, tile_y] = door.GetTileCoords();
@@ -295,8 +323,11 @@ void DoorEditorContent::Draw(bool* p_open) {
 
     ImGui::PushID(static_cast<int>(i));
     const std::string row_label = absl::StrFormat("[%zu] %s", i, type_name);
-    if (ImGui::Selectable(row_label.c_str(),
-                          selected_door_index == static_cast<int>(i))) {
+    const bool row_selected = ImGui::Selectable(
+        row_label.c_str(), selected_door_index == static_cast<int>(i));
+    gui::AutoRegisterLastItem("selectable", absl::StrFormat("door_row_%zu", i),
+                              "Select a door in the current dungeon room");
+    if (row_selected) {
       if (canvas_viewer_) {
         canvas_viewer_->object_interaction().SelectEntity(EntityType::Door, i);
       }

--- a/src/app/editor/dungeon/inspectors/object_editor_content.cc
+++ b/src/app/editor/dungeon/inspectors/object_editor_content.cc
@@ -788,6 +788,9 @@ void ObjectEditorContent::HandleKeyboardShortcuts() {
   }
 
   const ImGuiIO& io = ImGui::GetIO();
+  if (io.WantTextInput) {
+    return;
+  }
 
   if (ImGui::IsKeyPressed(ImGuiKey_A) && io.KeyCtrl && !io.KeyShift) {
     SelectAllObjects();

--- a/src/app/editor/dungeon/inspectors/palette_editor_content.h
+++ b/src/app/editor/dungeon/inspectors/palette_editor_content.h
@@ -4,6 +4,7 @@
 #include <string>
 
 #include "app/editor/system/editor_panel.h"
+#include "app/gui/automation/widget_auto_register.h"
 #include "app/gui/core/icons.h"
 #include "app/gui/widgets/palette_editor_widget.h"
 
@@ -41,7 +42,9 @@ class PaletteEditorContent : public WindowContent {
   // ==========================================================================
 
   void Draw(bool* p_open) override {
-    if (!palette_editor_) return;
+    if (!palette_editor_)
+      return;
+    gui::AutoWidgetScope automation_scope("Dungeon/PaletteEditor");
     palette_editor_->Draw();
   }
 

--- a/src/app/editor/dungeon/interaction/door_interaction_handler.cc
+++ b/src/app/editor/dungeon/interaction/door_interaction_handler.cc
@@ -607,6 +607,10 @@ bool DoorInteractionHandler::MutateDoorType(size_t index,
   if (!HasValidContext())
     return false;
 
+  const uint8_t raw_type = static_cast<uint8_t>(new_type);
+  if ((raw_type & 0x01) != 0 || raw_type > 0x66)
+    return false;
+
   auto* room = GetCurrentRoom();
   if (!room)
     return false;

--- a/src/app/editor/dungeon/interaction/item_interaction_handler.cc
+++ b/src/app/editor/dungeon/interaction/item_interaction_handler.cc
@@ -299,6 +299,29 @@ bool ItemInteractionHandler::NudgeSelected(int delta_pixel_x,
   return true;
 }
 
+bool ItemInteractionHandler::MutateItemType(size_t index, uint8_t new_type) {
+  if (!HasValidContext()) {
+    return false;
+  }
+
+  auto* room = GetCurrentRoom();
+  if (!room) {
+    return false;
+  }
+
+  auto& pot_items = room->GetPotItems();
+  if (index >= pot_items.size() || pot_items[index].item == new_type) {
+    return false;
+  }
+
+  ctx_->NotifyMutation(MutationDomain::kItems);
+  pot_items[index].item = new_type;
+  room->MarkPotItemsDirty();
+  ctx_->NotifyInvalidateCache(MutationDomain::kItems);
+  ctx_->NotifyEntityChanged();
+  return true;
+}
+
 void ItemInteractionHandler::PlaceItemAtPosition(int canvas_x, int canvas_y) {
   if (!HasValidContext())
     return;

--- a/src/app/editor/dungeon/interaction/item_interaction_handler.h
+++ b/src/app/editor/dungeon/interaction/item_interaction_handler.h
@@ -75,6 +75,15 @@ class ItemInteractionHandler : public BaseEntityHandler {
   void DeleteAll();
   bool NudgeSelected(int delta_pixel_x, int delta_pixel_y);
 
+  /**
+   * @brief Change one pot item's raw type byte in place.
+   *
+   * Routes through the normal item mutation notifications so GUI edits retain
+   * the same dirty-state, cache invalidation, and undo behavior as canvas
+   * interactions.
+   */
+  bool MutateItemType(size_t index, uint8_t new_type);
+
  private:
   // Placement state
   bool item_placement_mode_ = false;

--- a/src/app/editor/dungeon/ui/window/item_editor_panel.h
+++ b/src/app/editor/dungeon/ui/window/item_editor_panel.h
@@ -12,7 +12,9 @@
 #include "app/editor/dungeon/dungeon_canvas_viewer.h"
 #include "app/editor/dungeon/dungeon_room_store.h"
 #include "app/editor/system/workspace/editor_panel.h"
+#include "app/gui/automation/widget_auto_register.h"
 #include "app/gui/core/icons.h"
+#include "app/gui/core/input.h"
 #include "app/gui/core/style_guard.h"
 #include "imgui/imgui.h"
 #include "zelda3/dungeon/room.h"
@@ -54,6 +56,7 @@ class ItemEditorPanel : public WindowContent {
   // ==========================================================================
 
   void Draw(bool* p_open) override {
+    gui::AutoWidgetScope automation_scope("Dungeon/ItemEditor");
     if (!current_room_id_ || !rooms_) {
       ImGui::TextDisabled(tr("No room data available"));
       return;
@@ -261,9 +264,31 @@ class ItemEditorPanel : public WindowContent {
       return;
     }
 
-    // Responsive list height - use remaining available space
-    float list_height =
-        std::max(120.0f, ImGui::GetContentRegionAvail().y - 10.0f);
+    if (selected_item_index >= 0 &&
+        selected_item_index < static_cast<int>(items.size()) &&
+        canvas_viewer_) {
+      uint8_t raw_item_type = items[selected_item_index].item;
+      ImGui::AlignTextToFramePadding();
+      ImGui::TextUnformatted(tr("Selected raw type"));
+      ImGui::SameLine();
+      ImGui::SetNextItemWidth(72.0f);
+      const bool type_changed = gui::InputScalarDeferred(
+          "##SelectedItemRawType", ImGuiDataType_U8, &raw_item_type, "%02X",
+          ImGuiInputTextFlags_CharsHexadecimal,
+          {reinterpret_cast<uintptr_t>(rooms_),
+           static_cast<uint64_t>(*current_room_id_),
+           static_cast<uint64_t>(selected_item_index)});
+      gui::AutoRegisterLastItem("input_scalar", "selected_item_raw_type",
+                                "Selected pot item raw type byte");
+      if (type_changed) {
+        canvas_viewer_->object_interaction()
+            .entity_coordinator()
+            .item_handler()
+            .MutateItemType(selected_item_index, raw_item_type);
+      }
+    }
+
+    float list_height = std::max(100.0f, ImGui::GetContentRegionAvail().y);
     ImGui::BeginChild("##ItemList", ImVec2(0, list_height), true);
     for (size_t i = 0; i < items.size(); ++i) {
       const auto& item = items[i];
@@ -273,17 +298,19 @@ class ItemEditorPanel : public WindowContent {
       const char* item_name =
           (item.item < kPotItemCount) ? kPotItemNames[item.item] : "Unknown";
 
-      ImGui::Text(tr("[%zu] %s (0x%02X)"), i, item_name, item.item);
+      const std::string row_label =
+          absl::StrFormat("[%zu] %s (0x%02X)", i, item_name, item.item);
+      const bool row_selected = ImGui::Selectable(
+          row_label.c_str(), selected_item_index == static_cast<int>(i));
+      gui::AutoRegisterLastItem(
+          "selectable", absl::StrFormat("item_row_%zu", i),
+          "Select a pot item in the current dungeon room");
       ImGui::SameLine();
       ImGui::TextColored(theme.text_secondary_gray, "@ (%d,%d)",
                          item.GetTileX(), item.GetTileY());
 
-      if (ImGui::IsItemClicked() && canvas_viewer_) {
+      if (row_selected && canvas_viewer_) {
         canvas_viewer_->object_interaction().SelectEntity(EntityType::Item, i);
-      }
-      if (selected_item_index == static_cast<int>(i)) {
-        ImGui::SameLine();
-        ImGui::TextColored(theme.status_success, ICON_MD_CHECK_CIRCLE);
       }
 
       ImGui::PopID();

--- a/src/app/editor/dungeon/ui/window/sprite_editor_panel.h
+++ b/src/app/editor/dungeon/ui/window/sprite_editor_panel.h
@@ -12,7 +12,9 @@
 #include "app/editor/dungeon/dungeon_canvas_viewer.h"
 #include "app/editor/dungeon/dungeon_room_store.h"
 #include "app/editor/system/workspace/editor_panel.h"
+#include "app/gui/automation/widget_auto_register.h"
 #include "app/gui/core/icons.h"
+#include "app/gui/core/input.h"
 #include "app/gui/core/style_guard.h"
 #include "imgui/imgui.h"
 #include "zelda3/dungeon/room.h"
@@ -54,6 +56,7 @@ class SpriteEditorPanel : public WindowContent {
   // ==========================================================================
 
   void Draw(bool* p_open) override {
+    gui::AutoWidgetScope automation_scope("Dungeon/SpriteEditor");
     if (!current_room_id_ || !rooms_) {
       ImGui::TextDisabled(tr("No room data available"));
       return;
@@ -218,12 +221,14 @@ class SpriteEditorPanel : public WindowContent {
     auto& room = (*rooms_)[*current_room_id_];
     auto& sprites = room.GetSprites();
     int selected_sprite_list_index = -1;
-    if (canvas_viewer_ &&
-        canvas_viewer_->object_interaction().HasEntitySelection()) {
-      const auto selected_entity =
-          canvas_viewer_->object_interaction().GetSelectedEntity();
-      if (selected_entity.type == EntityType::Sprite) {
-        selected_sprite_list_index = static_cast<int>(selected_entity.index);
+    if (canvas_viewer_) {
+      const auto& selected_entities = canvas_viewer_->object_interaction()
+                                          .entity_coordinator()
+                                          .GetSelectedEntities();
+      if (selected_entities.size() == 1 &&
+          selected_entities.front().type == EntityType::Sprite) {
+        selected_sprite_list_index =
+            static_cast<int>(selected_entities.front().index);
       }
     }
 
@@ -256,6 +261,39 @@ class SpriteEditorPanel : public WindowContent {
       return;
     }
 
+    if (selected_sprite_list_index >= 0 &&
+        selected_sprite_list_index < static_cast<int>(sprites.size()) &&
+        canvas_viewer_) {
+      const auto& sprite = sprites[selected_sprite_list_index];
+      int sprite_x = sprite.x();
+      int sprite_y = sprite.y();
+      ImGui::TextUnformatted(tr("Selected position"));
+      ImGui::SameLine();
+      ImGui::SetNextItemWidth(64.0f);
+      const bool x_changed = gui::InputScalarDeferred(
+          "##SelectedSpriteX", ImGuiDataType_S32, &sprite_x, "%d", 0,
+          {reinterpret_cast<uintptr_t>(rooms_),
+           static_cast<uint64_t>(*current_room_id_),
+           static_cast<uint64_t>(selected_sprite_list_index)});
+      gui::AutoRegisterLastItem("input_int", "selected_sprite_x",
+                                "Selected sprite X coordinate");
+      ImGui::SameLine();
+      ImGui::SetNextItemWidth(64.0f);
+      const bool y_changed = gui::InputScalarDeferred(
+          "##SelectedSpriteY", ImGuiDataType_S32, &sprite_y, "%d", 0,
+          {reinterpret_cast<uintptr_t>(rooms_),
+           static_cast<uint64_t>(*current_room_id_),
+           static_cast<uint64_t>(selected_sprite_list_index)});
+      gui::AutoRegisterLastItem("input_int", "selected_sprite_y",
+                                "Selected sprite Y coordinate");
+      if (x_changed || y_changed) {
+        auto& handler = canvas_viewer_->object_interaction()
+                            .entity_coordinator()
+                            .sprite_handler();
+        handler.NudgeSelected(sprite_x - sprite.x(), sprite_y - sprite.y());
+      }
+    }
+
     // Split view: list on top, properties below
     float available = ImGui::GetContentRegionAvail().y;
     float list_height = std::max(100.0f, available * 0.4f);
@@ -283,7 +321,11 @@ class SpriteEditorPanel : public WindowContent {
         label += " " ICON_MD_STAR;
       }
 
-      if (ImGui::Selectable(label.c_str(), is_selected)) {
+      const bool row_selected = ImGui::Selectable(label.c_str(), is_selected);
+      gui::AutoRegisterLastItem("selectable",
+                                absl::StrFormat("sprite_row_%zu", i),
+                                "Select a sprite in the current dungeon room");
+      if (row_selected) {
         if (canvas_viewer_) {
           canvas_viewer_->object_interaction().SelectEntity(EntityType::Sprite,
                                                             i);

--- a/src/app/editor/dungeon/ui/window/water_fill_panel.h
+++ b/src/app/editor/dungeon/ui/window/water_fill_panel.h
@@ -18,6 +18,7 @@
 #include "app/editor/dungeon/dungeon_room_store.h"
 #include "app/editor/system/workspace/editor_panel.h"
 #include "app/gui/core/icons.h"
+#include "core/features.h"
 #include "util/file_util.h"
 #include "zelda3/dungeon/dungeon_rom_addresses.h"
 #include "zelda3/dungeon/water_fill_zone.h"
@@ -58,6 +59,8 @@ class WaterFillPanel : public WindowContent {
     const size_t rom_size = viewer_->rom()->vector().size();
     const bool reserved_region_present =
         zelda3::HasWaterFillReservedRegion(rom_size);
+    const bool save_enabled =
+        core::FeatureFlags::get().dungeon.kSaveWaterFillZones;
     if (!reserved_region_present) {
       ImGui::TextColored(theme.status_error, ICON_MD_ERROR
                          " WaterFill reserved region missing (use an "
@@ -66,6 +69,19 @@ class WaterFillPanel : public WindowContent {
           tr("Expected ROM >= 0x%X bytes (WaterFill end). Current ROM is %zu "
              "bytes."),
           zelda3::kWaterFillTableEnd, rom_size);
+      ImGui::Separator();
+    }
+
+    if (!save_enabled) {
+      ImGui::TextColored(theme.text_warning_yellow, ICON_MD_LOCK
+                         " Read-only: Water Fill saving is disabled");
+      ImGui::TextWrapped(
+          tr("Set save_dungeon_water_fill_zones=true in the .yaze project and "
+             "reopen it before authoring zones."));
+      if (interaction_ && interaction_->mode_manager().GetMode() ==
+                              InteractionMode::PaintWaterFill) {
+        interaction_->mode_manager().SetMode(InteractionMode::Select);
+      }
       ImGui::Separator();
     }
 
@@ -81,7 +97,7 @@ class WaterFillPanel : public WindowContent {
     json_options.filters.push_back({"Water Fill Zones", "json"});
     json_options.filters.push_back({"All Files", "*"});
 
-    ImGui::BeginDisabled(!reserved_region_present);
+    ImGui::BeginDisabled(!reserved_region_present || !save_enabled);
     if (ImGui::Button(ICON_MD_UPLOAD " Import Zones...")) {
       std::string path =
           util::FileDialogWrapper::ShowOpenFileDialog(json_options);
@@ -205,7 +221,8 @@ class WaterFillPanel : public WindowContent {
 
         bool is_painting = (interaction_->mode_manager().GetMode() ==
                             InteractionMode::PaintWaterFill);
-        const bool can_paint = reserved_region_present && room_loaded;
+        const bool can_paint =
+            reserved_region_present && room_loaded && save_enabled;
         ImGui::BeginDisabled(!can_paint);
         if (ImGui::Checkbox(tr("Paint Mode"), &is_painting)) {
           if (is_painting) {
@@ -253,7 +270,7 @@ class WaterFillPanel : public WindowContent {
       uint8_t mask = room.water_fill_sram_bit_mask();
       std::string preview =
           (mask == 0) ? "Auto (0x00)" : absl::StrFormat("0x%02X", mask);
-      ImGui::BeginDisabled(!reserved_region_present);
+      ImGui::BeginDisabled(!reserved_region_present || !save_enabled);
       if (ImGui::BeginCombo(tr("SRAM Bit Mask ($7EF411)"), preview.c_str())) {
         auto option = [&](const char* label, uint8_t val) {
           const bool selected = (mask == val);

--- a/src/app/editor/dungeon/workspace/dungeon_workbench_content.cc
+++ b/src/app/editor/dungeon/workspace/dungeon_workbench_content.cc
@@ -360,11 +360,13 @@ void DungeonWorkbenchContent::SetEmbeddedEditorPanels(
 void DungeonWorkbenchContent::FocusRoomInspector() {
   layout_state_.show_right_inspector = true;
   inspector_mode_ = InspectorMode::Room;
+  compact_inspector_detail_requested_ = true;
 }
 
 void DungeonWorkbenchContent::FocusSelectionInspector() {
   layout_state_.show_right_inspector = true;
   inspector_mode_ = InspectorMode::Selection;
+  compact_inspector_detail_requested_ = true;
 }
 
 void DungeonWorkbenchContent::FocusEntranceBrowser() {
@@ -1243,7 +1245,6 @@ void DungeonWorkbenchContent::SetAllSaveFlags(bool value) {
   flags.kSavePotItems = value;
   flags.kSavePalettes = value;
   flags.kSaveCollision = value;
-  flags.kSaveWaterFillZones = value;
   flags.kSaveBlocks = value;
   flags.kSaveTorches = value;
   flags.kSavePits = value;
@@ -1284,7 +1285,16 @@ void DungeonWorkbenchContent::DrawApplyScopeControls(int room_id) {
     draw_checkbox("Palettes", &flags.kSavePalettes);
     ImGui::TableNextRow();
     draw_checkbox("Collision Maps", &flags.kSaveCollision);
-    draw_checkbox("Water Fill", &flags.kSaveWaterFillZones);
+    ImGui::TableNextColumn();
+    ImGui::BeginDisabled();
+    ImGui::Checkbox("Water Fill", &flags.kSaveWaterFillZones);
+    ImGui::EndDisabled();
+    if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled)) {
+      ImGui::SetTooltip(
+          "Water Fill save scope is fixed when the project opens. Change "
+          "save_dungeon_water_fill_zones in the .yaze file, then reopen the "
+          "project.");
+    }
     ImGui::TableNextRow();
     draw_checkbox("Blocks", &flags.kSaveBlocks);
     draw_checkbox("Torches", &flags.kSaveTorches);
@@ -1947,6 +1957,7 @@ void DungeonWorkbenchContent::DrawInspectorPrimarySelector(
     }
     if (pressed) {
       inspector_mode_ = mode;
+      compact_inspector_detail_requested_ = true;
     }
     if (!stack) {
       ImGui::SameLine(0.0f, spacing);
@@ -1966,6 +1977,7 @@ void DungeonWorkbenchContent::DrawInspectorPrimarySelector(
   }
   if (tools_pressed) {
     inspector_mode_ = InspectorMode::Tools;
+    compact_inspector_detail_requested_ = true;
   }
 }
 
@@ -2000,6 +2012,7 @@ void DungeonWorkbenchContent::DrawInspectorCompactSummary(
     if (workbench::DrawActionButton(ICON_MD_OPEN_IN_FULL " Open Selection",
                                     ImVec2(-1, 0))) {
       inspector_mode_ = InspectorMode::Selection;
+      compact_inspector_detail_requested_ = true;
     }
   } else {
     ImGui::TextDisabled(tr("Nothing selected"));
@@ -2026,7 +2039,8 @@ void DungeonWorkbenchContent::DrawInspectorShelf(DungeonCanvasViewer& viewer,
   // Use the resolved pane layout instead of GetContentRegionAvail().x. The
   // latter changes when a vertical scrollbar appears, which can make the
   // inspector alternate between full and compact content every frame.
-  if (compact) {
+  if (compact && inspector_mode_ != InspectorMode::Tools &&
+      !compact_inspector_detail_requested_) {
     DrawInspectorCompactSummary(viewer);
     return;
   }

--- a/src/app/editor/dungeon/workspace/dungeon_workbench_content.cc
+++ b/src/app/editor/dungeon/workspace/dungeon_workbench_content.cc
@@ -29,6 +29,7 @@
 #include "app/editor/dungeon/workspace/dungeon_pit_damage_view_model.h"
 #include "app/editor/dungeon/workspace/dungeon_workbench_inspector_helpers.h"
 #include "app/editor/dungeon/workspace/dungeon_workbench_layout.h"
+#include "app/gui/automation/widget_auto_register.h"
 #include "app/gui/core/icons.h"
 #include "app/gui/core/input.h"
 #include "app/gui/core/layout_helpers.h"
@@ -944,6 +945,43 @@ void DungeonWorkbenchContent::DrawInspectorHeader(float button_size,
 
   ImGui::Dummy(ImVec2(0.0f, 2.0f));
   DrawInspectorPrimarySelector(std::max(button_size, 26.0f));
+  if (current_room_id_ && *current_room_id_ >= 0) {
+    ImGui::AlignTextToFramePadding();
+    ImGui::TextUnformatted(tr("Room"));
+    ImGui::SameLine();
+    uint16_t requested_room_id = static_cast<uint16_t>(*current_room_id_);
+    ImGui::SetNextItemWidth(82.0f);
+    const bool can_jump_room = static_cast<bool>(on_room_selected_);
+    if (!can_jump_room) {
+      ImGui::BeginDisabled();
+    }
+    bool room_changed = false;
+    {
+      gui::AutoWidgetScope automation_scope("Dungeon/Workbench");
+      room_changed = gui::InputScalarDeferred(
+          "##WorkbenchRoomId", ImGuiDataType_U16, &requested_room_id, "%04X",
+          ImGuiInputTextFlags_CharsHexadecimal,
+          {reinterpret_cast<uintptr_t>(current_room_id_)});
+      gui::AutoRegisterLastItem("input_scalar", "room_id",
+                                "Current dungeon room ID");
+    }
+    if (!can_jump_room) {
+      ImGui::EndDisabled();
+    }
+    if (room_changed && on_room_selected_) {
+      const int target_room_id = std::clamp(static_cast<int>(requested_room_id),
+                                            0, zelda3::kNumberOfRooms - 1);
+      if (target_room_id != *current_room_id_) {
+        *current_room_id_ = target_room_id;
+        on_room_selected_(target_room_id);
+      }
+    }
+    if (ImGui::IsItemHovered()) {
+      const int preview_room_id = std::clamp(
+          static_cast<int>(requested_room_id), 0, zelda3::kNumberOfRooms - 1);
+      ImGui::SetTooltip(tr("Open room 0x%03X"), preview_room_id);
+    }
+  }
   ImGui::Separator();
 }
 
@@ -1828,7 +1866,14 @@ void DungeonWorkbenchContent::DrawInspectorToolStrip() {
       if (!enabled) {
         ImGui::BeginDisabled();
       }
-      if (gui::ToggleButton(btn_id, active, ImVec2(-1, 0)) && enabled) {
+      const bool pressed = gui::ToggleButton(btn_id, active, ImVec2(-1, 0));
+      {
+        gui::AutoWidgetScope automation_scope("Dungeon/Workbench");
+        gui::AutoRegisterLastItem(
+            "button", absl::StrFormat("tool_%s", GetWorkbenchToolId(tool)),
+            "Open a Dungeon Workbench tool");
+      }
+      if (pressed && enabled) {
         OpenTool(tool);
       }
       if (!enabled) {
@@ -1891,7 +1936,16 @@ void DungeonWorkbenchContent::DrawInspectorPrimarySelector(
   auto draw_mode = [&](const char* label, float width, InspectorMode mode) {
     const ImVec2 size(stack ? ImGui::GetContentRegionAvail().x : width,
                       segment_height);
-    if (gui::ToggleButton(label, inspector_mode_ == mode, size)) {
+    const bool pressed =
+        gui::ToggleButton(label, inspector_mode_ == mode, size);
+    {
+      gui::AutoWidgetScope automation_scope("Dungeon/Workbench");
+      gui::AutoRegisterLastItem(
+          "button",
+          mode == InspectorMode::Room ? "mode_room" : "mode_selection",
+          "Switch Dungeon Workbench inspector mode");
+    }
+    if (pressed) {
       inspector_mode_ = mode;
     }
     if (!stack) {
@@ -1903,8 +1957,14 @@ void DungeonWorkbenchContent::DrawInspectorPrimarySelector(
   draw_mode("Selection", selection_width, InspectorMode::Selection);
   const ImVec2 tools_size(
       stack ? ImGui::GetContentRegionAvail().x : tools_width, segment_height);
-  if (gui::ToggleButton("Tools", inspector_mode_ == InspectorMode::Tools,
-                        tools_size)) {
+  const bool tools_pressed = gui::ToggleButton(
+      "Tools", inspector_mode_ == InspectorMode::Tools, tools_size);
+  {
+    gui::AutoWidgetScope automation_scope("Dungeon/Workbench");
+    gui::AutoRegisterLastItem("button", "mode_tools",
+                              "Switch Dungeon Workbench inspector mode");
+  }
+  if (tools_pressed) {
     inspector_mode_ = InspectorMode::Tools;
   }
 }
@@ -2008,34 +2068,7 @@ void DungeonWorkbenchContent::DrawInspectorShelfRoom(
   workbench::DrawInspectorSectionHeader(ICON_MD_CASTLE " Room Summary");
   if (room_id >= 0) {
     ImGui::AlignTextToFramePadding();
-    ImGui::TextUnformatted(tr("Room"));
-    ImGui::SameLine();
-    uint16_t requested_room_id = static_cast<uint16_t>(room_id);
-    ImGui::SetNextItemWidth(74.0f);
-    const bool can_jump_room = static_cast<bool>(on_room_selected_);
-    if (!can_jump_room) {
-      ImGui::BeginDisabled();
-    }
-    if (auto res = gui::InputHexWordEx("##WorkbenchRoomId", &requested_room_id,
-                                       74.0f, true);
-        res.ShouldApply()) {
-      const int target_room_id = std::clamp(static_cast<int>(requested_room_id),
-                                            0, zelda3::kNumberOfRooms - 1);
-      if (target_room_id != room_id && on_room_selected_) {
-        if (current_room_id_) {
-          *current_room_id_ = target_room_id;
-        }
-        on_room_selected_(target_room_id);
-      }
-    }
-    if (!can_jump_room) {
-      ImGui::EndDisabled();
-    }
-    if (ImGui::IsItemHovered()) {
-      const int preview_room_id = std::clamp(
-          static_cast<int>(requested_room_id), 0, zelda3::kNumberOfRooms - 1);
-      ImGui::SetTooltip(tr("Open room 0x%03X"), preview_room_id);
-    }
+    ImGui::Text(tr("Room 0x%03X"), room_id);
     ImGui::SameLine();
     if (ImGui::SmallButton(ICON_MD_CONTENT_COPY "##CopyRoomId")) {
       char buf[16];
@@ -2044,6 +2077,46 @@ void DungeonWorkbenchContent::DrawInspectorShelfRoom(
     }
     if (ImGui::IsItemHovered()) {
       ImGui::SetTooltip(tr("Copy room ID (0x%03X) to clipboard"), room_id);
+    }
+
+    if (auto* rooms = viewer.rooms();
+        rooms && room_id < static_cast<int>(rooms->size())) {
+      auto& objects = (*rooms)[room_id].GetTileObjects();
+      if (!objects.empty()) {
+        const auto selected_indices =
+            viewer.object_interaction().GetSelectedObjectIndices();
+        int requested_object_index =
+            selected_indices.size() == 1
+                ? static_cast<int>(selected_indices.front())
+                : 0;
+        ImGui::AlignTextToFramePadding();
+        ImGui::TextUnformatted(tr("Object"));
+        ImGui::SameLine();
+        ImGui::SetNextItemWidth(74.0f);
+        bool object_index_changed = false;
+        {
+          gui::AutoWidgetScope automation_scope("Dungeon/Workbench");
+          object_index_changed = gui::InputScalarDeferred(
+              "##WorkbenchObjectIndex", ImGuiDataType_S32,
+              &requested_object_index, "%d", 0,
+              {reinterpret_cast<uintptr_t>(rooms),
+               static_cast<uint64_t>(room_id)});
+          gui::AutoRegisterLastItem("input_int", "object_index",
+                                    "Select and locate a room object by index");
+        }
+        if (object_index_changed) {
+          const size_t target_index = static_cast<size_t>(std::clamp(
+              requested_object_index, 0, static_cast<int>(objects.size()) - 1));
+          viewer.object_interaction().SetSelectedObjects({target_index});
+          viewer.ScrollToTile(objects[target_index].x(),
+                              objects[target_index].y());
+          inspector_mode_ = InspectorMode::Selection;
+        }
+        if (ImGui::IsItemHovered()) {
+          ImGui::SetTooltip(tr("Select object index 0-%zu"),
+                            objects.size() - 1);
+        }
+      }
     }
   } else {
     ImGui::TextUnformatted(tr("Room: None"));
@@ -2575,10 +2648,20 @@ void DungeonWorkbenchContent::DrawInspectorShelfSelection(
             ImGui::SetNextItemWidth(60);
             bool x_changed =
                 ImGui::DragInt("##SelObjX", &pos_x, 0.1f, 0, 63, "X:%d");
+            {
+              gui::AutoWidgetScope automation_scope("Dungeon/Workbench");
+              gui::AutoRegisterLastItem("drag_int", "selected_object_x",
+                                        "Selected room object X coordinate");
+            }
             ImGui::SameLine();
             ImGui::SetNextItemWidth(60);
             bool y_changed =
                 ImGui::DragInt("##SelObjY", &pos_y, 0.1f, 0, 63, "Y:%d");
+            {
+              gui::AutoWidgetScope automation_scope("Dungeon/Workbench");
+              gui::AutoRegisterLastItem("drag_int", "selected_object_y",
+                                        "Selected room object Y coordinate");
+            }
             if (x_changed || y_changed) {
               int delta_x = pos_x - obj.x_;
               int delta_y = pos_y - obj.y_;

--- a/src/app/editor/dungeon/workspace/dungeon_workbench_content.h
+++ b/src/app/editor/dungeon/workspace/dungeon_workbench_content.h
@@ -255,6 +255,7 @@ class DungeonWorkbenchContent : public WindowContent {
   enum class InspectorMode : uint8_t { Room, Selection, Tools };
   InspectorMode inspector_mode_ = InspectorMode::Room;
   bool inspector_selection_was_active_ = false;
+  bool compact_inspector_detail_requested_ = false;
   WorkbenchTool active_tool_ = WorkbenchTool::ObjectSelector;
 
   char compare_search_buf_[64] = {};

--- a/src/app/editor/editor_manager.cc
+++ b/src/app/editor/editor_manager.cc
@@ -4212,10 +4212,13 @@ absl::Status EditorManager::SaveRomInternal(
                                    screen_editor->HasPendingScreenChanges())) {
     RETURN_IF_ERROR(save_editor(screen_editor));
   }
+  // A coordinated save must not materialize an unrelated lazy editor. Its
+  // serializer can project broad writes (and correctly trip manifest guards)
+  // even though the user never opened or edited that domain.
   RETURN_IF_ERROR(
-      save_editor(current_editor_set->GetEditor(EditorType::kDungeon)));
-  RETURN_IF_ERROR(
-      save_editor(current_editor_set->GetEditor(EditorType::kOverworld)));
+      save_editor(current_editor_set->GetExistingEditor(EditorType::kDungeon)));
+  RETURN_IF_ERROR(save_editor(
+      current_editor_set->GetExistingEditor(EditorType::kOverworld)));
 
   if (core::FeatureFlags::get().kSaveMessages) {
     RETURN_IF_ERROR(EnsureEditorAssetsLoaded(EditorType::kMessage));

--- a/src/app/editor/menu/menu_builder.cc
+++ b/src/app/editor/menu/menu_builder.cc
@@ -1,6 +1,7 @@
 #include "app/editor/menu/menu_builder.h"
 
 #include "absl/strings/str_cat.h"
+#include "app/gui/automation/widget_auto_register.h"
 #include "util/i18n/tr.h"
 
 namespace yaze {
@@ -243,7 +244,13 @@ void MenuBuilder::DrawMenuItem(const MenuItem& item) {
       const char* shortcut_str =
           item.shortcut.empty() ? nullptr : item.shortcut.c_str();
 
-      if (ImGui::MenuItem(label.c_str(), shortcut_str, checked, enabled)) {
+      const bool activated =
+          ImGui::MenuItem(label.c_str(), shortcut_str, checked, enabled);
+      if (item.label == "Save ROM" || item.label == "Quit") {
+        gui::AutoRegisterLastItem("menuitem", item.label,
+                                  "Stable file-menu harness action");
+      }
+      if (activated) {
         if (item.callback) {
           item.callback();
         }

--- a/src/app/editor/shell/feedback/popup_manager.cc
+++ b/src/app/editor/shell/feedback/popup_manager.cc
@@ -13,6 +13,7 @@
 #include "app/editor/editor_manager.h"
 #include "app/editor/layout/layout_presets.h"
 #include "app/gui/app/feature_flags_menu.h"
+#include "app/gui/automation/widget_id_registry.h"
 #include "app/gui/core/icons.h"
 #include "app/gui/core/input.h"
 #include "app/gui/core/style.h"
@@ -1401,7 +1402,14 @@ void PopupManager::DrawDungeonPotItemSaveConfirmPopup() {
     return;
   }
   SameLine();
-  if (Button(tr("Save anyway"), ImVec2(0, 0))) {
+  const bool save_anyway = Button(tr("Save anyway"), ImVec2(0, 0));
+  if (ImGui::GetItemID() != 0) {
+    gui::WidgetIdRegistry::Instance().RegisterWidget(
+        "dungeon.pot_item_save_confirm/button:Save anyway", "button",
+        ImGui::GetItemID(),
+        "Continue the pending dungeon save with pot item writes enabled");
+  }
+  if (save_anyway) {
     editor_manager_->ResolvePotItemSaveConfirmation(
         EditorManager::PotItemSaveDecision::kSaveWithPotItems);
     Hide(PopupID::kDungeonPotItemSaveConfirm);

--- a/src/app/gui/automation/widget_id_registry.cc
+++ b/src/app/gui/automation/widget_id_registry.cc
@@ -62,6 +62,7 @@ WidgetIdRegistry& WidgetIdRegistry::Instance() {
 }
 
 void WidgetIdRegistry::BeginFrame() {
+  absl::MutexLock lock(&mutex_);
   ImGuiContext* ctx = ImGui::GetCurrentContext();
   if (ctx) {
     current_frame_ = ctx->FrameCount;
@@ -77,6 +78,7 @@ void WidgetIdRegistry::BeginFrame() {
 }
 
 void WidgetIdRegistry::EndFrame() {
+  absl::MutexLock lock(&mutex_);
   for (auto& [_, info] : widgets_) {
     if (!info.seen_in_current_frame) {
       info.visible = false;
@@ -160,6 +162,7 @@ void WidgetIdRegistry::RegisterWidget(const std::string& full_path,
                                       const std::string& type, ImGuiID imgui_id,
                                       const std::string& description,
                                       const WidgetMetadata& metadata) {
+  absl::MutexLock lock(&mutex_);
   WidgetInfo& info = widgets_[full_path];
   info.full_path = full_path;
   info.type = type;
@@ -228,6 +231,7 @@ void WidgetIdRegistry::RegisterWidget(const std::string& full_path,
 
 std::vector<std::string> WidgetIdRegistry::FindWidgets(
     const std::string& pattern) const {
+  absl::MutexLock lock(&mutex_);
   std::vector<std::string> matches;
 
   // Simple glob-style pattern matching
@@ -263,6 +267,7 @@ std::vector<std::string> WidgetIdRegistry::FindWidgets(
 }
 
 ImGuiID WidgetIdRegistry::GetWidgetId(const std::string& full_path) const {
+  absl::MutexLock lock(&mutex_);
   auto it = widgets_.find(full_path);
   if (it != widgets_.end()) {
     return it->second.imgui_id;
@@ -270,21 +275,30 @@ ImGuiID WidgetIdRegistry::GetWidgetId(const std::string& full_path) const {
   return 0;
 }
 
-const WidgetIdRegistry::WidgetInfo* WidgetIdRegistry::GetWidgetInfo(
+std::optional<WidgetIdRegistry::WidgetInfo> WidgetIdRegistry::GetWidgetInfo(
     const std::string& full_path) const {
+  absl::MutexLock lock(&mutex_);
   auto it = widgets_.find(full_path);
   if (it != widgets_.end()) {
-    return &it->second;
+    return it->second;
   }
-  return nullptr;
+  return std::nullopt;
+}
+
+std::unordered_map<std::string, WidgetIdRegistry::WidgetInfo>
+WidgetIdRegistry::GetAllWidgets() const {
+  absl::MutexLock lock(&mutex_);
+  return widgets_;
 }
 
 void WidgetIdRegistry::Clear() {
+  absl::MutexLock lock(&mutex_);
   widgets_.clear();
   current_frame_ = -1;
 }
 
 std::string WidgetIdRegistry::ExportCatalog(const std::string& format) const {
+  absl::MutexLock lock(&mutex_);
   std::ostringstream ss;
 
   if (format == "json") {

--- a/src/app/gui/automation/widget_id_registry.h
+++ b/src/app/gui/automation/widget_id_registry.h
@@ -8,6 +8,7 @@
 #include <vector>
 
 #include "absl/strings/string_view.h"
+#include "absl/synchronization/mutex.h"
 #include "absl/time/time.h"
 #include "imgui/imgui.h"
 
@@ -113,12 +114,10 @@ class WidgetIdRegistry {
   // Query widgets for test automation
   std::vector<std::string> FindWidgets(const std::string& pattern) const;
   ImGuiID GetWidgetId(const std::string& full_path) const;
-  const WidgetInfo* GetWidgetInfo(const std::string& full_path) const;
+  std::optional<WidgetInfo> GetWidgetInfo(const std::string& full_path) const;
 
-  // Get all registered widgets
-  const std::unordered_map<std::string, WidgetInfo>& GetAllWidgets() const {
-    return widgets_;
-  }
+  // Get a thread-safe snapshot of all registered widgets.
+  std::unordered_map<std::string, WidgetInfo> GetAllWidgets() const;
 
   // Clear all registered widgets (useful between frames for dynamic UIs)
   void Clear();
@@ -138,9 +137,10 @@ class WidgetIdRegistry {
   void TrimStaleEntries();
   bool ShouldPrune(const WidgetInfo& info) const;
 
-  std::unordered_map<std::string, WidgetInfo> widgets_;
-  int current_frame_ = -1;
-  absl::Time frame_time_;
+  mutable absl::Mutex mutex_;
+  std::unordered_map<std::string, WidgetInfo> widgets_ ABSL_GUARDED_BY(mutex_);
+  int current_frame_ ABSL_GUARDED_BY(mutex_) = -1;
+  absl::Time frame_time_ ABSL_GUARDED_BY(mutex_);
   int stale_frame_limit_ = 600;  // frames before pruning a widget
 };
 

--- a/src/app/gui/core/input.cc
+++ b/src/app/gui/core/input.cc
@@ -2,9 +2,12 @@
 #include "util/i18n/tr.h"
 
 #include <algorithm>
+#include <array>
+#include <cstring>
 #include <functional>
 #include <limits>
 #include <string>
+#include <unordered_map>
 #include <variant>
 
 #include "absl/strings/string_view.h"
@@ -295,6 +298,55 @@ namespace gui {
 
 namespace {
 
+constexpr size_t kMaxDeferredScalarBytes = sizeof(uint64_t);
+
+struct DeferredScalarEdit {
+  ImGuiDataType data_type = ImGuiDataType_COUNT;
+  InputScalarTargetIdentity target_identity;
+  alignas(uint64_t) std::array<uint8_t, kMaxDeferredScalarBytes> candidate = {};
+  alignas(
+      uint64_t) std::array<uint8_t, kMaxDeferredScalarBytes> source_model = {};
+  int last_seen_frame = -1;
+  bool editing = false;
+  bool commit_blocked = false;
+};
+
+struct DeferredScalarStorage {
+  ImGuiContext* context = nullptr;
+  int last_frame = -1;
+  std::unordered_map<ImGuiID, DeferredScalarEdit> edits;
+};
+
+thread_local DeferredScalarStorage g_deferred_scalar_storage;
+
+void ResetDeferredScalarEdit(DeferredScalarEdit& edit, ImGuiDataType data_type,
+                             const void* data, size_t data_size, int frame,
+                             InputScalarTargetIdentity target_identity) {
+  edit = {};
+  edit.data_type = data_type;
+  edit.target_identity = target_identity;
+  std::memcpy(edit.candidate.data(), data, data_size);
+  std::memcpy(edit.source_model.data(), data, data_size);
+  edit.last_seen_frame = frame;
+}
+
+void PrepareDeferredScalarStorage(ImGuiContext* context, int frame) {
+  auto& storage = g_deferred_scalar_storage;
+  if (storage.context != context || frame < storage.last_frame) {
+    storage.context = context;
+    storage.edits.clear();
+  }
+
+  for (auto it = storage.edits.begin(); it != storage.edits.end();) {
+    if (frame - it->second.last_seen_frame > 1) {
+      it = storage.edits.erase(it);
+    } else {
+      ++it;
+    }
+  }
+  storage.last_frame = frame;
+}
+
 bool IsValueWheelAdjustmentAllowedForCurrentItem() {
   if (!ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenBlockedByPopup)) {
     return false;
@@ -332,6 +384,84 @@ bool ApplyHexMouseWheel(T* data, T min_value, T max_value) {
 
 const int kStepOneHex = 0x01;
 const int kStepFastHex = 0x0F;
+
+bool InputScalarDeferred(const char* label, ImGuiDataType data_type, void* data,
+                         const char* format, ImGuiInputTextFlags flags,
+                         InputScalarTargetIdentity target_identity) {
+  ImGuiContext* context = ImGui::GetCurrentContext();
+  ImGuiWindow* window = context ? ImGui::GetCurrentWindow() : nullptr;
+  if (!context || !window || window->SkipItems || !label || !data ||
+      data_type < 0 || data_type >= ImGuiDataType_COUNT) {
+    return false;
+  }
+
+  const ImGuiDataTypeInfo* data_type_info = ImGui::DataTypeGetInfo(data_type);
+  const size_t data_size = data_type_info->Size;
+  if (data_size == 0 || data_size > kMaxDeferredScalarBytes) {
+    return false;
+  }
+
+  const int frame = context->FrameCount;
+  PrepareDeferredScalarStorage(context, frame);
+
+  const ImGuiID item_id = ImGui::GetID(label);
+  auto [it, inserted] = g_deferred_scalar_storage.edits.try_emplace(item_id);
+  DeferredScalarEdit& edit = it->second;
+  const bool target_changed =
+      !inserted && !(edit.target_identity == target_identity);
+  const bool reset_before_draw = inserted || edit.data_type != data_type ||
+                                 (target_changed && !edit.editing);
+  if (reset_before_draw) {
+    ResetDeferredScalarEdit(edit, data_type, data, data_size, frame,
+                            target_identity);
+  } else if (target_changed) {
+    // The same ImGui item now refers to a different semantic entity. Keep the
+    // active text buffer alive for ImGui, but make this edit non-committable.
+    edit.target_identity = target_identity;
+    edit.commit_blocked = true;
+  } else if (edit.editing &&
+             std::memcmp(edit.source_model.data(), data, data_size) != 0) {
+    // Keep feeding ImGui the same candidate until the item naturally
+    // deactivates, but remember that it is no longer safe to commit.
+    edit.commit_blocked = true;
+  } else if (!edit.editing) {
+    ResetDeferredScalarEdit(edit, data_type, data, data_size, frame,
+                            target_identity);
+  }
+  edit.last_seen_frame = frame;
+
+  const ImGuiInputTextFlags scalar_flags =
+      flags & ~ImGuiInputTextFlags_EnterReturnsTrue;
+  ImGui::InputScalar(label, data_type, edit.candidate.data(), nullptr, nullptr,
+                     format, scalar_flags);
+
+  if (ImGui::IsItemDeactivatedAfterEdit()) {
+    // A newly restored widget may share an ID with ImGui's one-frame
+    // deactivation backup. Never let that stale buffer become a fresh commit.
+    if (reset_before_draw || edit.commit_blocked) {
+      ResetDeferredScalarEdit(edit, data_type, data, data_size, frame,
+                              target_identity);
+      return false;
+    }
+    const bool changed =
+        std::memcmp(data, edit.candidate.data(), data_size) != 0;
+    if (changed) {
+      std::memcpy(data, edit.candidate.data(), data_size);
+    }
+    ResetDeferredScalarEdit(edit, data_type, data, data_size, frame,
+                            target_identity);
+    return changed;
+  }
+
+  if (ImGui::IsItemActive()) {
+    edit.editing = true;
+  } else if (edit.editing) {
+    // Escape or another non-commit deactivation discards the pending value.
+    ResetDeferredScalarEdit(edit, data_type, data, data_size, frame,
+                            target_identity);
+  }
+  return false;
+}
 
 bool InputHex(const char* label, uint64_t* data) {
   return ImGui::InputScalar(label, ImGuiDataType_U64, data, &kStepOneHex,

--- a/src/app/gui/core/input.h
+++ b/src/app/gui/core/input.h
@@ -36,12 +36,46 @@ IMGUI_API bool InputHexByte(const char* label, uint8_t* data,
 IMGUI_API bool InputHexByte(const char* label, uint8_t* data, uint8_t max_value,
                             float input_width = 50.f, bool no_step = false);
 
+/**
+ * @brief Draw a scalar editor that commits the model value atomically.
+ *
+ * ImGui::InputScalar writes through its data pointer for every intermediate
+ * text edit. This helper instead keeps the in-progress value per ImGuiID and
+ * writes @p data only when the item is deactivated after an edit. Pressing
+ * Enter remains compatible with ImGui Test Engine's ItemInputValue because the
+ * standard input deactivates on Enter; EnterReturnsTrue is intentionally
+ * removed from @p flags.
+ *
+ * Pending state is discarded if the widget disappears for a frame, its data
+ * type changes, the backing model changes, or @p target_identity changes while
+ * an edit is active. Supplying semantic identity keeps a stable automation ID
+ * from carrying pending text across rooms, selections, or palette targets.
+ */
+// Semantic identity is independent of the ImGuiID so automation selectors stay
+// stable while pending edits remain bound to their room/entity/component.
+struct InputScalarTargetIdentity {
+  uint64_t context = 0;
+  uint64_t container = 0;
+  uint64_t element = 0;
+  uint64_t component = 0;
+
+  bool operator==(const InputScalarTargetIdentity& other) const {
+    return context == other.context && container == other.container &&
+           element == other.element && component == other.component;
+  }
+};
+
+IMGUI_API bool InputScalarDeferred(
+    const char* label, ImGuiDataType data_type, void* data,
+    const char* format = nullptr, ImGuiInputTextFlags flags = 0,
+    InputScalarTargetIdentity target_identity = {});
+
 // Result type for InputHex functions that need to distinguish between
 // immediate changes (button/wheel) and text-edit changes (deferred)
 struct InputHexResult {
-  bool changed;           // Value was modified (any source)
-  bool immediate;         // Change was from button/wheel (apply now)
-  bool text_committed;    // Change was from text edit and committed (deactivated)
+  bool changed;         // Value was modified (any source)
+  bool immediate;       // Change was from button/wheel (apply now)
+  bool text_committed;  // Change was from text edit and committed (deactivated)
 
   // Convenience: true if change should be applied immediately
   // Use this instead of: InputHex(...) && IsItemDeactivatedAfterEdit()

--- a/src/app/gui/widgets/palette_editor_widget.cc
+++ b/src/app/gui/widgets/palette_editor_widget.cc
@@ -7,7 +7,9 @@
 #include "absl/strings/str_format.h"
 #include "app/gfx/resource/arena.h"
 #include "app/gfx/util/palette_manager.h"
+#include "app/gui/automation/widget_auto_register.h"
 #include "app/gui/core/color.h"
+#include "app/gui/core/input.h"
 #include "app/gui/core/popup_id.h"
 #include "app/gui/core/theme_manager.h"
 #include "app/gui/plots/implot_support.h"
@@ -258,6 +260,20 @@ void PaletteEditorWidget::DrawPaletteSelector() {
     }
     ImGui::EndCombo();
   }
+
+  int requested_palette_id = current_palette_id_;
+  ImGui::TextUnformatted(tr("Palette ID"));
+  ImGui::SameLine();
+  ImGui::SetNextItemWidth(72.0f);
+  const bool palette_id_changed = gui::InputScalarDeferred(
+      "##DungeonPaletteId", ImGuiDataType_S32, &requested_palette_id, "%d", 0,
+      {reinterpret_cast<uintptr_t>(game_data_)});
+  gui::AutoRegisterLastItem("input_int", "palette_id",
+                            "Dungeon main palette ID");
+  if (palette_id_changed) {
+    current_palette_id_ = std::clamp(requested_palette_id, 0, num_palettes - 1);
+    selected_color_index_ = -1;
+  }
 }
 
 void PaletteEditorWidget::DrawColorPicker() {
@@ -355,6 +371,9 @@ void PaletteEditorWidget::DrawDungeonRenderPalette() {
     const bool clicked = ImGui::ColorButton("##render_color", display_color,
                                             ImGuiColorEditFlags_NoTooltip,
                                             ImVec2(swatch_size, swatch_size));
+    gui::AutoRegisterLastItem("color_button",
+                              absl::StrFormat("palette_swatch_%03d", i),
+                              "Dungeon render palette swatch");
     const ImVec2 swatch_min = ImGui::GetItemRectMin();
     const ImVec2 swatch_max = ImGui::GetItemRectMax();
     const bool double_clicked =
@@ -450,6 +469,33 @@ void PaletteEditorWidget::DrawDungeonRenderColorPicker() {
       editing_color_ = gui::ConvertSnesColorToImVec4(edited_color);
     } else {
       LOG_ERROR("PaletteEditorWidget", "Failed to apply palette color: %s",
+                status.message().data());
+    }
+  }
+
+  uint16_t raw_color = current_color.snes();
+  ImGui::AlignTextToFramePadding();
+  ImGui::TextUnformatted(tr("Raw BGR555"));
+  ImGui::SameLine();
+  ImGui::SetNextItemWidth(96.0f);
+  const bool raw_changed = gui::InputScalarDeferred(
+      "##SelectedDungeonPaletteBgr555", ImGuiDataType_U16, &raw_color, "%04X",
+      ImGuiInputTextFlags_CharsHexadecimal,
+      {reinterpret_cast<uintptr_t>(game_data_),
+       static_cast<uint64_t>(target->source),
+       static_cast<uint64_t>(target->palette_index),
+       static_cast<uint64_t>(target->color_index)});
+  gui::AutoRegisterLastItem("input_scalar", "selected_palette_bgr555",
+                            "Selected dungeon palette raw BGR555 color");
+  if (raw_changed) {
+    raw_color &= 0x7FFF;
+    const gfx::SnesColor raw_edited_color(raw_color);
+    const absl::Status status =
+        ApplyDungeonRenderColorEdit(selected_color_index_, raw_edited_color);
+    if (status.ok()) {
+      editing_color_ = gui::ConvertSnesColorToImVec4(raw_edited_color);
+    } else {
+      LOG_ERROR("PaletteEditorWidget", "Failed to apply raw palette color: %s",
                 status.message().data());
     }
   }

--- a/src/app/platform/wasm/wasm_control_api.cc
+++ b/src/app/platform/wasm/wasm_control_api.cc
@@ -2122,11 +2122,11 @@ std::string WasmControlApi::GetUIElementBounds(const std::string& element_id) {
 
   // Query the WidgetIdRegistry for the specific widget
   auto& registry = gui::WidgetIdRegistry::Instance();
-  const auto* widget_info = registry.GetWidgetInfo(element_id);
+  const auto widget_info = registry.GetWidgetInfo(element_id);
 
   result["id"] = element_id;
 
-  if (widget_info == nullptr) {
+  if (!widget_info.has_value()) {
     result["found"] = false;
     result["error"] = "Element not found: " + element_id;
     return result.dump();

--- a/src/app/service/grpc_support.cmake
+++ b/src/app/service/grpc_support.cmake
@@ -63,6 +63,18 @@ target_link_libraries(yaze_grpc_support PUBLIC
   ${YAZE_SDL2_TARGETS}
 )
 
+# The remote GUI harness must compile its real ImGui Test Engine path in
+# developer/test builds. Without this target-local definition the service
+# silently compiles the success-returning stub path even though the engine is
+# available elsewhere in the process.
+if(TARGET ImGuiTestEngine)
+  target_link_libraries(yaze_grpc_support PUBLIC ImGuiTestEngine)
+  target_compile_definitions(yaze_grpc_support PRIVATE
+    YAZE_ENABLE_IMGUI_TEST_ENGINE=1
+    IMGUI_DEFINE_MATH_OPERATORS=1
+  )
+endif()
+
 # Add JSON support
 if(YAZE_ENABLE_JSON)
   target_link_libraries(yaze_grpc_support PUBLIC nlohmann_json::nlohmann_json)

--- a/src/app/service/imgui_test_harness_internal.h
+++ b/src/app/service/imgui_test_harness_internal.h
@@ -1,0 +1,49 @@
+#ifndef YAZE_APP_SERVICE_IMGUI_TEST_HARNESS_INTERNAL_H_
+#define YAZE_APP_SERVICE_IMGUI_TEST_HARNESS_INTERNAL_H_
+
+#ifdef YAZE_WITH_GRPC
+
+#include <string>
+
+#include "absl/status/statusor.h"
+#include "absl/strings/string_view.h"
+#include "imgui/imgui.h"
+
+namespace yaze {
+namespace test {
+
+enum class HarnessTestStatus;
+struct HarnessTestExecution;
+
+namespace internal {
+
+struct ParsedTarget {
+  std::string type;
+  std::string label;
+};
+
+struct ResolvedWidgetSelector {
+  ParsedTarget target;
+  std::string resolved_widget_key;
+  std::string resolved_path;
+  ImGuiID imgui_id = 0;
+};
+
+// Resolve a stable registry key to both its descriptive metadata and exact
+// ImGui identifier. Keeping the identifier is what makes duplicate labels
+// safe for harness actions.
+absl::StatusOr<ResolvedWidgetSelector> ResolveWidgetSelector(
+    absl::string_view target, absl::string_view widget_key);
+
+// Replay RPC responses describe queue acceptance, while the execution record
+// describes the terminal action result. Always let the latter win.
+void ApplyTerminalHarnessExecution(const HarnessTestExecution& execution,
+                                   bool* step_success,
+                                   std::string* step_message);
+
+}  // namespace internal
+}  // namespace test
+}  // namespace yaze
+
+#endif  // YAZE_WITH_GRPC
+#endif  // YAZE_APP_SERVICE_IMGUI_TEST_HARNESS_INTERNAL_H_

--- a/src/app/service/imgui_test_harness_service.cc
+++ b/src/app/service/imgui_test_harness_service.cc
@@ -1,5 +1,6 @@
 #include "app/service/imgui_test_harness_service.h"
 #include "app/application.h"
+#include "app/service/imgui_test_harness_internal.h"
 
 #ifdef YAZE_WITH_GRPC
 
@@ -48,11 +49,11 @@ std::deque<std::shared_ptr<DynamicTestData>> g_dynamic_tests
 
 void KeepDynamicTestData(const std::shared_ptr<DynamicTestData>& data) {
   absl::MutexLock lock(&g_dynamic_tests_mutex);
-  constexpr size_t kMaxKeepAlive = 64;
+  // ImGuiTest stores UserData as a raw pointer and registered tests remain
+  // available for replay for the lifetime of the engine. Retain every backing
+  // closure for that same lifetime; evicting an older entry can otherwise
+  // leave a queued or re-runnable test with dangling UserData.
   g_dynamic_tests.push_back(data);
-  while (g_dynamic_tests.size() > kMaxKeepAlive) {
-    g_dynamic_tests.pop_front();
-  }
 }
 
 void RunDynamicTest(ImGuiTestContext* ctx) {
@@ -268,17 +269,6 @@ absl::Status WaitForHarnessTestCompletion(TestManager* manager,
       "Harness test %s did not reach a terminal state", test_id));
 }
 
-struct ParsedTarget {
-  std::string type;
-  std::string label;
-};
-
-struct ResolvedWidgetSelector {
-  ParsedTarget target;
-  std::string resolved_widget_key;
-  std::string resolved_path;
-};
-
 struct ParsedCondition {
   std::string type;
   std::string target;
@@ -307,7 +297,8 @@ std::string ExtractTypeFromPath(absl::string_view path) {
   return std::string(segment.substr(0, colon));
 }
 
-absl::StatusOr<ParsedTarget> ParseTargetString(absl::string_view target) {
+absl::StatusOr<internal::ParsedTarget> ParseTargetString(
+    absl::string_view target) {
   if (target.empty()) {
     return absl::InvalidArgumentError(
         "Missing target. Provide 'type:label' or widget_key.");
@@ -319,11 +310,15 @@ absl::StatusOr<ParsedTarget> ParseTargetString(absl::string_view target) {
         "Invalid target format. Use 'type:label' (e.g. 'button:Open ROM').");
   }
 
-  ParsedTarget parsed;
+  internal::ParsedTarget parsed;
   parsed.type = std::string(target.substr(0, colon_pos));
   parsed.label = std::string(target.substr(colon_pos + 1));
   return parsed;
 }
+
+}  // namespace
+
+namespace internal {
 
 absl::StatusOr<ResolvedWidgetSelector> ResolveWidgetSelector(
     absl::string_view target, absl::string_view widget_key) {
@@ -340,6 +335,11 @@ absl::StatusOr<ResolvedWidgetSelector> ResolveWidgetSelector(
     resolved.resolved_widget_key = key;
     resolved.resolved_path =
         info->full_path.empty() ? key : std::string(info->full_path);
+    resolved.imgui_id = info->imgui_id;
+    if (resolved.imgui_id == 0) {
+      return absl::FailedPreconditionError(absl::StrFormat(
+          "widget_key '%s' resolved without a valid ImGui ID", key));
+    }
     resolved.target.type = info->type.empty()
                                ? ExtractTypeFromPath(resolved.resolved_path)
                                : std::string(info->type);
@@ -364,6 +364,21 @@ absl::StatusOr<ResolvedWidgetSelector> ResolveWidgetSelector(
   return resolved;
 }
 
+void ApplyTerminalHarnessExecution(const HarnessTestExecution& execution,
+                                   bool* step_success,
+                                   std::string* step_message) {
+  if (step_success) {
+    *step_success = execution.status == HarnessTestStatus::kPassed;
+  }
+  if (step_message && !execution.error_message.empty()) {
+    *step_message = execution.error_message;
+  }
+}
+
+}  // namespace internal
+
+namespace {
+
 absl::StatusOr<ParsedCondition> ParseConditionString(absl::string_view value) {
   if (value.empty()) {
     return absl::InvalidArgumentError(
@@ -385,11 +400,11 @@ absl::StatusOr<ParsedCondition> ParseConditionString(absl::string_view value) {
 absl::StatusOr<ParsedCondition> ResolveCondition(
     absl::string_view condition, absl::string_view widget_key,
     absl::string_view default_type_for_widget,
-    ResolvedWidgetSelector* resolved_selector) {
-  std::optional<ResolvedWidgetSelector> widget_selector;
+    internal::ResolvedWidgetSelector* resolved_selector) {
+  std::optional<internal::ResolvedWidgetSelector> widget_selector;
   if (!widget_key.empty()) {
-    absl::StatusOr<ResolvedWidgetSelector> resolved =
-        ResolveWidgetSelector("", widget_key);
+    absl::StatusOr<internal::ResolvedWidgetSelector> resolved =
+        internal::ResolveWidgetSelector("", widget_key);
     if (!resolved.ok()) {
       return resolved.status();
     }
@@ -398,7 +413,7 @@ absl::StatusOr<ParsedCondition> ResolveCondition(
       *resolved_selector = *resolved;
     }
   } else if (resolved_selector) {
-    *resolved_selector = ResolvedWidgetSelector{};
+    *resolved_selector = internal::ResolvedWidgetSelector{};
   }
 
   if (condition.empty()) {
@@ -751,8 +766,8 @@ absl::Status ImGuiTestHarnessServiceImpl::Click(const ClickRequest* request,
   test_manager_->AppendHarnessTestLog(
       test_id, absl::StrCat("Queued click request: ", request_summary));
 
-  absl::StatusOr<ResolvedWidgetSelector> resolved_selector =
-      ResolveWidgetSelector(requested_target, requested_widget_key);
+  absl::StatusOr<internal::ResolvedWidgetSelector> resolved_selector =
+      internal::ResolveWidgetSelector(requested_target, requested_widget_key);
   if (!resolved_selector.ok()) {
     auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
         std::chrono::steady_clock::now() - start);
@@ -775,6 +790,7 @@ absl::Status ImGuiTestHarnessServiceImpl::Click(const ClickRequest* request,
 
   const std::string widget_type = resolved_selector->target.type;
   const std::string widget_label = resolved_selector->target.label;
+  const ImGuiID widget_id = resolved_selector->imgui_id;
 
 #if defined(YAZE_ENABLE_IMGUI_TEST_ENGINE) && YAZE_ENABLE_IMGUI_TEST_ENGINE
   ImGuiTestEngine* engine = test_manager_->GetUITestEngine();
@@ -813,16 +829,38 @@ absl::Status ImGuiTestHarnessServiceImpl::Click(const ClickRequest* request,
   auto test_data = std::make_shared<DynamicTestData>();
   TestManager* manager = test_manager_;
   test_data->test_func = [manager, captured_id = test_id, widget_type,
-                          widget_label, click_type,
+                          widget_label, widget_id, click_type,
                           mouse_button](ImGuiTestContext* ctx) {
     manager->MarkHarnessTestRunning(captured_id);
     try {
+      const ImGuiTestRef widget_ref = widget_id != 0
+                                          ? ImGuiTestRef(widget_id)
+                                          : ImGuiTestRef(widget_label.c_str());
+      const ImGuiTestItemInfo item =
+          ctx->ItemInfo(widget_ref, ImGuiTestOpFlags_NoError);
+      if (item.ID == 0) {
+        const std::string error_message =
+            absl::StrFormat("Click target '%s' not found", widget_label);
+        manager->AppendHarnessTestLog(captured_id, error_message);
+        manager->MarkHarnessTestCompleted(
+            captured_id, HarnessTestStatus::kFailed, error_message);
+        return;
+      }
+
       if (click_type == ClickRequest::CLICK_TYPE_DOUBLE) {
-        ctx->ItemDoubleClick(widget_label.c_str());
+        ctx->ItemDoubleClick(ImGuiTestRef(item.ID));
       } else {
-        ctx->ItemClick(widget_label.c_str(), mouse_button);
+        ctx->ItemClick(ImGuiTestRef(item.ID), mouse_button);
       }
       ctx->Yield();
+      if (ctx->IsError()) {
+        const std::string error_message =
+            absl::StrFormat("Click failed for '%s'", widget_label);
+        manager->AppendHarnessTestLog(captured_id, error_message);
+        manager->MarkHarnessTestCompleted(
+            captured_id, HarnessTestStatus::kFailed, error_message);
+        return;
+      }
       const std::string success_message =
           absl::StrFormat("Clicked %s '%s'", widget_type, widget_label);
       manager->AppendHarnessTestLog(captured_id, success_message);
@@ -859,18 +897,15 @@ absl::Status ImGuiTestHarnessServiceImpl::Click(const ClickRequest* request,
   test_manager_->AppendHarnessTestLog(test_id, message);
 
 #else
-  std::string message =
-      absl::StrFormat("[STUB] Clicked %s '%s' (ImGuiTestEngine not available)",
-                      widget_type, widget_label);
-
+  const std::string message = "ImGuiTestEngine is not available in this build";
   test_manager_->MarkHarnessTestRunning(test_id);
-  test_manager_->MarkHarnessTestCompleted(test_id, HarnessTestStatus::kPassed,
+  test_manager_->MarkHarnessTestCompleted(test_id, HarnessTestStatus::kFailed,
                                           message);
   test_manager_->AppendHarnessTestLog(test_id, message);
 
   auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
       std::chrono::steady_clock::now() - start);
-  response->set_success(true);
+  response->set_success(false);
   response->set_message(message);
   response->set_execution_time_ms(elapsed.count());
 #endif
@@ -925,8 +960,8 @@ absl::Status ImGuiTestHarnessServiceImpl::Type(const TypeRequest* request,
   test_manager_->AppendHarnessTestLog(
       test_id, absl::StrFormat("Queued type request: %s", request_summary));
 
-  absl::StatusOr<ResolvedWidgetSelector> resolved_selector =
-      ResolveWidgetSelector(requested_target, requested_widget_key);
+  absl::StatusOr<internal::ResolvedWidgetSelector> resolved_selector =
+      internal::ResolveWidgetSelector(requested_target, requested_widget_key);
   if (!resolved_selector.ok()) {
     auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
         std::chrono::steady_clock::now() - start);
@@ -949,6 +984,7 @@ absl::Status ImGuiTestHarnessServiceImpl::Type(const TypeRequest* request,
 
   const std::string widget_type = resolved_selector->target.type;
   const std::string widget_label = resolved_selector->target.label;
+  const ImGuiID widget_id = resolved_selector->imgui_id;
 
 #if defined(YAZE_ENABLE_IMGUI_TEST_ENGINE) && YAZE_ENABLE_IMGUI_TEST_ENGINE
   ImGuiTestEngine* engine = test_manager_->GetUITestEngine();
@@ -970,11 +1006,15 @@ absl::Status ImGuiTestHarnessServiceImpl::Type(const TypeRequest* request,
   auto test_data = std::make_shared<DynamicTestData>();
   TestManager* manager = test_manager_;
   test_data->test_func = [manager, captured_id = test_id, widget_type,
-                          widget_label, clear_first, text,
+                          widget_label, widget_id, clear_first, text,
                           rpc_state](ImGuiTestContext* ctx) {
     manager->MarkHarnessTestRunning(captured_id);
     try {
-      ImGuiTestItemInfo item = ctx->ItemInfo(widget_label.c_str());
+      const ImGuiTestRef widget_ref = widget_id != 0
+                                          ? ImGuiTestRef(widget_id)
+                                          : ImGuiTestRef(widget_label.c_str());
+      ImGuiTestItemInfo item =
+          ctx->ItemInfo(widget_ref, ImGuiTestOpFlags_NoError);
       if (item.ID == 0) {
         std::string error_message =
             absl::StrFormat("Input field '%s' not found", widget_label);
@@ -985,13 +1025,23 @@ absl::Status ImGuiTestHarnessServiceImpl::Type(const TypeRequest* request,
         return;
       }
 
-      ctx->ItemClick(widget_label.c_str());
+      ctx->ItemClick(ImGuiTestRef(item.ID));
       if (clear_first) {
         ctx->KeyPress(ImGuiMod_Shortcut | ImGuiKey_A);
         ctx->KeyPress(ImGuiKey_Delete);
       }
 
-      ctx->ItemInputValue(widget_label.c_str(), text.c_str());
+      ctx->ItemInputValue(ImGuiTestRef(item.ID), text.c_str());
+      ctx->Yield();
+      if (ctx->IsError()) {
+        const std::string error_message =
+            absl::StrFormat("Type failed for '%s'", widget_label);
+        manager->AppendHarnessTestLog(captured_id, error_message);
+        manager->MarkHarnessTestCompleted(
+            captured_id, HarnessTestStatus::kFailed, error_message);
+        rpc_state->SetResult(false, error_message);
+        return;
+      }
 
       std::string success_message =
           absl::StrFormat("Typed '%s' into %s '%s'%s", text, widget_type,
@@ -1051,16 +1101,14 @@ absl::Status ImGuiTestHarnessServiceImpl::Type(const TypeRequest* request,
 
 #else
   test_manager_->MarkHarnessTestRunning(test_id);
-  std::string message = absl::StrFormat(
-      "[STUB] Typed '%s' into %s '%s' (ImGuiTestEngine not available)",
-      request->text(), widget_type, widget_label);
-  test_manager_->MarkHarnessTestCompleted(test_id, HarnessTestStatus::kPassed,
+  const std::string message = "ImGuiTestEngine is not available in this build";
+  test_manager_->MarkHarnessTestCompleted(test_id, HarnessTestStatus::kFailed,
                                           message);
   test_manager_->AppendHarnessTestLog(test_id, message);
 
   auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
       std::chrono::steady_clock::now() - start);
-  response->set_success(true);
+  response->set_success(false);
   response->set_message(message);
   response->set_execution_time_ms(elapsed.count());
 #endif
@@ -1119,7 +1167,7 @@ absl::Status ImGuiTestHarnessServiceImpl::Wait(const WaitRequest* request,
   test_manager_->AppendHarnessTestLog(
       test_id, absl::StrFormat("Queued wait condition: %s", request_summary));
 
-  ResolvedWidgetSelector resolved_selector;
+  internal::ResolvedWidgetSelector resolved_selector;
   absl::StatusOr<ParsedCondition> parsed_condition = ResolveCondition(
       requested_condition, requested_widget_key,
       /*default_type_for_widget=*/"element_visible", &resolved_selector);
@@ -1145,6 +1193,7 @@ absl::Status ImGuiTestHarnessServiceImpl::Wait(const WaitRequest* request,
 
   const std::string condition_type = parsed_condition->type;
   const std::string condition_target = parsed_condition->target;
+  const ImGuiID widget_id = resolved_selector.imgui_id;
   const std::string resolved_condition =
       absl::StrFormat("%s:%s", condition_type, condition_target);
 
@@ -1168,7 +1217,7 @@ absl::Status ImGuiTestHarnessServiceImpl::Wait(const WaitRequest* request,
   auto test_data = std::make_shared<DynamicTestData>();
   TestManager* manager = test_manager_;
   test_data->test_func = [manager, captured_id = test_id, condition_type,
-                          condition_target, timeout_ms,
+                          condition_target, widget_id, timeout_ms,
                           poll_interval_ms](ImGuiTestContext* ctx) {
     manager->MarkHarnessTestRunning(captured_id);
     auto poll_start = std::chrono::steady_clock::now();
@@ -1181,19 +1230,22 @@ absl::Status ImGuiTestHarnessServiceImpl::Wait(const WaitRequest* request,
     try {
       while (std::chrono::steady_clock::now() - poll_start < timeout) {
         bool current_state = false;
+        const ImGuiTestRef widget_ref =
+            widget_id != 0 ? ImGuiTestRef(widget_id)
+                           : ImGuiTestRef(condition_target.c_str());
 
         if (condition_type == "window_visible") {
-          ImGuiTestItemInfo window_info = ctx->WindowInfo(
-              condition_target.c_str(), ImGuiTestOpFlags_NoError);
+          ImGuiTestItemInfo window_info =
+              ctx->WindowInfo(widget_ref, ImGuiTestOpFlags_NoError);
           current_state = (window_info.ID != 0);
         } else if (condition_type == "element_visible") {
           ImGuiTestItemInfo item =
-              ctx->ItemInfo(condition_target.c_str(), ImGuiTestOpFlags_NoError);
+              ctx->ItemInfo(widget_ref, ImGuiTestOpFlags_NoError);
           current_state = (item.ID != 0 && item.RectClipped.GetWidth() > 0 &&
                            item.RectClipped.GetHeight() > 0);
         } else if (condition_type == "element_enabled") {
           ImGuiTestItemInfo item =
-              ctx->ItemInfo(condition_target.c_str(), ImGuiTestOpFlags_NoError);
+              ctx->ItemInfo(widget_ref, ImGuiTestOpFlags_NoError);
           current_state =
               (item.ID != 0 && !(item.ItemFlags & ImGuiItemFlags_Disabled));
         } else {
@@ -1247,6 +1299,7 @@ absl::Status ImGuiTestHarnessServiceImpl::Wait(const WaitRequest* request,
   test->UserData = test_data.get();
 
   ImGuiTestEngine_QueueTest(engine, test, ImGuiTestRunFlags_RunFromGui);
+  KeepDynamicTestData(test_data);
 
   auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
       std::chrono::steady_clock::now() - start);
@@ -1259,16 +1312,14 @@ absl::Status ImGuiTestHarnessServiceImpl::Wait(const WaitRequest* request,
 
 #else
   test_manager_->MarkHarnessTestRunning(test_id);
-  std::string message = absl::StrFormat(
-      "[STUB] Condition '%s' met (ImGuiTestEngine not available)",
-      resolved_condition);
-  test_manager_->MarkHarnessTestCompleted(test_id, HarnessTestStatus::kPassed,
+  const std::string message = "ImGuiTestEngine is not available in this build";
+  test_manager_->MarkHarnessTestCompleted(test_id, HarnessTestStatus::kFailed,
                                           message);
   test_manager_->AppendHarnessTestLog(test_id, message);
 
   auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
       std::chrono::steady_clock::now() - start);
-  response->set_success(true);
+  response->set_success(false);
   response->set_message(message);
   response->set_elapsed_ms(elapsed.count());
 #endif
@@ -1325,7 +1376,7 @@ absl::Status ImGuiTestHarnessServiceImpl::Assert(const AssertRequest* request,
   test_manager_->AppendHarnessTestLog(
       test_id, absl::StrFormat("Queued assertion: %s", request_summary));
 
-  ResolvedWidgetSelector resolved_selector;
+  internal::ResolvedWidgetSelector resolved_selector;
   absl::StatusOr<ParsedCondition> parsed_condition = ResolveCondition(
       requested_condition, requested_widget_key,
       /*default_type_for_widget=*/"exists", &resolved_selector);
@@ -1350,6 +1401,21 @@ absl::Status ImGuiTestHarnessServiceImpl::Assert(const AssertRequest* request,
 
   const std::string assertion_type = parsed_condition->type;
   const std::string assertion_target = parsed_condition->target;
+  const ImGuiID widget_id = resolved_selector.imgui_id;
+  const std::string widget_label = resolved_selector.target.label;
+
+  if (assertion_type == "value_equals" && widget_id == 0) {
+    const std::string message =
+        "value_equals requires widget_key so the input is unambiguous";
+    response->set_success(false);
+    response->set_message(message);
+    response->set_actual_value("N/A");
+    response->set_expected_value(assertion_target);
+    test_manager_->MarkHarnessTestCompleted(test_id, HarnessTestStatus::kFailed,
+                                            message);
+    test_manager_->AppendHarnessTestLog(test_id, message);
+    return finalize(absl::OkStatus());
+  }
 
 #if defined(YAZE_ENABLE_IMGUI_TEST_ENGINE) && YAZE_ENABLE_IMGUI_TEST_ENGINE
   ImGuiTestEngine* engine = test_manager_->GetUITestEngine();
@@ -1367,7 +1433,8 @@ absl::Status ImGuiTestHarnessServiceImpl::Assert(const AssertRequest* request,
   auto test_data = std::make_shared<DynamicTestData>();
   TestManager* manager = test_manager_;
   test_data->test_func = [manager, captured_id = test_id, assertion_type,
-                          assertion_target](ImGuiTestContext* ctx) {
+                          assertion_target, widget_id,
+                          widget_label](ImGuiTestContext* ctx) {
     manager->MarkHarnessTestRunning(captured_id);
 
     auto complete_with = [manager, captured_id](bool passed,
@@ -1390,20 +1457,30 @@ absl::Status ImGuiTestHarnessServiceImpl::Assert(const AssertRequest* request,
       std::string actual_value;
       std::string expected_value;
       std::string message;
+      const ImGuiTestRef widget_ref =
+          widget_id != 0 ? ImGuiTestRef(widget_id)
+                         : ImGuiTestRef(assertion_target.c_str());
 
       if (assertion_type == "visible") {
-        ImGuiTestItemInfo window_info =
-            ctx->WindowInfo(assertion_target.c_str(), ImGuiTestOpFlags_NoError);
-        bool is_visible = (window_info.ID != 0);
+        const ImGuiTestItemInfo item =
+            widget_id != 0
+                ? ctx->ItemInfo(widget_ref, ImGuiTestOpFlags_NoError)
+                : ctx->WindowInfo(widget_ref, ImGuiTestOpFlags_NoError);
+        const bool is_visible =
+            item.ID != 0 &&
+            (widget_id == 0 || (item.RectClipped.GetWidth() > 0 &&
+                                item.RectClipped.GetHeight() > 0));
         passed = is_visible;
         actual_value = is_visible ? "visible" : "hidden";
         expected_value = "visible";
+        const std::string target_description =
+            widget_id != 0 ? widget_label : assertion_target;
         message =
-            passed ? absl::StrFormat("'%s' is visible", assertion_target)
-                   : absl::StrFormat("'%s' is not visible", assertion_target);
+            passed ? absl::StrFormat("'%s' is visible", target_description)
+                   : absl::StrFormat("'%s' is not visible", target_description);
       } else if (assertion_type == "enabled") {
         ImGuiTestItemInfo item =
-            ctx->ItemInfo(assertion_target.c_str(), ImGuiTestOpFlags_NoError);
+            ctx->ItemInfo(widget_ref, ImGuiTestOpFlags_NoError);
         bool is_enabled =
             (item.ID != 0 && !(item.ItemFlags & ImGuiItemFlags_Disabled));
         passed = is_enabled;
@@ -1414,16 +1491,35 @@ absl::Status ImGuiTestHarnessServiceImpl::Assert(const AssertRequest* request,
                    : absl::StrFormat("'%s' is not enabled", assertion_target);
       } else if (assertion_type == "exists") {
         ImGuiTestItemInfo item =
-            ctx->ItemInfo(assertion_target.c_str(), ImGuiTestOpFlags_NoError);
+            ctx->ItemInfo(widget_ref, ImGuiTestOpFlags_NoError);
         bool exists = (item.ID != 0);
         passed = exists;
         actual_value = exists ? "exists" : "not found";
         expected_value = "exists";
         message = passed ? absl::StrFormat("'%s' exists", assertion_target)
                          : absl::StrFormat("'%s' not found", assertion_target);
+      } else if (assertion_type == "value_equals") {
+        const ImGuiTestItemInfo item =
+            ctx->ItemInfo(widget_ref, ImGuiTestOpFlags_NoError);
+        if (item.ID == 0) {
+          passed = false;
+          actual_value = "not found";
+          expected_value = assertion_target;
+          message = absl::StrFormat("Input '%s' not found", widget_label);
+        } else {
+          const char* value = ctx->ItemReadAsString(ImGuiTestRef(item.ID));
+          actual_value = value ? value : "";
+          expected_value = assertion_target;
+          passed = !ctx->IsError() && actual_value == expected_value;
+          message = passed ? absl::StrFormat("'%s' equals '%s'", widget_label,
+                                             expected_value)
+                           : absl::StrFormat(
+                                 "'%s' does not equal '%s' (actual: '%s')",
+                                 widget_label, expected_value, actual_value);
+        }
       } else if (assertion_type == "text_contains") {
         size_t second_colon = assertion_target.find(':');
-        if (second_colon == std::string::npos) {
+        if (widget_id == 0 && second_colon == std::string::npos) {
           std::string error_message =
               "text_contains requires format "
               "'text_contains:target:expected_text'";
@@ -1432,12 +1528,21 @@ absl::Status ImGuiTestHarnessServiceImpl::Assert(const AssertRequest* request,
           return;
         }
 
-        std::string input_target = assertion_target.substr(0, second_colon);
-        std::string expected_text = assertion_target.substr(second_colon + 1);
+        const std::string input_target =
+            widget_id != 0 ? widget_label
+                           : assertion_target.substr(0, second_colon);
+        const std::string expected_text =
+            widget_id != 0 ? assertion_target
+                           : assertion_target.substr(second_colon + 1);
+        const ImGuiTestRef input_ref = widget_id != 0
+                                           ? ImGuiTestRef(widget_id)
+                                           : ImGuiTestRef(input_target.c_str());
 
-        ImGuiTestItemInfo item = ctx->ItemInfo(input_target.c_str());
+        ImGuiTestItemInfo item =
+            ctx->ItemInfo(input_ref, ImGuiTestOpFlags_NoError);
         if (item.ID != 0) {
-          std::string actual_text = "(text_retrieval_not_fully_implemented)";
+          const char* value = ctx->ItemReadAsString(ImGuiTestRef(item.ID));
+          const std::string actual_text = value ? value : "";
           passed = actual_text.find(expected_text) != std::string::npos;
           actual_value = actual_text;
           expected_value = absl::StrFormat("contains '%s'", expected_text);
@@ -1482,6 +1587,7 @@ absl::Status ImGuiTestHarnessServiceImpl::Assert(const AssertRequest* request,
   test->UserData = test_data.get();
 
   ImGuiTestEngine_QueueTest(engine, test, ImGuiTestRunFlags_RunFromGui);
+  KeepDynamicTestData(test_data);
 
   response->set_success(true);
   std::string message = absl::StrFormat("Queued assertion for '%s:%s'",
@@ -1493,14 +1599,12 @@ absl::Status ImGuiTestHarnessServiceImpl::Assert(const AssertRequest* request,
 
 #else
   test_manager_->MarkHarnessTestRunning(test_id);
-  std::string message = absl::StrFormat(
-      "[STUB] Assertion '%s:%s' passed (ImGuiTestEngine not available)",
-      assertion_type, assertion_target);
-  test_manager_->MarkHarnessTestCompleted(test_id, HarnessTestStatus::kPassed,
+  const std::string message = "ImGuiTestEngine is not available in this build";
+  test_manager_->MarkHarnessTestCompleted(test_id, HarnessTestStatus::kFailed,
                                           message);
   test_manager_->AppendHarnessTestLog(test_id, message);
 
-  response->set_success(true);
+  response->set_success(false);
   response->set_message(message);
   response->set_actual_value("(stub)");
   response->set_expected_value("(stub)");
@@ -2061,9 +2165,8 @@ absl::Status ImGuiTestHarnessServiceImpl::ReplayTest(
             test_manager_, sub_response.test_id(), &execution);
         if (wait_status.ok()) {
           have_execution = true;
-          if (!execution.error_message.empty()) {
-            step_message = execution.error_message;
-          }
+          internal::ApplyTerminalHarnessExecution(execution, &step_success,
+                                                  &step_message);
         } else {
           status = wait_status;
           step_success = false;
@@ -2085,9 +2188,8 @@ absl::Status ImGuiTestHarnessServiceImpl::ReplayTest(
             test_manager_, sub_response.test_id(), &execution);
         if (wait_status.ok()) {
           have_execution = true;
-          if (!execution.error_message.empty()) {
-            step_message = execution.error_message;
-          }
+          internal::ApplyTerminalHarnessExecution(execution, &step_success,
+                                                  &step_message);
         } else {
           status = wait_status;
           step_success = false;
@@ -2110,9 +2212,8 @@ absl::Status ImGuiTestHarnessServiceImpl::ReplayTest(
             test_manager_, sub_response.test_id(), &execution);
         if (wait_status.ok()) {
           have_execution = true;
-          if (!execution.error_message.empty()) {
-            step_message = execution.error_message;
-          }
+          internal::ApplyTerminalHarnessExecution(execution, &step_success,
+                                                  &step_message);
         } else {
           status = wait_status;
           step_success = false;
@@ -2132,9 +2233,8 @@ absl::Status ImGuiTestHarnessServiceImpl::ReplayTest(
             test_manager_, sub_response.test_id(), &execution);
         if (wait_status.ok()) {
           have_execution = true;
-          if (!execution.error_message.empty()) {
-            step_message = execution.error_message;
-          }
+          internal::ApplyTerminalHarnessExecution(execution, &step_success,
+                                                  &step_message);
         } else {
           status = wait_status;
           step_success = false;

--- a/src/app/service/imgui_test_harness_service.cc
+++ b/src/app/service/imgui_test_harness_service.cc
@@ -33,6 +33,12 @@
 #include "protos/imgui_test_harness.pb.h"
 #include "yaze.h"  // For YAZE_VERSION_STRING
 
+// The Windows SDK defines Yield as a function-like macro, which collides with
+// ImGuiTestContext::Yield when this translation unit is built with clang-cl.
+#ifdef Yield
+#undef Yield
+#endif
+
 #if defined(YAZE_ENABLE_IMGUI_TEST_ENGINE) && YAZE_ENABLE_IMGUI_TEST_ENGINE
 #include "imgui_test_engine/imgui_te_context.h"
 #include "imgui_test_engine/imgui_te_engine.h"

--- a/src/app/service/imgui_test_harness_service.cc
+++ b/src/app/service/imgui_test_harness_service.cc
@@ -833,6 +833,70 @@ absl::Status ImGuiTestHarnessServiceImpl::Click(const ClickRequest* request,
                           mouse_button](ImGuiTestContext* ctx) {
     manager->MarkHarnessTestRunning(captured_id);
     try {
+      if (widget_type == "shortcut") {
+        ImGuiKeyChord chord = 0;
+        if (widget_label == "Save ROM") {
+          chord = ImGuiMod_Shortcut | ImGuiKey_S;
+        } else if (widget_label == "Quit") {
+          // A successful quit destroys the harness before a simulated key
+          // press can finish and report its result. Invoke the same guarded
+          // application action directly, fail if unsaved work blocks it, and
+          // let the caller prove process and listener teardown.
+          auto* controller = Application::Instance().GetController();
+          auto* editor_manager =
+              controller != nullptr ? controller->editor_manager() : nullptr;
+          if (editor_manager == nullptr) {
+            const std::string error_message =
+                "Application quit is unavailable before editor startup";
+            manager->AppendHarnessTestLog(captured_id, error_message);
+            manager->MarkHarnessTestCompleted(
+                captured_id, HarnessTestStatus::kFailed, error_message);
+            return;
+          }
+
+          editor_manager->Quit();
+          if (!editor_manager->quit()) {
+            const std::string error_message = absl::StrCat(
+                "Application quit was blocked: ",
+                editor_manager->GetPendingUnsavedSessionActionPrompt());
+            manager->AppendHarnessTestLog(captured_id, error_message);
+            manager->MarkHarnessTestCompleted(
+                captured_id, HarnessTestStatus::kFailed, error_message);
+            return;
+          }
+
+          const std::string success_message = "Requested application quit";
+          manager->AppendHarnessTestLog(captured_id, success_message);
+          manager->MarkHarnessTestCompleted(
+              captured_id, HarnessTestStatus::kPassed, success_message);
+          return;
+        } else {
+          const std::string error_message = absl::StrFormat(
+              "Unsupported harness shortcut '%s'", widget_label);
+          manager->AppendHarnessTestLog(captured_id, error_message);
+          manager->MarkHarnessTestCompleted(
+              captured_id, HarnessTestStatus::kFailed, error_message);
+          return;
+        }
+
+        ctx->KeyPress(chord);
+        ctx->Yield(2);
+        if (ctx->IsError()) {
+          const std::string error_message =
+              absl::StrFormat("Shortcut failed for '%s'", widget_label);
+          manager->AppendHarnessTestLog(captured_id, error_message);
+          manager->MarkHarnessTestCompleted(
+              captured_id, HarnessTestStatus::kFailed, error_message);
+          return;
+        }
+        const std::string success_message =
+            absl::StrFormat("Pressed shortcut '%s'", widget_label);
+        manager->AppendHarnessTestLog(captured_id, success_message);
+        manager->MarkHarnessTestCompleted(
+            captured_id, HarnessTestStatus::kPassed, success_message);
+        return;
+      }
+
       const ImGuiTestRef widget_ref = widget_id != 0
                                           ? ImGuiTestRef(widget_id)
                                           : ImGuiTestRef(widget_label.c_str());

--- a/src/app/service/imgui_test_harness_service.cc
+++ b/src/app/service/imgui_test_harness_service.cc
@@ -325,7 +325,7 @@ absl::StatusOr<ResolvedWidgetSelector> ResolveWidgetSelector(
   ResolvedWidgetSelector resolved;
   if (!widget_key.empty()) {
     const std::string key(widget_key);
-    const gui::WidgetIdRegistry::WidgetInfo* info =
+    std::optional<gui::WidgetIdRegistry::WidgetInfo> info =
         gui::WidgetIdRegistry::Instance().GetWidgetInfo(key);
     if (!info) {
       return absl::NotFoundError(absl::StrFormat(
@@ -1791,6 +1791,7 @@ absl::Status ImGuiTestHarnessServiceImpl::Screenshot(
 
   Application::Instance().GetController()->RequestScreenshot(
       {.preferred_path = requested_path,
+       .reveal_to_user = false,
        .callback = [state](absl::StatusOr<ScreenshotArtifact> result) {
          state->result = std::move(result);
          state->done.store(true);

--- a/src/app/testing/test_manager.cc
+++ b/src/app/testing/test_manager.cc
@@ -1724,6 +1724,7 @@ std::string TestManager::RegisterHarnessTest(const std::string& name,
   harness_history_[test_id] = execution;
   TrimHarnessHistoryLocked();
   HarnessAggregate& aggregate = harness_aggregates_[name];
+  aggregate.category = category;
   aggregate.latest_execution = execution;
   harness_history_order_.push_back(test_id);
   return test_id;
@@ -1757,40 +1758,40 @@ void TestManager::MarkHarnessTestCompleted(
     const std::vector<std::string>& assertion_failures,
     const std::vector<std::string>& logs,
     const std::map<std::string, int32_t>& metrics) {
-  absl::MutexLock lock(&harness_history_mutex_);
-  auto it = harness_history_.find(test_id);
-  if (it == harness_history_.end()) {
-    return;
+  HarnessTestExecution execution_snapshot;
+  {
+    absl::MutexLock lock(&harness_history_mutex_);
+    auto it = harness_history_.find(test_id);
+    if (it == harness_history_.end()) {
+      return;
+    }
+    HarnessTestExecution& execution = it->second;
+    execution.status = status;
+    execution.completed_at = absl::Now();
+    execution.duration = execution.completed_at - execution.started_at;
+    execution.error_message = message;
+    execution.metrics = metrics;
+    execution.assertion_failures = assertion_failures;
+    execution.logs.insert(execution.logs.end(), logs.begin(), logs.end());
+
+    HarnessAggregate& aggregate = harness_aggregates_[execution.name];
+    aggregate.latest_execution = execution;
+    aggregate.total_runs += 1;
+    if (status == HarnessTestStatus::kPassed) {
+      aggregate.pass_count += 1;
+    } else if (status == HarnessTestStatus::kFailed ||
+               status == HarnessTestStatus::kTimeout) {
+      aggregate.fail_count += 1;
+    }
+    aggregate.total_duration += execution.duration;
+    aggregate.last_run = execution.completed_at;
+    execution_snapshot = execution;
   }
-  HarnessTestExecution& execution = it->second;
-  execution.status = status;
-  execution.completed_at = absl::Now();
-  execution.duration = execution.completed_at - execution.started_at;
-  execution.error_message = message;
-  execution.metrics = metrics;
-  execution.assertion_failures = assertion_failures;
-  execution.logs.insert(execution.logs.end(), logs.begin(), logs.end());
 
-  bool capture_failure_context = status == HarnessTestStatus::kFailed ||
-                                 status == HarnessTestStatus::kTimeout;
-
-  harness_aggregates_[execution.name].latest_execution = execution;
-  harness_aggregates_[execution.name].total_runs += 1;
-  if (status == HarnessTestStatus::kPassed) {
-    harness_aggregates_[execution.name].pass_count += 1;
-  } else if (status == HarnessTestStatus::kFailed ||
-             status == HarnessTestStatus::kTimeout) {
-    harness_aggregates_[execution.name].fail_count += 1;
-  }
-  harness_aggregates_[execution.name].total_duration += execution.duration;
-  harness_aggregates_[execution.name].last_run = execution.completed_at;
-
-  if (capture_failure_context) {
+  NotifyHarnessListener(execution_snapshot);
+  if (status == HarnessTestStatus::kFailed ||
+      status == HarnessTestStatus::kTimeout) {
     CaptureFailureContext(test_id);
-  }
-
-  if (harness_listener_) {
-    harness_listener_->OnHarnessTestUpdated(execution);
   }
 }
 #endif
@@ -1858,36 +1859,58 @@ std::vector<HarnessTestSummary> TestManager::ListHarnessTestSummaries(
 
 #if defined(YAZE_WITH_GRPC)
 void TestManager::CaptureFailureContext(const std::string& test_id) {
-  absl::MutexLock lock(&harness_history_mutex_);
-  auto it = harness_history_.find(test_id);
-  if (it == harness_history_.end()) {
+  HarnessTestStatus expected_status = HarnessTestStatus::kUnspecified;
+  absl::Time expected_completed_at = absl::InfinitePast();
+  {
+    absl::MutexLock lock(&harness_history_mutex_);
+    auto it = harness_history_.find(test_id);
+    if (it == harness_history_.end()) {
+      return;
+    }
+    expected_status = it->second.status;
+    expected_completed_at = it->second.completed_at;
+  }
+
+  auto apply_capture =
+      [this, test_id, expected_status, expected_completed_at](
+          absl::StatusOr<ScreenshotArtifact> screenshot_artifact) {
+        absl::MutexLock lock(&harness_history_mutex_);
+        auto it = harness_history_.find(test_id);
+        if (it == harness_history_.end()) {
+          return;
+        }
+        HarnessTestExecution& execution = it->second;
+        if (execution.status != expected_status ||
+            execution.completed_at != expected_completed_at) {
+          return;
+        }
+        execution.failure_context =
+            screenshot_artifact.ok()
+                ? "Harness failure context captured successfully"
+                : "Harness failure context capture unavailable";
+        if (screenshot_artifact.ok()) {
+          execution.screenshot_path = screenshot_artifact->file_path;
+          execution.screenshot_size_bytes =
+              screenshot_artifact->file_size_bytes;
+        }
+        HarnessAggregate& aggregate = harness_aggregates_[execution.name];
+        if (aggregate.latest_execution.test_id == test_id) {
+          harness_aggregates_[execution.name].latest_execution = execution;
+        }
+      };
+
+  FailureScreenshotRequester screenshot_requester;
+  {
+    absl::MutexLock lock(&mutex_);
+    screenshot_requester = failure_screenshot_requester_;
+  }
+  if (!screenshot_requester) {
+    apply_capture(absl::FailedPreconditionError("Controller unavailable"));
     return;
   }
-  HarnessTestExecution& execution = it->second;
-  // absl::MutexLock does not support Unlock/Lock; scope the lock instead
-  {
-    absl::MutexLock unlock_guard(&harness_history_mutex_);
-    // This block is just to clarify lock scope, but the lock is already held
-    // so we do nothing here.
-  }
 
-  auto screenshot_artifact = test::CaptureHarnessScreenshot("harness_failures");
-  std::string failure_context;
-  if (screenshot_artifact.ok()) {
-    failure_context = "Harness failure context captured successfully";
-  } else {
-    failure_context = "Harness failure context capture unavailable";
-  }
-
-  execution.failure_context = failure_context;
-  if (screenshot_artifact.ok()) {
-    execution.screenshot_path = screenshot_artifact->file_path;
-    execution.screenshot_size_bytes = screenshot_artifact->file_size_bytes;
-  }
-
-  if (harness_listener_) {
-    harness_listener_->OnHarnessTestUpdated(execution);
-  }
+  screenshot_requester(GenerateFailureScreenshotPath(test_id),
+                       std::move(apply_capture));
 }
 #else
 void TestManager::CaptureFailureContext(const std::string& test_id) {
@@ -1908,9 +1931,34 @@ absl::Status TestManager::ReplayLastPlan() {
   return absl::FailedPreconditionError("Harness plan replay not available");
 }
 
-void TestManager::SetHarnessListener(HarnessListener* listener) {
+void TestManager::SetHarnessListener(
+    std::shared_ptr<HarnessListener> listener) {
   absl::MutexLock lock(&mutex_);
-  harness_listener_ = listener;
+  harness_listener_ = std::move(listener);
+}
+
+void TestManager::ClearHarnessListener(const HarnessListener* listener) {
+  absl::MutexLock lock(&mutex_);
+  if (harness_listener_.get() == listener) {
+    harness_listener_.reset();
+  }
+}
+
+void TestManager::SetFailureScreenshotRequester(
+    FailureScreenshotRequester requester) {
+  absl::MutexLock lock(&mutex_);
+  failure_screenshot_requester_ = std::move(requester);
+}
+
+void TestManager::NotifyHarnessListener(const HarnessTestExecution& execution) {
+  std::shared_ptr<HarnessListener> listener;
+  {
+    absl::MutexLock lock(&mutex_);
+    listener = harness_listener_;
+  }
+  if (listener) {
+    listener->OnHarnessTestUpdated(execution);
+  }
 }
 #else
 absl::Status TestManager::ReplayLastPlan() {

--- a/src/app/testing/test_manager.h
+++ b/src/app/testing/test_manager.h
@@ -15,6 +15,7 @@
 #include "absl/strings/string_view.h"
 #include "absl/synchronization/mutex.h"
 #include "absl/time/time.h"
+#include "app/service/screenshot_utils.h"
 #include "rom/rom.h"
 
 #define IMGUI_DEFINE_MATH_OPERATORS
@@ -278,6 +279,11 @@ class TestManager {
 
   // Harness test introspection (IT-05)
 #if defined(YAZE_WITH_GRPC)
+  using FailureScreenshotCallback =
+      std::function<void(absl::StatusOr<ScreenshotArtifact>)>;
+  using FailureScreenshotRequester =
+      std::function<void(const std::string&, FailureScreenshotCallback)>;
+
   std::string RegisterHarnessTest(const std::string& name,
                                   const std::string& category)
       ABSL_LOCKS_EXCLUDED(harness_history_mutex_);
@@ -304,7 +310,9 @@ class TestManager {
   void CaptureFailureContext(const std::string& test_id)
       ABSL_LOCKS_EXCLUDED(harness_history_mutex_);
 
-  void SetHarnessListener(HarnessListener* listener);
+  void SetHarnessListener(std::shared_ptr<HarnessListener> listener);
+  void ClearHarnessListener(const HarnessListener* listener);
+  void SetFailureScreenshotRequester(FailureScreenshotRequester requester);
 
   absl::Status ReplayLastPlan();
 #else
@@ -395,7 +403,9 @@ class TestManager {
   size_t harness_history_limit_ = 200;
   mutable absl::Mutex harness_history_mutex_;
 #if defined(YAZE_WITH_GRPC)
-  HarnessListener* harness_listener_ ABSL_GUARDED_BY(mutex_) = nullptr;
+  std::shared_ptr<HarnessListener> harness_listener_ ABSL_GUARDED_BY(mutex_);
+  FailureScreenshotRequester failure_screenshot_requester_
+      ABSL_GUARDED_BY(mutex_);
 #endif
 #endif  // defined(YAZE_WITH_GRPC)
 
@@ -404,6 +414,8 @@ class TestManager {
       ABSL_EXCLUSIVE_LOCKS_REQUIRED(harness_history_mutex_);
   void TrimHarnessHistoryLocked()
       ABSL_EXCLUSIVE_LOCKS_REQUIRED(harness_history_mutex_);
+  void NotifyHarnessListener(const HarnessTestExecution& execution)
+      ABSL_LOCKS_EXCLUDED(mutex_);
 #endif
 
   absl::Mutex mutex_;

--- a/src/core/project.cc
+++ b/src/core/project.cc
@@ -736,6 +736,9 @@ absl::StatusOr<std::string> YazeProject::SerializeToString() const {
        << (feature_flags.dungeon.kSaveBlocks ? "true" : "false") << "\n";
   file << "save_dungeon_collision="
        << (feature_flags.dungeon.kSaveCollision ? "true" : "false") << "\n";
+  file << "save_dungeon_water_fill_zones="
+       << (feature_flags.dungeon.kSaveWaterFillZones ? "true" : "false")
+       << "\n";
   file << "save_dungeon_chests="
        << (feature_flags.dungeon.kSaveChests ? "true" : "false") << "\n";
   file << "save_dungeon_pot_items="
@@ -1050,6 +1053,8 @@ absl::Status YazeProject::ParseFromString(const std::string& content) {
         feature_flags.dungeon.kSaveBlocks = ParseBool(value);
       else if (key == "save_dungeon_collision")
         feature_flags.dungeon.kSaveCollision = ParseBool(value);
+      else if (key == "save_dungeon_water_fill_zones")
+        feature_flags.dungeon.kSaveWaterFillZones = ParseBool(value);
       else if (key == "save_dungeon_chests")
         feature_flags.dungeon.kSaveChests = ParseBool(value);
       else if (key == "save_dungeon_pot_items")

--- a/src/zelda3/dungeon/room.cc
+++ b/src/zelda3/dungeon/room.cc
@@ -2102,13 +2102,19 @@ absl::Status Room::SaveObjects(const DungeonStreamLayout* layout) {
     return absl::OutOfRangeError("Door pointer slot is out of range");
   }
   const int door_pointer_pc = write_pos + door_list_offset;
+  ASSIGN_OR_RETURN(const uint32_t source_door_pointer,
+                   rom_->ReadLong(door_pointer_slot));
 
   // Write encoded bytes to ROM (includes 0xF0 0xFF + door list)
   RETURN_IF_ERROR(rom_->WriteVector(write_pos, encoded_bytes));
 
-  // Write door pointer: first byte after 0xF0 0xFF (per ZScreamDungeon Save.cs)
-  RETURN_IF_ERROR(rom_->WriteLong(
-      door_pointer_slot, static_cast<uint32_t>(PcToSnes(door_pointer_pc))));
+  // Write door pointer: first byte after 0xF0 0xFF (per ZScreamDungeon
+  // Save.cs). Preserve the source pointer's slow/fast ROM bank mirror; both
+  // encodings address the same bytes, but normalizing an unchanged pointer
+  // creates an unrelated ROM diff.
+  uint32_t encoded_door_pointer = PcToSnes(door_pointer_pc);
+  encoded_door_pointer |= source_door_pointer & 0x800000u;
+  RETURN_IF_ERROR(rom_->WriteLong(door_pointer_slot, encoded_door_pointer));
 
   ClearObjectStreamDirty();
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -493,6 +493,7 @@ if(YAZE_BUILD_TESTS)
   if(YAZE_ENABLE_GRPC)
     list(APPEND STABLE_INTEGRATION_TEST_SOURCES
       integration/grpc_server_smoke_test.cc
+      integration/imgui_test_harness_logic_test.cc
     )
   endif()
 

--- a/test/fixtures/gui/d6_edit_and_save.json
+++ b/test/fixtures/gui/d6_edit_and_save.json
@@ -1,0 +1,237 @@
+{
+  "schema_version": 1,
+  "name": "Oracle D6 edit and save qualification",
+  "description": "Edit five prequalified D6 values through stable GUI selectors, then perform a full ROM save with explicit pot confirmation.",
+  "steps": [
+    {
+      "action": "wait",
+      "widget_key": "Dungeon/Workbench/input_scalar:room_id",
+      "timeout_ms": 10000,
+      "expect": { "success": true, "status": "passed" }
+    },
+    {
+      "action": "type",
+      "widget_key": "Dungeon/Workbench/input_scalar:room_id",
+      "text": "A8",
+      "clear_first": true,
+      "expect": { "success": true, "status": "passed" }
+    },
+    {
+      "action": "assert",
+      "widget_key": "Dungeon/Workbench/input_scalar:room_id",
+      "condition": "value_equals:00A8",
+      "expect": { "success": true, "status": "passed" }
+    },
+    {
+      "action": "click",
+      "widget_key": "Dungeon/Workbench/button:mode_tools",
+      "expect": { "success": true, "status": "passed" }
+    },
+    {
+      "action": "click",
+      "widget_key": "Dungeon/Workbench/button:tool_door",
+      "expect": { "success": true, "status": "passed" }
+    },
+    {
+      "action": "click",
+      "widget_key": "Dungeon/DoorEditor/selectable:door_row_2",
+      "expect": { "success": true, "status": "passed" }
+    },
+    {
+      "action": "type",
+      "widget_key": "Dungeon/DoorEditor/input_scalar:selected_door_raw_type",
+      "text": "00",
+      "clear_first": true,
+      "expect": { "success": true, "status": "passed" }
+    },
+    {
+      "action": "assert",
+      "widget_key": "Dungeon/DoorEditor/input_scalar:selected_door_raw_type",
+      "condition": "value_equals:00",
+      "expect": { "success": true, "status": "passed" }
+    },
+    {
+      "action": "type",
+      "widget_key": "Dungeon/Workbench/input_scalar:room_id",
+      "text": "B8",
+      "clear_first": true,
+      "expect": { "success": true, "status": "passed" }
+    },
+    {
+      "action": "assert",
+      "widget_key": "Dungeon/Workbench/input_scalar:room_id",
+      "condition": "value_equals:00B8",
+      "expect": { "success": true, "status": "passed" }
+    },
+    {
+      "action": "click",
+      "widget_key": "Dungeon/Workbench/button:mode_room",
+      "expect": { "success": true, "status": "passed" }
+    },
+    {
+      "action": "type",
+      "widget_key": "Dungeon/Workbench/input_int:object_index",
+      "text": "128",
+      "clear_first": true,
+      "expect": { "success": true, "status": "passed" }
+    },
+    {
+      "action": "assert",
+      "widget_key": "Dungeon/Workbench/input_int:object_index",
+      "condition": "value_equals:128",
+      "expect": { "success": true, "status": "passed" }
+    },
+    {
+      "action": "type",
+      "widget_key": "Dungeon/Workbench/drag_int:selected_object_y",
+      "text": "8",
+      "clear_first": true,
+      "expect": { "success": true, "status": "passed" }
+    },
+    {
+      "action": "assert",
+      "widget_key": "Dungeon/Workbench/drag_int:selected_object_y",
+      "condition": "value_equals:Y:8",
+      "expect": { "success": true, "status": "passed" }
+    },
+    {
+      "action": "type",
+      "widget_key": "Dungeon/Workbench/input_scalar:room_id",
+      "text": "D8",
+      "clear_first": true,
+      "expect": { "success": true, "status": "passed" }
+    },
+    {
+      "action": "assert",
+      "widget_key": "Dungeon/Workbench/input_scalar:room_id",
+      "condition": "value_equals:00D8",
+      "expect": { "success": true, "status": "passed" }
+    },
+    {
+      "action": "click",
+      "widget_key": "Dungeon/Workbench/button:mode_tools",
+      "expect": { "success": true, "status": "passed" }
+    },
+    {
+      "action": "click",
+      "widget_key": "Dungeon/Workbench/button:tool_sprite",
+      "expect": { "success": true, "status": "passed" }
+    },
+    {
+      "action": "click",
+      "widget_key": "Dungeon/SpriteEditor/selectable:sprite_row_2",
+      "expect": { "success": true, "status": "passed" }
+    },
+    {
+      "action": "type",
+      "widget_key": "Dungeon/SpriteEditor/input_int:selected_sprite_x",
+      "text": "5",
+      "clear_first": true,
+      "expect": { "success": true, "status": "passed" }
+    },
+    {
+      "action": "assert",
+      "widget_key": "Dungeon/SpriteEditor/input_int:selected_sprite_x",
+      "condition": "value_equals:5",
+      "expect": { "success": true, "status": "passed" }
+    },
+    {
+      "action": "click",
+      "widget_key": "Dungeon/Workbench/button:tool_item",
+      "expect": { "success": true, "status": "passed" }
+    },
+    {
+      "action": "click",
+      "widget_key": "Dungeon/ItemEditor/selectable:item_row_5",
+      "expect": { "success": true, "status": "passed" }
+    },
+    {
+      "action": "type",
+      "widget_key": "Dungeon/ItemEditor/input_scalar:selected_item_raw_type",
+      "text": "09",
+      "clear_first": true,
+      "expect": { "success": true, "status": "passed" }
+    },
+    {
+      "action": "assert",
+      "widget_key": "Dungeon/ItemEditor/input_scalar:selected_item_raw_type",
+      "condition": "value_equals:09",
+      "expect": { "success": true, "status": "passed" }
+    },
+    {
+      "action": "type",
+      "widget_key": "Dungeon/Workbench/input_scalar:room_id",
+      "text": "DA",
+      "clear_first": true,
+      "expect": { "success": true, "status": "passed" }
+    },
+    {
+      "action": "assert",
+      "widget_key": "Dungeon/Workbench/input_scalar:room_id",
+      "condition": "value_equals:00DA",
+      "expect": { "success": true, "status": "passed" }
+    },
+    {
+      "action": "click",
+      "widget_key": "Dungeon/Workbench/button:mode_tools",
+      "expect": { "success": true, "status": "passed" }
+    },
+    {
+      "action": "click",
+      "widget_key": "Dungeon/Workbench/button:tool_palette",
+      "expect": { "success": true, "status": "passed" }
+    },
+    {
+      "action": "type",
+      "widget_key": "Dungeon/PaletteEditor/input_int:palette_id",
+      "text": "7",
+      "clear_first": true,
+      "expect": { "success": true, "status": "passed" }
+    },
+    {
+      "action": "assert",
+      "widget_key": "Dungeon/PaletteEditor/input_int:palette_id",
+      "condition": "value_equals:7",
+      "expect": { "success": true, "status": "passed" }
+    },
+    {
+      "action": "click",
+      "widget_key": "Dungeon/PaletteEditor/color_button:palette_swatch_040",
+      "expect": { "success": true, "status": "passed" }
+    },
+    {
+      "action": "type",
+      "widget_key": "Dungeon/PaletteEditor/input_scalar:selected_palette_bgr555",
+      "text": "7FFE",
+      "clear_first": true,
+      "expect": { "success": true, "status": "passed" }
+    },
+    {
+      "action": "assert",
+      "widget_key": "Dungeon/PaletteEditor/input_scalar:selected_palette_bgr555",
+      "condition": "value_equals:7FFE",
+      "expect": { "success": true, "status": "passed" }
+    },
+    {
+      "action": "click",
+      "target": "menu:File",
+      "expect": { "success": true, "status": "passed" }
+    },
+    {
+      "action": "click",
+      "widget_key": "menuitem:Save ROM",
+      "expect": { "success": true, "status": "passed" }
+    },
+    {
+      "action": "wait",
+      "widget_key": "dungeon.pot_item_save_confirm/button:Save anyway",
+      "timeout_ms": 10000,
+      "expect": { "success": true, "status": "passed" }
+    },
+    {
+      "action": "click",
+      "widget_key": "dungeon.pot_item_save_confirm/button:Save anyway",
+      "expect": { "success": true, "status": "passed" }
+    }
+  ]
+}

--- a/test/fixtures/gui/d6_edit_and_save.json
+++ b/test/fixtures/gui/d6_edit_and_save.json
@@ -28,13 +28,31 @@
       "expect": { "success": true, "status": "passed" }
     },
     {
+      "action": "wait",
+      "widget_key": "Dungeon/Workbench/button:tool_door",
+      "timeout_ms": 5000,
+      "expect": { "success": true, "status": "passed" }
+    },
+    {
       "action": "click",
       "widget_key": "Dungeon/Workbench/button:tool_door",
       "expect": { "success": true, "status": "passed" }
     },
     {
+      "action": "wait",
+      "widget_key": "Dungeon/DoorEditor/selectable:door_row_2",
+      "timeout_ms": 5000,
+      "expect": { "success": true, "status": "passed" }
+    },
+    {
       "action": "click",
       "widget_key": "Dungeon/DoorEditor/selectable:door_row_2",
+      "expect": { "success": true, "status": "passed" }
+    },
+    {
+      "action": "wait",
+      "widget_key": "Dungeon/DoorEditor/input_scalar:selected_door_raw_type",
+      "timeout_ms": 5000,
       "expect": { "success": true, "status": "passed" }
     },
     {
@@ -69,6 +87,12 @@
       "expect": { "success": true, "status": "passed" }
     },
     {
+      "action": "wait",
+      "widget_key": "Dungeon/Workbench/input_int:object_index",
+      "timeout_ms": 5000,
+      "expect": { "success": true, "status": "passed" }
+    },
+    {
       "action": "type",
       "widget_key": "Dungeon/Workbench/input_int:object_index",
       "text": "128",
@@ -76,22 +100,21 @@
       "expect": { "success": true, "status": "passed" }
     },
     {
-      "action": "assert",
-      "widget_key": "Dungeon/Workbench/input_int:object_index",
-      "condition": "value_equals:128",
+      "action": "wait",
+      "widget_key": "Dungeon/Workbench/drag_int:selected_object_y",
+      "timeout_ms": 5000,
       "expect": { "success": true, "status": "passed" }
     },
     {
       "action": "type",
       "widget_key": "Dungeon/Workbench/drag_int:selected_object_y",
       "text": "8",
-      "clear_first": true,
       "expect": { "success": true, "status": "passed" }
     },
     {
       "action": "assert",
       "widget_key": "Dungeon/Workbench/drag_int:selected_object_y",
-      "condition": "value_equals:Y:8",
+      "condition": "value_equals:8",
       "expect": { "success": true, "status": "passed" }
     },
     {
@@ -113,13 +136,31 @@
       "expect": { "success": true, "status": "passed" }
     },
     {
+      "action": "wait",
+      "widget_key": "Dungeon/Workbench/button:tool_sprite",
+      "timeout_ms": 5000,
+      "expect": { "success": true, "status": "passed" }
+    },
+    {
       "action": "click",
       "widget_key": "Dungeon/Workbench/button:tool_sprite",
       "expect": { "success": true, "status": "passed" }
     },
     {
+      "action": "wait",
+      "widget_key": "Dungeon/SpriteEditor/selectable:sprite_row_2",
+      "timeout_ms": 5000,
+      "expect": { "success": true, "status": "passed" }
+    },
+    {
       "action": "click",
       "widget_key": "Dungeon/SpriteEditor/selectable:sprite_row_2",
+      "expect": { "success": true, "status": "passed" }
+    },
+    {
+      "action": "wait",
+      "widget_key": "Dungeon/SpriteEditor/input_int:selected_sprite_x",
+      "timeout_ms": 5000,
       "expect": { "success": true, "status": "passed" }
     },
     {
@@ -143,6 +184,12 @@
     {
       "action": "click",
       "widget_key": "Dungeon/ItemEditor/selectable:item_row_5",
+      "expect": { "success": true, "status": "passed" }
+    },
+    {
+      "action": "wait",
+      "widget_key": "Dungeon/ItemEditor/input_scalar:selected_item_raw_type",
+      "timeout_ms": 5000,
       "expect": { "success": true, "status": "passed" }
     },
     {
@@ -182,6 +229,12 @@
       "expect": { "success": true, "status": "passed" }
     },
     {
+      "action": "wait",
+      "widget_key": "Dungeon/PaletteEditor/input_int:palette_id",
+      "timeout_ms": 5000,
+      "expect": { "success": true, "status": "passed" }
+    },
+    {
       "action": "type",
       "widget_key": "Dungeon/PaletteEditor/input_int:palette_id",
       "text": "7",
@@ -200,6 +253,12 @@
       "expect": { "success": true, "status": "passed" }
     },
     {
+      "action": "wait",
+      "widget_key": "Dungeon/PaletteEditor/input_scalar:selected_palette_bgr555",
+      "timeout_ms": 5000,
+      "expect": { "success": true, "status": "passed" }
+    },
+    {
       "action": "type",
       "widget_key": "Dungeon/PaletteEditor/input_scalar:selected_palette_bgr555",
       "text": "7FFE",
@@ -214,12 +273,7 @@
     },
     {
       "action": "click",
-      "target": "menu:File",
-      "expect": { "success": true, "status": "passed" }
-    },
-    {
-      "action": "click",
-      "widget_key": "menuitem:Save ROM",
+      "target": "shortcut:Save ROM",
       "expect": { "success": true, "status": "passed" }
     },
     {

--- a/test/fixtures/gui/d6_reopen_assert.json
+++ b/test/fixtures/gui/d6_reopen_assert.json
@@ -28,13 +28,31 @@
       "expect": { "success": true, "status": "passed" }
     },
     {
+      "action": "wait",
+      "widget_key": "Dungeon/Workbench/button:tool_door",
+      "timeout_ms": 5000,
+      "expect": { "success": true, "status": "passed" }
+    },
+    {
       "action": "click",
       "widget_key": "Dungeon/Workbench/button:tool_door",
       "expect": { "success": true, "status": "passed" }
     },
     {
+      "action": "wait",
+      "widget_key": "Dungeon/DoorEditor/selectable:door_row_2",
+      "timeout_ms": 5000,
+      "expect": { "success": true, "status": "passed" }
+    },
+    {
       "action": "click",
       "widget_key": "Dungeon/DoorEditor/selectable:door_row_2",
+      "expect": { "success": true, "status": "passed" }
+    },
+    {
+      "action": "wait",
+      "widget_key": "Dungeon/DoorEditor/input_scalar:selected_door_raw_type",
+      "timeout_ms": 5000,
       "expect": { "success": true, "status": "passed" }
     },
     {
@@ -62,6 +80,12 @@
       "expect": { "success": true, "status": "passed" }
     },
     {
+      "action": "wait",
+      "widget_key": "Dungeon/Workbench/input_int:object_index",
+      "timeout_ms": 5000,
+      "expect": { "success": true, "status": "passed" }
+    },
+    {
       "action": "type",
       "widget_key": "Dungeon/Workbench/input_int:object_index",
       "text": "128",
@@ -69,15 +93,15 @@
       "expect": { "success": true, "status": "passed" }
     },
     {
-      "action": "assert",
-      "widget_key": "Dungeon/Workbench/input_int:object_index",
-      "condition": "value_equals:128",
+      "action": "wait",
+      "widget_key": "Dungeon/Workbench/drag_int:selected_object_y",
+      "timeout_ms": 5000,
       "expect": { "success": true, "status": "passed" }
     },
     {
       "action": "assert",
       "widget_key": "Dungeon/Workbench/drag_int:selected_object_y",
-      "condition": "value_equals:Y:8",
+      "condition": "value_equals:8",
       "expect": { "success": true, "status": "passed" }
     },
     {
@@ -99,13 +123,31 @@
       "expect": { "success": true, "status": "passed" }
     },
     {
+      "action": "wait",
+      "widget_key": "Dungeon/Workbench/button:tool_sprite",
+      "timeout_ms": 5000,
+      "expect": { "success": true, "status": "passed" }
+    },
+    {
       "action": "click",
       "widget_key": "Dungeon/Workbench/button:tool_sprite",
       "expect": { "success": true, "status": "passed" }
     },
     {
+      "action": "wait",
+      "widget_key": "Dungeon/SpriteEditor/selectable:sprite_row_2",
+      "timeout_ms": 5000,
+      "expect": { "success": true, "status": "passed" }
+    },
+    {
       "action": "click",
       "widget_key": "Dungeon/SpriteEditor/selectable:sprite_row_2",
+      "expect": { "success": true, "status": "passed" }
+    },
+    {
+      "action": "wait",
+      "widget_key": "Dungeon/SpriteEditor/input_int:selected_sprite_x",
+      "timeout_ms": 5000,
       "expect": { "success": true, "status": "passed" }
     },
     {
@@ -122,6 +164,12 @@
     {
       "action": "click",
       "widget_key": "Dungeon/ItemEditor/selectable:item_row_5",
+      "expect": { "success": true, "status": "passed" }
+    },
+    {
+      "action": "wait",
+      "widget_key": "Dungeon/ItemEditor/input_scalar:selected_item_raw_type",
+      "timeout_ms": 5000,
       "expect": { "success": true, "status": "passed" }
     },
     {
@@ -154,6 +202,12 @@
       "expect": { "success": true, "status": "passed" }
     },
     {
+      "action": "wait",
+      "widget_key": "Dungeon/PaletteEditor/input_int:palette_id",
+      "timeout_ms": 5000,
+      "expect": { "success": true, "status": "passed" }
+    },
+    {
       "action": "type",
       "widget_key": "Dungeon/PaletteEditor/input_int:palette_id",
       "text": "7",
@@ -169,6 +223,12 @@
     {
       "action": "click",
       "widget_key": "Dungeon/PaletteEditor/color_button:palette_swatch_040",
+      "expect": { "success": true, "status": "passed" }
+    },
+    {
+      "action": "wait",
+      "widget_key": "Dungeon/PaletteEditor/input_scalar:selected_palette_bgr555",
+      "timeout_ms": 5000,
       "expect": { "success": true, "status": "passed" }
     },
     {

--- a/test/fixtures/gui/d6_reopen_assert.json
+++ b/test/fixtures/gui/d6_reopen_assert.json
@@ -1,0 +1,181 @@
+{
+  "schema_version": 1,
+  "name": "Oracle D6 reopen assertions",
+  "description": "After a fresh Yaze launch, assert that all five D6 GUI edits were reloaded from the disposable ROM.",
+  "steps": [
+    {
+      "action": "wait",
+      "widget_key": "Dungeon/Workbench/input_scalar:room_id",
+      "timeout_ms": 10000,
+      "expect": { "success": true, "status": "passed" }
+    },
+    {
+      "action": "type",
+      "widget_key": "Dungeon/Workbench/input_scalar:room_id",
+      "text": "A8",
+      "clear_first": true,
+      "expect": { "success": true, "status": "passed" }
+    },
+    {
+      "action": "assert",
+      "widget_key": "Dungeon/Workbench/input_scalar:room_id",
+      "condition": "value_equals:00A8",
+      "expect": { "success": true, "status": "passed" }
+    },
+    {
+      "action": "click",
+      "widget_key": "Dungeon/Workbench/button:mode_tools",
+      "expect": { "success": true, "status": "passed" }
+    },
+    {
+      "action": "click",
+      "widget_key": "Dungeon/Workbench/button:tool_door",
+      "expect": { "success": true, "status": "passed" }
+    },
+    {
+      "action": "click",
+      "widget_key": "Dungeon/DoorEditor/selectable:door_row_2",
+      "expect": { "success": true, "status": "passed" }
+    },
+    {
+      "action": "assert",
+      "widget_key": "Dungeon/DoorEditor/input_scalar:selected_door_raw_type",
+      "condition": "value_equals:00",
+      "expect": { "success": true, "status": "passed" }
+    },
+    {
+      "action": "type",
+      "widget_key": "Dungeon/Workbench/input_scalar:room_id",
+      "text": "B8",
+      "clear_first": true,
+      "expect": { "success": true, "status": "passed" }
+    },
+    {
+      "action": "assert",
+      "widget_key": "Dungeon/Workbench/input_scalar:room_id",
+      "condition": "value_equals:00B8",
+      "expect": { "success": true, "status": "passed" }
+    },
+    {
+      "action": "click",
+      "widget_key": "Dungeon/Workbench/button:mode_room",
+      "expect": { "success": true, "status": "passed" }
+    },
+    {
+      "action": "type",
+      "widget_key": "Dungeon/Workbench/input_int:object_index",
+      "text": "128",
+      "clear_first": true,
+      "expect": { "success": true, "status": "passed" }
+    },
+    {
+      "action": "assert",
+      "widget_key": "Dungeon/Workbench/input_int:object_index",
+      "condition": "value_equals:128",
+      "expect": { "success": true, "status": "passed" }
+    },
+    {
+      "action": "assert",
+      "widget_key": "Dungeon/Workbench/drag_int:selected_object_y",
+      "condition": "value_equals:Y:8",
+      "expect": { "success": true, "status": "passed" }
+    },
+    {
+      "action": "type",
+      "widget_key": "Dungeon/Workbench/input_scalar:room_id",
+      "text": "D8",
+      "clear_first": true,
+      "expect": { "success": true, "status": "passed" }
+    },
+    {
+      "action": "assert",
+      "widget_key": "Dungeon/Workbench/input_scalar:room_id",
+      "condition": "value_equals:00D8",
+      "expect": { "success": true, "status": "passed" }
+    },
+    {
+      "action": "click",
+      "widget_key": "Dungeon/Workbench/button:mode_tools",
+      "expect": { "success": true, "status": "passed" }
+    },
+    {
+      "action": "click",
+      "widget_key": "Dungeon/Workbench/button:tool_sprite",
+      "expect": { "success": true, "status": "passed" }
+    },
+    {
+      "action": "click",
+      "widget_key": "Dungeon/SpriteEditor/selectable:sprite_row_2",
+      "expect": { "success": true, "status": "passed" }
+    },
+    {
+      "action": "assert",
+      "widget_key": "Dungeon/SpriteEditor/input_int:selected_sprite_x",
+      "condition": "value_equals:5",
+      "expect": { "success": true, "status": "passed" }
+    },
+    {
+      "action": "click",
+      "widget_key": "Dungeon/Workbench/button:tool_item",
+      "expect": { "success": true, "status": "passed" }
+    },
+    {
+      "action": "click",
+      "widget_key": "Dungeon/ItemEditor/selectable:item_row_5",
+      "expect": { "success": true, "status": "passed" }
+    },
+    {
+      "action": "assert",
+      "widget_key": "Dungeon/ItemEditor/input_scalar:selected_item_raw_type",
+      "condition": "value_equals:09",
+      "expect": { "success": true, "status": "passed" }
+    },
+    {
+      "action": "type",
+      "widget_key": "Dungeon/Workbench/input_scalar:room_id",
+      "text": "DA",
+      "clear_first": true,
+      "expect": { "success": true, "status": "passed" }
+    },
+    {
+      "action": "assert",
+      "widget_key": "Dungeon/Workbench/input_scalar:room_id",
+      "condition": "value_equals:00DA",
+      "expect": { "success": true, "status": "passed" }
+    },
+    {
+      "action": "click",
+      "widget_key": "Dungeon/Workbench/button:mode_tools",
+      "expect": { "success": true, "status": "passed" }
+    },
+    {
+      "action": "click",
+      "widget_key": "Dungeon/Workbench/button:tool_palette",
+      "expect": { "success": true, "status": "passed" }
+    },
+    {
+      "action": "type",
+      "widget_key": "Dungeon/PaletteEditor/input_int:palette_id",
+      "text": "7",
+      "clear_first": true,
+      "expect": { "success": true, "status": "passed" }
+    },
+    {
+      "action": "assert",
+      "widget_key": "Dungeon/PaletteEditor/input_int:palette_id",
+      "condition": "value_equals:7",
+      "expect": { "success": true, "status": "passed" }
+    },
+    {
+      "action": "click",
+      "widget_key": "Dungeon/PaletteEditor/color_button:palette_swatch_040",
+      "expect": { "success": true, "status": "passed" }
+    },
+    {
+      "action": "assert",
+      "widget_key": "Dungeon/PaletteEditor/input_scalar:selected_palette_bgr555",
+      "condition": "value_equals:7FFE",
+      "expect": { "success": true, "status": "passed" }
+    }
+  ]
+}

--- a/test/integration/imgui_test_harness_logic_test.cc
+++ b/test/integration/imgui_test_harness_logic_test.cc
@@ -2,6 +2,8 @@
 
 #include <gtest/gtest.h>
 
+#include <algorithm>
+#include <memory>
 #include <string>
 
 #include "app/gui/automation/widget_id_registry.h"
@@ -14,6 +16,37 @@ class WidgetRegistryReset {
  public:
   WidgetRegistryReset() { gui::WidgetIdRegistry::Instance().Clear(); }
   ~WidgetRegistryReset() { gui::WidgetIdRegistry::Instance().Clear(); }
+};
+
+class ReentrantHarnessListener : public HarnessListener {
+ public:
+  explicit ReentrantHarnessListener(TestManager* manager) : manager_(manager) {}
+
+  void OnHarnessTestUpdated(const HarnessTestExecution& execution) override {
+    ++update_count;
+    auto current = manager_->GetHarnessTestExecution(execution.test_id);
+    history_query_succeeded = current.ok();
+  }
+
+  void OnHarnessPlanSummary(const std::string&) override {}
+
+  int update_count = 0;
+  bool history_query_succeeded = false;
+
+ private:
+  TestManager* manager_;
+};
+
+class HarnessCallbackReset {
+ public:
+  explicit HarnessCallbackReset(TestManager* manager) : manager_(manager) {}
+  ~HarnessCallbackReset() {
+    manager_->SetFailureScreenshotRequester({});
+    manager_->SetHarnessListener(nullptr);
+  }
+
+ private:
+  TestManager* manager_;
 };
 
 TEST(ImGuiTestHarnessLogicTest,
@@ -53,6 +86,25 @@ TEST(ImGuiTestHarnessLogicTest, WidgetKeyWithoutImGuiIdFailsClosed) {
             std::string::npos);
 }
 
+TEST(ImGuiTestHarnessLogicTest, WidgetRegistryQueriesReturnStableSnapshots) {
+  WidgetRegistryReset reset;
+  auto& registry = gui::WidgetIdRegistry::Instance();
+  registry.RegisterWidget("Dungeon/Workbench/button:mode", "button", 0x101,
+                          "mode");
+
+  const auto widget = registry.GetWidgetInfo("Dungeon/Workbench/button:mode");
+  const auto all_widgets = registry.GetAllWidgets();
+  ASSERT_TRUE(widget.has_value());
+  ASSERT_EQ(all_widgets.count("Dungeon/Workbench/button:mode"), 1);
+
+  registry.RegisterWidget("Dungeon/Workbench/button:mode", "button", 0x202,
+                          "updated mode");
+
+  EXPECT_EQ(widget->imgui_id, 0x101u);
+  EXPECT_EQ(all_widgets.at("Dungeon/Workbench/button:mode").imgui_id, 0x101u);
+  EXPECT_EQ(registry.GetWidgetId("Dungeon/Workbench/button:mode"), 0x202u);
+}
+
 TEST(ImGuiTestHarnessLogicTest,
      ReplayTerminalFailureOverridesQueuedRpcSuccess) {
   HarnessTestExecution execution;
@@ -79,6 +131,170 @@ TEST(ImGuiTestHarnessLogicTest, ReplayTerminalPassOverridesQueuedFailure) {
 
   EXPECT_TRUE(step_success);
   EXPECT_EQ(step_message, "Queued assertion");
+}
+
+TEST(ImGuiTestHarnessLogicTest,
+     FailedCompletionReturnsAndPersistsUnavailableContext) {
+  auto& manager = TestManager::Get();
+  HarnessCallbackReset reset(&manager);
+  manager.SetHarnessListener(nullptr);
+  manager.SetFailureScreenshotRequester({});
+  const std::string test_id =
+      manager.RegisterHarnessTest("failure-deadlock-regression", "grpc");
+
+  manager.MarkHarnessTestRunning(test_id);
+  manager.MarkHarnessTestCompleted(test_id, HarnessTestStatus::kFailed,
+                                   "expected failure");
+
+  auto execution = manager.GetHarnessTestExecution(test_id);
+  ASSERT_TRUE(execution.ok()) << execution.status();
+  EXPECT_EQ(execution->status, HarnessTestStatus::kFailed);
+  EXPECT_EQ(execution->failure_context,
+            "Harness failure context capture unavailable");
+
+  const std::string followup_id =
+      manager.RegisterHarnessTest("failure-deadlock-followup", "grpc");
+  EXPECT_FALSE(followup_id.empty());
+}
+
+TEST(ImGuiTestHarnessLogicTest, FailureContextUpdatesAggregateLatestExecution) {
+  auto& manager = TestManager::Get();
+  HarnessCallbackReset reset(&manager);
+  manager.SetHarnessListener(nullptr);
+  manager.SetFailureScreenshotRequester({});
+  constexpr char kName[] = "failure-context-aggregate-regression";
+  const std::string test_id = manager.RegisterHarnessTest(kName, "grpc");
+
+  manager.MarkHarnessTestRunning(test_id);
+  manager.MarkHarnessTestCompleted(test_id, HarnessTestStatus::kTimeout,
+                                   "expected timeout");
+
+  auto execution = manager.GetHarnessTestExecution(test_id);
+  ASSERT_TRUE(execution.ok()) << execution.status();
+  auto summaries = manager.ListHarnessTestSummaries("grpc");
+  auto summary = std::find_if(summaries.begin(), summaries.end(),
+                              [&](const HarnessTestSummary& entry) {
+                                return entry.latest_execution.name == kName;
+                              });
+  ASSERT_NE(summary, summaries.end());
+  EXPECT_EQ(summary->latest_execution.status, execution->status);
+  EXPECT_EQ(summary->latest_execution.failure_context,
+            execution->failure_context);
+  EXPECT_EQ(summary->latest_execution.screenshot_path,
+            execution->screenshot_path);
+  EXPECT_EQ(summary->fail_count, 1);
+}
+
+TEST(ImGuiTestHarnessLogicTest,
+     DelayedFailureContextDoesNotReplaceNewerAggregateExecution) {
+  auto& manager = TestManager::Get();
+  HarnessCallbackReset reset(&manager);
+  manager.SetHarnessListener(nullptr);
+  TestManager::FailureScreenshotCallback delayed_callback;
+  manager.SetFailureScreenshotRequester(
+      [&](const std::string&, TestManager::FailureScreenshotCallback callback) {
+        delayed_callback = std::move(callback);
+      });
+  constexpr char kName[] = "failure-context-stale-aggregate-regression";
+  const std::string failed_id = manager.RegisterHarnessTest(kName, "grpc");
+  manager.MarkHarnessTestRunning(failed_id);
+  manager.MarkHarnessTestCompleted(failed_id, HarnessTestStatus::kFailed,
+                                   "expected failure");
+  ASSERT_TRUE(static_cast<bool>(delayed_callback));
+
+  const std::string passed_id = manager.RegisterHarnessTest(kName, "grpc");
+  manager.MarkHarnessTestRunning(passed_id);
+  manager.MarkHarnessTestCompleted(passed_id, HarnessTestStatus::kPassed);
+
+  delayed_callback(absl::FailedPreconditionError("capture unavailable"));
+  manager.SetFailureScreenshotRequester({});
+
+  auto summaries = manager.ListHarnessTestSummaries("grpc");
+  auto summary = std::find_if(summaries.begin(), summaries.end(),
+                              [&](const HarnessTestSummary& entry) {
+                                return entry.latest_execution.name == kName;
+                              });
+  ASSERT_NE(summary, summaries.end());
+  EXPECT_EQ(summary->latest_execution.test_id, passed_id);
+  EXPECT_EQ(summary->latest_execution.status, HarnessTestStatus::kPassed);
+  auto failed_execution = manager.GetHarnessTestExecution(failed_id);
+  ASSERT_TRUE(failed_execution.ok()) << failed_execution.status();
+  EXPECT_EQ(failed_execution->failure_context,
+            "Harness failure context capture unavailable");
+}
+
+TEST(ImGuiTestHarnessLogicTest,
+     SuccessfulFailureCaptureEnrichesHistoryWithoutDuplicateTelemetry) {
+  auto& manager = TestManager::Get();
+  HarnessCallbackReset reset(&manager);
+  auto listener = std::make_shared<ReentrantHarnessListener>(&manager);
+  manager.SetHarnessListener(listener);
+  TestManager::FailureScreenshotCallback delayed_callback;
+  manager.SetFailureScreenshotRequester(
+      [&](const std::string&, TestManager::FailureScreenshotCallback callback) {
+        delayed_callback = std::move(callback);
+      });
+  constexpr char kName[] = "failure-context-success-regression";
+  const std::string test_id = manager.RegisterHarnessTest(kName, "grpc");
+  manager.MarkHarnessTestRunning(test_id);
+  manager.MarkHarnessTestCompleted(test_id, HarnessTestStatus::kFailed,
+                                   "expected failure");
+  ASSERT_TRUE(static_cast<bool>(delayed_callback));
+  EXPECT_EQ(listener->update_count, 1);
+
+  ScreenshotArtifact artifact;
+  artifact.file_path = "/tmp/harness-failure.bmp";
+  artifact.file_size_bytes = 1234;
+  delayed_callback(artifact);
+
+  auto execution = manager.GetHarnessTestExecution(test_id);
+  ASSERT_TRUE(execution.ok()) << execution.status();
+  EXPECT_EQ(execution->failure_context,
+            "Harness failure context captured successfully");
+  EXPECT_EQ(execution->screenshot_path, artifact.file_path);
+  EXPECT_EQ(execution->screenshot_size_bytes, artifact.file_size_bytes);
+  EXPECT_EQ(listener->update_count, 1);
+
+  manager.SetFailureScreenshotRequester({});
+  manager.ClearHarnessListener(listener.get());
+}
+
+TEST(ImGuiTestHarnessLogicTest, ListenerCanReenterHistoryQuery) {
+  auto& manager = TestManager::Get();
+  HarnessCallbackReset reset(&manager);
+  auto listener = std::make_shared<ReentrantHarnessListener>(&manager);
+  manager.SetHarnessListener(listener);
+  const std::string test_id =
+      manager.RegisterHarnessTest("listener-reentry-regression", "grpc");
+
+  manager.MarkHarnessTestRunning(test_id);
+  manager.MarkHarnessTestCompleted(test_id, HarnessTestStatus::kPassed);
+
+  EXPECT_EQ(listener->update_count, 1);
+  EXPECT_TRUE(listener->history_query_succeeded);
+  manager.ClearHarnessListener(listener.get());
+}
+
+TEST(ImGuiTestHarnessLogicTest, ListenerLifetimeSurvivesCallerRelease) {
+  auto& manager = TestManager::Get();
+  HarnessCallbackReset reset(&manager);
+  auto listener = std::make_shared<ReentrantHarnessListener>(&manager);
+  std::weak_ptr<ReentrantHarnessListener> weak_listener = listener;
+  manager.SetHarnessListener(listener);
+  listener.reset();
+  ASSERT_FALSE(weak_listener.expired());
+
+  const std::string test_id =
+      manager.RegisterHarnessTest("listener-lifetime-regression", "grpc");
+  manager.MarkHarnessTestRunning(test_id);
+  manager.MarkHarnessTestCompleted(test_id, HarnessTestStatus::kPassed);
+
+  auto retained_listener = weak_listener.lock();
+  ASSERT_NE(retained_listener, nullptr);
+  EXPECT_EQ(retained_listener->update_count, 1);
+  manager.ClearHarnessListener(retained_listener.get());
+  retained_listener.reset();
+  EXPECT_TRUE(weak_listener.expired());
 }
 
 }  // namespace

--- a/test/integration/imgui_test_harness_logic_test.cc
+++ b/test/integration/imgui_test_harness_logic_test.cc
@@ -1,0 +1,85 @@
+#include "app/service/imgui_test_harness_internal.h"
+
+#include <gtest/gtest.h>
+
+#include <string>
+
+#include "app/gui/automation/widget_id_registry.h"
+#include "app/testing/test_manager.h"
+
+namespace yaze::test {
+namespace {
+
+class WidgetRegistryReset {
+ public:
+  WidgetRegistryReset() { gui::WidgetIdRegistry::Instance().Clear(); }
+  ~WidgetRegistryReset() { gui::WidgetIdRegistry::Instance().Clear(); }
+};
+
+TEST(ImGuiTestHarnessLogicTest,
+     WidgetKeyPreservesExactIdsWhenLabelsAreDuplicated) {
+  WidgetRegistryReset reset;
+  auto& registry = gui::WidgetIdRegistry::Instance();
+
+  gui::WidgetIdRegistry::WidgetMetadata metadata;
+  metadata.label = "Save anyway";
+  registry.RegisterWidget("first/button:Save anyway", "button", 0xA11CE001,
+                          "first duplicate", metadata);
+  registry.RegisterWidget("second/button:Save anyway", "button", 0xA11CE002,
+                          "second duplicate", metadata);
+
+  auto first = internal::ResolveWidgetSelector("", "first/button:Save anyway");
+  auto second =
+      internal::ResolveWidgetSelector("", "second/button:Save anyway");
+
+  ASSERT_TRUE(first.ok()) << first.status();
+  ASSERT_TRUE(second.ok()) << second.status();
+  EXPECT_EQ(first->target.label, second->target.label);
+  EXPECT_EQ(first->imgui_id, 0xA11CE001u);
+  EXPECT_EQ(second->imgui_id, 0xA11CE002u);
+  EXPECT_NE(first->imgui_id, second->imgui_id);
+}
+
+TEST(ImGuiTestHarnessLogicTest, WidgetKeyWithoutImGuiIdFailsClosed) {
+  WidgetRegistryReset reset;
+  gui::WidgetIdRegistry::Instance().RegisterWidget(
+      "broken/button:Save anyway", "button", 0, "invalid test widget");
+
+  auto resolved =
+      internal::ResolveWidgetSelector("", "broken/button:Save anyway");
+
+  ASSERT_FALSE(resolved.ok());
+  EXPECT_NE(std::string(resolved.status().message()).find("valid ImGui ID"),
+            std::string::npos);
+}
+
+TEST(ImGuiTestHarnessLogicTest,
+     ReplayTerminalFailureOverridesQueuedRpcSuccess) {
+  HarnessTestExecution execution;
+  execution.status = HarnessTestStatus::kFailed;
+  execution.error_message = "exact widget action failed";
+  bool step_success = true;
+  std::string step_message = "Queued click";
+
+  internal::ApplyTerminalHarnessExecution(execution, &step_success,
+                                          &step_message);
+
+  EXPECT_FALSE(step_success);
+  EXPECT_EQ(step_message, "exact widget action failed");
+}
+
+TEST(ImGuiTestHarnessLogicTest, ReplayTerminalPassOverridesQueuedFailure) {
+  HarnessTestExecution execution;
+  execution.status = HarnessTestStatus::kPassed;
+  bool step_success = false;
+  std::string step_message = "Queued assertion";
+
+  internal::ApplyTerminalHarnessExecution(execution, &step_success,
+                                          &step_message);
+
+  EXPECT_TRUE(step_success);
+  EXPECT_EQ(step_message, "Queued assertion");
+}
+
+}  // namespace
+}  // namespace yaze::test

--- a/test/integration/imgui_test_harness_logic_test.cc
+++ b/test/integration/imgui_test_harness_logic_test.cc
@@ -86,6 +86,15 @@ TEST(ImGuiTestHarnessLogicTest, WidgetKeyWithoutImGuiIdFailsClosed) {
             std::string::npos);
 }
 
+TEST(ImGuiTestHarnessLogicTest, ShortcutTargetPreservesCommandName) {
+  auto resolved = internal::ResolveWidgetSelector("shortcut:Save ROM", "");
+
+  ASSERT_TRUE(resolved.ok()) << resolved.status();
+  EXPECT_EQ(resolved->target.type, "shortcut");
+  EXPECT_EQ(resolved->target.label, "Save ROM");
+  EXPECT_EQ(resolved->imgui_id, 0u);
+}
+
 TEST(ImGuiTestHarnessLogicTest, WidgetRegistryQueriesReturnStableSnapshots) {
   WidgetRegistryReset reset;
   auto& registry = gui::WidgetIdRegistry::Instance();

--- a/test/integration/palette_manager_test.cc
+++ b/test/integration/palette_manager_test.cc
@@ -432,6 +432,36 @@ TEST_F(PaletteManagerTest, DungeonRenderEditsMapToManagedHudAndDungeonColors) {
 }
 
 TEST_F(PaletteManagerTest,
+       DungeonRenderDisplaySlot40MapsToDungeonPaletteColor7) {
+  Rom rom;
+  ASSERT_TRUE(rom.LoadFromData(std::vector<uint8_t>(0x100000, 0)).ok());
+  zelda3::GameData game_data(&rom);
+  SeedPaletteGroup(game_data.palette_groups.get_group("hud"), 1, 32, 0x0100);
+  SeedPaletteGroup(game_data.palette_groups.get_group("dungeon_main"), 8, 90,
+                   0x0200);
+
+  auto& manager = PaletteManager::Get();
+  manager.Initialize(&game_data);
+
+  gui::PaletteEditorWidget widget;
+  widget.Initialize(&game_data);
+  widget.SetDungeonRenderPaletteMode(true);
+  widget.SetCurrentPaletteId(7);
+
+  constexpr int kDungeonDisplayIndex = 40;
+  constexpr int kDungeonColorIndex = 7;
+  const SnesColor edited_color(0x7FFE);
+  ASSERT_TRUE(
+      widget.ApplyDungeonRenderColorEdit(kDungeonDisplayIndex, edited_color)
+          .ok());
+
+  EXPECT_TRUE(manager.IsColorModified("dungeon_main", 7, kDungeonColorIndex));
+  EXPECT_EQ(manager.GetColor("dungeon_main", 7, kDungeonColorIndex).snes(),
+            edited_color.snes());
+  EXPECT_FALSE(manager.IsColorModified("hud", 0, kDungeonColorIndex));
+}
+
+TEST_F(PaletteManagerTest,
        DungeonWriteRangesMapHudAndDungeonColorsExactlyAndCoalesce) {
   Rom rom;
   ASSERT_TRUE(rom.LoadFromData(std::vector<uint8_t>(0x100000, 0)).ok());

--- a/test/unit/core/project_paths_test.cc
+++ b/test/unit/core/project_paths_test.cc
@@ -122,6 +122,25 @@ symbols_filename=symbols.txt
   EXPECT_NE(saved.find("rom_backup_folder=backups"), std::string::npos);
 }
 
+TEST(ProjectPathsTest, WaterFillSaveScopeRoundTripsThroughIni) {
+  ScopedTempDir temp(MakeUniqueTempDir("yaze_water_fill_save_scope"));
+  const auto project_file = temp.path() / "WaterFillScope.yaze";
+
+  YazeProject project;
+  project.filepath = project_file.string();
+  project.name = "Water Fill Save Scope";
+  project.feature_flags.dungeon.kSaveWaterFillZones = false;
+  ASSERT_TRUE(project.Save().ok());
+
+  const auto saved = ReadTextFile(project_file);
+  EXPECT_NE(saved.find("save_dungeon_water_fill_zones=false"),
+            std::string::npos);
+
+  YazeProject reopened;
+  ASSERT_TRUE(reopened.Open(project_file.string()).ok());
+  EXPECT_FALSE(reopened.feature_flags.dungeon.kSaveWaterFillZones);
+}
+
 #ifndef __EMSCRIPTEN__
 TEST(ProjectPathsTest, SaveAtomicallyReplacesExistingDescriptor) {
   ScopedTempDir temp(MakeUniqueTempDir("yaze_project_atomic_save"));

--- a/test/unit/editor/editor_manager_rom_write_policy_test.cc
+++ b/test/unit/editor/editor_manager_rom_write_policy_test.cc
@@ -2076,6 +2076,39 @@ TEST(GraphicsSaveStoplossTest,
   EXPECT_EQ(editor_set->GetExistingEditor(EditorType::kGraphics), nullptr);
 }
 
+TEST(EditorManagerRomWritePolicyTest,
+     CleanSaveDoesNotMaterializeUnopenedOverworldEditor) {
+  FeatureFlagsGuard guard;
+  ScopedImGuiContext imgui;
+
+  auto renderer = std::make_unique<gfx::NullRenderer>();
+  auto manager = std::make_unique<EditorManager>();
+  manager->Initialize(renderer.get(), "");
+  manager->SetAssetLoadMode(AssetLoadMode::kLazy);
+  manager->user_settings().prefs().backup_before_save = false;
+
+  const auto rom_path = MakeTempFilePath("yaze_clean_lazy_editor_save.sfc");
+  ScopedFileCleanup cleanup{rom_path};
+  WriteTestRom(rom_path, "CLEAN LAZY EDITOR SAVE");
+
+  ASSERT_OK(manager->OpenRomOrProject(rom_path.string()));
+  DisableRomWritesForTest();
+
+  auto* editor_set = manager->GetCurrentEditorSet();
+  ASSERT_NE(editor_set, nullptr);
+  EXPECT_NE(editor_set->GetExistingEditor(EditorType::kDungeon), nullptr);
+  EXPECT_EQ(editor_set->GetExistingEditor(EditorType::kOverworld), nullptr);
+
+  auto* project = manager->GetCurrentProject();
+  ASSERT_NE(project, nullptr);
+  project->workspace_settings.backup_on_save = false;
+  project->rom_metadata.expected_hash.clear();
+
+  ASSERT_OK(manager->SaveRom());
+  EXPECT_NE(editor_set->GetExistingEditor(EditorType::kDungeon), nullptr);
+  EXPECT_EQ(editor_set->GetExistingEditor(EditorType::kOverworld), nullptr);
+}
+
 TEST(GraphicsSaveStoplossTest,
      PendingSheetsBlockBothSaveScopeStatesBeforeSerialization) {
   FeatureFlagsGuard guard;

--- a/test/unit/editor/editor_manager_rom_write_policy_test.cc
+++ b/test/unit/editor/editor_manager_rom_write_policy_test.cc
@@ -2096,7 +2096,10 @@ TEST(EditorManagerRomWritePolicyTest,
 
   auto* editor_set = manager->GetCurrentEditorSet();
   ASSERT_NE(editor_set, nullptr);
-  EXPECT_NE(editor_set->GetExistingEditor(EditorType::kDungeon), nullptr);
+  auto* dungeon_editor = editor_set->GetEditor(EditorType::kDungeon);
+  ASSERT_NE(dungeon_editor, nullptr);
+  EXPECT_EQ(editor_set->GetExistingEditor(EditorType::kDungeon),
+            dungeon_editor);
   EXPECT_EQ(editor_set->GetExistingEditor(EditorType::kOverworld), nullptr);
 
   auto* project = manager->GetCurrentProject();
@@ -2105,7 +2108,8 @@ TEST(EditorManagerRomWritePolicyTest,
   project->rom_metadata.expected_hash.clear();
 
   ASSERT_OK(manager->SaveRom());
-  EXPECT_NE(editor_set->GetExistingEditor(EditorType::kDungeon), nullptr);
+  EXPECT_EQ(editor_set->GetExistingEditor(EditorType::kDungeon),
+            dungeon_editor);
   EXPECT_EQ(editor_set->GetExistingEditor(EditorType::kOverworld), nullptr);
 }
 

--- a/test/unit/editor/sprite_door_handler_test.cc
+++ b/test/unit/editor/sprite_door_handler_test.cc
@@ -42,7 +42,6 @@ class SpriteInteractionHandlerTest : public ::testing::Test {
     ctx_.on_invalidate_cache = [this]() {
       invalidate_count_++;
     };
-
     handler_.SetContext(&ctx_);
   }
 
@@ -238,6 +237,9 @@ class DoorInteractionHandlerTest : public ::testing::Test {
     ctx_.on_invalidate_cache = [this]() {
       invalidate_count_++;
     };
+    ctx_.on_entity_changed = [this]() {
+      entity_changed_count_++;
+    };
 
     handler_.SetContext(&ctx_);
   }
@@ -263,6 +265,7 @@ class DoorInteractionHandlerTest : public ::testing::Test {
   DoorInteractionHandler handler_;
   int mutation_count_ = 0;
   int invalidate_count_ = 0;
+  int entity_changed_count_ = 0;
 };
 
 TEST_F(DoorInteractionHandlerTest, PlacementBlocksAtDoorLimit) {
@@ -409,6 +412,32 @@ TEST_F(DoorInteractionHandlerTest, MutateDoorTypeRejectsOutOfRangeIndex) {
   AddDoors(1);
   EXPECT_FALSE(handler_.MutateDoorType(5, zelda3::DoorType::CurtainDoor));
   EXPECT_EQ(rooms_[0].GetDoors()[0].type, zelda3::DoorType::NormalDoor);
+}
+
+TEST_F(DoorInteractionHandlerTest,
+       MutateDoorTypeRejectsOddAndOutOfRangeRawValuesWithoutSideEffects) {
+  zelda3::Room::Door door;
+  door.position = 0x08;
+  door.type = zelda3::DoorType::NormalDoor;
+  door.direction = zelda3::DoorDirection::North;
+  const auto [byte1, byte2] = door.EncodeBytes();
+  door.byte1 = byte1;
+  door.byte2 = byte2;
+  rooms_[0].AddDoor(door);
+  rooms_[0].ClearObjectStreamDirty();
+
+  for (const uint8_t raw_type : {uint8_t{0x01}, uint8_t{0x68}}) {
+    EXPECT_FALSE(
+        handler_.MutateDoorType(0, static_cast<zelda3::DoorType>(raw_type)));
+    const auto& unchanged = rooms_[0].GetDoors()[0];
+    EXPECT_EQ(unchanged.type, zelda3::DoorType::NormalDoor);
+    EXPECT_EQ(unchanged.byte1, byte1);
+    EXPECT_EQ(unchanged.byte2, byte2);
+    EXPECT_FALSE(rooms_[0].object_stream_dirty());
+    EXPECT_EQ(mutation_count_, 0);
+    EXPECT_EQ(invalidate_count_, 0);
+    EXPECT_EQ(entity_changed_count_, 0);
+  }
 }
 
 TEST_F(DoorInteractionHandlerTest,
@@ -645,6 +674,22 @@ TEST_F(ItemInteractionHandlerTest, ClickReleaseWithoutMovementDoesNotMutate) {
   EXPECT_EQ(rooms_[0].GetPotItems()[0].position, 0x0408);
   EXPECT_EQ(mutation_count_, 0);
   EXPECT_EQ(invalidate_count_, 0);
+}
+
+TEST_F(ItemInteractionHandlerTest,
+       MutateItemTypeMarksDirtyAndFiresMutationCallbacks) {
+  AddItems(1);
+
+  ASSERT_TRUE(handler_.MutateItemType(0, 0x09));
+
+  EXPECT_EQ(rooms_[0].GetPotItems()[0].item, 0x09);
+  EXPECT_TRUE(rooms_[0].pot_items_dirty());
+  EXPECT_EQ(mutation_count_, 1);
+  EXPECT_EQ(invalidate_count_, 1);
+  EXPECT_FALSE(handler_.MutateItemType(0, 0x09));
+  EXPECT_FALSE(handler_.MutateItemType(1, 0x08));
+  EXPECT_EQ(mutation_count_, 1);
+  EXPECT_EQ(invalidate_count_, 1);
 }
 
 TEST_F(ItemInteractionHandlerTest, DeleteAllClearsItemsAndFiresCallbacks) {

--- a/test/unit/gui/property_inspector_test.cc
+++ b/test/unit/gui/property_inspector_test.cc
@@ -1,11 +1,13 @@
 #include "app/gui/widgets/property_inspector.h"
 
 #include <cstdint>
+#include <functional>
 #include <string>
 
 #include <gtest/gtest.h>
 
 #include "app/gui/core/color.h"
+#include "app/gui/core/input.h"
 #include "imgui/imgui.h"
 #include "imgui/imgui_internal.h"
 
@@ -182,6 +184,140 @@ TEST_F(PropertyInspectorTest, MultiplePropertiesRenderInsideTableWithoutError) {
   ImGui::EndTable();
   ImGui::End();
   SUCCEED();
+}
+
+class DeferredScalarInputTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    context_ = ImGui::CreateContext();
+    ImGui::SetCurrentContext(context_);
+    ImGuiIO& io = ImGui::GetIO();
+    io.DisplaySize = ImVec2(640.0f, 480.0f);
+    io.DeltaTime = 1.0f / 60.0f;
+    unsigned char* pixels = nullptr;
+    int width = 0;
+    int height = 0;
+    io.Fonts->GetTexDataAsRGBA32(&pixels, &width, &height);
+  }
+
+  void TearDown() override {
+    ImGui::DestroyContext(context_);
+    context_ = nullptr;
+  }
+
+  void RunFrame(const std::function<void(ImGuiIO&)>& inject_events = {}) {
+    ImGuiIO& io = ImGui::GetIO();
+    if (inject_events) {
+      inject_events(io);
+    }
+
+    ImGui::NewFrame();
+    ImGui::SetNextWindowPos(ImVec2(20.0f, 20.0f), ImGuiCond_Always);
+    ImGui::SetNextWindowSize(ImVec2(240.0f, 120.0f), ImGuiCond_Always);
+    ImGui::SetNextWindowFocus();
+    ImGui::Begin(
+        "DeferredScalarHost", nullptr,
+        ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_NoSavedSettings);
+    ImGui::SetNextItemWidth(100.0f);
+    committed_ = InputScalarDeferred("Value", ImGuiDataType_S32, &value_, "%d",
+                                     0, target_identity_);
+    const ImVec2 input_min = ImGui::GetItemRectMin();
+    const ImVec2 input_max = ImGui::GetItemRectMax();
+    input_center_ = ImVec2((input_min.x + input_max.x) * 0.5f,
+                           (input_min.y + input_max.y) * 0.5f);
+    ImGui::End();
+    ImGui::EndFrame();
+  }
+
+  void ActivateAndType(const char* text) {
+    RunFrame();
+    RunFrame([&](ImGuiIO& io) {
+      io.AddMousePosEvent(input_center_.x, input_center_.y);
+      io.AddMouseButtonEvent(ImGuiMouseButton_Left, true);
+    });
+    RunFrame([](ImGuiIO& io) {
+      io.AddMouseButtonEvent(ImGuiMouseButton_Left, false);
+    });
+    RunFrame([&](ImGuiIO& io) { io.AddInputCharactersUTF8(text); });
+  }
+
+  void RunFrameWithoutInput() {
+    ImGui::NewFrame();
+    ImGui::SetNextWindowPos(ImVec2(20.0f, 20.0f), ImGuiCond_Always);
+    ImGui::SetNextWindowSize(ImVec2(240.0f, 120.0f), ImGuiCond_Always);
+    ImGui::Begin(
+        "DeferredScalarHost", nullptr,
+        ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_NoSavedSettings);
+    ImGui::TextUnformatted("Input hidden");
+    ImGui::End();
+    ImGui::EndFrame();
+  }
+
+  ImGuiContext* context_ = nullptr;
+  ImVec2 input_center_{};
+  int value_ = 42;
+  bool committed_ = false;
+  InputScalarTargetIdentity target_identity_{1, 0, 0};
+};
+
+TEST_F(DeferredScalarInputTest, CommitsOnlyAfterEnterDeactivatesItem) {
+  ActivateAndType("99");
+  EXPECT_EQ(value_, 42);
+  EXPECT_FALSE(committed_);
+
+  RunFrame([](ImGuiIO& io) { io.AddKeyEvent(ImGuiKey_Enter, true); });
+
+  EXPECT_EQ(value_, 99);
+  EXPECT_TRUE(committed_);
+}
+
+TEST_F(DeferredScalarInputTest, EscapeDiscardsPendingCandidate) {
+  ActivateAndType("99");
+  EXPECT_EQ(value_, 42);
+  EXPECT_FALSE(committed_);
+
+  RunFrame([](ImGuiIO& io) { io.AddKeyEvent(ImGuiKey_Escape, true); });
+
+  EXPECT_EQ(value_, 42);
+  EXPECT_FALSE(committed_);
+}
+
+TEST_F(DeferredScalarInputTest, DisappearingWidgetCannotCommitStaleCandidate) {
+  ActivateAndType("99");
+  EXPECT_EQ(value_, 42);
+
+  RunFrameWithoutInput();
+  RunFrame();
+
+  EXPECT_EQ(value_, 42);
+  EXPECT_FALSE(committed_);
+}
+
+TEST_F(DeferredScalarInputTest, ModelChangeCancelsPendingCandidate) {
+  ActivateAndType("99");
+  EXPECT_EQ(value_, 42);
+
+  value_ = 77;
+  RunFrame([](ImGuiIO& io) { io.AddKeyEvent(ImGuiKey_Enter, true); });
+
+  EXPECT_EQ(value_, 77);
+  EXPECT_FALSE(committed_);
+}
+
+TEST_F(DeferredScalarInputTest,
+       EqualValuedSemanticTargetChangeCancelsPendingCandidate) {
+  ActivateAndType("99");
+  EXPECT_EQ(value_, 42);
+
+  target_identity_ = {2, 0, 0};
+  RunFrame();
+  EXPECT_EQ(value_, 42);
+  EXPECT_FALSE(committed_);
+
+  RunFrame([](ImGuiIO& io) { io.AddKeyEvent(ImGuiKey_Enter, true); });
+
+  EXPECT_EQ(value_, 42);
+  EXPECT_FALSE(committed_);
 }
 
 }  // namespace

--- a/test/unit/zelda3/dungeon/dungeon_save_test.cc
+++ b/test/unit/zelda3/dungeon/dungeon_save_test.cc
@@ -357,6 +357,47 @@ TEST_F(DungeonSaveTest, SaveObjects_FitsInSpace) {
   EXPECT_TRUE(status.ok()) << status.message();
 }
 
+TEST_F(DungeonSaveTest, SaveObjects_PreservesDoorPointerBankMirror) {
+  constexpr int kDoorListPc = 0x100000 + 2 + 6;
+  const uint32_t mirrored_pointer = PcToSnes(kDoorListPc) | 0x800000u;
+  WriteLongPointer(kDoorPointers, mirrored_pointer);
+
+  Room room(0, rom_.get());
+  room.LoadObjects();
+  Room::Door door;
+  door.position = 3;
+  door.direction = DoorDirection::North;
+  door.type = DoorType::NormalDoor;
+  room.AddDoor(door);
+
+  ASSERT_TRUE(room.SaveObjects().ok());
+  auto saved_pointer = rom_->ReadLong(kDoorPointers);
+  ASSERT_TRUE(saved_pointer.ok()) << saved_pointer.status().message();
+  EXPECT_EQ(*saved_pointer, mirrored_pointer);
+  EXPECT_EQ(SnesToPc(*saved_pointer), kDoorListPc);
+}
+
+TEST_F(DungeonSaveTest, SaveObjects_UpdatesMirroredDoorPointerOffset) {
+  constexpr int kOriginalDoorListPc = 0x100000 + 2 + 6;
+  WriteLongPointer(kDoorPointers, PcToSnes(kOriginalDoorListPc) | 0x800000u);
+
+  Room room(0, rom_.get());
+  room.LoadObjects();
+  ASSERT_TRUE(room.AddObject(RoomObject(0x10, 10, 10, 0, 0)).ok());
+  Room::Door door;
+  door.position = 3;
+  door.direction = DoorDirection::North;
+  door.type = DoorType::NormalDoor;
+  room.AddDoor(door);
+
+  ASSERT_TRUE(room.SaveObjects().ok());
+  auto saved_pointer = rom_->ReadLong(kDoorPointers);
+  ASSERT_TRUE(saved_pointer.ok()) << saved_pointer.status().message();
+  constexpr int kShiftedDoorListPc = kOriginalDoorListPc + 3;
+  EXPECT_EQ(*saved_pointer, PcToSnes(kShiftedDoorListPc) | 0x800000u);
+  EXPECT_EQ(SnesToPc(*saved_pointer), kShiftedDoorListPc);
+}
+
 TEST_F(DungeonSaveTest,
        SaveObjects_InvalidObjectFailsWithoutRomMutationAndStaysDirty) {
   room_->AddTileObject(RoomObject(/*id=*/0x140, /*x=*/10, /*y=*/10,


### PR DESCRIPTION
## Summary

- add stable Dungeon Workbench automation targets and semantic waits for D6 room edits
- make coordinated saves serialize only editors that are already loaded
- preserve the source door-pointer bank mirror during object-stream writes
- persist `save_dungeon_water_fill_zones` in native `.yaze` projects and keep disabled WaterFill data read-only without synthetic dirty state
- guard dungeon Delete/Ctrl+A behavior while text inputs own the keyboard
- add a fail-closed GUI qualification driver covering edit, save, backup, quit, reopen, readback, and exact ROM-byte containment

## D6 qualification batch

The checked-in fixtures edit and reopen-readback five values across four rooms:

- room `0xA8`: door type
- room `0xB8`: object Y coordinate
- room `0xD8`: sprite X coordinate and pot item
- room `0xDA`: palette color

This is progress toward #115, but it intentionally does **not** close that issue.

## Verification

- clean Yaze head: `1a0a2ed97f25b8bc4168b2375233f0cbfdad028a`
- focused build: `yaze`, `yaze_test_unit`, and `yaze_test_integration`
- focused unit/save gate: 24/24 passed
- ImGui harness logic: 12/12 passed
- pre-push smoke/UI gate: 13/13 + 40/40 passed
- clean-head GUI run:
  - edit/save replay: 48/48 steps
  - reopen assertions: 40/40 steps
  - both guarded application quits completed with process/listener teardown
  - pre-save backup matched baseline SHA-256 `b13ef69ede313756dcf560bf0f993663d68d0365609f2c20dcdec2c17f31f7b9`
  - saved ROM SHA-256 `d169961b9b83cddd33f63ce7b4a12c50d11939627c7f04dba8143672a91100e8`
  - 416 changed bytes in exactly 7 allowlisted ranges; 0 outside ranges
  - exact-head evidence summary SHA-256 `07e475201fc0c63725ab479281e8e6e3a17f1c98147e657d30e8b1ce54c630fc`
  - exact-head provenance SHA-256 `ca4c09a89a3d3c11988bc57e34c48ad3ed441c64a1ac285f98accc107cc93a92`
- Oracle build from the saved ROM passed:
  - patched ROM SHA-256 `7569b6ee5bf52170595122e44e903a0be273e24786108265edc44cb6d6e9f194`
  - 10,654/10,654 symbols loaded
- isolated Mesen runtime qualification passed for rooms `0x98`, `0xA8`, `0xB8`, `0xD8`, and `0xDA`: Dungeon mode, submode 0, Link state 0, camera OK, no warnings; each state was regenerated and verified against patched-ROM SHA-1 `e9481cf95304a69ff1cdd31096f60c719f3a14dc`

## Scope notes

- the Quit harness invokes the same guarded `EditorManager::Quit()` application action directly; process teardown is validated, but physical Cmd+Q/menu routing is not claimed
- WaterFill save scope is fixed when a project opens; change the project descriptor and reopen before authoring
- Mesen evidence uses synthetic warppad room loading for runtime stability, not a full D6 traversal
- no `.github/workflows/**` files are changed


