### PR TITLE
fix(dungeon): close editor stabilization gaps

### DIFF
--- a/src/app/editor/dungeon/interaction/sprite_interaction_handler.cc
+++ b/src/app/editor/dungeon/interaction/sprite_interaction_handler.cc
@@ -4,6 +4,7 @@
 
 // C++ standard library
 #include <algorithm>
+#include <cstdint>
 
 // Third-party library headers
 #include "absl/strings/str_format.h"
@@ -309,10 +310,12 @@ bool SpriteInteractionHandler::NudgeSelected(int delta_x, int delta_y) {
   }
 
   auto& sprite = sprites[*selected_sprite_index_];
-  const int next_x = std::clamp(static_cast<int>(sprite.x()) + delta_x, 0,
-                                dungeon_coords::kSpriteGridMax);
-  const int next_y = std::clamp(static_cast<int>(sprite.y()) + delta_y, 0,
-                                dungeon_coords::kSpriteGridMax);
+  const int64_t requested_x = static_cast<int64_t>(sprite.x()) + delta_x;
+  const int64_t requested_y = static_cast<int64_t>(sprite.y()) + delta_y;
+  const int next_x = static_cast<int>(
+      std::clamp<int64_t>(requested_x, 0, dungeon_coords::kSpriteGridMax));
+  const int next_y = static_cast<int>(
+      std::clamp<int64_t>(requested_y, 0, dungeon_coords::kSpriteGridMax));
   if (next_x == sprite.x() && next_y == sprite.y()) {
     return false;
   }

--- a/src/app/editor/dungeon/ui/window/sprite_editor_panel.h
+++ b/src/app/editor/dungeon/ui/window/sprite_editor_panel.h
@@ -1,6 +1,7 @@
 #ifndef YAZE_APP_EDITOR_DUNGEON_PANELS_SPRITE_EDITOR_PANEL_H_
 #define YAZE_APP_EDITOR_DUNGEON_PANELS_SPRITE_EDITOR_PANEL_H_
 
+#include <algorithm>
 #include <array>
 #include <cstdint>
 #include <functional>
@@ -10,6 +11,7 @@
 #include "absl/strings/str_format.h"
 #include "app/editor/agent/agent_ui_theme.h"
 #include "app/editor/dungeon/dungeon_canvas_viewer.h"
+#include "app/editor/dungeon/dungeon_coordinates.h"
 #include "app/editor/dungeon/dungeon_room_store.h"
 #include "app/editor/system/workspace/editor_panel.h"
 #include "app/gui/automation/widget_auto_register.h"
@@ -287,10 +289,15 @@ class SpriteEditorPanel : public WindowContent {
       gui::AutoRegisterLastItem("input_int", "selected_sprite_y",
                                 "Selected sprite Y coordinate");
       if (x_changed || y_changed) {
+        const int clamped_x =
+            std::clamp(sprite_x, 0, dungeon_coords::kSpriteGridMax);
+        const int clamped_y =
+            std::clamp(sprite_y, 0, dungeon_coords::kSpriteGridMax);
         auto& handler = canvas_viewer_->object_interaction()
                             .entity_coordinator()
                             .sprite_handler();
-        handler.NudgeSelected(sprite_x - sprite.x(), sprite_y - sprite.y());
+        handler.NudgeSelected(clamped_x - static_cast<int>(sprite.x()),
+                              clamped_y - static_cast<int>(sprite.y()));
       }
     }
 

--- a/src/app/editor/dungeon/workspace/dungeon_workbench_content.cc
+++ b/src/app/editor/dungeon/workspace/dungeon_workbench_content.cc
@@ -151,6 +151,10 @@ DungeonWorkbenchTestRect CaptureLastItemRectForTesting() {
 
 }  // namespace
 
+bool ResolveCompactInspectorDetailRequest(bool compact, bool detail_requested) {
+  return compact && detail_requested;
+}
+
 DungeonWorkbenchResponsiveLayout ResolveDungeonWorkbenchResponsiveLayout(
     float total_width, float min_canvas_width, float min_sidebar_width,
     float splitter_width, bool want_left, bool want_right) {
@@ -2035,6 +2039,9 @@ void DungeonWorkbenchContent::DrawInspectorShelf(DungeonCanvasViewer& viewer,
     inspector_mode_ = InspectorMode::Selection;
   }
   inspector_selection_was_active_ = has_selection;
+
+  compact_inspector_detail_requested_ = ResolveCompactInspectorDetailRequest(
+      compact, compact_inspector_detail_requested_);
 
   // Use the resolved pane layout instead of GetContentRegionAvail().x. The
   // latter changes when a vertical scrollbar appears, which can make the

--- a/src/app/editor/dungeon/workspace/dungeon_workbench_content.h
+++ b/src/app/editor/dungeon/workspace/dungeon_workbench_content.h
@@ -68,6 +68,8 @@ DungeonWorkbenchPaneLayout ResolveDungeonWorkbenchPaneLayout(
     float splitter_width, float stored_left_width, float stored_right_width,
     bool want_left, bool want_right);
 
+bool ResolveCompactInspectorDetailRequest(bool compact, bool detail_requested);
+
 // Single stable window for dungeon editing. This is step 2 in the Workbench plan.
 class DungeonWorkbenchContent : public WindowContent {
  public:

--- a/test/unit/editor/dungeon_workbench_content_test.cc
+++ b/test/unit/editor/dungeon_workbench_content_test.cc
@@ -150,6 +150,14 @@ TEST(DungeonWorkbenchContentLayoutTest,
   EXPECT_FALSE(hide_both.show_right);
 }
 
+TEST(DungeonWorkbenchContentLayoutTest,
+     CompactInspectorDetailRequestResetsOutsideCompactLayout) {
+  EXPECT_FALSE(ResolveCompactInspectorDetailRequest(false, false));
+  EXPECT_FALSE(ResolveCompactInspectorDetailRequest(true, false));
+  EXPECT_TRUE(ResolveCompactInspectorDetailRequest(true, true));
+  EXPECT_FALSE(ResolveCompactInspectorDetailRequest(false, true));
+}
+
 TEST(DungeonWorkbenchContentObjectSizeTest,
      SizeControlsEnableOnlyWhenSelectionContainsEditableObject) {
   const std::vector<zelda3::RoomObject> objects = {

--- a/test/unit/editor/sprite_door_handler_test.cc
+++ b/test/unit/editor/sprite_door_handler_test.cc
@@ -9,6 +9,7 @@
 
 #include <gtest/gtest.h>
 #include <array>
+#include <limits>
 #include <optional>
 
 #include "app/editor/dungeon/dungeon_room_store.h"
@@ -213,6 +214,24 @@ TEST_F(SpriteInteractionHandlerTest,
   EXPECT_FALSE(handler_.HasSelection());
   EXPECT_EQ(mutation_count_, mutations_before + 1);
   EXPECT_EQ(invalidate_count_, invalidations_before + 1);
+}
+
+TEST_F(SpriteInteractionHandlerTest,
+       ExtremeNudgeCoordinatesClampWithoutSignedOverflow) {
+  AddSprites(2);
+  handler_.SelectSprite(1);
+
+  EXPECT_TRUE(handler_.NudgeSelected(std::numeric_limits<int>::max(),
+                                     std::numeric_limits<int>::max()));
+  EXPECT_EQ(rooms_[0].GetSprites()[1].x(), dungeon_coords::kSpriteGridMax);
+  EXPECT_EQ(rooms_[0].GetSprites()[1].y(), dungeon_coords::kSpriteGridMax);
+
+  EXPECT_TRUE(handler_.NudgeSelected(std::numeric_limits<int>::min(),
+                                     std::numeric_limits<int>::min()));
+  EXPECT_EQ(rooms_[0].GetSprites()[1].x(), 0);
+  EXPECT_EQ(rooms_[0].GetSprites()[1].y(), 0);
+  EXPECT_EQ(mutation_count_, 2);
+  EXPECT_EQ(invalidate_count_, 2);
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary
- clamp direct sprite-coordinate input before computing movement deltas and widen sprite-backend nudge arithmetic to avoid signed overflow
- clear the compact-inspector detail latch after the visible inspector returns to a noncompact layout
- add focused extreme-coordinate and compact-layout regression coverage

## Stabilization batch
This keeps both Yaze P2 fixes together. The companion Oracle project-safety contract was published directly as [`f55fbed8`](https://github.com/scawful/Oracle-of-Secrets/commit/f55fbed8aafcac84f31127fcc98ea4382437343b), requiring exactly one `save_dungeon_water_fill_zones=false` declaration.

No workflow files or ROM writers are changed.

## Verification
- `CMAKE_BUILD_PARALLEL_LEVEL=4 cmake --build --preset mac-ai --target yaze_test_unit yaze_test_quick_unit_editor --parallel 4`
- focused dungeon regression selection: 19/19 passed
- pre-push unit smoke: 13/13 passed
- pre-push change-aware UI regression: 40/40 passed
- `clang-format --dry-run --Werror` on all six touched files
- `git diff --check`
