### PR TITLE
fix(dungeon): align object rendering and editor UX with ROM semantics

### DIFF
--- a/docs/internal/agents/dungeon-object-rendering-spec.md
+++ b/docs/internal/agents/dungeon-object-rendering-spec.md
@@ -3,8 +3,8 @@
 Status: ACTIVE  
 Owner: zelda3-hacking-expert  
 Created: 2025-12-06  
-Last Reviewed: 2026-02-17
-Next Review: 2026-03-03  
+Last Reviewed: 2026-09-09
+Next Review: 2026-12-09
 Coordination: Universe task lifecycle via `scripts/agents/coord` (snapshot optional: `docs/internal/agents/coordination-board.generated.md`)
 
 ## Scope
@@ -16,11 +16,12 @@ Coordination: Universe task lifecycle via `scripts/agents/coord` (snapshot optio
 - `LoadAndBuildRoom` (`assets/asm/usdasm/bank_01.asm:$01873A`):
   1) `LoadRoomHeader` ($01B564) pulls header bits: blockset/light bits to `$0414`, layer type bits to `$046C`, merge/effect bits to `$063C-$063F/$0640`, palette/spriteset/tag bytes immediately after.
   2) `RoomDraw_DrawFloors` ($0189DC): uses the first room word. High nibble → `$0490` (BG2 floor set), low nibble → `$046A` (BG1 floor set). Draws 4×4 quadrant “super squares” through `RoomDraw_FloorChunks`, targeting BG2 pointers first then BG1 pointers.
-  3) Layout pointer: reads the next byte at `$B7+BA` into `$040E`, converts to a 3-byte pointer via `RoomLayoutPointers`, resets `BA=0`, and runs `RoomDraw_DrawAllObjects` on that layout list (this is the template layer; it should stay underneath everything else).
-  4) Primary room objects: restores the room’s object pointer (`RoomData_ObjectDataPointers`) and runs `RoomDraw_DrawAllObjects` again (BA now points past the layout byte).
+  3) Layout pointer: reads the next byte at `$B7+BA` into `$040E`, converts to a 3-byte pointer via `RoomLayoutPointers`, resets `BA=0`, restores `RoomData_TilemapPointers_upper_layer`, and runs `RoomDraw_DrawAllObjects` on that layout list (this is the upper/BG1 template layer; it should stay underneath later upper objects).
+  4) Primary room objects: restores the room’s object pointer (`RoomData_ObjectDataPointers`) and runs `RoomDraw_DrawAllObjects` again against the upper/BG1 tilemap pointers (BA now points past the layout byte).
   5) BG2 overlay list: skips the `0xFFFF` sentinel (`INC BA` twice), reloads pointer tables with `RoomData_TilemapPointers_lower_layer`, and draws a third object list to BG2.
   6) BG1 overlay list: skips the next `0xFFFF`, reloads pointer tables with `RoomData_TilemapPointers_upper_layer`, and draws the final object list to BG1.
-  7) Pushable blocks (`$7EF940`) and torches (`$7EFB40`) are drawn after the four passes. Both use stored bit 13 to select upper/BG1 or lower/BG2: their draw routines mask the encoded word with `AND #$3FFF`, retaining bit 13 in the offset from the installed upper/BG1 tilemap base. Pushable-block bit 14 controls behavior/pit checks; torch bit 14 is reserved and bit 15 selects the initially lit art.
+  7) Door/control records are handled after the final object list. Marker records update transition metadata without painting room tiles; physical doors can write to BG1, BG2, or both and can promote priority on tiles already present.
+  8) Pushable blocks (`$7EF940`) and torches (`$7EFB40`) are drawn after the object and door passes. Both use stored bit 13 to select upper/BG1 or lower/BG2: their draw routines mask the encoded word with `AND #$3FFF`, retaining bit 13 in the offset from the installed upper/BG1 tilemap base. Pushable-block bit 14 controls behavior/pit checks; torch bit 14 is reserved and bit 15 selects the initially lit art.
 - Implication: BG merge and layer type are **not** exclusive—four object streams are processed in order, with explicit pointer swaps for BG2 then BG1 overlays. Layout objects should never overdraw later passes; if they do in the editor, the pass order is wrong.
 
 ## Object Encoding (RoomDraw_RoomObject at $01893C)
@@ -73,11 +74,12 @@ Coordination: Universe task lifecycle via `scripts/agents/coord` (snapshot optio
 - `RoomDraw_DrawAllObjects` is run four times with different tilemap pointer tables; `_BothBG` routines ignore the active pointer swap and write to both buffers. The editor must allow “BG merge” and “layer type” to coexist; never force a mutually exclusive radio button.
 - Ordering for correctness:
   1) Floors (BG2 then BG1)  
-  2) Layout list (BG2)  
-  3) Main list (BG2 by default, unless the routine itself writes both)  
+  2) Layout list (upper/BG1)
+  3) Main list (upper/BG1 by default, unless the routine itself writes both)
   4) BG2 overlay list (after first `0xFFFF`)  
   5) BG1 overlay list (after second `0xFFFF`)  
-  6) Pushable blocks and torches
+  6) Doors and control records
+  7) Pushable blocks and torches
 
 ## Selection & Outline Rules
 - Use the decoding rules above; do not infer size from UI icons.

--- a/docs/internal/agents/dungeon-object-rendering-spec.md
+++ b/docs/internal/agents/dungeon-object-rendering-spec.md
@@ -3,7 +3,7 @@
 Status: ACTIVE  
 Owner: zelda3-hacking-expert  
 Created: 2025-12-06  
-Last Reviewed: 2026-09-09
+Last Reviewed: 2026-09-10
 Next Review: 2026-12-09
 Coordination: Universe task lifecycle via `scripts/agents/coord` (snapshot optional: `docs/internal/agents/coordination-board.generated.md`)
 
@@ -45,9 +45,9 @@ Coordination: Universe task lifecycle via `scripts/agents/coord` (snapshot optio
 - Type 1 routine table: `.type1_routine` at `$018200`.
   - `Rightwards*` → arrow right; grows horizontally by `size` blocks. Base footprints: `2x4`, `2x2`, `4x4`, etc. Spacing suffix (`spaced2/4/8/12`) means step that many tiles between columns.
   - `Downwards*` → arrow down; grows vertically by `size` blocks with the same spacing conventions.
-  - `DiagonalAcute/Grave` → 45° diagonals; use diagonal arrow/corner icon. Size = nibble+1 tiles long (helper is `1to16`). `_BothBG` variants must draw to both BG1 and BG2.
+  - `DiagonalAcute/Grave` → 45° diagonals; use diagonal arrow/corner icon. Although routines 5/6 load `nibble+7`, they enter the shared loop at its pre-draw decrement; routines 17/18 load `nibble+6` and enter after that decrement. All four therefore draw `nibble+6` columns with a five-tile column stamp. `_BothBG` variants must draw to both BG1 and BG2.
   - `DiagonalCeiling*` (IDs 0xA0–0xAC): size = nibble + 4 (`GetSize_1to16_timesA` with `A=4`). Bounding box is square (`size × size`) because each step moves x+y by 1.
-  - `4x4Floor*/Blocks*/SuperSquare` (IDs 0xC0–0xCA, 0xD1–0xE8): use “large square” icon. They tile 4×4 blocks inside 16×16 “super squares” (128×128 pixels) and do **not** use the size nibble—dimensions are fixed per routine.
+  - `4x4Floor*/Blocks*/SuperSquare` (IDs 0xC0–0xCA, 0xD1–0xE8): use “large square” icon. For variable super-square routines, size bits 3–2 select `1..4` horizontal 4×4 blocks and bits 1–0 select `1..4` vertical blocks. `0xC4` and `0xDB` copy the room header's active Floor 1/Floor 2 eight-tile pattern instead of a normal object payload.
   - `Edge/Corner` variants: use L-corner or edge glyph; many have `_BothBG` meaning they write to BG1 and BG2 simultaneously (should not be layer-exclusive).
 - Type 2 routines (`.type2_routine`):
   - IDs 0x108–0x117: `RoomDraw_4x4Corner_BothBG` and “WeirdCorner*” draw to both layers—icon should denote dual-layer.
@@ -60,8 +60,9 @@ Coordination: Universe task lifecycle via `scripts/agents/coord` (snapshot optio
 
 ## Ceiling and Large Object Ground Truth
 - Corner/diagonal ceilings (Type 1 IDs 0xA0–0xAC): `RoomDraw_DiagonalCeiling*` ($018BE0–$018C36). Size = nibble+4; outline should be a square whose side equals that size; growth is along the diagonal (x+1,y+1 per step).
-- Big hole & overlays: ID 0xA4 → `RoomDraw_BigHole4x4_1to16` (fixed 4×4). IDs 0xD8/0xDA → `RoomDraw_WaterOverlayA/B8x8_1to16` (fixed 8×8 overlay; should remain on BG2 overlay pass).
-- 4x4 ceilings/floors: IDs 0xC5–0xCA, 0xD1–0xD2, 0xD9, 0xDF–0xE8 → `RoomDraw_4x4FloorIn4x4SuperSquare` (fixed 4×4 tiles repeated in super squares). Use “large square” glyph; ignore size nibble.
+- Big hole & overlays: ID 0xA4 → `RoomDraw_BigHole4x4_1to16`. IDs 0xD8/0xDA enter stateful water routines: saved water state changes tilemap writes, destination, HDMA geometry, and potentially the active layer mode. Yaze currently renders an editor approximation on BG2; structural coverage is tested, but full runtime-state parity is open.
+- 4x4 ceilings/floors: IDs 0xC5–0xCA, 0xD1–0xD2, 0xD9, 0xDF–0xE8 → `RoomDraw_4x4FloorIn4x4SuperSquare`. Use a “large square” glyph. The size nibble is split into two two-bit repeat counts, producing a `4..16` tile width and height.
+- Floor copies: `0xC4` loads the Floor 1 selector from `$046A`; `0xDB` loads Floor 2 from `$0490`. Both stamp that decoded 4×2 pattern twice per 4×4 block. Room-aware renderers must receive the in-memory room header values so unsaved floor edits preview correctly.
 - 2x2 ceilings:
   - Horizontal/right-growing: IDs 0x07–0x08 and 0xB8–0xB9 use `RoomDraw_Rightwards2x2_*` (size-driven width, height=2). Arrow right, outline width = `2 * size`, height = 2.
   - Vertical/down-growing: IDs 0x060 and 0x092–0x093 use `RoomDraw_Downwards2x2_*` (size-driven height, width=2). Arrow down, outline height = `2 * size`, width = 2. When the size nibble is 0 (`1to15or32`), treat size as 32 for bounds.
@@ -92,7 +93,9 @@ Coordination: Universe task lifecycle via `scripts/agents/coord` (snapshot optio
   - `2x4` routines: width=2, height=4; repeated along the growth axis.
   - `2x2` routines: width=2, height=2; repeated along the growth axis.
   - `4x4` routines: width=4, height=4; ignore size nibble unless the routine name includes `1to16`.
-  - Super-square routines: treat as 16×16 tiles when computing selection bounds (they stamp 4×4 blocks into a 32×32-tile area).
+  - Variable super-square routines: decode the two two-bit repeat counts; each count step contributes one 4×4 block.
+- Routine-name suffixes such as `plus3`, `plus7`, `plus12`, `plus13`, and `plus23` describe the final count/extent rule. They are not an origin offset. In particular, thin solid/corner objects `0x2F`, `0x30`, `0x34`, `0x6C`, `0x6D`, and `0x71` start at the encoded object position.
+- Diagonal ceilings use their full measured square footprint for rectangular selection. A centered inset excludes real edge tiles and is not source-backed.
 - `_BothBG` routines should carry a dual-layer badge in the palette and never be filtered out by the current layer toggle—selection must remain visible regardless of BG toggle because the object truly occupies both buffers.
 
 ## Mapping UI Symbology to Real Objects
@@ -116,19 +119,35 @@ Coordination: Universe task lifecycle via `scripts/agents/coord` (snapshot optio
   and mixed-layer for 0xFA6–0xFA9. Merged/swim auto stairs remain
   stored-placement objects.
 
-## Implementation Status (February 2026)
+## Evidence Status (September 2026)
 
-| Action Item | Status | Notes |
-|-------------|--------|-------|
-| **Object routine coverage** | Done | 448/448 vanilla objects mapped in `DrawRoutineRegistry`. |
-| **BothBG flag marking** | Done | `draws_to_both_bgs` set on routines 2, 9, 17, 18, 19, 35, 36, 37, 97. Validated by parity tests. |
-| **Room effect blend modes** | Done | `RoomLayerManager::ApplyRoomEffect()` handles all `EffectKey` types. |
-| **Translucent BG2 compositing** | Done | `CompositeToOutput()` uses SNES color math `(bg1 + bg2) / 2` with palette-aware nearest-color lookup. |
-| **Pit/mask object identification** | Done | `is_pit_or_mask` list validated; marks BG1 transparent to reveal BG2. |
-| **Palette offset correctness** | Done | `pal * 16` matches the SDL palette mirroring used by `Room::RenderRoomGraphics`, where dungeon banks already live in CGRAM/SDL rows 2-7. |
-| **Selection bounds / size helpers** | Partial | `ObjectGeometry` implements routine-based measurement; nibble-zero fallbacks (26/32) and diagonal ceiling `+4` anchor headroom handled in `object_geometry.cc`. |
-| **Three-stream object build order** | Done | Layout pass + three `DrawObjectList` streams (primary / BG2 overlay / BG1 overlay) in `room.cc`. |
-| **Symbology label alignment** | Not started | UI icons/badges not yet tied to routine family names. |
+Passing one row does not imply the rows below it pass. In particular, synthetic replay is an internal regression guard, not independent visual truth.
 
-**Validation:** 19 parity tests in `test/unit/zelda3/dungeon/object_drawing_comprehensive_test.cc`.
-See `docs/internal/agents/dungeon-object-parity-plan.md` for the full fix history.
+| Evidence tier | Current status | What it proves |
+| --- | --- | --- |
+| Registry and synthetic routine replay | Pass for the current audited set | Object-to-routine mapping, write order, coordinates, and layer routing stay internally consistent. |
+| USDASM-backed focused tests | Pass for audited doors, thin edges/corners, diagonal walls/ceilings, straight and spiral stairs, conditional caps, and Floor 1/Floor 2 copies | The asserted behavior follows named `bank_01.asm` routines rather than an older Yaze snapshot. |
+| ROM parser + drawer tests | Pass for existing vanilla fixtures; Floor 1/Floor 2 copy coverage is included | Real room bytes, header fields, tile words, and renderer placement agree for those cases. |
+| Room fingerprint goldens | Pass at their recorded revision | Full-room output did not drift from Yaze's own stored baseline. This is not independent emulator truth. |
+| Independent Mesen RGBA ROIs | Partial | Exact ROIs cover Sanctuary wall/carpet, bombable floor states, TableRock `0xDD`, BigHole `0xA4`, rails `0x5F`/`0x8A`, and one west `NormalDoorLower`. Other door families, diagonal families, and stateful water paths remain open. |
+| `z3ed dungeon-object-validate` | Pass at the last recorded canonical-ROM audit | Measured bounds and registered dimensions agree across the audited object/size/state cases; it does not prove pixels or runtime effects. |
+
+Run the maintained ladder with
+`YAZE_TEST_ROM_VANILLA=$PWD/roms/zelda3.sfc scripts/agents/audit-dungeon-visual-parity.sh --with-validate-report /tmp/yaze-dungeon-object-validation.json`.
+Its synthetic tier includes thin edges/corners, diagonals, conditional caps,
+floor copies, moving walls, water/stairs, and reveal-mask ordering; ROM and
+Mesen tiers remain separate so synthetic agreement is never presented as
+independent pixel proof.
+
+### Known preview boundaries
+
+- `0xD8`/`0xDA` water is structural/editor-preview coverage only until state-labeled Mesen captures verify each vanilla branch and layer-mode side effect.
+- Moving-floor objects have static tile stamps, but Yaze does not emulate the SNES runtime BG2 scrolling effect.
+- RGB averaging and indexed-palette fallback paths approximate SNES color math; only committed Mesen ROIs are pixel-parity claims.
+- More key, shutter, bombable, and exploding door ROIs are required before claiming full door-family parity.
+
+### Render issue capture UX
+
+The room canvas context menu exposes `Capture Issue` for room rendering, room palette, or the current selection. Opening or closing the dialog does not create a log entry. `Copy Report` and `Copy Diagnostics` only copy; `Save to Issue Log` is the explicit persistence action. Raw diagnostics and local file paths are collapsed by default.
+
+Historical implementation notes live in `docs/internal/plans/dungeon-object-rendering-parity-2026-04.md`; this file is the active behavior and evidence contract.

--- a/docs/internal/architecture/dungeon_editor_system.md
+++ b/docs/internal/architecture/dungeon_editor_system.md
@@ -105,7 +105,9 @@ New subsystem for visual editing of the 8x8 tile composition of dungeon objects.
 
 ### Room Layer Manager & Compositing (February 2026)
 
-Subsystem for accurate SNES-style layer compositing of dungeon room renders.
+Subsystem for SNES-informed layer compositing of dungeon room renders. The
+pass order and per-tile priority model follow the game, while some color-math
+and runtime-effect paths remain editor approximations.
 
 **Architecture:**
 - **RoomLayerManager** (`zelda3/dungeon/room_layer_manager.{h,cc}`) — Manages per-layer blend modes and composites BG1/BG2 layout + object buffers into the final output bitmap.
@@ -116,9 +118,9 @@ Subsystem for accurate SNES-style layer compositing of dungeon room renders.
   - `Torch_Show_Floor`: Sets BG1 layers to Dark (lantern reveals BG2 floor underneath).
   - `Red_Flashes`: No persistent blend change (Ganon fight lightning is temporal).
   - `Ganon_Room`: Sets BG2 layout to Translucent.
-- **CompositeToOutput()** — Priority-aware pixel compositing:
+- **CompositeToOutput()** — Priority-aware editor compositing:
   - Builds a palette RGB lookup table from the room's SDL surface palette.
-  - For translucent layers: computes `(bg1_rgb + bg2_rgb) / 2` per channel, then finds the nearest palette index within the same palette bank via `find_nearest_in_bank`.
+  - For translucent layers: approximates half-add color math with `(bg1_rgb + bg2_rgb) / 2`, then finds the nearest palette index within the same palette bank via `find_nearest_in_bank`. Treat committed Mesen ROIs—not this approximation alone—as pixel-parity evidence.
   - For dark layers: dims BG1 pixels to simulate unlit rooms.
   - Respects SNES priority bits: BG2 priority=1 tiles render above BG1 priority=0 tiles.
 
@@ -132,7 +134,7 @@ Subsystem for accurate SNES-style layer compositing of dungeon room renders.
 - Per-routine metadata includes `draws_to_both_bgs` for routines that explicitly write both tilemaps (for example, routine 2/kRightwards2x4 and routine 19/Corner4x4). Routine 97/PrisonCell follows the current object-stream tilemap selected by `$BF` and is not dual-layer.
 
 **Validation:**
-- 19 parity tests in `test/unit/zelda3/dungeon/object_drawing_comprehensive_test.cc` validate routine coverage, palette offsets, pit/mask identification, BothBG flags, water layer semantics, room effects, and layer merge behavior.
+- `object_drawing_comprehensive_test.cc` validates registry coverage and selected invariants. ROM-backed tests validate real room bytes; committed Mesen RGBA ROIs provide independent pixel evidence for the documented subset. See `docs/internal/agents/dungeon-object-rendering-spec.md`.
 
 ## Current Limitations / Gaps
 

--- a/docs/internal/plans/dungeon-object-rendering-parity-2026-04.md
+++ b/docs/internal/plans/dungeon-object-rendering-parity-2026-04.md
@@ -1,6 +1,10 @@
-# Dungeon object rendering parity — implementation plan
+# Dungeon object rendering parity — historical implementation plan
 
-**Status:** In progress
+**Status:** Superseded as a live status source
+
+Current behavior, evidence tiers, and open parity boundaries are maintained in
+[`dungeon-object-rendering-spec.md`](../agents/dungeon-object-rendering-spec.md).
+Keep this plan for implementation history; do not append current status here.
 
 **Created:** 2026-04-15
 

--- a/scripts/agents/audit-dungeon-visual-parity.sh
+++ b/scripts/agents/audit-dungeon-visual-parity.sh
@@ -64,6 +64,49 @@ require_test_suite() {
   fi
 }
 
+require_clean_validation_report() {
+  local report_path="$1"
+  if ! command -v python3 >/dev/null 2>&1; then
+    echo "python3 is required to validate the Tier 5 JSON report." >&2
+    exit 1
+  fi
+
+  python3 - "$report_path" <<'PY'
+import json
+import sys
+
+report_path = sys.argv[1]
+try:
+    with open(report_path, encoding="utf-8") as report_file:
+        report = json.load(report_file)
+    summary = report["summary"]
+    test_cases = int(summary["test_cases"])
+    mismatch_count = int(summary["mismatch_count"])
+    empty_traces = int(summary["empty_traces"])
+    expected_empty_traces = int(summary["expected_empty_traces"])
+except (OSError, ValueError, KeyError, TypeError, json.JSONDecodeError) as error:
+    print(f"Invalid Tier 5 report {report_path}: {error}", file=sys.stderr)
+    raise SystemExit(1)
+
+if test_cases <= 0:
+    print(f"Tier 5 report contains no validation cases: {report_path}",
+          file=sys.stderr)
+    raise SystemExit(1)
+if mismatch_count != 0:
+    print(f"Tier 5 failed: mismatch_count={mismatch_count} across "
+          f"{test_cases} cases ({report_path})", file=sys.stderr)
+    raise SystemExit(1)
+if empty_traces != expected_empty_traces:
+    print(f"Tier 5 failed: empty_traces={empty_traces}, "
+          f"expected_empty_traces={expected_empty_traces} ({report_path})",
+          file=sys.stderr)
+    raise SystemExit(1)
+
+print(f"Tier 5 PASS: mismatch_count=0 across {test_cases} cases; "
+      f"empty_traces={empty_traces}")
+PY
+}
+
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --build-dir)
@@ -87,13 +130,18 @@ done
 
 resolve_bins
 
-echo "== Tier 1: synthetic replay + mapping (no ROM) =="
+if [[ -n "$REPORT_PATH" && -z "${YAZE_TEST_ROM_VANILLA:-}" ]]; then
+  echo "--with-validate-report requires YAZE_TEST_ROM_VANILLA." >&2
+  exit 1
+fi
+
+echo "== Tier 1: synthetic replay + geometry/layer mapping (no ROM) =="
 cmake --build "$BUILD_DIR" --target yaze_test_unit --parallel 4
-"$UNIT_BIN" --gtest_filter='ObjectDrawerRegistryReplayTest.BigHole*:ObjectDrawerRegistryReplayTest.TableRock*:ObjectDrawerRegistryReplayTest.FloodWater*:ObjectDrawerRegistryReplayTest.LongHorizontal*:DrawRoutineMappingTest.*Plus23*'
+"$UNIT_BIN" --gtest_filter='DrawRoutineMappingTest.*Plus3*:DrawRoutineMappingTest.*Plus23*:DrawRoutineMappingTest.*Corner*:DrawRoutineMappingTest.*DiagonalCeiling*:DrawRoutineMappingTest.MapsMovingWall*:ObjectDrawerRegistryReplayTest.FloorCopy*:ObjectDrawerRegistryReplayTest.BuiltInWallRoutingAndDiagonalCount*:ObjectDrawerRegistryReplayTest.ConditionalEdgeCaps*:ObjectDrawerRegistryReplayTest.StraightInterroom*:ObjectDrawerRegistryReplayTest.WaterHopStairs*:ObjectDrawerRegistryReplayTest.MovingWalls*:ObjectDrawerRegistryReplayTest.BigHole*:ObjectDrawerRegistryReplayTest.TableRock*:ObjectDrawerRegistryReplayTest.FloodWater*:ObjectDrawerRegistryReplayTest.LongHorizontal*:ObjectDrawerMaskPropagationTest.LaterBG1WriteClearsOnlyItsStreamRevealBit'
 
 echo
 echo "== Tier 2: ROM-backed parser/drawer parity (skips without ROM) =="
-"$UNIT_BIN" --gtest_filter='SupportedRomRoles/RoomObjectRomParityTest.VisualParityGap*:SupportedRomRoles/RoomObjectRomParityTest.BigHole*:SupportedRomRoles/RoomObjectRomParityTest.TableRock*:SupportedRomRoles/RoomObjectRomParityTest.FloodWater*:SupportedRomRoles/RoomObjectRomParityTest.LongRail*'
+"$UNIT_BIN" --gtest_filter='SupportedRomRoles/RoomObjectRomParityTest.WallCorner*:SupportedRomRoles/RoomObjectRomParityTest.WeirdCorner*:SupportedRomRoles/RoomObjectRomParityTest.FloorCopy*:SupportedRomRoles/RoomObjectRomParityTest.VisualParityGap*:SupportedRomRoles/RoomObjectRomParityTest.BigHole*:SupportedRomRoles/RoomObjectRomParityTest.TableRock*:SupportedRomRoles/RoomObjectRomParityTest.FloodWater*:SupportedRomRoles/RoomObjectRomParityTest.LongRail*'
 
 if [[ -n "${YAZE_TEST_ROM_VANILLA:-}" ]]; then
   echo
@@ -109,13 +157,19 @@ if [[ -n "${YAZE_TEST_ROM_VANILLA:-}" ]]; then
     "$ROM_BIN" \
       --gtest_filter='DungeonObjectRomValidationTest.TileCountTable_KnownValues'
 
-  if [[ -n "$REPORT_PATH" && -x "$Z3ED_BIN" ]]; then
+  if [[ -n "$REPORT_PATH" ]]; then
     echo
     echo "== Tier 5: z3ed dungeon-object-validate bounds audit =="
+    cmake --build "$BUILD_DIR" --target z3ed --parallel 4
+    if [[ ! -x "$Z3ED_BIN" ]]; then
+      echo "Required Tier 5 binary not found after build: $Z3ED_BIN" >&2
+      exit 1
+    fi
     "$Z3ED_BIN" dungeon-object-validate \
       --rom "$YAZE_TEST_ROM_VANILLA" \
       --report "$REPORT_PATH" \
       --format json
+    require_clean_validation_report "$REPORT_PATH"
     echo "Wrote validation report to $REPORT_PATH"
   fi
 else

--- a/scripts/agents/audit-dungeon-visual-parity.sh
+++ b/scripts/agents/audit-dungeon-visual-parity.sh
@@ -103,7 +103,8 @@ if [[ -n "${YAZE_TEST_ROM_VANILLA:-}" ]]; then
   require_test_suite "$INTEG_BIN" DungeonRoomRegressionFixturesTest
   require_test_suite "$ROM_BIN" DungeonObjectRomValidationTest
   YAZE_TEST_ROM_VANILLA="$YAZE_TEST_ROM_VANILLA" \
-    "$INTEG_BIN" --gtest_filter='DungeonRoomRegressionFixturesTest.*'
+    "$INTEG_BIN" \
+      --gtest_filter='DungeonRoomRegressionFixturesTest.*:DungeonRoomRenderParityTest.*'
   YAZE_TEST_ROM_VANILLA="$YAZE_TEST_ROM_VANILLA" \
     "$ROM_BIN" \
       --gtest_filter='DungeonObjectRomValidationTest.TileCountTable_KnownValues'

--- a/src/app/controller.cc
+++ b/src/app/controller.cc
@@ -327,6 +327,7 @@ void Controller::DoRender() const {
     // In HEADLESS mode, we MUST still end the ImGui frame to satisfy assertions
     // even if we don't render to a window.
     ImGui::Render();
+    gfx::Arena::Get().DrainRetiredBitmaps(renderer_.get());
     ProcessScreenshotRequests();
     return;
   }
@@ -338,6 +339,7 @@ void Controller::DoRender() const {
   window_backend_->RenderImGui(renderer_.get());
 
   renderer_->Present();
+  gfx::Arena::Get().DrainRetiredBitmaps(renderer_.get());
 
 #if defined(YAZE_ENABLE_IMGUI_TEST_ENGINE) && YAZE_ENABLE_IMGUI_TEST_ENGINE
   test::TestManager::Get().OnPostSwap();
@@ -366,6 +368,10 @@ void Controller::OnExit() {
 #endif
 
   if (renderer_) {
+    // Retired handles contain no Bitmap pointers and are safe to destroy once
+    // the final submitted frame is no longer using them.
+    gfx::Arena::Get().DrainRetiredBitmaps(renderer_.get());
+    gfx::Arena::Get().Initialize(nullptr);
     renderer_->Shutdown();
   }
   if (window_backend_) {

--- a/src/app/editor/dungeon/dungeon_canvas_connected_view.cc
+++ b/src/app/editor/dungeon/dungeon_canvas_connected_view.cc
@@ -23,23 +23,6 @@ namespace yaze::editor {
 
 namespace {
 
-bool IsExitDoorType(zelda3::DoorType type) {
-  switch (type) {
-    case zelda3::DoorType::FancyDungeonExit:
-    case zelda3::DoorType::FancyDungeonExitLower:
-    case zelda3::DoorType::CaveExit:
-    case zelda3::DoorType::LitCaveExitLower:
-    case zelda3::DoorType::ExitLower:
-    case zelda3::DoorType::UnusedCaveExit:
-    case zelda3::DoorType::BombableCaveExit:
-    case zelda3::DoorType::WaterfallDoor:
-    case zelda3::DoorType::ExitMarker:
-      return true;
-    default:
-      return false;
-  }
-}
-
 bool IsHeaderBackedInterroomStaircaseObject(int16_t object_id) {
   const int routine_id =
       zelda3::DrawRoutineRegistry::Get().GetRoutineIdForObject(object_id);
@@ -195,7 +178,7 @@ DungeonConnectedRoomLinkDiagnostics CollectDungeonConnectedRoomLinkDiagnostics(
   const auto& doors = room.GetDoors();
   for (size_t door_index = 0; door_index < doors.size(); ++door_index) {
     const auto& door = doors[door_index];
-    if (IsExitDoorType(door.type)) {
+    if (!zelda3::IsRoomConnectionDoorType(door.type)) {
       continue;
     }
 
@@ -432,7 +415,7 @@ bool DungeonCanvasViewer::RoomHasNonExitDoorInDirection(
   }
 
   for (const auto& door : room->GetDoors()) {
-    if (door.direction == dir && !IsExitDoorType(door.type)) {
+    if (door.direction == dir && zelda3::IsRoomConnectionDoorType(door.type)) {
       return true;
     }
   }

--- a/src/app/editor/dungeon/dungeon_canvas_context_menu.cc
+++ b/src/app/editor/dungeon/dungeon_canvas_context_menu.cc
@@ -28,12 +28,19 @@ void DungeonCanvasViewer::AddInteractionContextMenuItems(int room_id) {
     return;
   }
 
-  for (auto& item : BuildSelectionContextMenuItems(room_id)) {
-    canvas_.AddContextMenuItem(std::move(item));
-  }
+  canvas_.AddContextMenuItem(BuildSelectionContextMenu(room_id));
   auto insert_menu = BuildInsertContextMenu();
   insert_menu.separator_after = true;
   canvas_.AddContextMenuItem(insert_menu);
+}
+
+gui::CanvasMenuItem DungeonCanvasViewer::BuildSelectionContextMenu(
+    int room_id) {
+  gui::CanvasMenuItem selection_menu;
+  selection_menu.label = "Selection";
+  selection_menu.icon = ICON_MD_SELECT_ALL;
+  selection_menu.subitems = BuildSelectionContextMenuItems(room_id);
+  return selection_menu;
 }
 
 void DungeonCanvasViewer::AddLoadedRoomContextMenuItems(int room_id) {
@@ -109,10 +116,17 @@ DungeonCanvasViewer::GetObjectUnderContextCursor(int room_id) {
   }
 
   const ImGuiIO& io = ImGui::GetIO();
+  ImVec2 screen_position = io.MousePos;
+  if (!ImGui::IsMouseClicked(ImGuiMouseButton_Right)) {
+    if (const auto popup_anchor = canvas_.context_menu_open_screen_position();
+        popup_anchor.has_value()) {
+      screen_position = *popup_anchor;
+    }
+  }
   const DungeonCanvasTransform transform(
       canvas_.zero_point(), canvas_.scrolling(), canvas_.global_scale());
   const auto [canvas_x, canvas_y] =
-      transform.ScreenToRoomPixelCoordinates(io.MousePos);
+      transform.ScreenToRoomPixelCoordinates(screen_position);
   if (!dungeon_coords::IsWithinBounds(canvas_x, canvas_y)) {
     return std::nullopt;
   }
@@ -132,6 +146,13 @@ DungeonCanvasViewer::GetObjectUnderContextCursor(int room_id) {
 
 std::vector<gui::CanvasMenuItem>
 DungeonCanvasViewer::BuildSelectionContextMenuItems(int room_id) {
+  return BuildSelectionContextMenuItems(room_id,
+                                        GetObjectUnderContextCursor(room_id));
+}
+
+std::vector<gui::CanvasMenuItem>
+DungeonCanvasViewer::BuildSelectionContextMenuItems(
+    int room_id, std::optional<zelda3::RoomObject> context_object) {
   auto& interaction = object_interaction_;
   const auto selected = interaction.GetSelectedObjectIndices();
   const bool has_selection = !selected.empty();
@@ -223,15 +244,15 @@ DungeonCanvasViewer::BuildSelectionContextMenuItems(int room_id) {
         shortcut);
   };
 
-  const auto context_sample_object = GetObjectUnderContextCursor(room_id);
-  std::optional<size_t> sample_item_index;
-  if (context_sample_object.has_value()) {
-    sample_item_index = items.size();
-    items.emplace_back("Sample Object", ICON_MD_COLORIZE,
-                       [this, object = *context_sample_object]() {
-                         SetPreviewObject(object);
-                       });
-  }
+  gui::CanvasMenuItem sample_item("Use Object as Brush", ICON_MD_COLORIZE,
+                                  [this, context_object]() {
+                                    if (context_object.has_value()) {
+                                      SetPreviewObject(*context_object);
+                                    }
+                                  });
+  sample_item.enabled_condition = enabled_if(context_object.has_value());
+  sample_item.separator_after = true;
+  items.push_back(std::move(sample_item));
 
   if (has_selection) {
     items.emplace_back(
@@ -335,13 +356,6 @@ DungeonCanvasViewer::BuildSelectionContextMenuItems(int room_id) {
     items.push_back(std::move(cancel_item));
   }
 
-  if (sample_item_index.has_value() && items.size() > *sample_item_index + 1) {
-    items[*sample_item_index].separator_after = true;
-  }
-
-  if (!items.empty()) {
-    items.back().separator_after = true;
-  }
   return items;
 }
 
@@ -372,15 +386,15 @@ gui::CanvasMenuItem DungeonCanvasViewer::BuildRoomContextMenu(int room_id) {
 
 gui::CanvasMenuItem DungeonCanvasViewer::BuildReportContextMenu(int room_id) {
   gui::CanvasMenuItem report_menu;
-  report_menu.label = "Report";
+  report_menu.label = "Capture Issue";
   report_menu.icon = ICON_MD_BUG_REPORT;
   report_menu.subitems.emplace_back(
-      "Render Issue...", ICON_MD_BUG_REPORT, [this, room_id]() {
+      "Room Rendering...", ICON_MD_BUG_REPORT, [this, room_id]() {
         if (!rooms_ || room_id < 0 || room_id >= zelda3::kNumberOfRooms) {
           return;
         }
         OpenIssueReportPopup(
-            absl::StrFormat("Report Room 0x%03X Render Issue", room_id),
+            absl::StrFormat("Capture Room 0x%03X Rendering Issue", room_id),
             absl::StrFormat("Room 0x%03X render mismatch", room_id),
             "Dungeon Render Issue Report",
             BuildDrawIssueReport((*rooms_)[room_id], room_id), room_id,
@@ -388,12 +402,12 @@ gui::CanvasMenuItem DungeonCanvasViewer::BuildReportContextMenu(int room_id) {
                 DungeonIssueCategory::GeneralRoomRenderMismatch));
       });
   report_menu.subitems.emplace_back(
-      "Palette Issue...", ICON_MD_PALETTE, [this, room_id]() {
+      "Room Palette...", ICON_MD_PALETTE, [this, room_id]() {
         if (!rooms_ || room_id < 0 || room_id >= zelda3::kNumberOfRooms) {
           return;
         }
         OpenIssueReportPopup(
-            absl::StrFormat("Report Room 0x%03X Palette Issue", room_id),
+            absl::StrFormat("Capture Room 0x%03X Palette Issue", room_id),
             absl::StrFormat("Room 0x%03X palette mismatch", room_id),
             "Dungeon Palette Issue Report",
             BuildDrawIssueReport((*rooms_)[room_id], room_id), room_id,
@@ -402,12 +416,12 @@ gui::CanvasMenuItem DungeonCanvasViewer::BuildReportContextMenu(int room_id) {
   if (object_interaction_.GetSelectionCount() > 0 ||
       object_interaction_.HasEntitySelection()) {
     report_menu.subitems.emplace_back(
-        "Selection Issue...", ICON_MD_FACT_CHECK, [this, room_id]() {
+        "Current Selection...", ICON_MD_FACT_CHECK, [this, room_id]() {
           if (!rooms_ || room_id < 0 || room_id >= zelda3::kNumberOfRooms) {
             return;
           }
           OpenIssueReportPopup(
-              absl::StrFormat("Report Selection Issue for Room 0x%03X",
+              absl::StrFormat("Capture Selection Issue for Room 0x%03X",
                               room_id),
               absl::StrFormat("Room 0x%03X selection or entity mismatch",
                               room_id),

--- a/src/app/editor/dungeon/dungeon_canvas_issue_report.cc
+++ b/src/app/editor/dungeon/dungeon_canvas_issue_report.cc
@@ -20,6 +20,7 @@
 #include "absl/time/clock.h"
 #include "absl/time/time.h"
 #include "app/editor/dungeon/ui/reporting/dungeon_issue_report_storage.h"
+#include "app/gfx/resource/arena.h"
 #include "app/gui/core/icons.h"
 #include "app/gui/core/ui_helpers.h"
 #ifdef YAZE_WITH_GRPC
@@ -46,16 +47,15 @@ constexpr float kIssueReportNotesHeight = 120.0f;
 constexpr float kIssueReportDiagnosticsHeight = 180.0f;
 constexpr char kIssueReportSummaryHint[] = "What looks wrong?";
 constexpr char kIssueReportPopupIdDiagnostics[] = "##DungeonIssueDiagnostics";
-constexpr char kIssueReportSectionPaths[] = "Paths";
+constexpr char kIssueReportSectionPaths[] = "Local files";
 constexpr char kIssueReportSectionDiagnostics[] = "Diagnostics";
 constexpr char kIssueReportStatusSavedScreenshot[] =
     "Captured room screenshot to %s";
 constexpr char kIssueReportStatusSavedLog[] = "Saved issue report to %s";
-constexpr char kIssueReportStatusStartedLog[] = "Started issue report in %s";
 constexpr char kIssueReportStatusCopiedReport[] =
-    "Copied report to clipboard and saved issue report to %s";
+    "Copied report to clipboard. Nothing was submitted.";
 constexpr char kIssueReportStatusCopiedDiagnostics[] =
-    "Copied diagnostics and saved issue report to %s";
+    "Copied diagnostics to clipboard. Nothing was submitted.";
 constexpr char kIssueReportCaptureButtonLabel[] =
     ICON_MD_ADD_A_PHOTO " Capture Screenshot";
 constexpr char kIssueReportRecaptureButtonLabel[] =
@@ -170,20 +170,95 @@ struct ObjectTraceReport {
   std::vector<zelda3::ObjectDrawer::TileTrace> writes;
 };
 
+struct ScopedBitmapRetirement {
+  std::array<gfx::Bitmap*, 2> bitmaps;
+
+  ~ScopedBitmapRetirement() {
+    for (gfx::Bitmap* bitmap : bitmaps) {
+      if (bitmap != nullptr) {
+        gfx::Arena::Get().RetireBitmap(*bitmap);
+      }
+    }
+  }
+};
+
 ObjectTraceReport BuildObjectTraceReport(
-    Rom* rom, int room_id, const zelda3::RoomObject& obj,
+    Rom* rom, const zelda3::Room& room, size_t selected_index,
     const gfx::PaletteGroup& palette_group) {
   if (rom == nullptr || !rom->is_loaded()) {
     return {.summary = "\nDrawer trace: unavailable (ROM not loaded)"};
   }
 
-  zelda3::ObjectDrawer drawer(rom, room_id, /*room_gfx_buffer=*/nullptr);
+  const auto& objects = room.GetTileObjects();
+  if (selected_index >= objects.size()) {
+    return {.summary = "\nDrawer trace: unavailable (stale selection)"};
+  }
+  if (!zelda3::UsesRoomObjectStream(objects[selected_index])) {
+    return {.summary =
+                "\nDrawer trace: unavailable (special-table object uses the "
+                "dedicated room pass)"};
+  }
+
+  // The report must follow the same primary -> BG2 overlay -> BG1 overlay
+  // order as Room::RenderObjectsToBackground. Earlier object writes can own a
+  // physical tilemap entry and therefore override the matching layout word
+  // used by conditional edge/cap routines.
+  zelda3::ObjectDrawer drawer(rom, room.id(), room.get_gfx_buffer().data());
+  drawer.SetRoomFloorGraphics(room.floor1(), room.floor2());
+  drawer.SetAllowTrackCornerAliases(
+      zelda3::RoomAllowsTrackCornerAliases(objects));
+  drawer.SetBG1RevealMaskSource(gfx::BG1RevealMaskSource::kBG2Objects);
   gfx::BackgroundBuffer bg1(512, 512);
   gfx::BackgroundBuffer bg2(512, 512);
+  gfx::BackgroundBuffer layout_bg1(512, 512);
+  gfx::BackgroundBuffer layout_bg2(512, 512);
+  ScopedBitmapRetirement retire_trace_bitmaps{{&bg1.bitmap(), &bg2.bitmap()}};
+  for (auto* buffer : {&bg1, &bg2}) {
+    buffer->EnsureBitmapInitialized();
+    buffer->bitmap().Fill(255);
+    buffer->ClearBuffer();
+  }
+  layout_bg1.buffer() = room.bg1_buffer().buffer();
+  layout_bg2.buffer() = room.bg2_buffer().buffer();
+
   std::vector<zelda3::ObjectDrawer::TileTrace> trace;
-  drawer.SetTraceCollector(&trace, /*trace_only=*/true);
-  const auto status = drawer.DrawObject(obj, bg1, bg2, palette_group);
-  drawer.ClearTraceCollector();
+  absl::Status status = absl::NotFoundError("selected object not replayed");
+  bool selected_was_replayed = false;
+  for (uint8_t pass = 0; pass < 3 && !selected_was_replayed; ++pass) {
+    for (size_t index = 0; index < objects.size(); ++index) {
+      const auto& stored_obj = objects[index];
+      if (!zelda3::UsesRoomObjectStream(stored_obj)) {
+        continue;
+      }
+      const uint8_t list_index =
+          std::min<uint8_t>(stored_obj.GetLayerValue(), 2);
+      if (list_index != pass) {
+        continue;
+      }
+
+      zelda3::RoomObject render_obj = stored_obj;
+      render_obj.layer_ = zelda3::MapRoomObjectListIndexToDrawLayer(list_index);
+      if (index == selected_index) {
+        drawer.SetTraceCollector(&trace, /*trace_only=*/false);
+        status =
+            drawer.DrawObject(render_obj, bg1, bg2, palette_group,
+                              room.GetDungeonState(), &layout_bg1, &layout_bg2);
+        drawer.ClearTraceCollector();
+        selected_was_replayed = true;
+        break;
+      }
+
+      status =
+          drawer.DrawObject(render_obj, bg1, bg2, palette_group,
+                            room.GetDungeonState(), &layout_bg1, &layout_bg2);
+      if (!status.ok()) {
+        break;
+      }
+    }
+    if (!status.ok() && !selected_was_replayed) {
+      break;
+    }
+  }
   if (!status.ok()) {
     return {.summary = absl::StrFormat("\nDrawer trace: unavailable (%s)",
                                        std::string(status.message()).c_str())};
@@ -211,7 +286,8 @@ ObjectTraceReport BuildObjectTraceReport(
   }
 
   std::string out = absl::StrFormat(
-      "\nDrawer trace: status=ok writes=%zu unique_cells=%zu "
+      "\nDrawer trace: status=ok context=room-stream-prefix+layout-tilewords "
+      "writes=%zu unique_cells=%zu "
       "bounds_tiles=(%d,%d)..(%d,%d) layer_counts BG1=%d BG2=%d BG3=%d",
       trace.size(), unique_cells.size(), min_x, min_y, max_x, max_y,
       layer_counts[zelda3::RoomObject::LayerType::BG1],
@@ -444,11 +520,11 @@ std::string DungeonCanvasViewer::BuildRoomMetadataSummary(
 
   std::string summary = absl::StrFormat(
       "Room 0x%03X [%s] | B:%02X P:%02X->%02X L:%02X S:%02X | %s | Group:%s | "
-      "Floor:%d Effect:%d Tag1:%d Tag2:%d\n%s\n%s",
+      "Floor1:%d Floor2:%d Effect:%d Tag1:%d Tag2:%d\n%s\n%s",
       room_id, zelda3::GetRoomLabel(room_id).c_str(), room.blockset(),
       room.palette(), resolved_palette_id, room.layout_id(), room.spriteset(),
       entrance_context, GetBlocksetGroupName(room.blockset()), room.floor1(),
-      room.effect(), room.tag1(), room.tag2(),
+      room.floor2(), room.effect(), room.tag1(), room.tag2(),
       BuildReportSessionSummary(rom_, project_).c_str(),
       BuildEffectiveBlockListSummary(room).c_str());
 
@@ -506,7 +582,34 @@ std::string DungeonCanvasViewer::BuildDrawIssueReport(const zelda3::Room& room,
             BuildSelectedObjectSemanticsSummary(obj).c_str());
         if (auto tiles = obj.GetTiles(); tiles.ok()) {
           report += "\n";
-          report += FormatObjectTileSample(*tiles, 16, "Object tiles:");
+          report += FormatObjectTileSample(*tiles, 16, "Descriptor tiles:");
+        }
+        if (obj.id_ == 0x00C4 || obj.id_ == 0x00DB) {
+          const bool uses_floor1 = obj.id_ == 0x00C4;
+          const uint8_t floor_pattern =
+              uses_floor1 ? room.floor1() : room.floor2();
+          report += absl::StrFormat(
+              "\nFloor copy source: Floor %d (room.floor%d) pattern=%d",
+              uses_floor1 ? 1 : 2, uses_floor1 ? 1 : 2,
+              static_cast<int>(floor_pattern));
+          if (rom_ != nullptr && rom_->is_loaded()) {
+            const auto effective_tiles = gfx::DecodeDungeonFloorTilePattern(
+                rom_->vector(), zelda3::kRoomObjectTileAddress,
+                zelda3::kRoomObjectTileAddressFloor, floor_pattern);
+            if (effective_tiles.has_value()) {
+              report += "\n";
+              report += FormatObjectTileSample(*effective_tiles,
+                                               effective_tiles->size(),
+                                               "Effective floor-copy tiles:");
+            } else {
+              report +=
+                  "\nEffective floor-copy tiles: unavailable "
+                  "(ROM tables out of range)";
+            }
+          } else {
+            report +=
+                "\nEffective floor-copy tiles: unavailable (ROM not loaded)";
+          }
         }
 
         auto [bounds_x, bounds_y, bounds_w, bounds_h] =
@@ -523,7 +626,7 @@ std::string DungeonCanvasViewer::BuildDrawIssueReport(const zelda3::Room& room,
             bounds_x, bounds_y, bounds_w, bounds_h, origin_x, origin_y,
             center_x, center_y);
         const auto trace_report =
-            BuildObjectTraceReport(rom_, room_id, obj, current_palette_group_);
+            BuildObjectTraceReport(rom_, room, index, current_palette_group_);
         report += trace_report.summary;
 
         auto& palette_debugger = zelda3::PaletteDebugger::Get();
@@ -660,7 +763,7 @@ std::string DungeonCanvasViewer::BuildSelectionIssueReport(
         report += FormatObjectTileSample(*tiles, 10, "tiles:");
       }
       const auto trace_report =
-          BuildObjectTraceReport(rom_, room_id, obj, current_palette_group_);
+          BuildObjectTraceReport(rom_, room, index, current_palette_group_);
       report += "\n  ";
       report += BuildObjectTraceBoundsSummary(trace_report.writes, bounds_x,
                                               bounds_y, bounds_w, bounds_h);
@@ -759,7 +862,9 @@ void DungeonCanvasViewer::DrawIssueReportStorageSummary() const {
     return;
   }
 
-  gui::SeparatorText(kIssueReportSectionPaths);
+  if (!ImGui::CollapsingHeader(kIssueReportSectionPaths)) {
+    return;
+  }
   if (!issue_report_popup_log_target_path_.empty()) {
     ImGui::TextWrapped(tr("Log target: %s"),
                        issue_report_popup_log_target_path_.c_str());
@@ -809,17 +914,7 @@ absl::Status DungeonCanvasViewer::PrepareIssueReportPopup(
   std::snprintf(issue_report_summary_, sizeof(issue_report_summary_), "%s",
                 summary.c_str());
   issue_report_notes_[0] = '\0';
-  const auto initial_persist_status = EnsureIssueReportPersisted();
-  if (initial_persist_status.ok()) {
-    SetIssueReportPopupStatus(
-        absl::StrFormat(kIssueReportStatusStartedLog,
-                        issue_report_popup_last_log_path_.c_str()),
-        false);
-  } else {
-    SetIssueReportPopupStatus(std::string(initial_persist_status.message()),
-                              true);
-  }
-  return initial_persist_status;
+  return absl::OkStatus();
 }
 
 void DungeonCanvasViewer::OpenIssueReportPopup(const std::string& title,
@@ -840,6 +935,8 @@ void DungeonCanvasViewer::OpenIssueReportPopup(const std::string& title,
         }
         ImGui::Separator();
       }
+      ImGui::TextDisabled(
+          tr("Local capture only. Nothing is uploaded or submitted."));
 
       const char* category_preview =
           GetIssueCategoryLabel(issue_report_category_index_);
@@ -873,11 +970,8 @@ void DungeonCanvasViewer::OpenIssueReportPopup(const std::string& title,
 
       DrawIssueReportStorageSummary();
       DrawIssueReportStatusMessage();
-      ImGui::TextDisabled(
-          tr("Reports auto-save on open, screenshot capture, copy, or close."));
 
-      if (ImGui::CollapsingHeader(kIssueReportSectionDiagnostics,
-                                  ImGuiTreeNodeFlags_DefaultOpen)) {
+      if (ImGui::CollapsingHeader(kIssueReportSectionDiagnostics)) {
         ImGui::InputTextMultiline(
             kIssueReportPopupIdDiagnostics,
             issue_report_popup_diagnostics_.data(),
@@ -894,16 +988,10 @@ void DungeonCanvasViewer::OpenIssueReportPopup(const std::string& title,
         const auto status = CaptureIssueReportScreenshot();
         if (status.ok()) {
           MarkIssueReportDirty();
-          const auto persist_status = EnsureIssueReportPersisted();
-          if (persist_status.ok()) {
-            SetIssueReportPopupStatus(
-                absl::StrFormat(kIssueReportStatusSavedScreenshot,
-                                issue_report_popup_screenshot_path_.c_str()),
-                false);
-          } else {
-            SetIssueReportPopupStatus(std::string(persist_status.message()),
-                                      true);
-          }
+          SetIssueReportPopupStatus(
+              absl::StrFormat(kIssueReportStatusSavedScreenshot,
+                              issue_report_popup_screenshot_path_.c_str()),
+              false);
         } else {
           SetIssueReportPopupStatus(std::string(status.message()), true);
         }
@@ -925,46 +1013,20 @@ void DungeonCanvasViewer::OpenIssueReportPopup(const std::string& title,
       if (ImGui::Button(ICON_MD_CONTENT_COPY " Copy Report")) {
         std::string report = BuildIssueReportClipboardText();
         ImGui::SetClipboardText(report.c_str());
-        const auto status = EnsureIssueReportPersisted();
-        if (status.ok()) {
-          SetIssueReportPopupStatus(
-              absl::StrFormat(kIssueReportStatusCopiedReport,
-                              issue_report_popup_last_log_path_.c_str()),
-              false);
-        } else {
-          SetIssueReportPopupStatus(std::string(status.message()), true);
-        }
+        SetIssueReportPopupStatus(kIssueReportStatusCopiedReport, false);
       }
       ImGui::SameLine();
       if (ImGui::Button(ICON_MD_ASSIGNMENT " Copy Diagnostics")) {
         ImGui::SetClipboardText(issue_report_popup_diagnostics_.c_str());
-        const auto status = EnsureIssueReportPersisted();
-        if (status.ok()) {
-          SetIssueReportPopupStatus(
-              absl::StrFormat(kIssueReportStatusCopiedDiagnostics,
-                              issue_report_popup_last_log_path_.c_str()),
-              false);
-        } else {
-          SetIssueReportPopupStatus(std::string(status.message()), true);
-        }
+        SetIssueReportPopupStatus(kIssueReportStatusCopiedDiagnostics, false);
       }
       ImGui::SameLine();
       if (ImGui::Button(ICON_MD_CLOSE " Close")) {
-        const auto status = EnsureIssueReportPersisted();
-        if (!status.ok()) {
-          SetIssueReportPopupStatus(std::string(status.message()), true);
-          ImGui::EndPopup();
-          return;
-        }
         canvas_.ClosePersistentPopup(issue_report_popup_id_);
         ImGui::CloseCurrentPopup();
       }
       ImGui::EndPopup();
       return;
-    }
-
-    if (!issue_report_popup_persisted_) {
-      (void)EnsureIssueReportPersisted();
     }
   });
 }

--- a/src/app/editor/dungeon/dungeon_canvas_overlays.cc
+++ b/src/app/editor/dungeon/dungeon_canvas_overlays.cc
@@ -353,21 +353,14 @@ void DungeonCanvasViewer::HandleTouchLongPressContextMenu(
     }
 
     if (!ImGui::IsPopupOpen(kPopupId)) {
-      const auto& objects = room.GetTileObjects();
-      for (size_t idx = 0; idx < objects.size(); ++idx) {
-        const auto& obj = objects[idx];
-        const int obj_px = obj.x() * 8;
-        const int obj_py = obj.y() * 8;
-        auto [obj_w, obj_h] =
-            zelda3::DimensionService::Get().GetPixelDimensions(obj);
-        obj_w = std::max(obj_w, 8);
-        obj_h = std::max(obj_h, 8);
-        if (rel_x >= obj_px && rel_x < obj_px + obj_w && rel_y >= obj_py &&
-            rel_y < obj_py + obj_h) {
-          object_interaction_.SetSelectedObjects({idx});
-          ImGui::OpenPopup(kPopupId);
-          break;
-        }
+      const auto object_index =
+          object_interaction_.entity_coordinator()
+              .tile_handler()
+              .GetEntityAtPosition(static_cast<int>(rel_x),
+                                   static_cast<int>(rel_y));
+      if (object_index.has_value()) {
+        object_interaction_.SetSelectedObjects({*object_index});
+        ImGui::OpenPopup(kPopupId);
       }
     }
   }

--- a/src/app/editor/dungeon/dungeon_canvas_viewer.cc
+++ b/src/app/editor/dungeon/dungeon_canvas_viewer.cc
@@ -214,6 +214,11 @@ void DungeonCanvasViewer::DrawDungeonCanvas(int room_id) {
   PopulateCanvasContextMenu(room_id);
 
   auto canvas_rt = gui::BeginCanvas(canvas_, frame_opts);
+  const bool pointer_pressed = ImGui::IsMouseClicked(ImGuiMouseButton_Left) ||
+                               ImGui::IsMouseClicked(ImGuiMouseButton_Right) ||
+                               ImGui::IsMouseClicked(ImGuiMouseButton_Middle);
+  UpdateRoomCanvasShortcutFocus(canvas_rt.hovered, pointer_pressed,
+                                ImGui::GetFrameCount());
   SyncCanvasCaptureRegion(canvas_rt);
   ConsumePendingCanvasScroll(canvas_rt);
   canvas_rt.scrolling = canvas_.scrolling();
@@ -235,6 +240,21 @@ void DungeonCanvasViewer::DrawDungeonCanvas(int room_id) {
 
   gui::EndCanvas(canvas_, canvas_rt, frame_opts);
   SyncViewerStateFromCanvasConfig();
+}
+
+void DungeonCanvasViewer::UpdateRoomCanvasShortcutFocus(bool hovered,
+                                                        bool pointer_pressed,
+                                                        int frame_index) {
+  room_canvas_last_draw_frame_ = frame_index;
+  if (pointer_pressed) {
+    room_canvas_shortcut_focus_ = hovered;
+  }
+}
+
+bool DungeonCanvasViewer::HasRoomCanvasShortcutFocusForFrame(
+    int frame_index) const {
+  return object_interaction_enabled_ && room_canvas_shortcut_focus_ &&
+         room_canvas_last_draw_frame_ == frame_index;
 }
 
 void DungeonCanvasViewer::DrawChangePingOverlay(

--- a/src/app/editor/dungeon/dungeon_canvas_viewer.h
+++ b/src/app/editor/dungeon/dungeon_canvas_viewer.h
@@ -22,6 +22,7 @@
 #include "imgui/imgui.h"
 #include "rom/rom.h"
 #include "zelda3/dungeon/dungeon_editor_system.h"
+#include "zelda3/dungeon/object_layer_semantics.h"
 #include "zelda3/dungeon/room.h"
 #include "zelda3/dungeon/room_layer_manager.h"
 #include "zelda3/game_data.h"
@@ -217,16 +218,58 @@ class DungeonCanvasViewer {
         [this](int target_room, std::optional<size_t> target_door_index,
                int target_tile_x, int target_tile_y) {
           NavigateToRoom(target_room);
-          if (target_tile_x >= 0 && target_tile_y >= 0) {
+          bool focused_target_door = false;
+          if (target_door_index.has_value() && rooms_ != nullptr) {
+            auto* target = rooms_->TryEnsureRoom(target_room);
+            if (target != nullptr &&
+                *target_door_index < target->GetDoors().size()) {
+              const auto [x, y, width, height] =
+                  target->GetDoors()[*target_door_index].GetEditorBounds();
+              ScrollToTile((x + width / 2) / 8, (y + height / 2) / 8);
+              TriggerCanvasPingRect(x, y, width, height);
+              object_interaction_.SelectEntity(EntityType::Door,
+                                               *target_door_index);
+              focused_target_door = true;
+            }
+          }
+          if (!focused_target_door && target_tile_x >= 0 &&
+              target_tile_y >= 0) {
             ScrollToTile(target_tile_x, target_tile_y);
             TriggerCanvasPingRect(target_tile_x * 8, target_tile_y * 8, 24, 24);
-          } else {
+          } else if (!focused_target_door) {
             TriggerChangePing();
           }
-          if (target_door_index.has_value()) {
-            object_interaction_.SelectEntity(EntityType::Door,
-                                             *target_door_index);
+        });
+    object_interaction_.SetObjectSelectionVisibilityPredicate(
+        [this](int room_id, const zelda3::RoomObject& object) {
+          bool allow_track_corner_aliases = true;
+          if (zelda3::IsTrackCornerAliasObjectId(object.id_)) {
+            allow_track_corner_aliases = false;
+            if (rooms_ != nullptr) {
+              if (const auto* room = rooms_->GetIfMaterialized(room_id)) {
+                allow_track_corner_aliases =
+                    zelda3::RoomAllowsTrackCornerAliases(
+                        room->GetTileObjects());
+              }
+            }
           }
+          const auto semantics = zelda3::GetEffectiveObjectLayerSemantics(
+              object, allow_track_corner_aliases);
+          auto is_visible = [this, room_id](zelda3::LayerType layer) {
+            return IsLayerVisible(room_id, layer) &&
+                   GetLayerBlendMode(room_id, layer) !=
+                       zelda3::LayerBlendMode::Off;
+          };
+          switch (semantics.effective_bg_layer) {
+            case zelda3::EffectiveBgLayer::kBg1:
+              return is_visible(zelda3::LayerType::BG1_Objects);
+            case zelda3::EffectiveBgLayer::kBg2:
+              return is_visible(zelda3::LayerType::BG2_Objects);
+            case zelda3::EffectiveBgLayer::kBothBg1Bg2:
+              return is_visible(zelda3::LayerType::BG1_Objects) ||
+                     is_visible(zelda3::LayerType::BG2_Objects);
+          }
+          return true;
         });
   }
 
@@ -678,6 +721,10 @@ class DungeonCanvasViewer {
 
   // Object manipulation
   void DeleteSelectedObjects() { object_interaction_.HandleDeleteSelected(); }
+  bool CanHandleRoomCanvasShortcut() const {
+    return ImGui::GetCurrentContext() != nullptr &&
+           HasRoomCanvasShortcutFocusForFrame(ImGui::GetFrameCount());
+  }
 
   // Entity visibility controls
   void SetSpritesVisible(bool visible) {
@@ -828,6 +875,9 @@ class DungeonCanvasViewer {
   void DrawChangePingOverlay(const gui::CanvasRuntime& canvas_rt,
                              const zelda3::Room& room);
   void RecordVisitedRoom(int room_id);
+  void UpdateRoomCanvasShortcutFocus(bool hovered, bool pointer_pressed,
+                                     int frame_index);
+  bool HasRoomCanvasShortcutFocusForFrame(int frame_index) const;
 
   // Room graphics management
   // Load: Read from ROM, Render: Process pixels, Draw: Display on canvas
@@ -883,6 +933,8 @@ class DungeonCanvasViewer {
 
   // Object interaction state
   bool object_interaction_enabled_ = true;
+  bool room_canvas_shortcut_focus_ = false;
+  int room_canvas_last_draw_frame_ = -1;
 
   // Per-room layer managers (4-way visibility, blend modes, per-object translucency)
   std::map<int, zelda3::RoomLayerManager> room_layer_managers_;

--- a/src/app/editor/dungeon/dungeon_canvas_viewer.h
+++ b/src/app/editor/dungeon/dungeon_canvas_viewer.h
@@ -799,7 +799,10 @@ class DungeonCanvasViewer {
   void AddInteractionContextMenuItems(int room_id);
   void AddLoadedRoomContextMenuItems(int room_id);
   gui::CanvasMenuItem BuildInsertContextMenu();
+  gui::CanvasMenuItem BuildSelectionContextMenu(int room_id);
   std::vector<gui::CanvasMenuItem> BuildSelectionContextMenuItems(int room_id);
+  std::vector<gui::CanvasMenuItem> BuildSelectionContextMenuItems(
+      int room_id, std::optional<zelda3::RoomObject> context_object);
   std::optional<zelda3::RoomObject> GetObjectUnderContextCursor(int room_id);
   gui::CanvasMenuItem BuildRoomContextMenu(int room_id);
   gui::CanvasMenuItem BuildReportContextMenu(int room_id);

--- a/src/app/editor/dungeon/dungeon_editor_v2.cc
+++ b/src/app/editor/dungeon/dungeon_editor_v2.cc
@@ -674,6 +674,10 @@ void DungeonEditorV2::Initialize() {
         },
         [this](bool enabled) { QueueWorkbenchWorkflowMode(enabled); }, rom_);
     workbench_panel_ = workbench.get();
+    workbench_panel_->SetPrimaryCanvasDrawnCallback(
+        [this](DungeonCanvasViewer& viewer) {
+          ConsumeRoomCanvasDeleteShortcut(viewer);
+        });
     workbench_panel_->SetUndoRedoProvider(
         [this]() { return undo_manager_.CanUndo(); },
         [this]() { return undo_manager_.CanRedo(); },
@@ -1161,6 +1165,7 @@ void DungeonEditorV2::InvalidateDungeonPaletteUsers(
 
 absl::Status DungeonEditorV2::Update() {
   ProcessPendingWorkflowMode();
+  ExpireStaleRoomCanvasDeleteShortcut();
 
   // Mirror the workbench inspector to the LEFT when user_settings says so.
   // Persisted across sessions via UserSettings::dungeon_inspector_side.
@@ -1193,13 +1198,6 @@ absl::Status DungeonEditorV2::Update() {
 
   // Keyboard Shortcuts (only if not typing in a text field)
   if (!ImGui::GetIO().WantTextInput) {
-    if (ImGui::IsKeyPressed(ImGuiKey_Delete)) {
-      // Delegate delete to current room viewer.
-      if (auto* viewer = GetViewerForRoom(current_room_id_)) {
-        viewer->DeleteSelectedObjects();
-      }
-    }
-
     if (ImGui::GetIO().KeyCtrl && ImGui::GetIO().KeyShift &&
         ImGui::IsKeyPressed(ImGuiKey_W, false)) {
       ToggleWorkbenchWorkflowMode();
@@ -1676,6 +1674,7 @@ void DungeonEditorV2::DrawRoomTab(int room_id) {
     if (ImGui::BeginChild("##StandaloneRoomBody",
                           ImVec2(0.0f, -status_bar_reserved), false)) {
       viewer->DrawDungeonCanvas(room_id);
+      ConsumeRoomCanvasDeleteShortcut(*viewer);
     }
     ImGui::EndChild();
 
@@ -1699,6 +1698,38 @@ void DungeonEditorV2::DrawRoomTab(int room_id) {
     };
     DungeonStatusBar::Draw(status);
   }
+}
+
+void DungeonEditorV2::QueueRoomCanvasDeleteShortcut() {
+  if (ImGui::GetCurrentContext() == nullptr) {
+    room_canvas_delete_shortcut_frame_.reset();
+    return;
+  }
+  room_canvas_delete_shortcut_frame_ = ImGui::GetFrameCount();
+}
+
+void DungeonEditorV2::ExpireStaleRoomCanvasDeleteShortcut() {
+  if (!room_canvas_delete_shortcut_frame_.has_value()) {
+    return;
+  }
+  if (ImGui::GetCurrentContext() == nullptr ||
+      *room_canvas_delete_shortcut_frame_ != ImGui::GetFrameCount()) {
+    room_canvas_delete_shortcut_frame_.reset();
+  }
+}
+
+bool DungeonEditorV2::ConsumeRoomCanvasDeleteShortcut(
+    DungeonCanvasViewer& viewer) {
+  ExpireStaleRoomCanvasDeleteShortcut();
+  if (!room_canvas_delete_shortcut_frame_.has_value() ||
+      ImGui::GetIO().WantTextInput || ImGui::IsAnyItemActive() ||
+      !viewer.CanHandleRoomCanvasShortcut()) {
+    return false;
+  }
+
+  room_canvas_delete_shortcut_frame_.reset();
+  viewer.DeleteSelectedObjects();
+  return true;
 }
 
 void DungeonEditorV2::OnRoomSelected(int room_id, RoomSelectionIntent intent) {

--- a/src/app/editor/dungeon/dungeon_editor_v2.h
+++ b/src/app/editor/dungeon/dungeon_editor_v2.h
@@ -48,6 +48,7 @@ class DungeonEditorV2MinecartTrackTestPeer;
 class DungeonEditorV2ObjectTileEditorTestPeer;
 class DungeonEditorV2RegularEntranceTestPeer;
 class DungeonEditorV2ReloadTestPeer;
+class DungeonEditorV2ShortcutTestPeer;
 class DungeonEditorV2SpawnPointTestPeer;
 class DungeonEditorV2SpawnRejectionTestPeer;
 class MinecartTrackEditorPanel;
@@ -218,6 +219,11 @@ class DungeonEditorV2 : public Editor {
   void ToggleWorkbenchWorkflowMode(bool show_toast = true);
   bool IsWorkbenchWorkflowEnabled() const;
 
+  // ShortcutManager runs before this editor draws. Queue destructive keyboard
+  // actions so the room canvas can establish ownership for the current frame
+  // before the action is evaluated.
+  void QueueRoomCanvasDeleteShortcut();
+
   // Panel card IDs for programmatic access
   static constexpr const char* kRoomSelectorId = "dungeon.room_selector";
   static constexpr const char* kEntranceListId = "dungeon.entrance_list";
@@ -260,6 +266,7 @@ class DungeonEditorV2 : public Editor {
   friend class DungeonEditorV2ObjectTileEditorTestPeer;
   friend class DungeonEditorV2RegularEntranceTestPeer;
   friend class DungeonEditorV2ReloadTestPeer;
+  friend class DungeonEditorV2ShortcutTestPeer;
   friend class DungeonEditorV2SpawnPointTestPeer;
   friend class DungeonEditorV2SpawnRejectionTestPeer;
   friend class DungeonEditorV2RomSafetyTest_UndoSnapshotLeakDetection_Test;
@@ -331,6 +338,8 @@ class DungeonEditorV2 : public Editor {
   DungeonCanvasViewer* GetWorkbenchCompareViewer(int room_id);
   void RefreshWorkbenchViewerRuntimeContext(DungeonCanvasViewer* viewer,
                                             int room_id);
+  bool ConsumeRoomCanvasDeleteShortcut(DungeonCanvasViewer& viewer);
+  void ExpireStaleRoomCanvasDeleteShortcut();
   void TouchViewerLru(int room_id);
   void RemoveViewerFromLru(int room_id);
 
@@ -355,6 +364,8 @@ class DungeonEditorV2 : public Editor {
     bool has_palette_transaction = false;
   };
   std::optional<SaveTransactionSnapshot> save_transaction_snapshot_;
+
+  std::optional<int> room_canvas_delete_shortcut_frame_;
 
   // Current selection state
   int current_entrance_id_ = 0;

--- a/src/app/editor/dungeon/dungeon_object_interaction.h
+++ b/src/app/editor/dungeon/dungeon_object_interaction.h
@@ -221,6 +221,11 @@ class DungeonObjectInteraction {
   void SetSelectionChangeCallback(std::function<void()> callback) {
     selection_.SetSelectionChangedCallback(std::move(callback));
   }
+  void SetObjectSelectionVisibilityPredicate(
+      std::function<bool(int, const zelda3::RoomObject&)> predicate) {
+    interaction_context_.is_object_visible_for_selection = std::move(predicate);
+    entity_coordinator_.SetContext(&interaction_context_);
+  }
 
   // Helper for click selection with proper mode handling
 

--- a/src/app/editor/dungeon/dungeon_object_selector.cc
+++ b/src/app/editor/dungeon/dungeon_object_selector.cc
@@ -17,6 +17,7 @@
 
 // Project headers
 #include "app/editor/dungeon/ui/window/object_tile_editor_panel.h"
+#include "app/gfx/resource/arena.h"
 #include "app/gui/core/agent_theme.h"
 #include "app/gui/core/drag_drop.h"
 #include "app/gui/core/icons.h"
@@ -107,6 +108,10 @@ void DrawFallbackPreviewTile(ImDrawList* draw_list, ImVec2 top_left,
 }
 
 }  // namespace
+
+DungeonObjectSelector::~DungeonObjectSelector() {
+  RetirePreviewCache();
+}
 
 bool DungeonObjectSelector::IsRepresentableChestObjectId(int object_id) {
   return object_id == 0xF99 || object_id == 0xF9A || object_id == 0xFB1 ||
@@ -524,15 +529,17 @@ void DungeonObjectSelector::DrawObjectAssetBrowser() {
 
             const uint8_t preview_size =
                 zelda3::DefaultRoomObjectSizeForPlacement(obj_id);
-            uint32_t layout_key = (static_cast<uint32_t>(obj_id) << 16) |
-                                  static_cast<uint32_t>(preview_size);
             const bool can_capture_layout =
                 rom_ && rooms_ && current_room_id_ >= 0 &&
                 current_room_id_ < zelda3::kNumberOfRooms;
+            const zelda3::Room* layout_room =
+                can_capture_layout ? &(*rooms_)[current_room_id_] : nullptr;
+            const uint32_t layout_key =
+                MakeLayoutCacheKey(obj_id, preview_size, layout_room);
             if (can_capture_layout &&
                 layout_cache_.find(layout_key) == layout_cache_.end()) {
               zelda3::ObjectTileEditor editor(rom_);
-              auto& room_ref = (*rooms_)[current_room_id_];
+              auto& room_ref = *layout_room;
               auto layout_or = editor.CaptureObjectLayout(
                   obj_id, room_ref, current_palette_group_, preview_size);
               if (layout_or.ok()) {
@@ -692,14 +699,65 @@ zelda3::RoomObject DungeonObjectSelector::MakePreviewObject(int obj_id) const {
 }
 
 void DungeonObjectSelector::InvalidatePreviewCache() {
-  preview_cache_.clear();
+  RetirePreviewCache();
   layout_cache_.clear();
   ++preview_cache_invalidations_;
+}
+
+void DungeonObjectSelector::RetirePreviewCache() {
+  auto& arena = gfx::Arena::Get();
+  for (auto& [key, preview] : preview_cache_) {
+    (void)key;
+    if (preview != nullptr) {
+      arena.RetireBitmap(preview->bitmap());
+    }
+  }
+  preview_cache_.clear();
+}
+
+void DungeonObjectSelector::SynchronizePreviewCacheRoomContext(
+    const zelda3::Room& room) {
+  if (current_room_id_ == cached_preview_room_id_ &&
+      room.blockset() == cached_preview_blockset_ &&
+      room.render_entrance_blockset() == cached_preview_entrance_blockset_ &&
+      room.palette() == cached_preview_palette_ &&
+      room.floor1() == cached_preview_floor1_ &&
+      room.floor2() == cached_preview_floor2_) {
+    return;
+  }
+
+  InvalidatePreviewCache();
+  cached_preview_room_id_ = current_room_id_;
+  cached_preview_blockset_ = room.blockset();
+  cached_preview_entrance_blockset_ = room.render_entrance_blockset();
+  cached_preview_palette_ = room.palette();
+  cached_preview_floor1_ = room.floor1();
+  cached_preview_floor2_ = room.floor2();
+}
+
+uint32_t DungeonObjectSelector::MakeLayoutCacheKey(int object_id,
+                                                   uint8_t preview_size,
+                                                   const zelda3::Room* room) {
+  uint8_t room_floor = 0;
+  if (room != nullptr) {
+    if (object_id == 0xC4) {
+      room_floor = room->floor1() & 0x0F;
+    } else if (object_id == 0xDB) {
+      room_floor = room->floor2() & 0x0F;
+    }
+  }
+
+  return (static_cast<uint32_t>(object_id) << 16) |
+         (static_cast<uint32_t>(preview_size) << 8) | room_floor;
 }
 
 bool DungeonObjectSelector::GetOrCreatePreview(const zelda3::RoomObject& object,
                                                float size,
                                                gfx::BackgroundBuffer** out) {
+  if (out == nullptr) {
+    return false;
+  }
+  *out = nullptr;
   if (!rom_ || !rom_->is_loaded()) {
     return false;
   }
@@ -712,28 +770,24 @@ bool DungeonObjectSelector::GetOrCreatePreview(const zelda3::RoomObject& object,
       return false;  // Can't render without loaded room
     }
 
-    // Invalidate cache if room/palette/blockset changed
-    if (current_room_id_ != cached_preview_room_id_ ||
-        room.blockset() != cached_preview_blockset_ ||
-        room.palette() != cached_preview_palette_) {
-      InvalidatePreviewCache();
-      cached_preview_room_id_ = current_room_id_;
-      cached_preview_blockset_ = room.blockset();
-      cached_preview_palette_ = room.palette();
-    }
+    SynchronizePreviewCacheRoomContext(room);
   } else {
     return false;
   }
 
   // Check if already in cache
-  // Key: (object_id << 32) | (subtype << 16) | (blockset << 8) | palette
+  // Key: object, subtype, blockset, palette, and both room floor nibbles.
+  // Room/entrance changes clear the complete cache before this lookup.
   const uint8_t preview_size =
       zelda3::CanonicalRoomObjectSize(object.id_, object.size());
   int subtype = preview_size & 0x1F;
-  uint64_t cache_key = (static_cast<uint64_t>(object.id_) << 32) |
-                       (static_cast<uint64_t>(subtype) << 16) |
-                       (static_cast<uint64_t>(cached_preview_blockset_) << 8) |
-                       static_cast<uint64_t>(cached_preview_palette_);
+  uint64_t cache_key =
+      (static_cast<uint64_t>(object.id_) << 32) |
+      (static_cast<uint64_t>(subtype) << 24) |
+      (static_cast<uint64_t>(cached_preview_blockset_) << 16) |
+      (static_cast<uint64_t>(cached_preview_palette_) << 8) |
+      (static_cast<uint64_t>(cached_preview_floor1_ & 0x0F) << 4) |
+      static_cast<uint64_t>(cached_preview_floor2_ & 0x0F);
 
   auto it = preview_cache_.find(cache_key);
   if (it != preview_cache_.end()) {
@@ -763,32 +817,44 @@ bool DungeonObjectSelector::GetOrCreatePreview(const zelda3::RoomObject& object,
   auto render_status = editor.RenderLayoutToBitmap(
       layout, preview->bitmap(), gfx_data, current_palette_group_);
   if (!render_status.ok()) {
+    gfx::Arena::Get().RetireBitmap(preview->bitmap());
     return false;
   }
 
   auto& bitmap = preview->bitmap();
   // Texture creation and SDL sync
-  if (bitmap.surface()) {
-    // Sync to surface
-    SDL_LockSurface(bitmap.surface());
-    memcpy(bitmap.surface()->pixels, bitmap.mutable_data().data(),
-           bitmap.mutable_data().size());
-    SDL_UnlockSurface(bitmap.surface());
-
-    // Create texture
-    gfx::Arena::Get().QueueTextureCommand(
-        gfx::Arena::TextureCommandType::CREATE, &bitmap);
-    gfx::Arena::Get().ProcessTextureQueue(nullptr);
-  }
-
-  if (!bitmap.texture()) {
+  if (!bitmap.surface()) {
+    gfx::Arena::Get().RetireBitmap(bitmap);
     return false;
   }
+  SDL_LockSurface(bitmap.surface());
+  memcpy(bitmap.surface()->pixels, bitmap.mutable_data().data(),
+         bitmap.mutable_data().size());
+  SDL_UnlockSurface(bitmap.surface());
 
-  // Store in cache and return
-  *out = preview.get();
-  preview_cache_[cache_key] = std::move(preview);
-  return true;
+  // Install the owner before queuing CREATE. The renderer may defer this
+  // command until DoRender, so the Bitmap address must remain valid even when
+  // this frame falls back to the symbolic preview.
+  auto [cache_it, inserted] =
+      preview_cache_.try_emplace(cache_key, std::move(preview));
+  if (!inserted) {
+    if (preview != nullptr) {
+      gfx::Arena::Get().RetireBitmap(preview->bitmap());
+    }
+    *out = cache_it->second.get();
+    return (*out)->bitmap().texture() != nullptr;
+  }
+
+  *out = cache_it->second.get();
+  auto& cached_bitmap = (*out)->bitmap();
+  gfx::Arena::Get().QueueTextureCommand(gfx::Arena::TextureCommandType::CREATE,
+                                        &cached_bitmap);
+  gfx::Arena::Get().ProcessTextureQueue(nullptr);
+
+  // A null texture is an expected deferred state when the Arena has no active
+  // renderer yet. Keep the cache entry and its queued owner alive; the next
+  // frame will draw it after DoRender processes CREATE.
+  return cached_bitmap.texture() != nullptr;
 }
 
 bool DungeonObjectSelector::DrawObjectPreview(const zelda3::RoomObject& object,

--- a/src/app/editor/dungeon/dungeon_object_selector.h
+++ b/src/app/editor/dungeon/dungeon_object_selector.h
@@ -36,6 +36,7 @@ struct DungeonObjectSelectorTestAccess;
 class DungeonObjectSelector {
  public:
   explicit DungeonObjectSelector(Rom* rom = nullptr) : rom_(rom) {}
+  ~DungeonObjectSelector();
 
   // Unified context setter (preferred)
   void SetContext(EditorContext ctx) {
@@ -60,8 +61,8 @@ class DungeonObjectSelector {
     current_palette_group_id_ = id;
   }
   // Replace the active palette group used by preview rendering. The preview
-  // cache is keyed on (object_id, subtype, room.blockset(), room.palette()),
-  // none of which capture the *contents* of the palette group: switching
+  // cache is keyed on object identity plus room blockset, palette, and floor
+  // graphics, none of which capture the *contents* of the palette group: switching
   // dungeons between two palette banks that happen to use the same numeric
   // slot value will keep cache hits valid by key but stale by color. Since
   // the cache rebuilds in well under a frame, we conservatively invalidate
@@ -195,12 +196,15 @@ class DungeonObjectSelector {
   // Performance: enable/disable graphical preview rendering
   bool enable_object_previews_ = true;
 
-  // Preview cache for object selector grid
-  // Key: object_id (or object_id+subtype for custom objects)
+  // Preview cache for object selector grid, keyed by object/subtype and the
+  // room graphics context that can change its rendered tiles.
   // Value: BackgroundBuffer with rendered preview
   std::map<uint64_t, std::unique_ptr<gfx::BackgroundBuffer>> preview_cache_;
   uint8_t cached_preview_blockset_ = 0xFF;
+  uint8_t cached_preview_entrance_blockset_ = 0xFF;
   uint8_t cached_preview_palette_ = 0xFF;
+  uint8_t cached_preview_floor1_ = 0xFF;
+  uint8_t cached_preview_floor2_ = 0xFF;
   int cached_preview_room_id_ = -1;
 
   std::map<uint32_t, zelda3::ObjectTileLayout> layout_cache_;
@@ -209,6 +213,10 @@ class DungeonObjectSelector {
   // cache invalidation contract without poking at the cache directly.
   std::size_t preview_cache_invalidations_ = 0;
 
+  void RetirePreviewCache();
+  void SynchronizePreviewCacheRoomContext(const zelda3::Room& room);
+  static uint32_t MakeLayoutCacheKey(int object_id, uint8_t preview_size,
+                                     const zelda3::Room* room);
   bool GetOrCreatePreview(const zelda3::RoomObject& object, float size,
                           gfx::BackgroundBuffer** out);
 };

--- a/src/app/editor/dungeon/inspectors/door_editor_content.cc
+++ b/src/app/editor/dungeon/inspectors/door_editor_content.cc
@@ -2,7 +2,6 @@
 #include "util/i18n/tr.h"
 
 #include <algorithm>
-#include <array>
 #include <string>
 
 #include "absl/strings/str_format.h"
@@ -28,32 +27,44 @@ ImVec4 DoorTypeAccent(const AgentUITheme& theme, zelda3::DoorType type) {
   return theme.status_success;
 }
 
-// Semantic icon prefix used by both the 20-type placement picker and the
-// "Selected Door" swap combo. Keeps the 20 core types scannable by category.
+// Semantic icon prefix used by both the placement picker and the "Selected
+// Door" swap combo. Keeps supported types scannable by category.
 const char* DoorTypeIcon(zelda3::DoorType type) {
   switch (type) {
     case zelda3::DoorType::NormalDoor:
     case zelda3::DoorType::NormalDoorLower:
+    case zelda3::DoorType::NormalDoorOneSidedShutter:
+    case zelda3::DoorType::ExplicitRoomDoor:
       return ICON_MD_DOOR_FRONT;
+    case zelda3::DoorType::ExitLower:
     case zelda3::DoorType::CaveExit:
     case zelda3::DoorType::FancyDungeonExit:
+    case zelda3::DoorType::FancyDungeonExitLower:
+    case zelda3::DoorType::LitCaveExitLower:
       return ICON_MD_EXIT_TO_APP;
     case zelda3::DoorType::DoubleSidedShutter:
+    case zelda3::DoorType::DoubleSidedShutterLower:
     case zelda3::DoorType::BottomSidedShutter:
+    case zelda3::DoorType::BottomShutterLower:
     case zelda3::DoorType::TopSidedShutter:
+    case zelda3::DoorType::TopShutterLower:
     case zelda3::DoorType::CurtainDoor:
       return ICON_MD_VIEW_DAY;
     case zelda3::DoorType::EyeWatchDoor:
       return ICON_MD_VISIBILITY;
     case zelda3::DoorType::SmallKeyDoor:
     case zelda3::DoorType::BigKeyDoor:
+    case zelda3::DoorType::UnopenableBigKeyDoor:
       return ICON_MD_KEY;
     case zelda3::DoorType::SmallKeyStairsUp:
     case zelda3::DoorType::SmallKeyStairsDown:
+    case zelda3::DoorType::SmallKeyStairsUpLower:
+    case zelda3::DoorType::SmallKeyStairsDownLower:
       return ICON_MD_STAIRS;
     case zelda3::DoorType::DashWall:
       return ICON_MD_BOLT;
     case zelda3::DoorType::BombableDoor:
+    case zelda3::DoorType::BombableCaveExit:
     case zelda3::DoorType::ExplodingWall:
       return ICON_MD_WHATSHOT;
     case zelda3::DoorType::WaterfallDoor:
@@ -74,6 +85,8 @@ std::string ShortDoorTypeLabel(zelda3::DoorType type) {
       return "Normal";
     case zelda3::DoorType::NormalDoorLower:
       return "Lower";
+    case zelda3::DoorType::ExitLower:
+      return "Exit Low";
     case zelda3::DoorType::CaveExit:
       return "Cave";
     case zelda3::DoorType::DoubleSidedShutter:
@@ -88,10 +101,18 @@ std::string ShortDoorTypeLabel(zelda3::DoorType type) {
       return "Up";
     case zelda3::DoorType::SmallKeyStairsDown:
       return "Down";
+    case zelda3::DoorType::SmallKeyStairsUpLower:
+      return "Up Low";
+    case zelda3::DoorType::SmallKeyStairsDownLower:
+      return "Down Low";
     case zelda3::DoorType::DashWall:
       return "Dash";
     case zelda3::DoorType::BombableDoor:
       return "Bomb";
+    case zelda3::DoorType::BombableCaveExit:
+      return "Bomb Exit";
+    case zelda3::DoorType::UnopenableBigKeyDoor:
+      return "B-Key Lock";
     case zelda3::DoorType::ExplodingWall:
       return "Blast";
     case zelda3::DoorType::CurtainDoor:
@@ -102,6 +123,10 @@ std::string ShortDoorTypeLabel(zelda3::DoorType type) {
       return "Top";
     case zelda3::DoorType::FancyDungeonExit:
       return "Exit";
+    case zelda3::DoorType::FancyDungeonExitLower:
+      return "Exit Low";
+    case zelda3::DoorType::LitCaveExitLower:
+      return "Lit Low";
     case zelda3::DoorType::WaterfallDoor:
       return "Water";
     case zelda3::DoorType::ExitMarker:
@@ -110,6 +135,16 @@ std::string ShortDoorTypeLabel(zelda3::DoorType type) {
       return "Layer";
     case zelda3::DoorType::DungeonSwapMarker:
       return "Swap";
+    case zelda3::DoorType::NormalDoorOneSidedShutter:
+      return "1-Side";
+    case zelda3::DoorType::DoubleSidedShutterLower:
+      return "2-Side L";
+    case zelda3::DoorType::ExplicitRoomDoor:
+      return "Explicit";
+    case zelda3::DoorType::BottomShutterLower:
+      return "Bottom L";
+    case zelda3::DoorType::TopShutterLower:
+      return "Top L";
   }
   return "Door";
 }
@@ -141,28 +176,7 @@ void DoorEditorContent::Draw(bool* p_open) {
   gui::AutoWidgetScope automation_scope("Dungeon/DoorEditor");
 
   const auto& theme = AgentUI::GetTheme();
-  static constexpr std::array<zelda3::DoorType, 20> kDoorTypes = {{
-      zelda3::DoorType::NormalDoor,
-      zelda3::DoorType::NormalDoorLower,
-      zelda3::DoorType::CaveExit,
-      zelda3::DoorType::DoubleSidedShutter,
-      zelda3::DoorType::EyeWatchDoor,
-      zelda3::DoorType::SmallKeyDoor,
-      zelda3::DoorType::BigKeyDoor,
-      zelda3::DoorType::SmallKeyStairsUp,
-      zelda3::DoorType::SmallKeyStairsDown,
-      zelda3::DoorType::DashWall,
-      zelda3::DoorType::BombableDoor,
-      zelda3::DoorType::ExplodingWall,
-      zelda3::DoorType::CurtainDoor,
-      zelda3::DoorType::BottomSidedShutter,
-      zelda3::DoorType::TopSidedShutter,
-      zelda3::DoorType::FancyDungeonExit,
-      zelda3::DoorType::WaterfallDoor,
-      zelda3::DoorType::ExitMarker,
-      zelda3::DoorType::LayerSwapMarker,
-      zelda3::DoorType::DungeonSwapMarker,
-  }};
+  static constexpr auto kDoorTypes = zelda3::GetPlaceableDoorTypes();
 
   if (ResolveCanvasViewer() &&
       canvas_viewer_->object_interaction().HasEntitySelection() &&

--- a/src/app/editor/dungeon/inspectors/object_editor_content.cc
+++ b/src/app/editor/dungeon/inspectors/object_editor_content.cc
@@ -65,18 +65,7 @@ const char* GetStoredPlacementLabel(const zelda3::RoomObject& object) {
   }
 }
 
-constexpr std::array<zelda3::DoorType, 20> kInspectorDoorTypes = {{
-    zelda3::DoorType::NormalDoor,         zelda3::DoorType::NormalDoorLower,
-    zelda3::DoorType::CaveExit,           zelda3::DoorType::DoubleSidedShutter,
-    zelda3::DoorType::EyeWatchDoor,       zelda3::DoorType::SmallKeyDoor,
-    zelda3::DoorType::BigKeyDoor,         zelda3::DoorType::SmallKeyStairsUp,
-    zelda3::DoorType::SmallKeyStairsDown, zelda3::DoorType::DashWall,
-    zelda3::DoorType::BombableDoor,       zelda3::DoorType::ExplodingWall,
-    zelda3::DoorType::CurtainDoor,        zelda3::DoorType::BottomSidedShutter,
-    zelda3::DoorType::TopSidedShutter,    zelda3::DoorType::FancyDungeonExit,
-    zelda3::DoorType::WaterfallDoor,      zelda3::DoorType::ExitMarker,
-    zelda3::DoorType::LayerSwapMarker,    zelda3::DoorType::DungeonSwapMarker,
-}};
+constexpr auto kInspectorDoorTypes = zelda3::GetPlaceableDoorTypes();
 
 bool MutateSelectedSprite(DungeonCanvasViewer* viewer,
                           std::function<void(zelda3::Sprite&)> mutator) {
@@ -535,13 +524,14 @@ void ObjectEditorContent::DrawSelectedDoorInfo() {
   const int neighbor_id =
       NeighborRoomId(viewer->current_room_id(), door.direction);
   std::optional<size_t> reciprocal_index;
-  if (neighbor_id >= 0 &&
+  if (zelda3::IsRoomConnectionDoorType(door.type) && neighbor_id >= 0 &&
       neighbor_id < static_cast<int>(viewer->rooms()->size())) {
     const auto opposite = OppositeDir(door.direction);
     const auto& neighbor_doors = (*viewer->rooms())[neighbor_id].GetDoors();
     for (size_t i = 0; i < neighbor_doors.size(); ++i) {
       const auto& neighbor_door = neighbor_doors[i];
-      if (neighbor_door.direction == opposite &&
+      if (zelda3::IsRoomConnectionDoorType(neighbor_door.type) &&
+          neighbor_door.direction == opposite &&
           neighbor_door.position == door.position) {
         reciprocal_index = i;
         break;
@@ -549,7 +539,8 @@ void ObjectEditorContent::DrawSelectedDoorInfo() {
     }
     if (!reciprocal_index) {
       for (size_t i = 0; i < neighbor_doors.size(); ++i) {
-        if (neighbor_doors[i].direction == opposite) {
+        if (zelda3::IsRoomConnectionDoorType(neighbor_doors[i].type) &&
+            neighbor_doors[i].direction == opposite) {
           reciprocal_index = i;
           break;
         }
@@ -799,7 +790,9 @@ void ObjectEditorContent::HandleKeyboardShortcuts() {
     DeselectAllObjects();
   }
   if (ImGui::IsKeyPressed(ImGuiKey_Delete)) {
-    if (selection_snapshot_.HasSelection()) {
+    auto* viewer = ResolveCanvasViewer();
+    if (selection_snapshot_.HasSelection() && viewer != nullptr &&
+        !ImGui::IsAnyItemActive() && viewer->CanHandleRoomCanvasShortcut()) {
       DeleteCurrentSelection();
     }
   }

--- a/src/app/editor/dungeon/interaction/door_interaction_handler.cc
+++ b/src/app/editor/dungeon/interaction/door_interaction_handler.cc
@@ -58,11 +58,21 @@ bool DoorInteractionHandler::HandleClick(int canvas_x, int canvas_y) {
   // Try to select door at position
   auto door_index = GetEntityAtPosition(canvas_x, canvas_y);
   if (door_index.has_value()) {
+    const auto* room = ctx_->GetCurrentRoomConst();
+    if (!room || *door_index >= room->GetDoors().size()) {
+      return false;
+    }
+    const auto [anchor_x, anchor_y] =
+        room->GetDoors()[*door_index].GetPixelCoords();
+
     SelectDoor(*door_index);
     is_dragging_ = true;
     drag_start_pos_ =
         ImVec2(static_cast<float>(canvas_x), static_cast<float>(canvas_y));
     drag_current_pos_ = drag_start_pos_;
+    drag_grab_offset_from_anchor_ =
+        ImVec2(static_cast<float>(canvas_x - anchor_x),
+               static_cast<float>(canvas_y - anchor_y));
     return true;
   }
 
@@ -104,8 +114,7 @@ void DoorInteractionHandler::HandleRelease() {
     return;
   }
 
-  int drag_x = static_cast<int>(drag_current_pos_.x);
-  int drag_y = static_cast<int>(drag_current_pos_.y);
+  const auto [drag_x, drag_y] = GetCurrentDragAnchorPosition();
 
   // Detect wall from final position
   zelda3::DoorDirection direction;
@@ -151,14 +160,13 @@ bool DoorInteractionHandler::HandleOverlayClick(int canvas_x, int canvas_y) {
   }
 
   const auto& door = doors[*selected_door_index_];
-  const auto [tile_x, tile_y] = door.GetTileCoords();
-  const auto dims = door.GetEditorDimensions();
+  const auto [door_x, door_y, door_w, door_h] = door.GetEditorBounds();
   const DungeonCanvasTransform transform = GetCanvasTransform();
   const float scale = transform.scale();
-  const ImVec2 door_pos =
-      transform.RoomPixelsToScreen(ImVec2(tile_x * 8.0f, tile_y * 8.0f));
+  const ImVec2 door_pos = transform.RoomPixelsToScreen(
+      ImVec2(static_cast<float>(door_x), static_cast<float>(door_y)));
   const ImVec2 door_size = transform.RoomSizeToScreen(
-      ImVec2(dims.width_tiles * 8.0f, dims.height_tiles * 8.0f));
+      ImVec2(static_cast<float>(door_w), static_cast<float>(door_h)));
   const auto badge = BuildPairBadgeOverlay(door, door_pos, door_size, scale);
   if (!badge.has_value() || badge->target_room_id < 0) {
     return false;
@@ -212,18 +220,9 @@ void DoorInteractionHandler::DrawGhostPreview() {
     return;  // Not near a wall
   }
 
-  // Get door position in tile coordinates
-  auto [tile_x, tile_y] = zelda3::DoorPositionManager::PositionToTileCoords(
-      snapped_door_position_, detected_door_direction_);
-
-  // Get door dimensions
-  auto dims = zelda3::GetEditorDoorDimensions(detected_door_direction_,
-                                              preview_door_type_);
-  int door_width_px = dims.width_tiles * 8;
-  int door_height_px = dims.height_tiles * 8;
-
-  // Convert to canvas pixel coordinates
-  auto [snap_canvas_x, snap_canvas_y] = RoomToCanvas(tile_x, tile_y);
+  const auto [snap_canvas_x, snap_canvas_y, door_width_px, door_height_px] =
+      zelda3::DoorPositionManager::GetDoorEditorBounds(
+          snapped_door_position_, detected_door_direction_, preview_door_type_);
 
   // Draw ghost preview
   ImDrawList* draw_list = ImGui::GetWindowDrawList();
@@ -316,13 +315,11 @@ void DoorInteractionHandler::DrawSelectionHighlight() {
     return;
 
   const auto& door = doors[*selected_door_index_];
-  auto [tile_x, tile_y] = door.GetTileCoords();
-  auto dims = door.GetEditorDimensions();
+  auto [door_x, door_y, door_w, door_h] = door.GetEditorBounds();
 
   // If dragging, use current drag position for door preview
   if (is_dragging_) {
-    int drag_x = static_cast<int>(drag_current_pos_.x);
-    int drag_y = static_cast<int>(drag_current_pos_.y);
+    const auto [drag_x, drag_y] = GetCurrentDragAnchorPosition();
 
     zelda3::DoorDirection dir;
     bool is_inner = false;
@@ -330,21 +327,19 @@ void DoorInteractionHandler::DrawSelectionHighlight() {
                                                        is_inner)) {
       uint8_t snap_pos = zelda3::DoorPositionManager::SnapToNearestPosition(
           drag_x, drag_y, dir);
-      auto [snap_x, snap_y] =
-          zelda3::DoorPositionManager::PositionToTileCoords(snap_pos, dir);
-      tile_x = snap_x;
-      tile_y = snap_y;
-      dims = zelda3::GetEditorDoorDimensions(dir, door.type);
+      std::tie(door_x, door_y, door_w, door_h) =
+          zelda3::DoorPositionManager::GetDoorEditorBounds(snap_pos, dir,
+                                                           door.type);
     }
   }
 
   ImDrawList* draw_list = ImGui::GetWindowDrawList();
   const DungeonCanvasTransform transform = GetCanvasTransform();
   const float scale = transform.scale();
-  const ImVec2 pos =
-      transform.RoomPixelsToScreen(ImVec2(tile_x * 8.0f, tile_y * 8.0f));
+  const ImVec2 pos = transform.RoomPixelsToScreen(
+      ImVec2(static_cast<float>(door_x), static_cast<float>(door_y)));
   const ImVec2 size = transform.RoomSizeToScreen(
-      ImVec2(dims.width_tiles * 8.0f, dims.height_tiles * 8.0f));
+      ImVec2(static_cast<float>(door_w), static_cast<float>(door_h)));
 
   // Animated selection
   static float pulse = 0.0f;
@@ -393,7 +388,8 @@ std::optional<DoorInteractionHandler::PairBadgeOverlay>
 DoorInteractionHandler::BuildPairBadgeOverlay(const zelda3::Room::Door& door,
                                               ImVec2 door_pos, ImVec2 door_size,
                                               float scale) const {
-  if (is_dragging_ || !ctx_ || !ctx_->rooms) {
+  if (is_dragging_ || !ctx_ || !ctx_->rooms ||
+      !zelda3::IsRoomConnectionDoorType(door.type)) {
     return std::nullopt;
   }
 
@@ -409,7 +405,8 @@ DoorInteractionHandler::BuildPairBadgeOverlay(const zelda3::Room::Door& door,
     bool any_on_opposite = false;
     for (size_t i = 0; i < neighbor_doors.size(); ++i) {
       const auto& nd = neighbor_doors[i];
-      if (nd.direction != opposite) {
+      if (nd.direction != opposite ||
+          !zelda3::IsRoomConnectionDoorType(nd.type)) {
         continue;
       }
 
@@ -709,12 +706,19 @@ bool DoorInteractionHandler::UpdateSnappedPosition(int canvas_x, int canvas_y) {
   return true;
 }
 
+std::pair<int, int> DoorInteractionHandler::GetCurrentDragAnchorPosition()
+    const {
+  return {
+      static_cast<int>(drag_current_pos_.x - drag_grab_offset_from_anchor_.x),
+      static_cast<int>(drag_current_pos_.y - drag_grab_offset_from_anchor_.y),
+  };
+}
+
 void DoorInteractionHandler::DrawSnapIndicators() {
   if (!is_dragging_ || !HasValidContext())
     return;
 
-  int drag_x = static_cast<int>(drag_current_pos_.x);
-  int drag_y = static_cast<int>(drag_current_pos_.y);
+  const auto [drag_x, drag_y] = GetCurrentDragAnchorPosition();
 
   zelda3::DoorDirection direction;
   bool is_inner = false;
@@ -737,20 +741,17 @@ void DoorInteractionHandler::DrawSnapIndicators() {
       *selected_door_index_ < room->GetDoors().size()) {
     indicator_type = room->GetDoors()[*selected_door_index_].type;
   }
-  auto dims = zelda3::GetEditorDoorDimensions(direction, indicator_type);
-
   // Draw indicators for 6 positions in this section
   for (uint8_t i = 0; i < 6; ++i) {
     uint8_t pos = start_pos + i;
-    auto [tile_x, tile_y] =
-        zelda3::DoorPositionManager::PositionToTileCoords(pos, direction);
-    float pixel_x = tile_x * 8.0f;
-    float pixel_y = tile_y * 8.0f;
+    const auto [pixel_x, pixel_y, width, height] =
+        zelda3::DoorPositionManager::GetDoorEditorBounds(pos, direction,
+                                                         indicator_type);
 
-    const ImVec2 snap_start =
-        transform.RoomPixelsToScreen(ImVec2(pixel_x, pixel_y));
+    const ImVec2 snap_start = transform.RoomPixelsToScreen(
+        ImVec2(static_cast<float>(pixel_x), static_cast<float>(pixel_y)));
     const ImVec2 snap_size = transform.RoomSizeToScreen(
-        ImVec2(dims.width_pixels(), dims.height_pixels()));
+        ImVec2(static_cast<float>(width), static_cast<float>(height)));
     const ImVec2 snap_end(snap_start.x + snap_size.x,
                           snap_start.y + snap_size.y);
 

--- a/src/app/editor/dungeon/interaction/door_interaction_handler.h
+++ b/src/app/editor/dungeon/interaction/door_interaction_handler.h
@@ -147,6 +147,10 @@ class DoorInteractionHandler : public BaseEntityHandler {
   bool is_dragging_ = false;
   ImVec2 drag_start_pos_;
   ImVec2 drag_current_pos_;
+  // Pointer position relative to the selected door's raw ROM anchor. Special
+  // doors can extend several tiles above/left of that anchor, so preserving
+  // this offset keeps the encoded position stable regardless of grab point.
+  ImVec2 drag_grab_offset_from_anchor_ = ImVec2(0.0f, 0.0f);
 
   /**
    * @brief Place door at snapped position
@@ -157,6 +161,8 @@ class DoorInteractionHandler : public BaseEntityHandler {
    * @brief Update snapped position based on cursor
    */
   bool UpdateSnappedPosition(int canvas_x, int canvas_y);
+
+  std::pair<int, int> GetCurrentDragAnchorPosition() const;
 
   std::optional<PairBadgeOverlay> BuildPairBadgeOverlay(
       const zelda3::Room::Door& door, ImVec2 door_pos, ImVec2 door_size,

--- a/src/app/editor/dungeon/interaction/interaction_context.h
+++ b/src/app/editor/dungeon/interaction/interaction_context.h
@@ -98,6 +98,13 @@ struct InteractionContext {
   // Called when entity (door/sprite/item) changes
   std::function<void()> on_entity_changed;
 
+  // View-derived eligibility for tile-object selection. This is intentionally
+  // separate from ObjectSelection's explicit stored-layer filter: hiding BG1
+  // or BG2 must remove that content from canvas hit-testing without changing
+  // which stored object stream the user chose to target.
+  std::function<bool(int, const zelda3::RoomObject&)>
+      is_object_visible_for_selection;
+
   // Called when an interactive door-pair badge requests navigation to the
   // adjacent room. The optional door index is in the target room.
   std::function<void(int target_room_id,
@@ -135,6 +142,11 @@ struct InteractionContext {
       return nullptr;
     }
     return &(*rooms)[current_room_id];
+  }
+
+  bool IsObjectVisibleForSelection(const zelda3::RoomObject& object) const {
+    return !is_object_visible_for_selection ||
+           is_object_visible_for_selection(current_room_id, object);
   }
 
   /**

--- a/src/app/editor/dungeon/interaction/tile_object_handler.cc
+++ b/src/app/editor/dungeon/interaction/tile_object_handler.cc
@@ -1050,6 +1050,7 @@ void TileObjectHandler::RenderGhostPreviewBitmap() {
 
   zelda3::ObjectDrawer drawer(ctx_->rom, ctx_->current_room_id, gfx_data);
   drawer.InitializeDrawRoutines();
+  drawer.SetRoomFloorGraphics(room->floor1(), room->floor2());
 
   // Replay at the same safe anchor ObjectGeometry uses for measurement so
   // routines that draw upward or leftward do not clip against buffer origin.

--- a/src/app/editor/dungeon/interaction/tile_object_handler.cc
+++ b/src/app/editor/dungeon/interaction/tile_object_handler.cc
@@ -297,7 +297,10 @@ void TileObjectHandler::HandleMarqueeSelection(
     }
 
     ctx_->selection->EndRectangleSelection(
-        room->GetTileObjects(), ObjectSelection::SelectionMode::Single);
+        room->GetTileObjects(), ObjectSelection::SelectionMode::Single,
+        [this](const zelda3::RoomObject& object) {
+          return ctx_->IsObjectVisibleForSelection(object);
+        });
   }
 }
 
@@ -503,6 +506,10 @@ std::optional<size_t> TileObjectHandler::GetEntityAtPosition(
   for (size_t i = objects.size(); i > 0; --i) {
     size_t index = i - 1;
     const auto& object = objects[index];
+
+    if (ctx_ && !ctx_->IsObjectVisibleForSelection(object)) {
+      continue;
+    }
 
     // Respect layer filter if available in context
     if (ctx_ && ctx_->selection &&

--- a/src/app/editor/dungeon/object_selection.cc
+++ b/src/app/editor/dungeon/object_selection.cc
@@ -157,7 +157,8 @@ void ObjectSelection::UpdateRectangleSelection(int canvas_x, int canvas_y) {
 }
 
 void ObjectSelection::EndRectangleSelection(
-    const std::vector<zelda3::RoomObject>& objects, SelectionMode mode) {
+    const std::vector<zelda3::RoomObject>& objects, SelectionMode mode,
+    std::function<bool(const zelda3::RoomObject&)> is_object_visible) {
   if (!rectangle_selection_active_) {
     LOG_ERROR("ObjectSelection",
               "EndRectangleSelection called when not active");
@@ -170,9 +171,32 @@ void ObjectSelection::EndRectangleSelection(
   auto [end_room_x, end_room_y] =
       CanvasToRoomCoordinates(rect_end_x_, rect_end_y_);
 
-  // Select objects in rectangle
-  SelectObjectsInRect(start_room_x, start_room_y, end_room_x, end_room_y,
-                      objects, mode);
+  // Visibility is view state, while PassesLayerFilter is the user's explicit
+  // stored-stream selection filter. Apply both without rewriting either one.
+  if (!is_object_visible) {
+    SelectObjectsInRect(start_room_x, start_room_y, end_room_x, end_room_y,
+                        objects, mode);
+  } else {
+    if (mode == SelectionMode::Single) {
+      selected_indices_.clear();
+    }
+    const int min_x = std::min(start_room_x, end_room_x);
+    const int max_x = std::max(start_room_x, end_room_x);
+    const int min_y = std::min(start_room_y, end_room_y);
+    const int max_y = std::max(start_room_y, end_room_y);
+    for (size_t index = 0; index < objects.size(); ++index) {
+      if (!is_object_visible(objects[index]) ||
+          !IsObjectInRectangle(objects[index], min_x, min_y, max_x, max_y)) {
+        continue;
+      }
+      if (mode == SelectionMode::Toggle && selected_indices_.contains(index)) {
+        selected_indices_.erase(index);
+      } else {
+        selected_indices_.insert(index);
+      }
+    }
+    NotifySelectionChanged();
+  }
 
   rectangle_selection_active_ = false;
 }

--- a/src/app/editor/dungeon/object_selection.h
+++ b/src/app/editor/dungeon/object_selection.h
@@ -146,9 +146,13 @@ class ObjectSelection {
    * @brief Complete rectangle selection operation
    * @param objects Object list to select from
    * @param mode How to modify the selection
+   * @param is_object_visible Optional view-state predicate applied in addition
+   *        to the explicit stored-layer filter
    */
-  void EndRectangleSelection(const std::vector<zelda3::RoomObject>& objects,
-                             SelectionMode mode = SelectionMode::Single);
+  void EndRectangleSelection(
+      const std::vector<zelda3::RoomObject>& objects,
+      SelectionMode mode = SelectionMode::Single,
+      std::function<bool(const zelda3::RoomObject&)> is_object_visible = {});
 
   /**
    * @brief Cancel rectangle selection without modifying selection

--- a/src/app/editor/dungeon/workspace/dungeon_workbench_content.cc
+++ b/src/app/editor/dungeon/workspace/dungeon_workbench_content.cc
@@ -754,6 +754,9 @@ void DungeonWorkbenchContent::DrawCanvasPane(
         } else {
           primary_viewer->DrawDungeonCanvas(*current_room_id_);
         }
+        if (on_primary_canvas_drawn_) {
+          on_primary_canvas_drawn_(*primary_viewer);
+        }
       }
       ImGui::EndChild();
 
@@ -1247,6 +1250,7 @@ void DungeonWorkbenchContent::SetAllSaveFlags(bool value) {
   flags.kSaveRoomHeaders = value;
   flags.kSaveChests = value;
   flags.kSavePotItems = value;
+  flags.kSaveEntrances = value;
   flags.kSavePalettes = value;
   flags.kSaveCollision = value;
   flags.kSaveBlocks = value;
@@ -1304,7 +1308,7 @@ void DungeonWorkbenchContent::DrawApplyScopeControls(int room_id) {
     draw_checkbox("Torches", &flags.kSaveTorches);
     ImGui::TableNextRow();
     draw_checkbox("Pits", &flags.kSavePits);
-    ImGui::TableNextColumn();
+    draw_checkbox("Entrances", &flags.kSaveEntrances);
     ImGui::EndTable();
   }
 

--- a/src/app/editor/dungeon/workspace/dungeon_workbench_content.h
+++ b/src/app/editor/dungeon/workspace/dungeon_workbench_content.h
@@ -135,6 +135,10 @@ class DungeonWorkbenchContent : public WindowContent {
   void SetOnInspectorSideChanged(std::function<void(bool)> cb) {
     on_inspector_side_changed_ = std::move(cb);
   }
+  void SetPrimaryCanvasDrawnCallback(
+      std::function<void(DungeonCanvasViewer&)> cb) {
+    on_primary_canvas_drawn_ = std::move(cb);
+  }
 
   // Lightweight state probes for unit tests; production rendering remains
   // driven by the Workbench inspector.
@@ -148,6 +152,7 @@ class DungeonWorkbenchContent : public WindowContent {
   GetPitDamageControlRectsForTesting() const {
     return pit_damage_control_rects_;
   }
+  void SetAllSaveFlagsForTesting(bool value) { SetAllSaveFlags(value); }
 
   /// Called by the editor when the current room changes.
   void NotifyRoomChanged(int previous_room_id) {
@@ -249,6 +254,7 @@ class DungeonWorkbenchContent : public WindowContent {
   std::function<void(int)> forget_recent_room_;
   std::function<void(bool)> set_workflow_mode_;
   std::function<void(bool)> on_inspector_side_changed_;
+  std::function<void(DungeonCanvasViewer&)> on_primary_canvas_drawn_;
   std::function<zelda3::PitDamageTable*()> get_pit_damage_table_;
   Rom* rom_ = nullptr;
 

--- a/src/app/editor/editor_manager.cc
+++ b/src/app/editor/editor_manager.cc
@@ -1078,6 +1078,10 @@ void EditorManager::SubscribeToEvents() {
         if (IsTransientPanelVisibilityId(e.base_panel_id)) {
           return;
         }
+        if (e.visible && layout_manager_) {
+          layout_manager_->DockPresetPositionOnPanelOpen(e.session_id,
+                                                         e.base_panel_id);
+        }
         auto& prefs = user_settings_.prefs();
         prefs.panel_visibility_state[e.category][e.base_panel_id] = e.visible;
         settings_dirty_ = true;
@@ -1676,6 +1680,27 @@ void EditorManager::HandleSessionSwitched(size_t new_index, RomSession* session,
       const size_t session_id = session ? session->session_id() : new_index;
       window_manager_.RestoreVisibilityState(session_id, it->second);
     }
+  }
+
+  // A user-facing ROM-session switch does not reactivate the editor through
+  // EditorActivator::SwitchToEditor. Refresh an existing layout context so
+  // optional panels opened afterward dock against this session's live tree.
+  // First-time layout construction must remain on the normal activation path,
+  // after EnsureEditorAssetsLoaded has initialized and registered the panels.
+  // Transient switches are frame-iteration implementation details and must not
+  // replace the user-facing session context.
+  const EditorType active_editor_type =
+      active_editor ? active_editor->type() : EditorType::kUnknown;
+  const size_t active_editor_index = EditorTypeIndex(active_editor_type);
+  const bool active_session_editor_initialized =
+      session != nullptr &&
+      active_editor_index < session->editor_initialized.size() &&
+      session->editor_initialized[active_editor_index];
+  if (!transient && active_editor != nullptr &&
+      EditorRegistry::IsPanelBasedEditor(active_editor_type) &&
+      active_session_editor_initialized &&
+      layout_manager_->IsLayoutInitialized(active_editor_type)) {
+    editor_activator_.InitializeEditorLayout(active_editor_type);
   }
 
 #ifdef YAZE_ENABLE_TESTING
@@ -2630,17 +2655,27 @@ void EditorManager::SetStartupLoadHints(const AppConfig& config) {
 void EditorManager::ApplyLayoutDefaultsMigrationIfNeeded() {
   constexpr int kTargetRevision =
       UserSettings::kLatestPanelLayoutDefaultsRevision;
+  const int previous_revision =
+      user_settings_.prefs().panel_layout_defaults_revision;
   if (!user_settings_.ApplyPanelLayoutDefaultsRevision(kTargetRevision)) {
     return;
   }
 
-  pending_layout_defaults_reset_ = true;
+  const bool includes_workspace_reset_revision =
+      previous_revision <
+          UserSettings::kLastWorkspaceResetPanelLayoutDefaultsRevision &&
+      kTargetRevision >=
+          UserSettings::kLastWorkspaceResetPanelLayoutDefaultsRevision;
+  pending_layout_defaults_reset_ =
+      pending_layout_defaults_reset_ || includes_workspace_reset_revision;
   settings_dirty_ = true;
   settings_dirty_timestamp_ = TimingManager::Get().GetElapsedTime();
 
   LOG_INFO("EditorManager",
-           "Applied panel layout defaults migration revision %d",
-           kTargetRevision);
+           "Applied panel layout defaults migration %d -> %d (%s)",
+           previous_revision, kTargetRevision,
+           includes_workspace_reset_revision ? "workspace reset"
+                                             : "targeted preferences");
 }
 
 std::string EditorManager::GetPreferredStartupCategory(
@@ -2770,6 +2805,44 @@ void EditorManager::MarkEditorLoaded(RomSession* session, EditorType type) {
   if (index < session->editor_assets_loaded.size()) {
     session->editor_assets_loaded[index] = true;
   }
+}
+
+void EditorManager::RestoreEditorLayoutAfterAssets(RomSession* session,
+                                                   EditorType type) {
+  if (!session || !layout_manager_) {
+    return;
+  }
+
+  const size_t index = EditorTypeIndex(type);
+  if (!EditorRegistry::IsPanelBasedEditor(type) ||
+      index >= session->editor_initialized.size() ||
+      !session->editor_initialized[index] ||
+      window_manager_.GetActiveSessionId() != session->session_id()) {
+    return;
+  }
+
+  const std::string category = EditorRegistry::GetEditorCategory(type);
+  // Session switching can happen before a lazily loaded editor registers its
+  // panels. Repeat the persisted visibility pass once those descriptors exist.
+  const auto visibility_it =
+      user_settings_.prefs().panel_visibility_state.find(category);
+  if (visibility_it != user_settings_.prefs().panel_visibility_state.end()) {
+    window_manager_.RestoreVisibilityState(session->session_id(),
+                                           visibility_it->second);
+  }
+
+  // Only the active category owns the shared dock tree. A cross-category
+  // activation will refresh its layout immediately after the category switch.
+  if (window_manager_.GetActiveCategory() == category &&
+      layout_manager_->IsLayoutInitialized(type)) {
+    editor_activator_.InitializeEditorLayout(type);
+  }
+}
+
+void EditorManager::RestoreActiveEditorLayoutAfterAssets(RomSession* session) {
+  const EditorType type = EditorRegistry::GetEditorTypeFromCategory(
+      window_manager_.GetActiveCategory());
+  RestoreEditorLayoutAfterAssets(session, type);
 }
 
 bool EditorManager::EditorRequiresGameData(EditorType type) const {
@@ -2995,10 +3068,15 @@ absl::Status EditorManager::EnsureEditorAssetsLoaded(EditorType type) {
     if (EditorInitRequiresGameData(type)) {
       return absl::OkStatus();
     }
+    bool initialized_now = false;
     if (!session->editor_initialized[index]) {
       RETURN_IF_ERROR(
           InitializeEditorForType(type, &session->editors, &session->rom));
       MarkEditorInitialized(session, type);
+      initialized_now = true;
+    }
+    if (initialized_now) {
+      RestoreEditorLayoutAfterAssets(session, type);
     }
     return absl::OkStatus();
   }
@@ -3012,22 +3090,30 @@ absl::Status EditorManager::EnsureEditorAssetsLoaded(EditorType type) {
     RETURN_IF_ERROR(EnsureGameDataLoaded());
   }
 
+  bool initialized_now = false;
   if (!session->editor_initialized[index]) {
     RETURN_IF_ERROR(
         InitializeEditorForType(type, &session->editors, &session->rom));
     MarkEditorInitialized(session, type);
+    initialized_now = true;
   }
 
   if (EditorRequiresGameData(type)) {
     RETURN_IF_ERROR(EnsureGameDataLoaded());
   }
 
+  bool loaded_now = false;
   if (!session->editor_assets_loaded[index]) {
     auto* editor = GetEditorByType(type, &session->editors);
     if (editor) {
       RETURN_IF_ERROR(editor->Load());
     }
     MarkEditorLoaded(session, type);
+    loaded_now = true;
+  }
+
+  if (initialized_now || loaded_now) {
+    RestoreEditorLayoutAfterAssets(session, type);
   }
 
   return absl::OkStatus();
@@ -3877,6 +3963,8 @@ absl::Status EditorManager::LoadAssets(uint64_t passed_handle) {
 
   // Apply user preferences to status bar
   status_bar_.SetEnabled(user_settings_.prefs().show_status_bar);
+
+  RestoreActiveEditorLayoutAfterAssets(current_session);
 
   gfx::PerformanceProfiler::Get().PrintSummary();
 

--- a/src/app/editor/editor_manager.h
+++ b/src/app/editor/editor_manager.h
@@ -80,6 +80,7 @@ struct AppConfig;
 namespace editor {
 
 std::optional<EditorType> ParseEditorTypeFromString(absl::string_view name);
+class EditorManagerLayoutTestPeer;
 
 /**
  * @class EditorManager
@@ -96,6 +97,8 @@ std::optional<EditorType> ParseEditorTypeFromString(absl::string_view name);
  * updates cross-cutting concerns accordingly.
  */
 class EditorManager : public ISessionConfigurator, public IEditorSwitcher {
+  friend class EditorManagerLayoutTestPeer;
+
  public:
   struct UiSyncState {
     uint64_t frame_id = 0;
@@ -491,6 +494,8 @@ class EditorManager : public ISessionConfigurator, public IEditorSwitcher {
   void ResetAssetState(RomSession* session);
   void MarkEditorInitialized(RomSession* session, EditorType type);
   void MarkEditorLoaded(RomSession* session, EditorType type);
+  void RestoreEditorLayoutAfterAssets(RomSession* session, EditorType type);
+  void RestoreActiveEditorLayoutAfterAssets(RomSession* session);
   Editor* GetEditorByType(EditorType type, EditorSet* editor_set) const;
   Editor* ResolveEditorForCategory(const std::string& category);
   void SyncEditorContextForCategory(const std::string& category);

--- a/src/app/editor/layout/layout_manager.cc
+++ b/src/app/editor/layout/layout_manager.cc
@@ -167,6 +167,65 @@ std::string ResolveProfilePresetName(const std::string& profile_id,
 
 }  // namespace
 
+void LayoutManager::DisableLazyDefaultDocking() {
+  lazy_default_dock_state_ = LazyDefaultDockState{};
+}
+
+void LayoutManager::RefreshLazyDefaultDockingContext(EditorType type,
+                                                     ImGuiID dockspace_id) {
+  const PanelLayoutPreset preset = LayoutPresets::GetDefaultPreset(type);
+  auto& state = lazy_default_dock_state_;
+  if (!preset.dock_only_default_visible_panels || !window_manager_ ||
+      state.dockspace != dockspace_id ||
+      !ImGui::DockBuilderGetNode(state.dockspace) ||
+      !ImGui::DockBuilderGetNode(state.center)) {
+    state.enabled = false;
+    return;
+  }
+
+  const size_t session_id = window_manager_->GetActiveSessionId();
+  state.enabled = true;
+  state.editor_type = type;
+  state.session_id = session_id;
+  state.attempted_panels = lazy_default_dock_attempts_[session_id][type];
+}
+
+void LayoutManager::MarkLazyDefaultDockAttempted(const std::string& panel_id) {
+  auto& state = lazy_default_dock_state_;
+  state.attempted_panels.insert(panel_id);
+  lazy_default_dock_attempts_[state.session_id][state.editor_type].insert(
+      panel_id);
+}
+
+void LayoutManager::DockOpenPresetPanels(EditorType type) {
+  if (!window_manager_) {
+    return;
+  }
+
+  const size_t session_id = window_manager_->GetActiveSessionId();
+  const PanelLayoutPreset preset = LayoutPresets::GetDefaultPreset(type);
+  const auto dock_if_open = [&](const std::string& panel_id) {
+    if (window_manager_->IsWindowOpen(session_id, panel_id)) {
+      DockPresetPositionOnFirstOpen(session_id, panel_id,
+                                    /*include_default_visible=*/true);
+    }
+  };
+  for (const auto& panel_id : preset.default_visible_panels) {
+    dock_if_open(panel_id);
+  }
+  for (const auto& panel_id : preset.optional_panels) {
+    dock_if_open(panel_id);
+  }
+}
+
+void LayoutManager::ProtectRestoredLayoutFromDefaultInitialization() {
+  if (current_editor_type_ != EditorType::kUnknown) {
+    MarkLayoutInitialized(current_editor_type_);
+  } else {
+    startup_reapply_pending_protection_ = true;
+  }
+}
+
 void LayoutManager::InitializeEditorLayout(EditorType type,
                                            ImGuiID dockspace_id) {
   // Phase 8.2 review (2026-04-25): one-shot protection set by
@@ -176,6 +235,7 @@ void LayoutManager::InitializeEditorLayout(EditorType type,
   // their first editor activation. Consume the flag, mark the type
   // initialized so subsequent activations behave normally, and bail.
   if (startup_reapply_pending_protection_) {
+    DisableLazyDefaultDocking();
     startup_reapply_pending_protection_ = false;
     last_dockspace_id_ = dockspace_id;
     current_editor_type_ = type;
@@ -187,17 +247,24 @@ void LayoutManager::InitializeEditorLayout(EditorType type,
     return;
   }
 
+  // Refresh the active editor/session even when its default dock tree was
+  // initialized earlier. Lazy optional-panel placement uses the live tree but
+  // keeps its one-shot history scoped to this ROM session and editor.
+  last_dockspace_id_ = dockspace_id;
+  current_editor_type_ = type;
+
   // Don't reinitialize if already set up
   if (IsLayoutInitialized(type)) {
+    RefreshLazyDefaultDockingContext(type, dockspace_id);
+    // Session visibility restoration intentionally does not publish panel-open
+    // events. Sweep the restored state after refreshing the session context so
+    // an already-visible optional panel still receives its one-shot default.
+    DockOpenPresetPanels(type);
     LOG_INFO("LayoutManager",
              "Layout for editor type %d already initialized, skipping",
              static_cast<int>(type));
     return;
   }
-
-  // Store dockspace ID and current editor type for potential rebuilds
-  last_dockspace_id_ = dockspace_id;
-  current_editor_type_ = type;
 
   LOG_INFO("LayoutManager", "Initializing layout for editor type %d",
            static_cast<int>(type));
@@ -225,6 +292,10 @@ void LayoutManager::InitializeEditorLayout(EditorType type,
 
   // Finalize the layout
   ImGui::DockBuilderFinish(dockspace_id);
+
+  // Visibility may have been restored before this editor's first layout
+  // build. Give already-open optional panels the same first-open placement.
+  DockOpenPresetPanels(type);
 
   // Mark as initialized
   MarkLayoutInitialized(type);
@@ -267,6 +338,8 @@ void LayoutManager::RebuildLayout(EditorType type, ImGuiID dockspace_id) {
 
   // Finalize the layout
   ImGui::DockBuilderFinish(dockspace_id);
+
+  DockOpenPresetPanels(type);
 
   // Mark as initialized
   MarkLayoutInitialized(type);
@@ -574,6 +647,11 @@ DockNodeIds BuildDockTree(ImGuiID dockspace_id, const DockSplitNeeds& needs,
 
 void LayoutManager::BuildLayoutFromPreset(EditorType type,
                                           ImGuiID dockspace_id) {
+  DisableLazyDefaultDocking();
+  // Every preset build replaces the one shared DockBuilder tree. Any prior
+  // first-open record points at nodes that were just destroyed, including
+  // records belonging to another editor or ROM session.
+  lazy_default_dock_attempts_.clear();
   auto preset = LayoutPresets::GetDefaultPreset(type);
 
   if (!window_manager_) {
@@ -620,6 +698,33 @@ void LayoutManager::BuildLayoutFromPreset(EditorType type,
   }
   // When compact, needs is all-false → BuildDockTree produces center-only.
   DockNodeIds ids = BuildDockTree(dockspace_id, needs, cfg);
+
+  // Keep the live default-tree geometry even for editors that do not use lazy
+  // docking. If the user returns to Dungeon/Overworld without rebuilding the
+  // shared dockspace, their optional panels can still resolve valid nodes.
+  auto& state = lazy_default_dock_state_;
+  state.enabled = preset.dock_only_default_visible_panels;
+  state.compact = is_compact;
+  state.editor_type = type;
+  state.session_id = session_id;
+  state.dockspace = dockspace_id;
+  state.center = ids.center;
+  state.left = ids.left;
+  state.right = ids.right;
+  state.bottom = ids.bottom;
+  state.top = ids.top;
+  state.left_top = ids.left_top;
+  state.left_bottom = ids.left_bottom;
+  state.right_top = ids.right_top;
+  state.right_bottom = ids.right_bottom;
+  state.left_ratio = cfg.left;
+  state.right_ratio = cfg.right;
+  state.bottom_ratio = cfg.bottom;
+  state.top_ratio = cfg.top;
+  state.vertical_split = cfg.vertical_split;
+  if (state.enabled) {
+    state.attempted_panels = lazy_default_dock_attempts_[session_id][type];
+  }
 
   auto get_dock_id = [&](DockPosition pos) -> ImGuiID {
     switch (pos) {
@@ -692,6 +797,173 @@ void LayoutManager::BuildLayoutFromPreset(EditorType type,
       }
     }
   }
+}
+
+bool LayoutManager::DockDefaultPositionOnFirstOpen(
+    size_t session_id, const std::string& panel_id) {
+  return DockPresetPositionOnFirstOpen(session_id, panel_id,
+                                       /*include_default_visible=*/false);
+}
+
+bool LayoutManager::DockPresetPositionOnPanelOpen(size_t session_id,
+                                                  const std::string& panel_id) {
+  return DockPresetPositionOnFirstOpen(session_id, panel_id,
+                                       /*include_default_visible=*/true);
+}
+
+bool LayoutManager::DockPresetPositionOnFirstOpen(
+    size_t session_id, const std::string& panel_id,
+    bool include_default_visible) {
+  auto& state = lazy_default_dock_state_;
+  if (!state.enabled || !window_manager_ || panel_id.empty() ||
+      session_id != state.session_id ||
+      !ImGui::DockBuilderGetNode(state.dockspace)) {
+    return false;
+  }
+
+  const PanelLayoutPreset preset =
+      LayoutPresets::GetDefaultPreset(state.editor_type);
+  const bool is_default_visible =
+      std::find(preset.default_visible_panels.begin(),
+                preset.default_visible_panels.end(),
+                panel_id) != preset.default_visible_panels.end();
+  if (!preset.dock_only_default_visible_panels ||
+      (!include_default_visible && is_default_visible)) {
+    return false;
+  }
+
+  const auto position_it = preset.panel_positions.find(panel_id);
+  if (position_it == preset.panel_positions.end() ||
+      state.attempted_panels.contains(panel_id)) {
+    return false;
+  }
+
+  const WindowDescriptor* desc =
+      window_manager_->GetWindowDescriptor(session_id, panel_id);
+  if (!desc) {
+    return false;
+  }
+  const std::string window_title =
+      window_manager_->GetWorkspaceWindowName(*desc);
+  if (window_title.empty()) {
+    return false;
+  }
+
+  // A panel restored into a valid dock node already has an intentional
+  // position. Count that as its one shot without moving it.
+  if (ImGuiWindow* window = ImGui::FindWindowByName(window_title.c_str());
+      window && window->DockId != 0 &&
+      ImGui::DockBuilderGetNode(window->DockId)) {
+    MarkLazyDefaultDockAttempted(panel_id);
+    return false;
+  }
+  if (ImGuiWindowSettings* settings =
+          ImGui::FindWindowSettingsByID(ImHashStr(window_title.c_str()));
+      settings && settings->DockId != 0 &&
+      ImGui::DockBuilderGetNode(settings->DockId)) {
+    MarkLazyDefaultDockAttempted(panel_id);
+    return false;
+  }
+
+  auto split_center = [&](ImGuiDir direction, float ratio,
+                          ImGuiID* region) -> ImGuiID {
+    if (*region != 0 && ImGui::DockBuilderGetNode(*region)) {
+      return *region;
+    }
+    if (state.center == 0 || !ImGui::DockBuilderGetNode(state.center)) {
+      return 0;
+    }
+    *region = ImGui::DockBuilderSplitNode(state.center, direction, ratio,
+                                          nullptr, &state.center);
+    return *region;
+  };
+
+  auto resolve_vertical_region = [&](bool right_side,
+                                     bool want_bottom) -> ImGuiID {
+    ImGuiID& region = right_side ? state.right : state.left;
+    ImGuiID& top = right_side ? state.right_top : state.left_top;
+    ImGuiID& bottom = right_side ? state.right_bottom : state.left_bottom;
+    const ImGuiDir side_direction = right_side ? ImGuiDir_Right : ImGuiDir_Left;
+    const float side_ratio = right_side ? state.right_ratio : state.left_ratio;
+    if (!split_center(side_direction, side_ratio, &region)) {
+      return 0;
+    }
+
+    if (want_bottom) {
+      if (bottom != 0 && ImGui::DockBuilderGetNode(bottom)) {
+        return bottom;
+      }
+      if (top == 0) {
+        bottom = region;
+        return bottom;
+      }
+      ImGuiID new_top = 0;
+      bottom = ImGui::DockBuilderSplitNode(
+          region, ImGuiDir_Down, state.vertical_split, nullptr, &new_top);
+      top = new_top;
+      return bottom;
+    }
+
+    if (top != 0 && ImGui::DockBuilderGetNode(top)) {
+      return top;
+    }
+    if (bottom == 0) {
+      top = region;
+      return top;
+    }
+    ImGuiID new_bottom = 0;
+    top = ImGui::DockBuilderSplitNode(
+        region, ImGuiDir_Up, 1.0f - state.vertical_split, nullptr, &new_bottom);
+    bottom = new_bottom;
+    return top;
+  };
+
+  ImGuiID target = 0;
+  if (state.compact) {
+    target = state.center;
+  } else {
+    switch (position_it->second) {
+      case DockPosition::Left:
+      case DockPosition::LeftTop:
+        target = resolve_vertical_region(false, false);
+        break;
+      case DockPosition::LeftBottom:
+        target = resolve_vertical_region(false, true);
+        break;
+      case DockPosition::Right:
+      case DockPosition::RightTop:
+        target = resolve_vertical_region(true, false);
+        break;
+      case DockPosition::RightBottom:
+        target = resolve_vertical_region(true, true);
+        break;
+      case DockPosition::Bottom:
+        target = split_center(ImGuiDir_Down, state.bottom_ratio, &state.bottom);
+        break;
+      case DockPosition::Top:
+        target = split_center(ImGuiDir_Up, state.top_ratio, &state.top);
+        break;
+      case DockPosition::Center:
+      default:
+        target = state.center;
+        break;
+    }
+  }
+
+  if (target == 0 || !ImGui::DockBuilderGetNode(target)) {
+    return false;
+  }
+
+  MarkLazyDefaultDockAttempted(panel_id);
+  ImGui::DockBuilderDockWindow(window_title.c_str(), target);
+  if (WindowContent* panel = window_manager_->GetWindowContent(panel_id);
+      panel && panel->PreferAutoHideTabBar()) {
+    if (ImGuiDockNode* node = ImGui::DockBuilderGetNode(target)) {
+      node->LocalFlags |= ImGuiDockNodeFlags_AutoHideTabBar;
+    }
+  }
+  ImGui::DockBuilderFinish(state.dockspace);
+  return true;
 }
 
 // Deprecated individual build methods - redirected to generic or kept empty
@@ -779,6 +1051,15 @@ void LayoutManager::LoadLayout(const std::string& name) {
     return;
   }
 
+  const auto imgui_it = saved_imgui_layouts_.find(name);
+  const bool has_imgui_layout =
+      imgui_it != saved_imgui_layouts_.end() && !imgui_it->second.empty();
+  // Only a saved ImGui layout owns placement. Legacy visibility-only layouts
+  // must leave the current lazy-default context intact.
+  if (has_imgui_layout) {
+    DisableLazyDefaultDocking();
+  }
+
   // Restore window visibility
   size_t session_id = window_manager_->GetActiveSessionId();
   window_manager_->RestoreVisibilityState(session_id, layout_it->second,
@@ -790,10 +1071,10 @@ void LayoutManager::LoadLayout(const std::string& name) {
   }
 
   // Restore ImGui docking layout if available
-  auto imgui_it = saved_imgui_layouts_.find(name);
-  if (imgui_it != saved_imgui_layouts_.end() && !imgui_it->second.empty()) {
+  if (has_imgui_layout) {
     ImGui::LoadIniSettingsFromMemory(imgui_it->second.c_str(),
                                      imgui_it->second.size());
+    ProtectRestoredLayoutFromDefaultInitialization();
   }
 
   LOG_INFO("LayoutManager", "Loaded layout '%s'", name.c_str());
@@ -837,13 +1118,19 @@ bool LayoutManager::RestoreTemporarySessionLayout(size_t session_id,
     return false;
   }
 
+  const bool has_imgui_layout = !temp_session_imgui_layout_.empty();
+  if (has_imgui_layout) {
+    DisableLazyDefaultDocking();
+  }
+
   window_manager_->RestoreVisibilityState(session_id, temp_session_visibility_,
                                           /*publish_events=*/true);
   window_manager_->RestorePinnedState(temp_session_pinned_);
 
-  if (!temp_session_imgui_layout_.empty()) {
+  if (has_imgui_layout) {
     ImGui::LoadIniSettingsFromMemory(temp_session_imgui_layout_.c_str(),
                                      temp_session_imgui_layout_.size());
+    ProtectRestoredLayoutFromDefaultInitialization();
   }
 
   if (clear_after_restore) {
@@ -897,12 +1184,17 @@ bool LayoutManager::RestoreNamedSnapshot(const std::string& name,
   if (snapshot.session_id != session_id) {
     return false;
   }
+  const bool has_imgui_layout = !snapshot.imgui_layout.empty();
+  if (has_imgui_layout) {
+    DisableLazyDefaultDocking();
+  }
   window_manager_->RestoreVisibilityState(session_id, snapshot.visibility,
                                           /*publish_events=*/true);
   window_manager_->RestorePinnedState(snapshot.pinned);
-  if (!snapshot.imgui_layout.empty()) {
+  if (has_imgui_layout) {
     ImGui::LoadIniSettingsFromMemory(snapshot.imgui_layout.c_str(),
                                      snapshot.imgui_layout.size());
+    ProtectRestoredLayoutFromDefaultInitialization();
   }
   if (remove_after_restore) {
     named_snapshots_.erase(it);
@@ -1025,6 +1317,10 @@ bool LayoutManager::ApplyBuiltInProfile(const std::string& profile_id,
              matched_profile.preset_name.c_str(), profile_id.c_str());
     return false;
   }
+
+  // The requested rebuild will establish a fresh lazy-default state. Avoid
+  // mutating the current dock tree while profile visibility is changing.
+  DisableLazyDefaultDocking();
 
   window_manager_->HideAllWindowsInSession(session_id);
   for (const auto& panel_id : preset.default_visible_panels) {
@@ -1206,6 +1502,7 @@ void LayoutManager::SaveLayoutsToDisk(LayoutScope scope) const {
 }
 
 void LayoutManager::ResetToDefaultLayout(EditorType type) {
+  DisableLazyDefaultDocking();
   layouts_initialized_[type] = false;
   LOG_INFO("LayoutManager", "Reset layout for editor type %d",
            static_cast<int>(type));
@@ -1223,6 +1520,7 @@ void LayoutManager::MarkLayoutInitialized(EditorType type) {
 }
 
 void LayoutManager::ClearInitializationFlags() {
+  DisableLazyDefaultDocking();
   layouts_initialized_.clear();
   LOG_INFO("LayoutManager", "Cleared all layout initialization flags");
 }
@@ -1399,6 +1697,10 @@ absl::Status LayoutManager::ApplyDockTree(const layout_designer::DockTree& tree,
                                       validation_error);
   }
 
+  // A custom tree owns all panel placement. Disable default first-open
+  // docking before the visibility pass publishes open events.
+  DisableLazyDefaultDocking();
+
   // Visibility pass (Phase 8 review 2026-04-24, refined 2026-04-25):
   //   - Open every panel referenced in the tree so users see what they
   //     docked rather than empty slots.
@@ -1470,11 +1772,7 @@ absl::Status LayoutManager::ApplyDockTree(const layout_designer::DockTree& tree,
   //     the next InitializeEditorLayout call consumes. Round-3 Codex
   //     noted that without this branch, applying from a no-editor
   //     context still left the original clobber bug intact.
-  if (current_editor_type_ != EditorType::kUnknown) {
-    MarkLayoutInitialized(current_editor_type_);
-  } else {
-    startup_reapply_pending_protection_ = true;
-  }
+  ProtectRestoredLayoutFromDefaultInitialization();
 
   return absl::OkStatus();
 }

--- a/src/app/editor/layout/layout_manager.h
+++ b/src/app/editor/layout/layout_manager.h
@@ -3,6 +3,7 @@
 
 #include <string>
 #include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 #include "absl/status/status.h"
@@ -104,6 +105,32 @@ class LayoutManager {
    * Useful for resetting layouts to their default state.
    */
   void RebuildLayout(EditorType type, ImGuiID dockspace_id);
+
+  /**
+   * @brief Dock a hidden-by-default panel at its preset position on first open.
+   *
+   * This is active only for default presets that intentionally build the
+   * startup dock tree from visible panels alone. Each panel is considered at
+   * most once per default-layout build, so closing and reopening a panel never
+   * overrides a position the user chose after its first open.
+   *
+   * @return true when the panel was assigned to a default dock node.
+   */
+  bool DockDefaultPositionOnFirstOpen(size_t session_id,
+                                      const std::string& panel_id);
+
+  /**
+   * @brief Rebind any preset panel when a visibility event opens it.
+   *
+   * Unlike DockDefaultPositionOnFirstOpen(), this accepts both default-visible
+   * and optional panels. This matters after another editor replaces the shared
+   * dock tree while a default panel is hidden: its next open event must attach
+   * it to the new live tree instead of leaving it floating.
+   *
+   * @return true when the panel was assigned to a preset dock node.
+   */
+  bool DockPresetPositionOnPanelOpen(size_t session_id,
+                                     const std::string& panel_id);
 
   /**
    * @brief Save the current layout with a custom name
@@ -421,6 +448,14 @@ class LayoutManager {
  private:
   // DockBuilder layout implementations for each editor type
   void BuildLayoutFromPreset(EditorType type, ImGuiID dockspace_id);
+  void DisableLazyDefaultDocking();
+  void RefreshLazyDefaultDockingContext(EditorType type, ImGuiID dockspace_id);
+  void DockOpenPresetPanels(EditorType type);
+  bool DockPresetPositionOnFirstOpen(size_t session_id,
+                                     const std::string& panel_id,
+                                     bool include_default_visible);
+  void MarkLazyDefaultDockAttempted(const std::string& panel_id);
+  void ProtectRestoredLayoutFromDefaultInitialization();
 
   void LoadLayoutsFromDiskInternal(LayoutScope scope, bool merge);
   void SaveLayoutsToDisk(LayoutScope scope) const;
@@ -475,6 +510,35 @@ class LayoutManager {
 
   // Current editor type being displayed
   EditorType current_editor_type_ = EditorType::kUnknown;
+
+  // Default presets may omit hidden panels from the initial dock tree. Keep
+  // enough state to create their preferred region lazily on first open.
+  struct LazyDefaultDockState {
+    bool enabled = false;
+    bool compact = false;
+    EditorType editor_type = EditorType::kUnknown;
+    size_t session_id = 0;
+    ImGuiID dockspace = 0;
+    ImGuiID center = 0;
+    ImGuiID left = 0;
+    ImGuiID right = 0;
+    ImGuiID bottom = 0;
+    ImGuiID top = 0;
+    ImGuiID left_top = 0;
+    ImGuiID left_bottom = 0;
+    ImGuiID right_top = 0;
+    ImGuiID right_bottom = 0;
+    float left_ratio = 0.17f;
+    float right_ratio = 0.24f;
+    float bottom_ratio = 0.22f;
+    float top_ratio = 0.12f;
+    float vertical_split = 0.52f;
+    std::unordered_set<std::string> attempted_panels;
+  };
+  LazyDefaultDockState lazy_default_dock_state_;
+  std::unordered_map<
+      size_t, std::unordered_map<EditorType, std::unordered_set<std::string>>>
+      lazy_default_dock_attempts_;
 
   // Saved layouts (panel visibility state)
   std::unordered_map<std::string, std::unordered_map<std::string, bool>>

--- a/src/app/editor/layout/layout_presets.cc
+++ b/src/app/editor/layout/layout_presets.cc
@@ -45,14 +45,14 @@ PanelLayoutPreset LayoutPresets::GetDefaultPreset(EditorType type) {
 
     case EditorType::kDungeon:
       preset.name = "Dungeon Default";
-      preset.description = "Room workbench with inspector and fast navigation";
+      preset.description =
+          "Room-first workbench with embedded browser, inspector, and tools";
 
       if (core::FeatureFlags::get().dungeon.kUseWorkbench) {
         preset.default_visible_panels = {
-            Panels::kDungeonWorkbench,    Panels::kDungeonObjectSelector,
-            Panels::kDungeonRoomGraphics, Panels::kDungeonRoomMatrix,
-            Panels::kDungeonDoorEditor,   Panels::kDungeonPaletteEditor,
+            Panels::kDungeonWorkbench,
         };
+        preset.dock_only_default_visible_panels = true;
 
         // Place optional panels around the workbench so they dock predictably
         // if/when the user opens them.

--- a/src/app/editor/system/commands/shortcut_configurator.cc
+++ b/src/app/editor/system/commands/shortcut_configurator.cc
@@ -452,8 +452,7 @@ void ConfigureEditorShortcuts(const ShortcutDependencies& deps,
               // Unified mode: handled by object selector click
               // No-op (mode is controlled by selecting an object)
             } else if (id == "dungeon.object.delete_tool") {
-              // Unified mode: delete selected objects
-              obj_editor->DeleteSelectedObjects();
+              dungeon_editor->QueueRoomCanvasDeleteShortcut();
             } else if (id == "dungeon.object.next_object") {
               obj_editor->CycleObjectSelection(1);
             } else if (id == "dungeon.object.prev_object") {
@@ -463,7 +462,7 @@ void ConfigureEditorShortcuts(const ShortcutDependencies& deps,
             } else if (id == "dungeon.object.paste") {
               obj_editor->PasteObjects();
             } else if (id == "dungeon.object.delete") {
-              obj_editor->DeleteSelectedObjects();
+              dungeon_editor->QueueRoomCanvasDeleteShortcut();
             }
           },
           Shortcut::Scope::kEditor);

--- a/src/app/editor/system/commands/shortcut_manager.cc
+++ b/src/app/editor/system/commands/shortcut_manager.cc
@@ -65,7 +65,11 @@ int ScopePriority(Shortcut::Scope scope) {
 
 bool ModsSatisfied(int pressed_mods, int required_mods) {
   if (required_mods == 0) {
-    return true;
+    // A plain-key command must not shadow a modified chord that is handled by
+    // the active panel (for example D vs Ctrl/Cmd+D in the dungeon editor).
+    constexpr int kRelevantMods =
+        ImGuiMod_Ctrl | ImGuiMod_Shift | ImGuiMod_Alt | ImGuiMod_Super;
+    return (pressed_mods & kRelevantMods) == 0;
   }
 
   auto has = [&](int mod) -> bool {

--- a/src/app/editor/system/session/user_settings.cc
+++ b/src/app/editor/system/session/user_settings.cc
@@ -1,6 +1,7 @@
 #include "app/editor/system/session/user_settings.h"
 
 #include <algorithm>
+#include <array>
 #include <filesystem>
 #include <fstream>
 #include <sstream>
@@ -77,6 +78,25 @@ void EraseEmbeddedDungeonUtilityPanelVisibility(
     } else {
       ++it;
     }
+  }
+}
+
+constexpr std::array<const char*, 10> kDungeonWorkbenchDuplicatePanels = {
+    "dungeon.room_selector",   "dungeon.room_matrix",
+    "dungeon.object_selector", "dungeon.sprite_editor",
+    "dungeon.item_editor",     "dungeon.room_graphics",
+    "dungeon.door_editor",     "dungeon.palette_editor",
+    "dungeon.entrance_list",   "dungeon.entrance_properties",
+};
+
+void ApplyDungeonWorkbenchVisibilityDefaults(
+    std::unordered_map<std::string, bool>* panel_state) {
+  if (!panel_state) {
+    return;
+  }
+  (*panel_state)["dungeon.workbench"] = true;
+  for (const char* panel_id : kDungeonWorkbenchDuplicatePanels) {
+    (*panel_state)[panel_id] = false;
   }
 }
 
@@ -1598,6 +1618,41 @@ bool UserSettings::ApplyPanelLayoutDefaultsRevision(int target_revision) {
     }
 
     prefs_.panel_layout_defaults_revision = 21;
+    applied = true;
+  }
+
+  // Revision 22: make the Dungeon Workbench the single default surface.
+  // These standalone panels duplicate tools already embedded in the
+  // Workbench and collectively squeeze the room canvas. Close only the live
+  // Dungeon visibility entries; pinned panels and saved/named layouts are
+  // explicit user customizations and must remain untouched.
+  if (prefs_.panel_layout_defaults_revision < 22 && target_revision >= 22) {
+    if (auto dungeon_it = prefs_.panel_visibility_state.find("Dungeon");
+        dungeon_it != prefs_.panel_visibility_state.end()) {
+      ApplyDungeonWorkbenchVisibilityDefaults(&dungeon_it->second);
+    }
+
+    prefs_.panel_layout_defaults_revision = 22;
+    applied = true;
+  }
+
+  // Revision 23: keep the global activity rail available, but collapse its
+  // wide tool catalog when Dungeon is the active/default workspace. The
+  // Workbench already embeds the useful room browser, canvas, and inspector;
+  // showing both left panes steals enough width for responsive layout to hide
+  // the room browser. Re-assert the revision-22 visibility set because an older
+  // concurrently-running build can persist those duplicate windows again.
+  if (prefs_.panel_layout_defaults_revision < 23 && target_revision >= 23) {
+    if (auto dungeon_it = prefs_.panel_visibility_state.find("Dungeon");
+        dungeon_it != prefs_.panel_visibility_state.end()) {
+      ApplyDungeonWorkbenchVisibilityDefaults(&dungeon_it->second);
+    }
+    if (prefs_.sidebar_active_category.empty() ||
+        prefs_.sidebar_active_category == "Dungeon") {
+      prefs_.sidebar_panel_expanded = false;
+    }
+
+    prefs_.panel_layout_defaults_revision = 23;
     applied = true;
   }
 

--- a/src/app/editor/system/session/user_settings.h
+++ b/src/app/editor/system/session/user_settings.h
@@ -189,11 +189,15 @@ class UserSettings {
   absl::Status Load();
   absl::Status Save();
 
-  // Applies a one-time layout defaults migration when target_revision is newer
-  // than persisted settings. Returns true when defaults were reset.
+  // Applies one-time layout-default migrations when target_revision is newer
+  // than persisted settings. Returns true when preferences changed; callers
+  // must not assume every revision requires rebuilding the whole workspace.
   bool ApplyPanelLayoutDefaultsRevision(int target_revision);
 
-  static constexpr int kLatestPanelLayoutDefaultsRevision = 21;
+  static constexpr int kLatestPanelLayoutDefaultsRevision = 23;
+  // Revisions through 21 changed whole-workspace arrangements. Later revisions
+  // are targeted preference migrations and must preserve the live ImGui layout.
+  static constexpr int kLastWorkspaceResetPanelLayoutDefaultsRevision = 21;
 
   Preferences& prefs() { return prefs_; }
   const Preferences& prefs() const { return prefs_; }
@@ -206,11 +210,12 @@ class UserSettings {
   // is normalized to "right". Caller must invoke Save() to persist.
   void SetDungeonInspectorSide(std::string side);
 
-  // Testing hook: redirect Load/Save to a caller-specified path. Production
-  // code should never call this; it only exists so unit tests can exercise
-  // JSON round-trip without touching the user's real settings file.
+  // Testing hook: redirect JSON plus legacy INI Load/Save to caller-owned
+  // paths. Production code should never call this; it only exists so unit
+  // tests can exercise settings migration without touching the user's files.
   void SetSettingsFilePathForTesting(std::string path) {
     settings_file_path_ = std::move(path);
+    legacy_settings_file_path_ = settings_file_path_ + ".legacy.ini";
   }
 
  private:

--- a/src/app/editor/system/workspace/editor_activator.cc
+++ b/src/app/editor/system/workspace/editor_activator.cc
@@ -63,10 +63,19 @@ void EditorActivator::SwitchToEditor(EditorType editor_type, bool force_visible,
   ImGuiContext* imgui_ctx = ImGui::GetCurrentContext();
   const bool frame_active = imgui_ctx != nullptr && imgui_ctx->WithinFrameScope;
   if (!frame_active && deps_.queue_deferred_action) {
-    deps_.queue_deferred_action(
-        [this, editor_type, force_visible, from_dialog]() {
-          SwitchToEditor(editor_type, force_visible, from_dialog);
-        });
+    const bool validate_session =
+        static_cast<bool>(deps_.get_current_session_id);
+    const size_t expected_session_id =
+        validate_session ? deps_.get_current_session_id() : 0;
+    deps_.queue_deferred_action([this, editor_type, force_visible, from_dialog,
+                                 validate_session, expected_session_id]() {
+      if (validate_session &&
+          (!deps_.get_current_session_id ||
+           deps_.get_current_session_id() != expected_session_id)) {
+        return;
+      }
+      SwitchToEditor(editor_type, force_visible, from_dialog);
+    });
     return;
   }
 
@@ -151,18 +160,11 @@ void EditorActivator::ActivatePanelBasedEditor(EditorType type,
     deps_.window_manager->OnEditorSwitch(old_category, new_category);
   }
 
-  // Initialize default layout on first activation
-  if (deps_.layout_manager &&
-      !deps_.layout_manager->IsLayoutInitialized(type)) {
-    if (deps_.queue_deferred_action) {
-      deps_.queue_deferred_action([this, type]() {
-        if (deps_.layout_manager &&
-            !deps_.layout_manager->IsLayoutInitialized(type)) {
-          ImGuiID dockspace_id = ImGui::GetID("MainDockSpace");
-          deps_.layout_manager->InitializeEditorLayout(type, dockspace_id);
-        }
-      });
-    }
+  // Activate the layout context on every editor activation. LayoutManager
+  // builds the default tree only once, but repeated calls refresh the live
+  // editor/session context used by lazy first-open panel docking.
+  if (deps_.layout_manager) {
+    QueueEditorLayoutInitialization(type);
   }
 }
 
@@ -183,9 +185,40 @@ void EditorActivator::DeactivatePanelBasedEditor(EditorType type,
         gui::GetAnimator().ClearWorkspaceTransitionState();
         deps_.window_manager->OnEditorSwitch(old_category, new_category);
       }
+
+      // The fallback editor was already active, so it does not pass through
+      // ActivatePanelBasedEditor again. Refresh its live docking context here
+      // before any of its hidden-by-default panels are opened.
+      const EditorType fallback_type = other->type();
+      if (deps_.layout_manager) {
+        QueueEditorLayoutInitialization(fallback_type);
+      }
       break;
     }
   }
+}
+
+void EditorActivator::QueueEditorLayoutInitialization(EditorType type) {
+  if (!deps_.layout_manager) {
+    return;
+  }
+  if (!deps_.queue_deferred_action) {
+    InitializeEditorLayout(type);
+    return;
+  }
+
+  const bool validate_session = static_cast<bool>(deps_.get_current_session_id);
+  const size_t expected_session_id =
+      validate_session ? deps_.get_current_session_id() : 0;
+  deps_.queue_deferred_action(
+      [this, type, validate_session, expected_session_id]() {
+        if (validate_session &&
+            (!deps_.get_current_session_id ||
+             deps_.get_current_session_id() != expected_session_id)) {
+          return;
+        }
+        InitializeEditorLayout(type);
+      });
 }
 
 void EditorActivator::HandleNonEditorClassSwitch(EditorType type,
@@ -269,15 +302,15 @@ void EditorActivator::InitializeEditorLayout(EditorType type) {
   ImGuiContext* ctx = ImGui::GetCurrentContext();
   if (!ctx || !ctx->WithinFrameScope) {
     if (deps_.queue_deferred_action) {
-      deps_.queue_deferred_action(
-          [this, type]() { InitializeEditorLayout(type); });
+      QueueEditorLayoutInitialization(type);
     }
     return;
   }
 
-  if (!deps_.layout_manager->IsLayoutInitialized(type)) {
-    ImGuiID dockspace_id = ImGui::GetID("MainDockSpace");
-    deps_.layout_manager->InitializeEditorLayout(type, dockspace_id);
+  const bool was_initialized = deps_.layout_manager->IsLayoutInitialized(type);
+  ImGuiID dockspace_id = ImGui::GetID("MainDockSpace");
+  deps_.layout_manager->InitializeEditorLayout(type, dockspace_id);
+  if (!was_initialized && deps_.layout_manager->IsLayoutInitialized(type)) {
     LOG_INFO("EditorActivator", "Initialized layout for editor type %d",
              static_cast<int>(type));
   }

--- a/src/app/editor/system/workspace/editor_activator.h
+++ b/src/app/editor/system/workspace/editor_activator.h
@@ -92,6 +92,7 @@ class EditorActivator {
   void ActivatePanelBasedEditor(EditorType type, Editor* editor);
   void DeactivatePanelBasedEditor(EditorType type, Editor* editor,
                                   EditorSet* editor_set);
+  void QueueEditorLayoutInitialization(EditorType type);
   void HandleNonEditorClassSwitch(EditorType type, bool force_visible);
 
   Dependencies deps_;

--- a/src/app/emu/render/emulator_render_service.cc
+++ b/src/app/emu/render/emulator_render_service.cc
@@ -206,6 +206,7 @@ absl::StatusOr<RenderResult> EmulatorRenderService::RenderDungeonObjectStatic(
   const auto& gfx_buffer = room.get_gfx_buffer();
   zelda3::ObjectDrawer drawer(rom_, req.room_id, gfx_buffer.data());
   drawer.InitializeDrawRoutines();
+  drawer.SetRoomFloorGraphics(room.floor1(), room.floor2());
 
   // Draw the object (ObjectDrawer needs the full palette group)
   auto status =

--- a/src/app/gfx/core/bitmap.h
+++ b/src/app/gfx/core/bitmap.h
@@ -20,6 +20,8 @@ namespace yaze {
  */
 namespace gfx {
 
+class Arena;
+
 // Pixel format constants
 constexpr Uint32 SNES_PIXELFORMAT_INDEXED =
     SDL_DEFINE_PIXELFORMAT(SDL_PIXELTYPE_INDEX8, 0, 0, 8, 1);
@@ -410,6 +412,27 @@ class Bitmap {
   void set_texture(TextureHandle texture) { texture_ = texture; }
 
  private:
+  friend class Arena;
+
+  // Arena alone may split a Bitmap's CPU and GPU resources during explicit
+  // owner retirement. Keeping these helpers private prevents ordinary callers
+  // from accidentally detaching a live bitmap.
+  SDL_Surface* DetachSurfaceForArena() noexcept {
+    SDL_Surface* surface = surface_;
+    surface_ = nullptr;
+    return surface;
+  }
+  TextureHandle DetachTextureForArena() noexcept {
+    TextureHandle texture = texture_;
+    texture_ = nullptr;
+    return texture;
+  }
+  void MarkRetiredByArena() noexcept {
+    active_ = false;
+    modified_ = false;
+    texture_pixels = nullptr;
+    generation_ = next_generation_++;
+  }
   int width_ = 0;
   int height_ = 0;
   int depth_ = 0;

--- a/src/app/gfx/render/background_buffer.cc
+++ b/src/app/gfx/render/background_buffer.cc
@@ -1,7 +1,9 @@
 #include "app/gfx/render/background_buffer.h"
 
 #include <algorithm>
+#include <array>
 #include <cstdint>
+#include <optional>
 #include <vector>
 
 #include "app/gfx/core/bitmap.h"
@@ -9,6 +11,29 @@
 #include "util/log.h"
 
 namespace yaze::gfx {
+
+std::optional<std::array<TileInfo, 8>> DecodeDungeonFloorTilePattern(
+    const std::vector<uint8_t>& rom_data, int tile_address,
+    int tile_address_floor, uint8_t floor_graphics) {
+  const int floor_offset = static_cast<int>(floor_graphics & 0x0F) << 4;
+  const auto table_is_readable = [&](int address) {
+    return address >= 0 && static_cast<size_t>(address + 7) < rom_data.size();
+  };
+  if (!table_is_readable(tile_address + floor_offset) ||
+      !table_is_readable(tile_address_floor + floor_offset)) {
+    return std::nullopt;
+  }
+
+  std::array<TileInfo, 8> tiles;
+  for (int index = 0; index < 4; ++index) {
+    const int main_address = tile_address + floor_offset + index * 2;
+    const int floor_address = tile_address_floor + floor_offset + index * 2;
+    tiles[index] = TileInfo(rom_data[main_address], rom_data[main_address + 1]);
+    tiles[index + 4] =
+        TileInfo(rom_data[floor_address], rom_data[floor_address + 1]);
+  }
+  return tiles;
+}
 
 BackgroundBuffer::BackgroundBuffer(int width, int height)
     : width_(width), height_(height) {}
@@ -82,10 +107,14 @@ uint16_t BackgroundBuffer::GetTileAt(int x_pos, int y_pos) const {
   return buffer_[index];
 }
 
-void BackgroundBuffer::ClearBuffer() {
+void BackgroundBuffer::ClearTileBuffer() {
   if (!buffer_.empty()) {
     std::fill(buffer_.begin(), buffer_.end(), 0);
   }
+}
+
+void BackgroundBuffer::ClearBuffer() {
+  ClearTileBuffer();
   ClearPriorityBuffer();
   ClearCoverageBuffer();
   ClearBG1RevealMask();
@@ -351,51 +380,28 @@ void BackgroundBuffer::DrawFloor(const std::vector<uint8_t>& rom_data,
               bitmap_.is_active(), bitmap_.width(), bitmap_.height());
   }
 
-  auto floor_offset = static_cast<uint8_t>(floor_graphics << 4);
-
-  // Create floor tiles from ROM data
-  gfx::TileInfo floorTile1(rom_data[tile_address + floor_offset],
-                           rom_data[tile_address + floor_offset + 1]);
-  gfx::TileInfo floorTile2(rom_data[tile_address + floor_offset + 2],
-                           rom_data[tile_address + floor_offset + 3]);
-  gfx::TileInfo floorTile3(rom_data[tile_address + floor_offset + 4],
-                           rom_data[tile_address + floor_offset + 5]);
-  gfx::TileInfo floorTile4(rom_data[tile_address + floor_offset + 6],
-                           rom_data[tile_address + floor_offset + 7]);
-
-  gfx::TileInfo floorTile5(rom_data[tile_address_floor + floor_offset],
-                           rom_data[tile_address_floor + floor_offset + 1]);
-  gfx::TileInfo floorTile6(rom_data[tile_address_floor + floor_offset + 2],
-                           rom_data[tile_address_floor + floor_offset + 3]);
-  gfx::TileInfo floorTile7(rom_data[tile_address_floor + floor_offset + 4],
-                           rom_data[tile_address_floor + floor_offset + 5]);
-  gfx::TileInfo floorTile8(rom_data[tile_address_floor + floor_offset + 6],
-                           rom_data[tile_address_floor + floor_offset + 7]);
+  const auto floor_tiles = DecodeDungeonFloorTilePattern(
+      rom_data, tile_address, tile_address_floor, floor_graphics);
+  if (!floor_tiles.has_value()) {
+    LOG_DEBUG("[DrawFloor]", "Floor pattern %d is outside the ROM data",
+              static_cast<int>(floor_graphics));
+    return;
+  }
 
   // Floor tiles specify which 8-color sub-palette from the 90-color dungeon
   // palette e.g., palette 6 = colors 48-55 (6 * 8 = 48)
 
   // Draw the floor tiles in a pattern
   // Convert TileInfo to 16-bit words with palette information
-  uint16_t word1 = gfx::TileInfoToWord(floorTile1);
-  uint16_t word2 = gfx::TileInfoToWord(floorTile2);
-  uint16_t word3 = gfx::TileInfoToWord(floorTile3);
-  uint16_t word4 = gfx::TileInfoToWord(floorTile4);
-  uint16_t word5 = gfx::TileInfoToWord(floorTile5);
-  uint16_t word6 = gfx::TileInfoToWord(floorTile6);
-  uint16_t word7 = gfx::TileInfoToWord(floorTile7);
-  uint16_t word8 = gfx::TileInfoToWord(floorTile8);
+  std::array<uint16_t, 8> words;
+  std::transform(floor_tiles->begin(), floor_tiles->end(), words.begin(),
+                 [](const TileInfo& tile) { return TileInfoToWord(tile); });
   for (int xx = 0; xx < 16; xx++) {
     for (int yy = 0; yy < 32; yy++) {
-      SetTileAt((xx * 4), (yy * 2), word1);
-      SetTileAt((xx * 4) + 1, (yy * 2), word2);
-      SetTileAt((xx * 4) + 2, (yy * 2), word3);
-      SetTileAt((xx * 4) + 3, (yy * 2), word4);
-
-      SetTileAt((xx * 4), (yy * 2) + 1, word5);
-      SetTileAt((xx * 4) + 1, (yy * 2) + 1, word6);
-      SetTileAt((xx * 4) + 2, (yy * 2) + 1, word7);
-      SetTileAt((xx * 4) + 3, (yy * 2) + 1, word8);
+      for (int column = 0; column < 4; ++column) {
+        SetTileAt((xx * 4) + column, yy * 2, words[column]);
+        SetTileAt((xx * 4) + column, (yy * 2) + 1, words[column + 4]);
+      }
     }
   }
 }

--- a/src/app/gfx/render/background_buffer.h
+++ b/src/app/gfx/render/background_buffer.h
@@ -1,7 +1,9 @@
 #ifndef YAZE_APP_GFX_BACKGROUND_BUFFER_H
 #define YAZE_APP_GFX_BACKGROUND_BUFFER_H
 
+#include <array>
 #include <cstdint>
+#include <optional>
 #include <vector>
 
 #include "app/gfx/core/bitmap.h"
@@ -15,6 +17,13 @@ enum class BG1RevealMaskSource : uint8_t {
   kBG2Objects = 1 << 1,
 };
 
+// Decode the eight 8x8 tiles selected by a dungeon room's floor-graphics
+// nibble. The first four words live in the main table and the second four in
+// the adjacent floor table, matching RoomDraw_DrawFloors in the game.
+std::optional<std::array<TileInfo, 8>> DecodeDungeonFloorTilePattern(
+    const std::vector<uint8_t>& rom_data, int tile_address,
+    int tile_address_floor, uint8_t floor_graphics);
+
 class BackgroundBuffer {
  public:
   BackgroundBuffer(int width = 512, int height = 512);
@@ -22,6 +31,7 @@ class BackgroundBuffer {
   // Buffer manipulation methods
   void SetTileAt(int x, int y, uint16_t value);
   uint16_t GetTileAt(int x, int y) const;
+  void ClearTileBuffer();
   void ClearBuffer();
 
   // Drawing methods

--- a/src/app/gfx/resource/arena.cc
+++ b/src/app/gfx/resource/arena.cc
@@ -16,6 +16,9 @@ namespace gfx {
 
 void Arena::Initialize(IRenderer* renderer) {
   renderer_ = renderer;
+  if (renderer != nullptr) {
+    is_shutdown_ = false;
+  }
 }
 
 Arena& Arena::Get() {
@@ -41,6 +44,55 @@ void Arena::QueueTextureCommand(TextureCommandType type, Bitmap* bitmap) {
 
 void Arena::ClearTextureQueue() {
   texture_command_queue_.clear();
+}
+
+void Arena::RetireBitmap(Bitmap& bitmap) {
+  // Texture commands retain Bitmap addresses. Remove them while the owner is
+  // still alive so no later generation check dereferences freed memory.
+  std::erase_if(texture_command_queue_,
+                [&bitmap](const TextureCommand& command) {
+                  return command.bitmap == &bitmap;
+                });
+
+  const TextureHandle texture = bitmap.texture();
+  if (!is_shutdown_ && texture != nullptr &&
+      std::find(retired_texture_handles_.begin(),
+                retired_texture_handles_.end(),
+                texture) == retired_texture_handles_.end()) {
+    retired_texture_handles_.push_back(texture);
+  }
+
+  // Detach before returning the surface so a second retirement is a no-op and
+  // the soon-to-be-destroyed Bitmap no longer advertises live resources.
+  SDL_Surface* surface = bitmap.DetachSurfaceForArena();
+  (void)bitmap.DetachTextureForArena();
+  bitmap.MarkRetiredByArena();
+  // Shutdown clears the tracked surfaces before editor-owned Bitmap objects
+  // are destroyed. Do not return a stale pointer to the pool in that case.
+  if (surface != nullptr && surfaces_.contains(surface)) {
+    FreeSurface(surface);
+  }
+}
+
+size_t Arena::DrainRetiredBitmaps(IRenderer* renderer) {
+  IRenderer* active_renderer = renderer ? renderer : renderer_;
+  if (active_renderer == nullptr) {
+    return 0;
+  }
+
+  size_t destroyed = 0;
+  auto it = retired_texture_handles_.begin();
+  while (it != retired_texture_handles_.end()) {
+    try {
+      active_renderer->DestroyTexture(*it);
+      it = retired_texture_handles_.erase(it);
+      ++destroyed;
+    } catch (...) {
+      LOG_ERROR("Arena", "Exception destroying retired bitmap texture");
+      ++it;
+    }
+  }
+  return destroyed;
 }
 
 bool Arena::ProcessSingleTexture(IRenderer* renderer) {
@@ -425,8 +477,17 @@ void Arena::FreeSurface(SDL_Surface* surface) {
 }
 
 void Arena::Shutdown() {
+  if (is_shutdown_) {
+    return;
+  }
+
   // Process any remaining batch updates before shutdown
   ProcessTextureQueue(renderer_);
+  DrainRetiredBitmaps(renderer_);
+
+  // Editor-owned Bitmap objects can outlive the renderer and window backend.
+  // Late retirement must only detach their stale resource fields.
+  is_shutdown_ = true;
 
   // Clear LRU cache tracking (doesn't destroy textures, just tracking)
   ClearSheetCache();
@@ -444,6 +505,8 @@ void Arena::Shutdown() {
 
   // Clear any remaining queue items
   texture_command_queue_.clear();
+  retired_texture_handles_.clear();
+  renderer_ = nullptr;
 }
 
 void Arena::NotifySheetModified(int sheet_index) {

--- a/src/app/gfx/resource/arena.h
+++ b/src/app/gfx/resource/arena.h
@@ -55,13 +55,33 @@ class Arena {
   enum class TextureCommandType { CREATE, UPDATE, DESTROY };
   struct TextureCommand {
     TextureCommandType type;
-    Bitmap* bitmap;  // The bitmap that needs a texture operation
+    Bitmap* bitmap;       // The bitmap that needs a texture operation
     uint32_t generation;  // Generation at queue time for staleness detection
   };
 
   void QueueTextureCommand(TextureCommandType type, Bitmap* bitmap);
   void ProcessTextureQueue(IRenderer* renderer);
   void ClearTextureQueue();
+
+  /**
+   * @brief Explicitly retire resources owned by a bitmap that is being erased.
+   *
+   * Cancels every deferred command that still references the Bitmap address,
+   * returns its SDL surface to the Arena, and moves its opaque texture handle
+   * to a pointer-free queue. The handle is intentionally not destroyed here:
+   * ImGui draw data for the current frame may still reference it.
+   */
+  void RetireBitmap(Bitmap& bitmap);
+
+  /**
+   * @brief Destroy texture handles retired earlier in the frame.
+   *
+   * Call only after ImGui rendering/Present has completed, or immediately
+   * before renderer shutdown. Failed destroys remain queued for a later call.
+   *
+   * @return Number of handles successfully destroyed.
+   */
+  size_t DrainRetiredBitmaps(IRenderer* renderer);
 
   /**
    * @brief Check if there are pending textures to process
@@ -97,10 +117,10 @@ class Arena {
    * @brief Statistics for texture queue processing
    */
   struct TextureQueueStats {
-    size_t textures_processed = 0;   // Total textures processed this session
-    size_t frames_with_work = 0;     // Frames that did texture work
-    float total_time_ms = 0.0f;      // Total time spent processing
-    float max_frame_time_ms = 0.0f;  // Maximum time spent in a single call
+    size_t textures_processed = 0;     // Total textures processed this session
+    size_t frames_with_work = 0;       // Frames that did texture work
+    float total_time_ms = 0.0f;        // Total time spent processing
+    float max_frame_time_ms = 0.0f;    // Maximum time spent in a single call
     float avg_texture_time_ms = 0.0f;  // Average time per texture
 
     void Reset() {
@@ -143,6 +163,9 @@ class Arena {
   size_t texture_command_queue_size() const {
     return texture_command_queue_.size();
   }
+  size_t retired_texture_handle_count() const {
+    return retired_texture_handles_.size();
+  }
 
   // Graphics sheet access (223 total sheets in YAZE)
   /**
@@ -157,7 +180,8 @@ class Arena {
    * @return Copy of the Bitmap at index i, or empty Bitmap if out of bounds
    */
   auto gfx_sheet(int i) {
-    if (i < 0 || i >= 223) return gfx::Bitmap{};
+    if (i < 0 || i >= 223)
+      return gfx::Bitmap{};
     return gfx_sheets_[i];
   }
 
@@ -167,7 +191,8 @@ class Arena {
    * @return Pointer to mutable Bitmap at index i, or nullptr if out of bounds
    */
   auto mutable_gfx_sheet(int i) {
-    if (i < 0 || i >= 223) return static_cast<gfx::Bitmap*>(nullptr);
+    if (i < 0 || i >= 223)
+      return static_cast<gfx::Bitmap*>(nullptr);
     return &gfx_sheets_[i];
   }
 
@@ -293,10 +318,10 @@ class Arena {
    * @brief Statistics for sheet cache performance
    */
   struct SheetCacheStats {
-    size_t hits = 0;           // Sheet accessed and already had texture
-    size_t misses = 0;         // Sheet accessed but needed texture creation
-    size_t evictions = 0;      // Textures evicted due to cache pressure
-    size_t current_size = 0;   // Current number of cached textures
+    size_t hits = 0;          // Sheet accessed and already had texture
+    size_t misses = 0;        // Sheet accessed but needed texture creation
+    size_t evictions = 0;     // Textures evicted due to cache pressure
+    size_t current_size = 0;  // Current number of cached textures
 
     void Reset() {
       hits = 0;
@@ -362,7 +387,9 @@ class Arena {
   } surface_pool_;
 
   std::vector<TextureCommand> texture_command_queue_;
+  std::vector<TextureHandle> retired_texture_handles_;
   IRenderer* renderer_ = nullptr;
+  bool is_shutdown_ = false;
   TextureQueueStats texture_queue_stats_;
 
   // Palette change notification system

--- a/src/app/gui/canvas/canvas.h
+++ b/src/app/gui/canvas/canvas.h
@@ -198,6 +198,10 @@ class Canvas {
 
   void AddContextMenuItem(const gui::CanvasMenuItem& item);
   void ClearContextMenuItems();
+  std::optional<ImVec2> context_menu_open_screen_position() const {
+    return context_menu_ ? context_menu_->context_open_screen_position()
+                         : std::nullopt;
+  }
 
   // Phase 4: Access to editor-provided menu definition
   CanvasMenuDefinition& editor_menu() { return editor_menu_; }

--- a/src/app/gui/canvas/canvas_context_menu.cc
+++ b/src/app/gui/canvas/canvas_context_menu.cc
@@ -42,6 +42,7 @@ void CanvasContextMenu::Initialize(const std::string& canvas_id) {
   is_draggable_ = false;
   auto_resize_ = false;
   scrolling_ = ImVec2(0, 0);
+  context_open_screen_position_.reset();
 
   // Create default menu items
   CreateDefaultMenuItems();
@@ -76,6 +77,10 @@ void CanvasContextMenu::Render(
   // Context menu (under default mouse threshold)
   if (ImVec2 drag_delta = ImGui::GetMouseDragDelta(ImGuiMouseButton_Right);
       enable_context_menu_ && drag_delta.x == 0.0F && drag_delta.y == 0.0F) {
+    if (ImGui::IsItemHovered() &&
+        ImGui::IsMouseReleased(ImGuiMouseButton_Right)) {
+      context_open_screen_position_ = ImGui::GetIO().MousePos;
+    }
     ImGui::OpenPopupOnItemClick(context_id.c_str(),
                                 ImGuiPopupFlags_MouseButtonRight);
   }

--- a/src/app/gui/canvas/canvas_context_menu.h
+++ b/src/app/gui/canvas/canvas_context_menu.h
@@ -2,6 +2,7 @@
 #define YAZE_APP_GUI_CANVAS_CANVAS_CONTEXT_MENU_H
 
 #include <functional>
+#include <optional>
 #include <string>
 #include <unordered_map>
 #include <vector>
@@ -63,6 +64,9 @@ class CanvasContextMenu {
   void SetEnabled(bool enabled) { enabled_ = enabled; }
   bool IsEnabled() const { return enabled_; }
   CanvasUsage GetUsageMode() const { return current_usage_; }
+  std::optional<ImVec2> context_open_screen_position() const {
+    return context_open_screen_position_;
+  }
 
   void SetCanvasState(const ImVec2& canvas_size, const ImVec2& content_size,
                       float global_scale, float grid_step, bool enable_grid,
@@ -86,6 +90,7 @@ class CanvasContextMenu {
   bool is_draggable_ = false;
   bool auto_resize_ = false;
   ImVec2 scrolling_;
+  std::optional<ImVec2> context_open_screen_position_;
 
   std::unique_ptr<PaletteEditorWidget> palette_editor_;
   uint64_t edit_palette_group_name_index_ = 0;

--- a/src/app/gui/widgets/dungeon_object_emulator_preview.cc
+++ b/src/app/gui/widgets/dungeon_object_emulator_preview.cc
@@ -851,6 +851,7 @@ void DungeonObjectEmulatorPreview::TriggerStaticRender() {
   object_drawer_ =
       std::make_unique<zelda3::ObjectDrawer>(rom_, room_id_, gfx_buffer.data());
   object_drawer_->InitializeDrawRoutines();
+  object_drawer_->SetRoomFloorGraphics(room.floor1(), room.floor2());
 
   // Clear background buffers (default 512x512)
   preview_bg1_.ClearBuffer();

--- a/src/cli/handlers/game/dungeon_graph_commands.cc
+++ b/src/cli/handlers/game/dungeon_graph_commands.cc
@@ -57,24 +57,6 @@ int GetRoomDungeonId(Rom* rom, int room_id) {
   return -1;  // Unknown dungeon
 }
 
-// Returns true for door types that exit the dungeon (overworld, cave exit, etc.)
-bool IsExitDoorType(zelda3::DoorType type) {
-  switch (type) {
-    case zelda3::DoorType::FancyDungeonExit:
-    case zelda3::DoorType::FancyDungeonExitLower:
-    case zelda3::DoorType::CaveExit:
-    case zelda3::DoorType::LitCaveExitLower:
-    case zelda3::DoorType::ExitLower:
-    case zelda3::DoorType::UnusedCaveExit:
-    case zelda3::DoorType::BombableCaveExit:
-    case zelda3::DoorType::WaterfallDoor:
-    case zelda3::DoorType::ExitMarker:
-      return true;
-    default:
-      return false;
-  }
-}
-
 // Compute neighbor room ID from door direction using ALTTP 16-wide grid.
 // Returns -1 if the computed ID is out of range.
 int NeighborRoomId(int room_id, zelda3::DoorDirection dir) {
@@ -121,7 +103,7 @@ zelda3::DoorDirection OppositeDir(zelda3::DoorDirection dir) {
 bool RoomHasDoorIn(Rom* rom, int room_id, zelda3::DoorDirection dir) {
   zelda3::Room neighbor_room = zelda3::LoadRoomFromRom(rom, room_id);
   for (const auto& door : neighbor_room.GetDoors()) {
-    if (door.direction == dir && !IsExitDoorType(door.type))
+    if (door.direction == dir && zelda3::IsRoomConnectionDoorType(door.type))
       return true;
   }
   return false;
@@ -597,8 +579,15 @@ absl::Status DungeonRoomGraphCommandHandler::Execute(
 
     // Door edges — infer neighbor from grid position + direction
     for (const auto& door : room.GetDoors()) {
-      bool is_exit = IsExitDoorType(door.type);
-      int neighbor = is_exit ? -1 : NeighborRoomId(room_id, door.direction);
+      const bool is_connection = zelda3::IsRoomConnectionDoorType(door.type);
+      const bool is_exit = zelda3::IsExitDoorType(door.type);
+      if (!is_connection && !is_exit) {
+        // Layer/dungeon swap markers control rendering state. They neither
+        // connect rooms nor represent an overworld exit.
+        continue;
+      }
+      int neighbor =
+          is_connection ? NeighborRoomId(room_id, door.direction) : -1;
       auto [tx, ty] = door.GetTileCoords();
 
       DoorEdge edge;
@@ -613,7 +602,7 @@ absl::Status DungeonRoomGraphCommandHandler::Execute(
 
       // Only follow non-exit doors that have a reciprocal door on the other side.
       // This prevents cascading across the entire dungeon grid.
-      if (!is_exit && neighbor >= 0 &&
+      if (is_connection && neighbor >= 0 &&
           visited.find(neighbor) == visited.end() &&
           RoomHasDoorIn(rom, neighbor, OppositeDir(door.direction))) {
         // Optional: skip neighbors with a different blockset than the start room

--- a/src/cli/handlers/tools/dungeon_object_validate_commands.cc
+++ b/src/cli/handlers/tools/dungeon_object_validate_commands.cc
@@ -730,6 +730,9 @@ absl::Status DungeonObjectValidateCommandHandler::Execute(
   if (room_mode) {
     zelda3::Room room = zelda3::LoadRoomHeaderFromRom(rom, room_id);
     room.LoadObjects();
+    for (auto& drawer : profile_drawers) {
+      drawer->SetRoomFloorGraphics(room.floor1(), room.floor2());
+    }
     const auto& room_objects = room.GetTileObjects();
     room_object_count = static_cast<int>(room_objects.size());
     if (write_trace_dump) {

--- a/src/util/log.h
+++ b/src/util/log.h
@@ -94,22 +94,23 @@ class LogManager {
 // The level check avoids the cost of string formatting if the message won't be
 // logged.
 
-#define LOG(level, category, format, ...)                         \
+#define YAZE_LOG_IMPL(level, category, format, ...)               \
   do {                                                            \
     yaze::util::LogManager::instance().log(                       \
         level, category, absl::StrFormat(format, ##__VA_ARGS__)); \
   } while (0)
 
-#define LOG_DEBUG(category, format, ...) \
-  LOG(yaze::util::LogLevel::YAZE_DEBUG, category, format, ##__VA_ARGS__)
+#define LOG_DEBUG(category, format, ...)                            \
+  YAZE_LOG_IMPL(yaze::util::LogLevel::YAZE_DEBUG, category, format, \
+                ##__VA_ARGS__)
 #define LOG_INFO(category, format, ...) \
-  LOG(yaze::util::LogLevel::INFO, category, format, ##__VA_ARGS__)
+  YAZE_LOG_IMPL(yaze::util::LogLevel::INFO, category, format, ##__VA_ARGS__)
 #define LOG_WARN(category, format, ...) \
-  LOG(yaze::util::LogLevel::WARNING, category, format, ##__VA_ARGS__)
+  YAZE_LOG_IMPL(yaze::util::LogLevel::WARNING, category, format, ##__VA_ARGS__)
 #define LOG_ERROR(category, format, ...) \
-  LOG(yaze::util::LogLevel::ERROR, category, format, ##__VA_ARGS__)
+  YAZE_LOG_IMPL(yaze::util::LogLevel::ERROR, category, format, ##__VA_ARGS__)
 #define LOG_FATAL(category, format, ...) \
-  LOG(yaze::util::LogLevel::FATAL, category, format, ##__VA_ARGS__)
+  YAZE_LOG_IMPL(yaze::util::LogLevel::FATAL, category, format, ##__VA_ARGS__)
 
 template <typename... Args>
 inline void logf(const absl::FormatSpec<Args...>& format, Args&&... args) {

--- a/src/zelda3/dungeon/door_position.cc
+++ b/src/zelda3/dungeon/door_position.cc
@@ -162,6 +162,10 @@ std::pair<int, int> DoorPositionManager::PositionToRenderTileCoords(
     // USDASM RoomDraw_OneSidedShutters_South ($01:AABB) writes through
     // $CB/$D7/$DA, i.e. rows y+1..y+3 from DoorTilemapPositions_South*.
     ++tile_y;
+  } else if (direction == DoorDirection::East) {
+    // USDASM RoomDraw_OneSidedShutters_East ($01:AC13) advances the
+    // tilemap destination by one word before writing its three columns.
+    ++tile_x;
   }
   return {tile_x, tile_y};
 }
@@ -357,10 +361,14 @@ std::tuple<int, int, int, int> DoorPositionManager::GetDoorBounds(
 
 std::tuple<int, int, int, int> DoorPositionManager::GetDoorEditorBounds(
     uint8_t position, DoorDirection direction, DoorType type) {
-  auto [pixel_x, pixel_y] = PositionToRenderPixelCoords(position, direction);
-  auto dims = GetEditorDoorDimensions(direction, type);
+  auto [tile_x, tile_y] = PositionToTileCoords(position, direction);
+  const auto footprint = GetEditorDoorFootprint(direction, type);
+  tile_x += footprint.offset_x_tiles;
+  tile_y += footprint.offset_y_tiles;
 
-  return {pixel_x, pixel_y, dims.width_pixels(), dims.height_pixels()};
+  return {tile_x * kTileSize, tile_y * kTileSize,
+          footprint.width_tiles * kTileSize,
+          footprint.height_tiles * kTileSize};
 }
 
 }  // namespace zelda3

--- a/src/zelda3/dungeon/door_types.h
+++ b/src/zelda3/dungeon/door_types.h
@@ -227,6 +227,24 @@ struct DoorDimensions {
 };
 
 /**
+ * @brief Visible editor footprint relative to the raw ROM door anchor.
+ *
+ * Door position tables store an anchor used by the game routines. The visible
+ * art does not always begin at that anchor, so editor interaction needs both
+ * an offset and dimensions instead of dimensions alone.
+ */
+struct DoorFootprint {
+  int offset_x_tiles;
+  int offset_y_tiles;
+  int width_tiles;
+  int height_tiles;
+
+  constexpr DoorDimensions dimensions() const {
+    return {width_tiles, height_tiles};
+  }
+};
+
+/**
  * @brief Get door dimensions based on direction
  *
  * Horizontal doors (North/South walls) are 4 tiles wide x 3 tiles tall.
@@ -245,21 +263,79 @@ constexpr DoorDimensions GetDoorDimensions(DoorDirection dir) {
 }
 
 /**
- * @brief Get editor interaction dimensions for a door.
+ * @brief Get the visible editor footprint for a door.
  *
- * Some north-door types render with a taller footprint than the generic
- * 4x3 ranged-door table. The editor uses these dimensions for hit-testing and
- * placement previews so selection matches what the user sees.
+ * Defaults mirror the directional one-sided shutter routines. South and East
+ * start one tile beyond their raw position-table anchor. A small set of exit
+ * routines use bespoke raw-anchor-relative footprints.
  *
  * Exploding walls intentionally keep the generic footprint here because their
  * visible open-state placement depends on runtime door state and a ROM lookup.
  */
+constexpr DoorFootprint GetEditorDoorFootprint(DoorDirection dir,
+                                               DoorType type) {
+  if (dir == DoorDirection::South) {
+    switch (type) {
+      case DoorType::FancyDungeonExit:
+      case DoorType::FancyDungeonExitLower:
+        return {-3, -4, 10, 8};
+      case DoorType::ExitLower:
+      case DoorType::CaveExit:
+      case DoorType::LitCaveExitLower:
+        return {0, 0, 4, 4};
+      default:
+        return {0, 1, 4, 3};
+    }
+  }
+
+  if (dir == DoorDirection::North && type == DoorType::CurtainDoor) {
+    return {0, 0, 4, 4};
+  }
+
+  switch (dir) {
+    case DoorDirection::North:
+      return {0, 0, 4, 3};
+    case DoorDirection::West:
+      return {0, 0, 3, 4};
+    case DoorDirection::East:
+      return {1, 0, 3, 4};
+    case DoorDirection::South:
+      break;
+  }
+  return {0, 0, 4, 3};
+}
+
+/** @brief Get visible editor dimensions for compatibility with UI callers. */
 constexpr DoorDimensions GetEditorDoorDimensions(DoorDirection dir,
                                                  DoorType type) {
-  if (dir == DoorDirection::North && type == DoorType::CurtainDoor) {
-    return {4, 4};
+  return GetEditorDoorFootprint(dir, type).dimensions();
+}
+
+/** @brief Return true for terminal exits that do not pair with another room. */
+constexpr bool IsExitDoorType(DoorType type) {
+  switch (type) {
+    case DoorType::FancyDungeonExit:
+    case DoorType::FancyDungeonExitLower:
+    case DoorType::CaveExit:
+    case DoorType::LitCaveExitLower:
+    case DoorType::ExitLower:
+    case DoorType::UnusedCaveExit:
+    case DoorType::BombableCaveExit:
+    case DoorType::WaterfallDoor:
+    case DoorType::ExitMarker:
+      return true;
+    default:
+      return false;
   }
-  return GetDoorDimensions(dir);
+}
+
+/** @brief Return true when a door can represent an adjacent-room connection. */
+constexpr bool IsRoomConnectionDoorType(DoorType type) {
+  if (IsExitDoorType(type)) {
+    return false;
+  }
+  return type != DoorType::DungeonSwapMarker &&
+         type != DoorType::LayerSwapMarker;
 }
 
 /**
@@ -279,22 +355,52 @@ constexpr DoorDirection DoorDirectionFromRaw(uint8_t raw_dir) {
 }
 
 /**
- * @brief Get commonly used door types for UI dropdowns
- * Returns the most frequently used door types (not all 52)
+ * @brief Get supported door types suitable for editor placement controls.
+ *
+ * The ROM tables contain additional entries explicitly identified as unused
+ * or glitchy. Those values remain available through raw-type editing, but are
+ * intentionally excluded from the primary placement UI.
  */
-constexpr std::array<DoorType, 20> GetAllDoorTypes() {
+constexpr std::array<DoorType, 32> GetPlaceableDoorTypes() {
   return {{
-      DoorType::NormalDoor,         DoorType::NormalDoorLower,
-      DoorType::CaveExit,           DoorType::DoubleSidedShutter,
-      DoorType::EyeWatchDoor,       DoorType::SmallKeyDoor,
-      DoorType::BigKeyDoor,         DoorType::SmallKeyStairsUp,
-      DoorType::SmallKeyStairsDown, DoorType::DashWall,
-      DoorType::BombableDoor,       DoorType::ExplodingWall,
-      DoorType::CurtainDoor,        DoorType::BottomSidedShutter,
-      DoorType::TopSidedShutter,    DoorType::FancyDungeonExit,
-      DoorType::WaterfallDoor,      DoorType::ExitMarker,
-      DoorType::LayerSwapMarker,    DoorType::DungeonSwapMarker,
+      DoorType::NormalDoor,
+      DoorType::NormalDoorLower,
+      DoorType::ExitLower,
+      DoorType::WaterfallDoor,
+      DoorType::FancyDungeonExit,
+      DoorType::FancyDungeonExitLower,
+      DoorType::CaveExit,
+      DoorType::LitCaveExitLower,
+      DoorType::ExitMarker,
+      DoorType::DungeonSwapMarker,
+      DoorType::LayerSwapMarker,
+      DoorType::DoubleSidedShutter,
+      DoorType::EyeWatchDoor,
+      DoorType::SmallKeyDoor,
+      DoorType::BigKeyDoor,
+      DoorType::SmallKeyStairsUp,
+      DoorType::SmallKeyStairsDown,
+      DoorType::SmallKeyStairsUpLower,
+      DoorType::SmallKeyStairsDownLower,
+      DoorType::DashWall,
+      DoorType::BombableCaveExit,
+      DoorType::UnopenableBigKeyDoor,
+      DoorType::BombableDoor,
+      DoorType::ExplodingWall,
+      DoorType::CurtainDoor,
+      DoorType::BottomSidedShutter,
+      DoorType::TopSidedShutter,
+      DoorType::NormalDoorOneSidedShutter,
+      DoorType::DoubleSidedShutterLower,
+      DoorType::ExplicitRoomDoor,
+      DoorType::BottomShutterLower,
+      DoorType::TopShutterLower,
   }};
+}
+
+// Compatibility alias for callers that used the former 20-item UI subset.
+constexpr std::array<DoorType, 32> GetAllDoorTypes() {
+  return GetPlaceableDoorTypes();
 }
 
 }  // namespace zelda3

--- a/src/zelda3/dungeon/draw_routines/corner_routines.cc
+++ b/src/zelda3/dungeon/draw_routines/corner_routines.cc
@@ -28,21 +28,32 @@ void DrawDiagonalCeiling(const DrawContext& ctx, DiagonalCeilingAnchor anchor) {
   const int side = (ctx.object.size_ & 0x0F) + 4;
   const gfx::TileInfo& fill_tile = ctx.tiles[0];
 
-  const bool mirror_x = anchor == DiagonalCeilingAnchor::kTopRight ||
-                        anchor == DiagonalCeilingAnchor::kBottomRight;
-  const bool mirror_y = anchor == DiagonalCeilingAnchor::kBottomLeft ||
-                        anchor == DiagonalCeilingAnchor::kBottomRight;
-
-  const int base_x = ctx.object.x_ - (mirror_x ? (side - 1) : 0);
-  const int base_y = ctx.object.y_ - (mirror_y ? (side - 1) : 0);
-
-  // Fill a right-triangle in the local square and mirror as needed.
+  // Each USDASM variant changes the repeated span and/or row direction. The
+  // names describe the triangle, not a common corner-origin mirror transform.
   for (int row = 0; row < side; ++row) {
-    const int span = side - row;
-    for (int col = 0; col < span; ++col) {
-      const int x = mirror_x ? (side - 1 - col) : col;
-      const int y = mirror_y ? (side - 1 - row) : row;
-      DrawRoutineUtils::WriteTile8(ctx.target_bg, base_x + x, base_y + y,
+    int first_column = 0;
+    int last_column = side - row - 1;
+    int y = ctx.object.y_ + row;
+
+    switch (anchor) {
+      case DiagonalCeilingAnchor::kTopLeft:
+        break;
+      case DiagonalCeilingAnchor::kBottomLeft:
+        last_column = row;
+        break;
+      case DiagonalCeilingAnchor::kTopRight:
+        first_column = row;
+        last_column = side - 1;
+        break;
+      case DiagonalCeilingAnchor::kBottomRight:
+        first_column = row;
+        last_column = side - 1;
+        y = ctx.object.y_ - row;
+        break;
+    }
+
+    for (int column = first_column; column <= last_column; ++column) {
+      DrawRoutineUtils::WriteTile8(ctx.target_bg, ctx.object.x_ + column, y,
                                    fill_tile);
     }
   }

--- a/src/zelda3/dungeon/draw_routines/diagonal_routines.cc
+++ b/src/zelda3/dungeon/draw_routines/diagonal_routines.cc
@@ -7,130 +7,43 @@ namespace yaze {
 namespace zelda3 {
 namespace draw_routines {
 
-void DrawDiagonalAcute_1to16(const DrawContext& ctx) {
-  // Pattern: Diagonal acute (/) - draws 5 tiles vertically, moves up-right
-  // Based on bank_01.asm RoomDraw_DiagonalAcute_1to16 at $018C58
-  // Uses RoomDraw_2x2and1 to draw 5 tiles at rows 0-4, then moves Y -= $7E
-  int size = ctx.object.size_ & 0x0F;
+namespace {
 
-  // Assembly: LDA #$0007; JSR RoomDraw_GetSize_1to16_timesA
-  // GetSize_1to16_timesA formula: ((B2 << 2) | B4) + A
-  // Since size_ already contains ((B2 << 2) | B4), count = size + 7
-  int count = size + 7;
-
-  if (ctx.tiles.size() < 5) return;
-
-  for (int s = 0; s < count; s++) {
-    // Draw 5 tiles in a vertical column (RoomDraw_2x2and1 pattern)
-    // Assembly stores to [$BF],Y, [$CB],Y, [$D7],Y, [$DA],Y, [$DD],Y
-    // These are rows 0, 1, 2, 3, 4 at the same X position
-    int tile_x = ctx.object.x_ + s;  // Move right each iteration
-    int tile_y = ctx.object.y_ - s;  // Move up each iteration (acute = /)
-
-    DrawRoutineUtils::WriteTile8(ctx.target_bg, tile_x, tile_y + 0,
-                                 ctx.tiles[0]);
-    DrawRoutineUtils::WriteTile8(ctx.target_bg, tile_x, tile_y + 1,
-                                 ctx.tiles[1]);
-    DrawRoutineUtils::WriteTile8(ctx.target_bg, tile_x, tile_y + 2,
-                                 ctx.tiles[2]);
-    DrawRoutineUtils::WriteTile8(ctx.target_bg, tile_x, tile_y + 3,
-                                 ctx.tiles[3]);
-    DrawRoutineUtils::WriteTile8(ctx.target_bg, tile_x, tile_y + 4,
-                                 ctx.tiles[4]);
+// USDASM routines 5/6 load size+7, then enter the shared loop at the label
+// that decrements once before the first draw. Routines 17/18 load size+6 and
+// enter before the draw. Both paths therefore render exactly size+6 columns.
+void DrawDiagonalColumns(const DrawContext& ctx, int y_step) {
+  if (ctx.tiles.size() < 5) {
+    return;
   }
+
+  const int count = (ctx.object.size_ & 0x0F) + 6;
+  for (int step = 0; step < count; ++step) {
+    const int tile_x = ctx.object.x_ + step;
+    const int tile_y = ctx.object.y_ + step * y_step;
+    for (int row = 0; row < 5; ++row) {
+      DrawRoutineUtils::WriteTile8(ctx.target_bg, tile_x, tile_y + row,
+                                   ctx.tiles[row]);
+    }
+  }
+}
+
+}  // namespace
+
+void DrawDiagonalAcute_1to16(const DrawContext& ctx) {
+  DrawDiagonalColumns(ctx, /*y_step=*/-1);
 }
 
 void DrawDiagonalGrave_1to16(const DrawContext& ctx) {
-  // Pattern: Diagonal grave (\) - draws 5 tiles vertically, moves down-right
-  // Based on bank_01.asm RoomDraw_DiagonalGrave_1to16 at $018C61
-  // Uses RoomDraw_2x2and1 to draw 5 tiles at rows 0-4, then moves Y += $82
-  int size = ctx.object.size_ & 0x0F;
-
-  // Assembly: LDA #$0007; JSR RoomDraw_GetSize_1to16_timesA
-  // GetSize_1to16_timesA formula: ((B2 << 2) | B4) + A
-  // Since size_ already contains ((B2 << 2) | B4), count = size + 7
-  int count = size + 7;
-
-  if (ctx.tiles.size() < 5) return;
-
-  for (int s = 0; s < count; s++) {
-    // Draw 5 tiles in a vertical column (RoomDraw_2x2and1 pattern)
-    // Assembly stores to [$BF],Y, [$CB],Y, [$D7],Y, [$DA],Y, [$DD],Y
-    // These are rows 0, 1, 2, 3, 4 at the same X position
-    int tile_x = ctx.object.x_ + s;  // Move right each iteration
-    int tile_y = ctx.object.y_ + s;  // Move down each iteration (grave = \)
-
-    DrawRoutineUtils::WriteTile8(ctx.target_bg, tile_x, tile_y + 0,
-                                 ctx.tiles[0]);
-    DrawRoutineUtils::WriteTile8(ctx.target_bg, tile_x, tile_y + 1,
-                                 ctx.tiles[1]);
-    DrawRoutineUtils::WriteTile8(ctx.target_bg, tile_x, tile_y + 2,
-                                 ctx.tiles[2]);
-    DrawRoutineUtils::WriteTile8(ctx.target_bg, tile_x, tile_y + 3,
-                                 ctx.tiles[3]);
-    DrawRoutineUtils::WriteTile8(ctx.target_bg, tile_x, tile_y + 4,
-                                 ctx.tiles[4]);
-  }
+  DrawDiagonalColumns(ctx, /*y_step=*/1);
 }
 
 void DrawDiagonalAcute_1to16_BothBG(const DrawContext& ctx) {
-  // Pattern: Diagonal acute (/) for both BG layers (objects 0x15, 0x18-0x1D,
-  // 0x20) Based on bank_01.asm RoomDraw_DiagonalAcute_1to16_BothBG at $018C6A
-  // Assembly: LDA #$0006; JSR RoomDraw_GetSize_1to16_timesA
-  // GetSize_1to16_timesA formula: ((B2 << 2) | B4) + A
-  // Since size_ already contains ((B2 << 2) | B4), count = size + 6
-  int size = ctx.object.size_ & 0x0F;
-  int count = size + 6;
-
-  if (ctx.tiles.size() < 5) return;
-
-  for (int s = 0; s < count; s++) {
-    int tile_x = ctx.object.x_ + s;
-    int tile_y = ctx.object.y_ - s;
-
-    DrawRoutineUtils::WriteTile8(ctx.target_bg, tile_x, tile_y + 0,
-                                 ctx.tiles[0]);
-    DrawRoutineUtils::WriteTile8(ctx.target_bg, tile_x, tile_y + 1,
-                                 ctx.tiles[1]);
-    DrawRoutineUtils::WriteTile8(ctx.target_bg, tile_x, tile_y + 2,
-                                 ctx.tiles[2]);
-    DrawRoutineUtils::WriteTile8(ctx.target_bg, tile_x, tile_y + 3,
-                                 ctx.tiles[3]);
-    DrawRoutineUtils::WriteTile8(ctx.target_bg, tile_x, tile_y + 4,
-                                 ctx.tiles[4]);
-  }
-  // Note: BothBG should write to both BG1 and BG2 - handled by DrawObject
-  // caller
+  DrawDiagonalColumns(ctx, /*y_step=*/-1);
 }
 
 void DrawDiagonalGrave_1to16_BothBG(const DrawContext& ctx) {
-  // Pattern: Diagonal grave (\) for both BG layers (objects 0x16-0x17,
-  // 0x1A-0x1B, 0x1E-0x1F) Based on bank_01.asm RoomDraw_DiagonalGrave_1to16_BothBG
-  // at $018CB9 Assembly: LDA #$0006; JSR RoomDraw_GetSize_1to16_timesA
-  // GetSize_1to16_timesA formula: ((B2 << 2) | B4) + A
-  // Since size_ already contains ((B2 << 2) | B4), count = size + 6
-  int size = ctx.object.size_ & 0x0F;
-  int count = size + 6;
-
-  if (ctx.tiles.size() < 5) return;
-
-  for (int s = 0; s < count; s++) {
-    int tile_x = ctx.object.x_ + s;
-    int tile_y = ctx.object.y_ + s;
-
-    DrawRoutineUtils::WriteTile8(ctx.target_bg, tile_x, tile_y + 0,
-                                 ctx.tiles[0]);
-    DrawRoutineUtils::WriteTile8(ctx.target_bg, tile_x, tile_y + 1,
-                                 ctx.tiles[1]);
-    DrawRoutineUtils::WriteTile8(ctx.target_bg, tile_x, tile_y + 2,
-                                 ctx.tiles[2]);
-    DrawRoutineUtils::WriteTile8(ctx.target_bg, tile_x, tile_y + 3,
-                                 ctx.tiles[3]);
-    DrawRoutineUtils::WriteTile8(ctx.target_bg, tile_x, tile_y + 4,
-                                 ctx.tiles[4]);
-  }
-  // Note: BothBG should write to both BG1 and BG2 - handled by DrawObject
-  // caller
+  DrawDiagonalColumns(ctx, /*y_step=*/1);
 }
 
 void RegisterDiagonalRoutines(std::vector<DrawRoutineInfo>& registry) {

--- a/src/zelda3/dungeon/draw_routines/downwards_routines.cc
+++ b/src/zelda3/dungeon/draw_routines/downwards_routines.cc
@@ -7,6 +7,42 @@ namespace yaze {
 namespace zelda3 {
 namespace draw_routines {
 
+namespace {
+
+void DrawDownwardsCorners2x1(const DrawContext& ctx, bool edge_is_left) {
+  if (ctx.tiles.size() < 6) {
+    return;
+  }
+
+  // USDASM caches tile 0 as the solid column. Tiles 1-2 form the opening
+  // cap, tile 3 repeats for size+10 rows, and tiles 4-5 form the closing cap.
+  // The routine name's "+12" is the minimum extent, not an X offset.
+  const int body_count = (ctx.object.size_ & 0x0F) + 10;
+  const int edge_x = ctx.object.x_ + (edge_is_left ? 0 : 1);
+  const int fill_x = ctx.object.x_ + (edge_is_left ? 1 : 0);
+  int y = ctx.object.y_;
+
+  if (!DrawRoutineUtils::ExistingTileMatchesAny(ctx, edge_x, y, {0x00E3})) {
+    DrawRoutineUtils::WriteTile8(ctx.target_bg, edge_x, y, ctx.tiles[1]);
+    DrawRoutineUtils::WriteTile8(ctx.target_bg, edge_x, y + 1, ctx.tiles[2]);
+    DrawRoutineUtils::WriteTile8(ctx.target_bg, fill_x, y, ctx.tiles[0]);
+    DrawRoutineUtils::WriteTile8(ctx.target_bg, fill_x, y + 1, ctx.tiles[0]);
+    y += 2;
+  }
+
+  for (int i = 0; i < body_count; ++i, ++y) {
+    DrawRoutineUtils::WriteTile8(ctx.target_bg, edge_x, y, ctx.tiles[3]);
+    DrawRoutineUtils::WriteTile8(ctx.target_bg, fill_x, y, ctx.tiles[0]);
+  }
+
+  DrawRoutineUtils::WriteTile8(ctx.target_bg, edge_x, y, ctx.tiles[4]);
+  DrawRoutineUtils::WriteTile8(ctx.target_bg, edge_x, y + 1, ctx.tiles[5]);
+  DrawRoutineUtils::WriteTile8(ctx.target_bg, fill_x, y, ctx.tiles[0]);
+  DrawRoutineUtils::WriteTile8(ctx.target_bg, fill_x, y + 1, ctx.tiles[0]);
+}
+
+}  // namespace
+
 void DrawDownwards2x2_1to15or32(const DrawContext& ctx) {
   // Pattern: Draws 2x2 tiles downward (object 0x60)
   // Size byte determines how many times to repeat (1-15 or 32)
@@ -191,7 +227,7 @@ void DrawDownwardsHasEdge1x1_1to16_plus3(const DrawContext& ctx) {
   int y = ctx.object.y_;
   // USDASM $01:8EC9-$01:8ED4 suppresses the leading corner when the existing
   // tile already contains the small vertical rail corner.
-  if (!DrawRoutineUtils::ExistingTileMatchesAny(ctx.target_bg, ctx.object.x_, y,
+  if (!DrawRoutineUtils::ExistingTileMatchesAny(ctx, ctx.object.x_, y,
                                                 {0x00E3})) {
     DrawRoutineUtils::WriteTile8(ctx.target_bg, ctx.object.x_, y, ctx.tiles[0]);
   }
@@ -220,102 +256,11 @@ void DrawDownwardsEdge1x1_1to16(const DrawContext& ctx) {
 }
 
 void DrawDownwardsLeftCorners2x1_1to16_plus12(const DrawContext& ctx) {
-  // Pattern: Left corner 2x1 tiles with +12 offset downward (object 0x6C)
-  const int size = ctx.object.size_ & 0x0F;
-  // USDASM $01:9045 - Object_Size_N_to_N_plus_15 with N=0x0A.
-  const int count = size + 10;
-  if (count <= 0 || ctx.tiles.empty()) {
-    return;
-  }
-
-  const int base_x = ctx.object.x_ + 12;
-  int current_y = ctx.object.y_;
-
-  const gfx::TileInfo& fill = ctx.tiles[0];
-  const gfx::TileInfo& start_top_left =
-      ctx.tiles.size() > 1 ? ctx.tiles[1] : fill;
-  const gfx::TileInfo& start_bottom_left =
-      ctx.tiles.size() > 2 ? ctx.tiles[2] : fill;
-  const gfx::TileInfo& body_left = ctx.tiles.size() > 3 ? ctx.tiles[3] : fill;
-  const gfx::TileInfo& end_top_left =
-      ctx.tiles.size() > 4 ? ctx.tiles[4] : body_left;
-  const gfx::TileInfo& end_bottom_left =
-      ctx.tiles.size() > 5 ? ctx.tiles[5] : fill;
-
-  if (!DrawRoutineUtils::ExistingTileMatchesAny(ctx.target_bg, base_x,
-                                                current_y, {0x00E3})) {
-    DrawRoutineUtils::WriteTile8(ctx.target_bg, base_x, current_y,
-                                 start_top_left);
-    DrawRoutineUtils::WriteTile8(ctx.target_bg, base_x + 1, current_y, fill);
-    DrawRoutineUtils::WriteTile8(ctx.target_bg, base_x, current_y + 1,
-                                 start_bottom_left);
-    DrawRoutineUtils::WriteTile8(ctx.target_bg, base_x + 1, current_y + 1,
-                                 fill);
-    current_y += 2;
-  }
-
-  for (int s = 0; s < count; ++s) {
-    DrawRoutineUtils::WriteTile8(ctx.target_bg, base_x, current_y + s,
-                                 body_left);
-    DrawRoutineUtils::WriteTile8(ctx.target_bg, base_x + 1, current_y + s,
-                                 fill);
-  }
-
-  current_y += count;
-  DrawRoutineUtils::WriteTile8(ctx.target_bg, base_x, current_y, end_top_left);
-  DrawRoutineUtils::WriteTile8(ctx.target_bg, base_x + 1, current_y, fill);
-  DrawRoutineUtils::WriteTile8(ctx.target_bg, base_x, current_y + 1,
-                               end_bottom_left);
-  DrawRoutineUtils::WriteTile8(ctx.target_bg, base_x + 1, current_y + 1, fill);
+  DrawDownwardsCorners2x1(ctx, /*edge_is_left=*/true);
 }
 
 void DrawDownwardsRightCorners2x1_1to16_plus12(const DrawContext& ctx) {
-  // Pattern: Right corner 2x1 tiles with +12 offset downward (object 0x6D)
-  const int size = ctx.object.size_ & 0x0F;
-  // USDASM $01:908F - mirrored variant of the left-corner routine.
-  const int count = size + 10;
-  if (count <= 0 || ctx.tiles.empty()) {
-    return;
-  }
-
-  const int base_x = ctx.object.x_ + 12;
-  int current_y = ctx.object.y_;
-
-  const gfx::TileInfo& fill = ctx.tiles[0];
-  const gfx::TileInfo& start_top_right =
-      ctx.tiles.size() > 1 ? ctx.tiles[1] : fill;
-  const gfx::TileInfo& start_bottom_right =
-      ctx.tiles.size() > 2 ? ctx.tiles[2] : fill;
-  const gfx::TileInfo& body_right = ctx.tiles.size() > 3 ? ctx.tiles[3] : fill;
-  const gfx::TileInfo& end_top_right =
-      ctx.tiles.size() > 4 ? ctx.tiles[4] : body_right;
-  const gfx::TileInfo& end_bottom_right =
-      ctx.tiles.size() > 5 ? ctx.tiles[5] : fill;
-
-  if (!DrawRoutineUtils::ExistingTileMatchesAny(ctx.target_bg, base_x + 1,
-                                                current_y, {0x00E3})) {
-    DrawRoutineUtils::WriteTile8(ctx.target_bg, base_x, current_y, fill);
-    DrawRoutineUtils::WriteTile8(ctx.target_bg, base_x + 1, current_y,
-                                 start_top_right);
-    DrawRoutineUtils::WriteTile8(ctx.target_bg, base_x, current_y + 1, fill);
-    DrawRoutineUtils::WriteTile8(ctx.target_bg, base_x + 1, current_y + 1,
-                                 start_bottom_right);
-    current_y += 2;
-  }
-
-  for (int s = 0; s < count; ++s) {
-    DrawRoutineUtils::WriteTile8(ctx.target_bg, base_x, current_y + s, fill);
-    DrawRoutineUtils::WriteTile8(ctx.target_bg, base_x + 1, current_y + s,
-                                 body_right);
-  }
-
-  current_y += count;
-  DrawRoutineUtils::WriteTile8(ctx.target_bg, base_x, current_y, fill);
-  DrawRoutineUtils::WriteTile8(ctx.target_bg, base_x + 1, current_y,
-                               end_top_right);
-  DrawRoutineUtils::WriteTile8(ctx.target_bg, base_x, current_y + 1, fill);
-  DrawRoutineUtils::WriteTile8(ctx.target_bg, base_x + 1, current_y + 1,
-                               end_bottom_right);
+  DrawDownwardsCorners2x1(ctx, /*edge_is_left=*/false);
 }
 
 void DrawDownwardsFloor4x4_1to16(const DrawContext& ctx) {
@@ -345,7 +290,7 @@ void DrawDownwards1x1Solid_1to16_plus3(const DrawContext& ctx) {
 
   for (int s = 0; s < count; ++s) {
     DrawRoutineUtils::WriteTile8(ctx.target_bg, ctx.object.x_,
-                                 ctx.object.y_ + s + 3, ctx.tiles[0]);
+                                 ctx.object.y_ + s, ctx.tiles[0]);
   }
 }
 
@@ -722,7 +667,7 @@ void RegisterDownwardsRoutines(std::vector<DrawRoutineInfo>& registry) {
       .function = DrawDownwardsLeftCorners2x1_1to16_plus12,
       .draws_to_both_bgs = false,
       .base_width = 2,
-      .base_height = 1,
+      .base_height = 14,
       .min_tiles = 6,  // cap + body + endpoint tile spans from subtype-1 table
       .category = Category::Downwards});
 
@@ -732,7 +677,7 @@ void RegisterDownwardsRoutines(std::vector<DrawRoutineInfo>& registry) {
       .function = DrawDownwardsRightCorners2x1_1to16_plus12,
       .draws_to_both_bgs = false,
       .base_width = 2,
-      .base_height = 1,
+      .base_height = 14,
       .min_tiles = 6,  // cap + body + endpoint tile spans from subtype-1 table
       .category = Category::Downwards});
 

--- a/src/zelda3/dungeon/draw_routines/downwards_routines.h
+++ b/src/zelda3/dungeon/draw_routines/downwards_routines.h
@@ -81,9 +81,9 @@ void DrawDownwardsHasEdge1x1_1to16_plus3(const DrawContext& ctx);
 void DrawDownwardsEdge1x1_1to16(const DrawContext& ctx);
 
 /**
- * @brief Draw left corner 2x1 tiles with +12 offset downward
+ * @brief Draw left corner 2x1 tiles with opening and closing caps
  *
- * Pattern: Left corner 2x1 tiles with +12 offset downward (object 0x6C)
+ * Pattern: Left corner 2x1 tiles with a size+12 extent (object 0x6C)
  * Based on bank_01.asm RoomDraw_DownwardsLeftCorners2x1_1to16_plus12
  *
  * @param ctx Draw context containing object, tiles, and target buffer
@@ -91,9 +91,9 @@ void DrawDownwardsEdge1x1_1to16(const DrawContext& ctx);
 void DrawDownwardsLeftCorners2x1_1to16_plus12(const DrawContext& ctx);
 
 /**
- * @brief Draw right corner 2x1 tiles with +12 offset downward
+ * @brief Draw right corner 2x1 tiles with opening and closing caps
  *
- * Pattern: Right corner 2x1 tiles with +12 offset downward (object 0x6D)
+ * Pattern: Right corner 2x1 tiles with a size+12 extent (object 0x6D)
  * Based on bank_01.asm RoomDraw_DownwardsRightCorners2x1_1to16_plus12
  *
  * @param ctx Draw context containing object, tiles, and target buffer

--- a/src/zelda3/dungeon/draw_routines/draw_routine_types.h
+++ b/src/zelda3/dungeon/draw_routines/draw_routine_types.h
@@ -34,6 +34,8 @@ struct DrawContext {
   const uint8_t* room_gfx_buffer;        // Room-specific graphics buffer
   gfx::BackgroundBuffer*
       secondary_bg;  // Secondary BG for dual-layer routines (nullable)
+  const gfx::BackgroundBuffer* target_layout_bg =
+      nullptr;  // Matching layout owner for logical tilemap reads
 
   // Canvas dimensions
   static constexpr int kMaxTilesX = 64;
@@ -106,6 +108,39 @@ inline bool ExistingTileMatchesAny(const gfx::BackgroundBuffer& bg, int tile_x,
     }
   }
   return false;
+}
+
+inline bool TileHasObjectCoverage(const gfx::BackgroundBuffer& bg, int tile_x,
+                                  int tile_y) {
+  const auto& coverage = bg.coverage_data();
+  const auto& bitmap = bg.bitmap();
+  if (coverage.empty() || bitmap.width() <= 0 || bitmap.height() <= 0) {
+    return false;
+  }
+
+  const int start_x = tile_x * 8;
+  const int start_y = tile_y * 8;
+  if (start_x < 0 || start_y < 0 || start_x >= bitmap.width() ||
+      start_y >= bitmap.height()) {
+    return false;
+  }
+
+  // ObjectDrawer marks the full 8x8 footprint even when a tile is visually
+  // transparent. Checking one pixel is therefore enough to establish which
+  // split buffer owns the effective SNES tilemap entry.
+  const size_t index = static_cast<size_t>(start_y * bitmap.width() + start_x);
+  return index < coverage.size() && coverage[index] != 0;
+}
+
+inline bool ExistingTileMatchesAny(const DrawContext& ctx, int tile_x,
+                                   int tile_y,
+                                   std::initializer_list<uint16_t> tile_ids) {
+  const gfx::BackgroundBuffer* effective_owner = &ctx.target_bg;
+  if (!TileHasObjectCoverage(ctx.target_bg, tile_x, tile_y) &&
+      ctx.target_layout_bg != nullptr) {
+    effective_owner = ctx.target_layout_bg;
+  }
+  return ExistingTileMatchesAny(*effective_owner, tile_x, tile_y, tile_ids);
 }
 
 /**

--- a/src/zelda3/dungeon/draw_routines/rightwards_routines.cc
+++ b/src/zelda3/dungeon/draw_routines/rightwards_routines.cc
@@ -7,6 +7,42 @@ namespace yaze {
 namespace zelda3 {
 namespace draw_routines {
 
+namespace {
+
+void DrawRightwardsCorners1x2(const DrawContext& ctx, bool edge_is_top) {
+  if (ctx.tiles.size() < 6) {
+    return;
+  }
+
+  // USDASM caches tile 0 as the solid row. Tiles 1-2 form the opening cap,
+  // tile 3 repeats for size+10 columns, and tiles 4-5 form the closing cap.
+  // The routine name's "+13" is the minimum extent, not an X offset.
+  const int body_count = (ctx.object.size_ & 0x0F) + 10;
+  const int edge_y = ctx.object.y_ + (edge_is_top ? 0 : 1);
+  const int fill_y = ctx.object.y_ + (edge_is_top ? 1 : 0);
+  int x = ctx.object.x_;
+
+  if (!DrawRoutineUtils::ExistingTileMatchesAny(ctx, x, edge_y, {0x00E2})) {
+    DrawRoutineUtils::WriteTile8(ctx.target_bg, x, edge_y, ctx.tiles[1]);
+    DrawRoutineUtils::WriteTile8(ctx.target_bg, x + 1, edge_y, ctx.tiles[2]);
+    DrawRoutineUtils::WriteTile8(ctx.target_bg, x, fill_y, ctx.tiles[0]);
+    DrawRoutineUtils::WriteTile8(ctx.target_bg, x + 1, fill_y, ctx.tiles[0]);
+    x += 2;
+  }
+
+  for (int i = 0; i < body_count; ++i, ++x) {
+    DrawRoutineUtils::WriteTile8(ctx.target_bg, x, edge_y, ctx.tiles[3]);
+    DrawRoutineUtils::WriteTile8(ctx.target_bg, x, fill_y, ctx.tiles[0]);
+  }
+
+  DrawRoutineUtils::WriteTile8(ctx.target_bg, x, edge_y, ctx.tiles[4]);
+  DrawRoutineUtils::WriteTile8(ctx.target_bg, x + 1, edge_y, ctx.tiles[5]);
+  DrawRoutineUtils::WriteTile8(ctx.target_bg, x, fill_y, ctx.tiles[0]);
+  DrawRoutineUtils::WriteTile8(ctx.target_bg, x + 1, fill_y, ctx.tiles[0]);
+}
+
+}  // namespace
+
 void DrawRightwards2x2_1to15or32(const DrawContext& ctx) {
   // Pattern: Draws 2x2 tiles rightward (object 0x00)
   // Size byte determines how many times to repeat (1-15 or 32)
@@ -265,7 +301,7 @@ void DrawRightwardsHasEdge1x1_1to16_plus3(const DrawContext& ctx) {
   int x = ctx.object.x_;
   // USDASM $01:8EF6-$01:8F01 suppresses the corner when the slot already
   // contains the small-rail corner tile.
-  if (!DrawRoutineUtils::ExistingTileMatchesAny(ctx.target_bg, x, ctx.object.y_,
+  if (!DrawRoutineUtils::ExistingTileMatchesAny(ctx, x, ctx.object.y_,
                                                 {0x00E2})) {
     DrawRoutineUtils::WriteTile8(ctx.target_bg, x, ctx.object.y_, ctx.tiles[0]);
   }
@@ -289,7 +325,7 @@ void DrawRightwardsHasEdge1x1_1to16_plus2(const DrawContext& ctx) {
   // USDASM $01:8F65-$01:8F7F skips the leading cap when the existing tile is
   // already the same corner, or one of the compatible trim corner tiles.
   if (!DrawRoutineUtils::ExistingTileMatchesAny(
-          ctx.target_bg, x, ctx.object.y_, {0x01DB, 0x01A6, 0x01DD, 0x01FC})) {
+          ctx, x, ctx.object.y_, {0x01DB, 0x01A6, 0x01DD, 0x01FC})) {
     DrawRoutineUtils::WriteTile8(ctx.target_bg, x, ctx.object.y_, ctx.tiles[0]);
   }
   x++;
@@ -310,7 +346,7 @@ void DrawRightwardsHasEdge1x1_1to16_plus23(const DrawContext& ctx) {
   int x = ctx.object.x_;
   // USDASM $01:8EF6-$01:8F01 uses the same small-rail-corner suppression path
   // for the long horizontal rail.
-  if (!DrawRoutineUtils::ExistingTileMatchesAny(ctx.target_bg, x, ctx.object.y_,
+  if (!DrawRoutineUtils::ExistingTileMatchesAny(ctx, x, ctx.object.y_,
                                                 {0x00E2})) {
     DrawRoutineUtils::WriteTile8(ctx.target_bg, x, ctx.object.y_, ctx.tiles[0]);
   }
@@ -323,62 +359,11 @@ void DrawRightwardsHasEdge1x1_1to16_plus23(const DrawContext& ctx) {
 }
 
 void DrawRightwardsTopCorners1x2_1to16_plus13(const DrawContext& ctx) {
-  // Pattern: Top corner 1x2 tiles with +13 offset (object 0x2F)
-  const int size = ctx.object.size_ & 0x0F;
-  // USDASM $01:8FBD - Object_Size_N_to_N_plus_15 with N=0x0A.
-  const int count = size + 10;
-  if (count <= 0 || ctx.tiles.empty()) {
-    return;
-  }
-
-  // Middle columns are (top=tile3, bottom=tile0). Ends use cap tiles.
-  const gfx::TileInfo& bottom_fill = ctx.tiles[0];
-  const gfx::TileInfo& top_fill =
-      ctx.tiles.size() > 3 ? ctx.tiles[3] : ctx.tiles[0];
-  const gfx::TileInfo& start_cap_top =
-      ctx.tiles.size() > 1 ? ctx.tiles[1] : top_fill;
-  const gfx::TileInfo& end_cap_top =
-      ctx.tiles.size() > 4 ? ctx.tiles[4] : top_fill;
-
-  for (int s = 0; s < count; ++s) {
-    const gfx::TileInfo& top_tile = (s == 0)           ? start_cap_top
-                                    : (s == count - 1) ? end_cap_top
-                                                       : top_fill;
-
-    DrawRoutineUtils::WriteTile8(ctx.target_bg, ctx.object.x_ + s + 13,
-                                 ctx.object.y_, top_tile);
-    DrawRoutineUtils::WriteTile8(ctx.target_bg, ctx.object.x_ + s + 13,
-                                 ctx.object.y_ + 1, bottom_fill);
-  }
+  DrawRightwardsCorners1x2(ctx, /*edge_is_top=*/true);
 }
 
 void DrawRightwardsBottomCorners1x2_1to16_plus13(const DrawContext& ctx) {
-  // Pattern: Bottom corner 1x2 tiles with +13 offset (object 0x30)
-  const int size = ctx.object.size_ & 0x0F;
-  // USDASM $01:9001 - mirrored variant of the top-corner routine.
-  const int count = size + 10;
-  if (count <= 0 || ctx.tiles.empty()) {
-    return;
-  }
-
-  const gfx::TileInfo& top_fill = ctx.tiles[0];
-  const gfx::TileInfo& bottom_fill =
-      ctx.tiles.size() > 3 ? ctx.tiles[3] : ctx.tiles[0];
-  const gfx::TileInfo& start_cap_bottom =
-      ctx.tiles.size() > 1 ? ctx.tiles[1] : bottom_fill;
-  const gfx::TileInfo& end_cap_bottom =
-      ctx.tiles.size() > 4 ? ctx.tiles[4] : bottom_fill;
-
-  for (int s = 0; s < count; ++s) {
-    const gfx::TileInfo& bottom_tile = (s == 0)           ? start_cap_bottom
-                                       : (s == count - 1) ? end_cap_bottom
-                                                          : bottom_fill;
-
-    DrawRoutineUtils::WriteTile8(ctx.target_bg, ctx.object.x_ + s + 13,
-                                 ctx.object.y_ + 1, top_fill);
-    DrawRoutineUtils::WriteTile8(ctx.target_bg, ctx.object.x_ + s + 13,
-                                 ctx.object.y_ + 2, bottom_tile);
-  }
+  DrawRightwardsCorners1x2(ctx, /*edge_is_top=*/false);
 }
 
 void DrawRightwards4x4_1to16(const DrawContext& ctx) {
@@ -404,18 +389,16 @@ void DrawRightwards4x4_1to16(const DrawContext& ctx) {
 }
 
 void DrawRightwards1x1Solid_1to16_plus3(const DrawContext& ctx) {
-  // Pattern: 1x1 solid tiles +3 offset (object 0x34)
-  int size = ctx.object.size_ & 0x0F;
+  if (ctx.tiles.empty()) {
+    return;
+  }
 
-  // Assembly: GetSize_1to16_timesA(4), so count = size + 4
-  int count = size + 4;
-
-  for (int s = 0; s < count; s++) {
-    if (ctx.tiles.size() >= 1) {
-      // Use first 8x8 tile from span
-      DrawRoutineUtils::WriteTile8(ctx.target_bg, ctx.object.x_ + s + 3,
-                                   ctx.object.y_, ctx.tiles[0]);
-    }
+  // USDASM loads A=4 into GetSize_1to16_timesA. That adds four draws; it
+  // does not move the object's origin by three tiles.
+  const int count = (ctx.object.size_ & 0x0F) + 4;
+  for (int s = 0; s < count; ++s) {
+    DrawRoutineUtils::WriteTile8(ctx.target_bg, ctx.object.x_ + s,
+                                 ctx.object.y_, ctx.tiles[0]);
   }
 }
 
@@ -941,7 +924,7 @@ void RegisterRightwardsRoutines(std::vector<DrawRoutineInfo>& registry) {
       .name = "RightwardsTopCorners1x2_1to16_plus13",
       .function = DrawRightwardsTopCorners1x2_1to16_plus13,
       .draws_to_both_bgs = false,
-      .base_width = 1,
+      .base_width = 14,
       .base_height = 2,
       .min_tiles = 6,  // cap + body + endpoint tile spans from subtype-1 table
       .category = DrawRoutineInfo::Category::Rightwards,
@@ -952,8 +935,8 @@ void RegisterRightwardsRoutines(std::vector<DrawRoutineInfo>& registry) {
       .name = "RightwardsBottomCorners1x2_1to16_plus13",
       .function = DrawRightwardsBottomCorners1x2_1to16_plus13,
       .draws_to_both_bgs = false,
-      .base_width = 1,
-      .base_height = 2,  // spans y+1 to y+2
+      .base_width = 14,
+      .base_height = 2,
       .min_tiles = 6,  // cap + body + endpoint tile spans from subtype-1 table
       .category = DrawRoutineInfo::Category::Rightwards,
   });

--- a/src/zelda3/dungeon/draw_routines/rightwards_routines.h
+++ b/src/zelda3/dungeon/draw_routines/rightwards_routines.h
@@ -96,18 +96,18 @@ void DrawRightwardsHasEdge1x1_1to16_plus2(const DrawContext& ctx);
 void DrawRightwardsHasEdge1x1_1to16_plus23(const DrawContext& ctx);
 
 /**
- * @brief Draw top corner 1x2 tiles with +13 offset
+ * @brief Draw top corner 1x2 tiles with opening and closing caps
  *
- * Pattern: Top corner 1x2 tiles with +13 offset (object 0x2F)
+ * Pattern: Top corner 1x2 tiles with a size+13 extent (object 0x2F)
  *
  * @param ctx Draw context containing object, tiles, and target buffer
  */
 void DrawRightwardsTopCorners1x2_1to16_plus13(const DrawContext& ctx);
 
 /**
- * @brief Draw bottom corner 1x2 tiles with +13 offset
+ * @brief Draw bottom corner 1x2 tiles with opening and closing caps
  *
- * Pattern: Bottom corner 1x2 tiles with +13 offset (object 0x30)
+ * Pattern: Bottom corner 1x2 tiles with a size+13 extent (object 0x30)
  *
  * @param ctx Draw context containing object, tiles, and target buffer
  */
@@ -123,9 +123,9 @@ void DrawRightwardsBottomCorners1x2_1to16_plus13(const DrawContext& ctx);
 void DrawRightwards4x4_1to16(const DrawContext& ctx);
 
 /**
- * @brief Draw 1x1 solid tiles +3 offset
+ * @brief Draw 1x1 solid tiles with a +3 extent
  *
- * Pattern: 1x1 solid tiles +3 offset (object 0x34)
+ * Pattern: 1x1 solid tiles with a size+3 minimum extent (object 0x34)
  *
  * @param ctx Draw context containing object, tiles, and target buffer
  */

--- a/src/zelda3/dungeon/draw_routines/special_routines.cc
+++ b/src/zelda3/dungeon/draw_routines/special_routines.cc
@@ -2241,8 +2241,8 @@ void RegisterSpecialRoutines(std::vector<DrawRoutineInfo>& registry) {
             int tile_y = ctx.object.y_;
             // USDASM $01:8EC9-$01:8ED4 suppresses the leading corner when the
             // current slot already contains the small vertical rail corner.
-            if (!DrawRoutineUtils::ExistingTileMatchesAny(
-                    ctx.target_bg, ctx.object.x_, tile_y, {0x00E3})) {
+            if (!DrawRoutineUtils::ExistingTileMatchesAny(ctx, ctx.object.x_,
+                                                          tile_y, {0x00E3})) {
               DrawRoutineUtils::WriteTile8(ctx.target_bg, ctx.object.x_, tile_y,
                                            ctx.tiles[0]);
             }

--- a/src/zelda3/dungeon/draw_routines/special_routines.cc
+++ b/src/zelda3/dungeon/draw_routines/special_routines.cc
@@ -1080,9 +1080,10 @@ void DrawTableRock4x4_1to16(const DrawContext& ctx) {
 
 void DrawWaterOverlay8x8_1to16(const DrawContext& ctx) {
   // ASM: RoomDraw_WaterOverlayA8x8_1to16 ($0195D6) / RoomDraw_WaterOverlayB8x8
-  // NOTE: In the original game, this is an HDMA control object that sets up
-  // the wavy water distortion effect. It doesn't draw tiles directly.
-  // For the editor, we draw the available tile data as a visual indicator.
+  // These are stateful routines: they configure HDMA geometry and also stamp
+  // state-dependent tile patterns. The editor currently models one visible
+  // stamp from the available object payload; runtime water state and layer-mode
+  // side effects still require independent emulator coverage.
 
   int size_x = ((ctx.object.size_ >> 2) & 0x03);
   int size_y = (ctx.object.size_ & 0x03);
@@ -1162,18 +1163,16 @@ void DrawSpiralStairs(const DrawContext& ctx, bool going_up, bool is_upper) {
   // ASM: RoomDraw_SpiralStairsGoingUpUpper, etc.
   // Calls RoomDraw_1x3N_rightwards with A=4 -> 4 columns x 3 rows = 12 tiles
   // Tile order is COLUMN-MAJOR (down first, then right).
-  // Upper variants render to BG1, lower variants render to BG2.
+  // The active object-list pointer chooses the raster target. Upper/lower only
+  // selects transition metadata and the fixed tilemap that receives the two
+  // priority-bit flank mutations; ObjectDrawer applies those after this draw.
   (void)going_up;
+  (void)is_upper;
 
   if (ctx.tiles.size() < 12)
     return;
 
-  gfx::BackgroundBuffer* dest = &ctx.target_bg;
-  if (!is_upper && ctx.secondary_bg != nullptr) {
-    dest = ctx.secondary_bg;
-  }
-
-  DrawColumnMajor(*dest, ctx.object.x_, ctx.object.y_, 4, 3, ctx.tiles);
+  DrawColumnMajor(ctx.target_bg, ctx.object.x_, ctx.object.y_, 4, 3, ctx.tiles);
 }
 
 void DrawAutoStairs(const DrawContext& ctx) {

--- a/src/zelda3/dungeon/geometry/object_geometry.cc
+++ b/src/zelda3/dungeon/geometry/object_geometry.cc
@@ -84,26 +84,19 @@ AnchorPos ChooseAnchor(const DrawRoutineInfo& routine,
   // Acute diagonals (ids 5, 17) move upward by (y - s) per step.
   if (routine.category == DrawRoutineInfo::Category::Diagonal &&
       (routine.id == 5 || routine.id == 17)) {
-    const int count = (routine.id == 5) ? (size_nibble + 7) : (size_nibble + 6);
+    const int count = size_nibble + 6;
     const int max_anchor =
         DrawContext::kMaxTilesY - 5;  // 4 rows headroom below
     anchor.y = std::clamp(count - 1, 0, std::max(0, max_anchor));
     return anchor;
   }
 
-  // Diagonal ceilings (Corner category, ids 75-78) anchor at the visual corner.
-  // The draw routine offsets base by -(side-1) for the mirrored axis, so
-  // bottom-anchored (76, 78) writes into negative Y and right-anchored (77, 78)
-  // writes into negative X without headroom. See corner_routines.cc.
+  // Only the bottom-right diagonal ceiling (78) walks upward from the encoded
+  // origin. Give that replay enough Y headroom so geometry is not clipped.
   if (routine.category == DrawRoutineInfo::Category::Corner &&
       routine.id >= 75 && routine.id <= 78) {
     const int side = size_nibble + 4;
-    const bool mirror_x = (routine.id == 77 || routine.id == 78);
-    const bool mirror_y = (routine.id == 76 || routine.id == 78);
-    if (mirror_x) {
-      anchor.x = std::clamp(side - 1, 0, DrawContext::kMaxTilesX - 1);
-    }
-    if (mirror_y) {
+    if (routine.id == 78) {
       anchor.y = std::clamp(side - 1, 0, DrawContext::kMaxTilesY - 1);
     }
     return anchor;
@@ -160,11 +153,7 @@ absl::StatusOr<GeometryBounds> ObjectGeometry::MeasureByRoutineId(
     return absl::InvalidArgumentError(
         absl::StrFormat("Unknown routine id %d", routine_id));
   }
-  auto bounds = MeasureRoutine(*info, object);
-  if (!bounds.ok()) {
-    return bounds;
-  }
-  return ApplySelectionBounds(*bounds, routine_id);
+  return MeasureRoutine(*info, object);
 }
 
 std::pair<int, int> ObjectGeometry::ResolveAnchor(int16_t object_id,
@@ -301,11 +290,7 @@ absl::StatusOr<GeometryBounds> ObjectGeometry::MeasureByObjectIdForState(
         absl::StrFormat("Unknown routine id %d", routine_id));
   }
 
-  auto bounds = MeasureRoutineForState(*routine, object, state);
-  if (!bounds.ok()) {
-    return bounds;
-  }
-  return ApplySelectionBounds(*bounds, routine_id);
+  return MeasureRoutineForState(*routine, object, state);
 }
 
 void ObjectGeometry::ClearCache() {
@@ -343,44 +328,6 @@ bool ObjectGeometry::IsLayerOneRoutine(int routine_id) {
   (void)
       routine_id;  // Currently unused - layer determined by object, not routine
   return false;
-}
-
-bool ObjectGeometry::IsDiagonalCeilingRoutine(int routine_id) {
-  // Diagonal ceiling routines from draw_routine_registry.h
-  // kDiagonalCeilingTopLeft = 75
-  // kDiagonalCeilingBottomLeft = 76
-  // kDiagonalCeilingTopRight = 77
-  // kDiagonalCeilingBottomRight = 78
-  return routine_id >= 75 && routine_id <= 78;
-}
-
-GeometryBounds ObjectGeometry::ApplySelectionBounds(
-    GeometryBounds render_bounds, int routine_id) {
-  if (!IsDiagonalCeilingRoutine(routine_id)) {
-    // Not a diagonal ceiling - return render bounds unchanged
-    return render_bounds;
-  }
-
-  // For diagonal ceilings, compute a tighter selection box.
-  // The visual triangle fills roughly 50% of the bounding box area.
-  // We use a selection rectangle that's 70% of the size, centered,
-  // to provide a reasonable hit target without excessive false positives.
-
-  int reduced_width = std::max(1, (render_bounds.width_tiles * 7) / 10);
-  int reduced_height = std::max(1, (render_bounds.height_tiles * 7) / 10);
-
-  // Center the reduced selection box within the render bounds
-  int offset_x = (render_bounds.width_tiles - reduced_width) / 2;
-  int offset_y = (render_bounds.height_tiles - reduced_height) / 2;
-
-  SelectionRect selection;
-  selection.x_tiles = render_bounds.min_x_tiles + offset_x;
-  selection.y_tiles = render_bounds.min_y_tiles + offset_y;
-  selection.width_tiles = reduced_width;
-  selection.height_tiles = reduced_height;
-
-  render_bounds.selection_bounds = selection;
-  return render_bounds;
 }
 
 }  // namespace zelda3

--- a/src/zelda3/dungeon/geometry/object_geometry.h
+++ b/src/zelda3/dungeon/geometry/object_geometry.h
@@ -2,7 +2,6 @@
 #define YAZE_ZELDA3_DUNGEON_GEOMETRY_OBJECT_GEOMETRY_H
 
 #include <cstdint>
-#include <optional>
 #include <tuple>
 #include <unordered_map>
 #include <vector>
@@ -39,8 +38,9 @@ struct SelectionRect {
  * BG1 mask rectangle - the area where BG1 pixels should be transparent
  * to allow BG2 content to show through during compositing.
  *
- * For triangular shapes (diagonal ceilings 0xA0-0xA3), the selection_bounds
- * provides a tighter hitbox than the full render_bounds bounding box.
+ * Selection uses this full rendered footprint. Shape-aware pixel hit testing
+ * belongs in the editor; shrinking this rectangle can make visible edge tiles
+ * impossible to select.
  */
 struct GeometryBounds {
   // Full rendered area (bounding box of all drawn tiles)
@@ -51,10 +51,6 @@ struct GeometryBounds {
 
   // Layer information for BG2 masking
   bool is_bg2_overlay = false;  // True if this object draws to BG2 (Layer 1)
-
-  // Optional tighter selection hitbox for non-rectangular shapes
-  // If not set, selection uses the full render bounds
-  std::optional<SelectionRect> selection_bounds;
 
   int max_x_tiles() const { return min_x_tiles + width_tiles; }
   int max_y_tiles() const { return min_y_tiles + height_tiles; }
@@ -75,24 +71,9 @@ struct GeometryBounds {
   bool RequiresBG1Mask() const { return is_bg2_overlay && width_tiles > 0; }
 
   /**
-   * @brief Check if this object has a tighter selection hitbox.
-   *
-   * For non-rectangular shapes like diagonal ceilings, the selection_bounds
-   * provides a more accurate hitbox for mouse interaction.
-   */
-  bool HasTighterSelectionBounds() const {
-    return selection_bounds.has_value();
-  }
-
-  /**
    * @brief Get the selection bounds for hit testing.
-   *
-   * Returns selection_bounds if set, otherwise returns the full render bounds.
    */
   SelectionRect GetSelectionBounds() const {
-    if (selection_bounds.has_value()) {
-      return *selection_bounds;
-    }
     return SelectionRect{min_x_tiles, min_y_tiles, width_tiles, height_tiles};
   }
 
@@ -192,27 +173,6 @@ class ObjectGeometry {
    * corresponding BG1 transparency for proper compositing.
    */
   static bool IsLayerOneRoutine(int routine_id);
-
-  /**
-   * @brief Check if a routine ID corresponds to a diagonal ceiling.
-   *
-   * Diagonal ceilings (routines 75-78 for objects 0xA0-0xA3) have triangular
-   * fill patterns that require tighter selection bounds than their bounding box.
-   */
-  static bool IsDiagonalCeilingRoutine(int routine_id);
-
-  /**
-   * @brief Compute tighter selection bounds for diagonal shapes.
-   *
-   * For triangular diagonal ceilings, this computes a selection rectangle
-   * that's roughly 70% of the bounding box, centered on the visual content.
-   *
-   * @param render_bounds Full render bounds from MeasureRoutine
-   * @param routine_id The routine ID to check for diagonal shapes
-   * @return GeometryBounds with selection_bounds set if applicable
-   */
-  static GeometryBounds ApplySelectionBounds(GeometryBounds render_bounds,
-                                             int routine_id);
 
  private:
   ObjectGeometry();

--- a/src/zelda3/dungeon/object_dimensions.cc
+++ b/src/zelda3/dungeon/object_dimensions.cc
@@ -285,31 +285,6 @@ ObjectDimensionTable::SelectionBounds ObjectDimensionTable::GetSelectionBounds(
   SelectionBounds bounds{0, 0, w, h};
 
   switch (object_id) {
-    // Offset +3 (1x1 solid +3)
-    case 0x34:
-      bounds.offset_x = 3;
-      break;
-
-    // Rightwards corners +13
-    case 0x2F:
-      bounds.offset_x = 13;
-      break;
-    case 0x30:
-      bounds.offset_x = 13;
-      bounds.offset_y = 1;
-      break;
-
-    // Downwards corners +12
-    case 0x6C:
-    case 0x6D:
-      bounds.offset_x = 12;
-      break;
-
-    // Downwards solid +3 writes from y+3 to y+(size+6).
-    case 0x71:
-      bounds.offset_y = 3;
-      break;
-
     // Moving wall west grows its fill left from the three-column platform.
     case 0xCD:
       bounds.offset_x = -moving_wall::ObjectCountForSize(size);
@@ -329,19 +304,9 @@ ObjectDimensionTable::SelectionBounds ObjectDimensionTable::GetSelectionBounds(
     bounds.offset_y = -(bounds.width - 1);
   }
 
-  // Diagonal ceilings: offsets depend on which corner is the origin.
-  // TopLeft (0xA0, 0xA5, 0xA9): extends down-right - no offset needed.
-  // BottomLeft (0xA1, 0xA6, 0xAA): extends up-right - offset_y negative.
-  if (object_id == 0xA1 || object_id == 0xA6 || object_id == 0xAA) {
-    bounds.offset_y = -(bounds.width - 1);
-  }
-  // TopRight (0xA2, 0xA7, 0xAB): extends down-left - offset_x negative.
-  if (object_id == 0xA2 || object_id == 0xA7 || object_id == 0xAB) {
-    bounds.offset_x = -(bounds.width - 1);
-  }
-  // BottomRight (0xA3, 0xA8, 0xAC): extends up-left - both offsets negative.
+  // Diagonal ceilings start at the encoded X coordinate. Only BottomRight
+  // (0xA3, 0xA8, 0xAC) walks upward from the encoded Y coordinate.
   if (object_id == 0xA3 || object_id == 0xA8 || object_id == 0xAC) {
-    bounds.offset_x = -(bounds.width - 1);
     bounds.offset_y = -(bounds.width - 1);
   }
 
@@ -388,12 +353,12 @@ void ObjectDimensionTable::InitializeDefaults() {
     dimensions_[id] = {2, 2, Dir::Horizontal, 2, false};
   }
 
-  // 0x09-0x14: Diagonal walls - non-BothBG (count = size + 7)
+  // 0x09-0x14: Diagonal walls - non-BothBG (count = size + 6)
   // Height = count + 4 tiles (5 tiles per column + diagonal extent)
   for (int id = 0x09; id <= 0x14; id++) {
     // Diagonal pattern: width = count tiles, height = count + 4 tiles
-    dimensions_[id] = {7, 11, Dir::Diagonal, 1,
-                       false};  // base 7 + size*1, height 11 + size*1
+    dimensions_[id] = {6, 10, Dir::Diagonal, 1,
+                       false};  // base 6 + size*1, height 10 + size*1
   }
 
   // 0x15-0x20: Diagonal walls - BothBG (count = size + 6)
@@ -413,11 +378,11 @@ void ObjectDimensionTable::InitializeDefaults() {
     dimensions_[id] = {3, 1, Dir::Horizontal, 1, false};
   }
 
-  // 0x2F: Top corners 1x2 +13
-  dimensions_[0x2F] = {10, 2, Dir::Horizontal, 1, false};
+  // 0x2F: Top corners 1x2, size+10 body plus two 2-tile caps.
+  dimensions_[0x2F] = {14, 2, Dir::Horizontal, 1, false};
 
-  // 0x30: Bottom corners 1x2 +13
-  dimensions_[0x30] = {10, 2, Dir::Horizontal, 1, false};
+  // 0x30: Bottom corners 1x2, size+10 body plus two 2-tile caps.
+  dimensions_[0x30] = {14, 2, Dir::Horizontal, 1, false};
 
   // 0x31-0x32: Nothing
   dimensions_[0x31] = {1, 1, Dir::None, 0, false};
@@ -553,7 +518,7 @@ void ObjectDimensionTable::InitializeDefaults() {
     dimensions_[id] = {1, 1, Dir::Vertical, 1, false};
   }
 
-  // 0x6C-0x6D: Downwards corners (+12 offset in draw routine).
+  // 0x6C-0x6D: Downwards corners rooted at the stored object position.
   // Canonical empty-canvas render:
   // - 2 opening rows
   // - (size + 10) body rows

--- a/src/zelda3/dungeon/object_drawer.cc
+++ b/src/zelda3/dungeon/object_drawer.cc
@@ -16,6 +16,7 @@
 #include "zelda3/dungeon/draw_routines/special_routines.h"
 #include "zelda3/dungeon/dungeon_rom_addresses.h"
 #include "zelda3/dungeon/object_dimensions.h"
+#include "zelda3/dungeon/object_layer_semantics.h"
 
 namespace yaze {
 namespace zelda3 {
@@ -245,13 +246,8 @@ absl::Status ObjectDrawer::DrawObject(
 
   // Check for custom object override first (guarded by feature flag).
   // We check this BEFORE routine lookup to allow overriding vanilla objects.
-  int subtype = object.size_ & 0x1F;
   bool is_custom_object = false;
-  const bool is_track_corner_alias = object.id_ >= 0x100 && object.id_ <= 0x103;
-  const bool allow_custom_override =
-      !is_track_corner_alias || this->allow_track_corner_aliases_;
-  if (core::FeatureFlags::get().kEnableCustomObjects && allow_custom_override &&
-      CustomObjectManager::Get().GetObjectInternal(object.id_, subtype).ok()) {
+  if (HasActiveCustomObjectOverride(object, allow_track_corner_aliases_)) {
     is_custom_object = true;
     // Custom objects default to drawing on the target layer only, unless all_bgs_ is set
     // Mask propagation is difficult without dimensions, so we rely on explicit transparency in the custom object tiles if needed
@@ -461,17 +457,18 @@ absl::Status ObjectDrawer::DrawObjectList(
   int to_bg1 = 0, to_bg2 = 0, both_bgs = 0;
 
   for (const auto& object : objects) {
-    // Track buffer routing for summary
-    bool use_bg2 = (object.layer_ == RoomObject::LayerType::BG2);
-    int routine_id = GetDrawRoutineId(object.id_);
-    bool is_both_bg = (object.all_bgs_ || RoutineDrawsToBothBGs(routine_id));
-
-    if (is_both_bg) {
-      both_bgs++;
-    } else if (use_bg2) {
-      to_bg2++;
-    } else {
-      to_bg1++;
+    const auto semantics =
+        GetEffectiveObjectLayerSemantics(object, allow_track_corner_aliases_);
+    switch (semantics.effective_bg_layer) {
+      case EffectiveBgLayer::kBg1:
+        ++to_bg1;
+        break;
+      case EffectiveBgLayer::kBg2:
+        ++to_bg2;
+        break;
+      case EffectiveBgLayer::kBothBg1Bg2:
+        ++both_bgs;
+        break;
     }
 
     auto s = DrawObject(object, bg1, bg2, palette_group, state, layout_bg1);
@@ -1512,7 +1509,9 @@ int ObjectDrawer::GetDrawRoutineId(int16_t object_id) const {
 void ObjectDrawer::DrawDoor(const DoorDef& door, int door_index,
                             gfx::BackgroundBuffer& bg1,
                             gfx::BackgroundBuffer& bg2,
-                            const DungeonState* state) {
+                            const DungeonState* state,
+                            gfx::BackgroundBuffer* layout_bg1,
+                            gfx::BackgroundBuffer* layout_bg2) {
   // Door rendering based on ZELDA3_DUNGEON_SPEC.md Section 5 and disassembly
   // Uses DoorType and DoorDirection enums for type safety
   // Position calculations via DoorPositionManager
@@ -1551,57 +1550,90 @@ void ObjectDrawer::DrawDoor(const DoorDef& door, int door_index,
   constexpr int kExplodingWallTilemapPositionBase = 0x19DE;
   constexpr int kExplodingWallOpenReplacementType = 0x54;
   constexpr int kNorthCurtainClosedOffset = 0x078A;
+  constexpr int kFancyDungeonExitObjectOffset = 0x2656;
+  constexpr int kCaveExitLightObjectOffset = 0x26F6;
   const auto& rom_data = rom_->data();
 
-  auto draw_from_object_data = [&](gfx::BackgroundBuffer& target,
-                                   int start_tile_x, int start_tile_y,
-                                   int width, int height, int tile_data_addr) {
+  auto draw_tile_word = [&](gfx::BackgroundBuffer& target, int tile_x,
+                            int tile_y, uint16_t tile_word) {
     auto& bitmap = target.bitmap();
     auto& priority_buffer = target.mutable_priority_data();
     auto& coverage_buffer = target.mutable_coverage_data();
     const int bitmap_width = bitmap.width();
+    const auto tile_info = gfx::WordToTileInfo(tile_word);
+    const int pixel_x = tile_x * 8;
+    const int pixel_y = tile_y * 8;
+
+    target.SetTileAt(tile_x, tile_y, tile_word);
+    target.ClearBG1RevealMaskRect(bg1_reveal_mask_source_, pixel_x, pixel_y, 8,
+                                  8);
+    DrawTileToBitmap(bitmap, tile_info, pixel_x, pixel_y, room_gfx_buffer_);
+
+    const uint8_t priority = tile_info.over_ ? 1 : 0;
+    const auto& bitmap_data = bitmap.vector();
+    for (int py = 0; py < 8; py++) {
+      const int dest_y = pixel_y + py;
+      if (dest_y < 0 || dest_y >= bitmap.height()) {
+        continue;
+      }
+      for (int px = 0; px < 8; px++) {
+        const int dest_x = pixel_x + px;
+        if (dest_x < 0 || dest_x >= bitmap_width) {
+          continue;
+        }
+        const int dest_index = dest_y * bitmap_width + dest_x;
+        if (dest_index >= 0 &&
+            dest_index < static_cast<int>(coverage_buffer.size())) {
+          coverage_buffer[dest_index] = 1;
+        }
+        if (dest_index < static_cast<int>(bitmap_data.size()) &&
+            bitmap_data[dest_index] != 255) {
+          priority_buffer[dest_index] = priority;
+        }
+      }
+    }
+  };
+
+  auto draw_object_data_tile = [&](gfx::BackgroundBuffer& target, int tile_x,
+                                   int tile_y, int tile_data_addr, int tile_idx,
+                                   uint16_t word_mask = 0) -> bool {
+    const int addr = tile_data_addr + (tile_idx * 2);
+    if (addr < 0 || addr + 1 >= static_cast<int>(rom_->size())) {
+      return false;
+    }
+
+    const uint16_t tile_word = static_cast<uint16_t>(
+        (rom_data[addr] | (rom_data[addr + 1] << 8)) | word_mask);
+    draw_tile_word(target, tile_x, tile_y, tile_word);
+    return true;
+  };
+
+  auto draw_from_object_data = [&](gfx::BackgroundBuffer& target,
+                                   int start_tile_x, int start_tile_y,
+                                   int width, int height, int tile_data_addr) {
     int tile_idx = 0;
 
     for (int dx = 0; dx < width; dx++) {
       for (int dy = 0; dy < height; dy++) {
-        const int addr = tile_data_addr + (tile_idx * 2);
-        const uint16_t tile_word = rom_data[addr] | (rom_data[addr + 1] << 8);
-        const auto tile_info = gfx::WordToTileInfo(tile_word);
-        const int pixel_x = (start_tile_x + dx) * 8;
-        const int pixel_y = (start_tile_y + dy) * 8;
-
-        target.ClearBG1RevealMaskRect(bg1_reveal_mask_source_, pixel_x, pixel_y,
-                                      8, 8);
-        DrawTileToBitmap(bitmap, tile_info, pixel_x, pixel_y, room_gfx_buffer_);
-
-        const uint8_t priority = tile_info.over_ ? 1 : 0;
-        const auto& bitmap_data = bitmap.vector();
-        for (int py = 0; py < 8; py++) {
-          const int dest_y = pixel_y + py;
-          if (dest_y < 0 || dest_y >= bitmap.height()) {
-            continue;
-          }
-          for (int px = 0; px < 8; px++) {
-            const int dest_x = pixel_x + px;
-            if (dest_x < 0 || dest_x >= bitmap_width) {
-              continue;
-            }
-            const int dest_index = dest_y * bitmap_width + dest_x;
-            if (dest_index >= 0 &&
-                dest_index < static_cast<int>(coverage_buffer.size())) {
-              coverage_buffer[dest_index] = 1;
-            }
-            if (dest_index < static_cast<int>(bitmap_data.size()) &&
-                bitmap_data[dest_index] != 255) {
-              priority_buffer[dest_index] = priority;
-            }
-          }
-        }
-
-        tile_idx++;
+        (void)draw_object_data_tile(target, start_tile_x + dx,
+                                    start_tile_y + dy, tile_data_addr,
+                                    tile_idx++);
       }
     }
   };
+
+  auto draw_from_object_data_row_major =
+      [&](gfx::BackgroundBuffer& target, int start_tile_x, int start_tile_y,
+          int width, int height, int tile_data_addr) {
+        int tile_idx = 0;
+        for (int dy = 0; dy < height; ++dy) {
+          for (int dx = 0; dx < width; ++dx) {
+            (void)draw_object_data_tile(target, start_tile_x + dx,
+                                        start_tile_y + dy, tile_data_addr,
+                                        tile_idx++);
+          }
+        }
+      };
 
   auto draw_repeated_tile = [&](gfx::BackgroundBuffer& target, int start_tile_x,
                                 int start_tile_y, int width, int height,
@@ -1654,9 +1686,275 @@ void ObjectDrawer::DrawDoor(const DoorDef& door, int door_index,
   };
   const int position_index = std::min<int>(door.position & 0x0F, 11);
 
+  enum class DoorPrioritySpan {
+    // RoomDraw_MakeDoorPartsHighPriority_{Vertical,Horizontal}.
+    kNormalLower,
+    // RoomDraw_MakeDoorHighPriorityLowerLayer_* (type $06).
+    kLowerLayerOnly,
+    // RoomDraw_MakeDoorHighPriority_* after a type $40-$66 raster.
+    kHighRange,
+  };
+
+  auto promote_priority_rect_on_layer =
+      [&](gfx::BackgroundBuffer& object_buffer,
+          gfx::BackgroundBuffer* layout_buffer, int start_tile_x,
+          int start_tile_y, int width_tiles, int height_tiles) {
+        auto promote_target = [&](gfx::BackgroundBuffer& target) {
+          for (int y = start_tile_y * 8; y < (start_tile_y + height_tiles) * 8;
+               ++y) {
+            for (int x = start_tile_x * 8; x < (start_tile_x + width_tiles) * 8;
+                 ++x) {
+              target.SetPriorityAt(x, y, 1);
+            }
+          }
+        };
+
+        // USDASM has one tilemap per background. Yaze splits each into layout and
+        // object buffers, so promote both potential pixel owners without changing
+        // either bitmap or coverage mask.
+        promote_target(object_buffer);
+        if (layout_buffer != nullptr && layout_buffer != &object_buffer) {
+          promote_target(*layout_buffer);
+        }
+      };
+
+  auto promote_upper_priority_rect = [&](int start_tile_x, int start_tile_y,
+                                         int width_tiles, int height_tiles) {
+    promote_priority_rect_on_layer(bg1, layout_bg1, start_tile_x, start_tile_y,
+                                   width_tiles, height_tiles);
+  };
+
+  auto promote_lower_priority_rect = [&](int start_tile_x, int start_tile_y,
+                                         int width_tiles, int height_tiles) {
+    promote_priority_rect_on_layer(bg2, layout_bg2, start_tile_x, start_tile_y,
+                                   width_tiles, height_tiles);
+  };
+
+  auto promote_door_priority = [&](DoorDirection render_direction,
+                                   int render_tile_x, int render_tile_y,
+                                   DoorPrioritySpan span) {
+    constexpr int kSectionSize = 32;
+    const auto section_start = [](int coordinate) {
+      return (coordinate / kSectionSize) * kSectionSize;
+    };
+    const auto section_end = [&](int coordinate) {
+      return section_start(coordinate) + kSectionSize;
+    };
+
+    int start_x = render_tile_x;
+    int start_y = render_tile_y;
+    int width = 0;
+    int height = 0;
+
+    switch (span) {
+      case DoorPrioritySpan::kNormalLower:
+        switch (render_direction) {
+          case DoorDirection::North:
+            start_y = section_start(render_tile_y);
+            width = 4;
+            height = 7;
+            break;
+          case DoorDirection::South:
+            // South raster coordinates are one row below the USDASM table
+            // anchor; the fixed priority span starts four rows below it.
+            start_y = render_tile_y + 3;
+            width = 4;
+            height = 7;
+            break;
+          case DoorDirection::West:
+            start_x = section_start(render_tile_x);
+            width = 5;
+            height = 4;
+            break;
+          case DoorDirection::East:
+            // East raster coordinates are one column right of the table
+            // anchor; the fixed priority span starts four columns right.
+            start_x = render_tile_x + 3;
+            width = 5;
+            height = 4;
+            break;
+        }
+        break;
+
+      case DoorPrioritySpan::kLowerLayerOnly:
+        switch (render_direction) {
+          case DoorDirection::North:
+            start_y = section_start(render_tile_y);
+            width = 4;
+            height = render_tile_y - start_y + 1;
+            break;
+          case DoorDirection::South:
+            start_y = render_tile_y + 1;
+            width = 4;
+            height = section_end(render_tile_y) - start_y;
+            break;
+          case DoorDirection::West:
+            start_x = section_start(render_tile_x);
+            width = render_tile_x - start_x + 1;
+            height = 4;
+            break;
+          case DoorDirection::East:
+            start_x = render_tile_x + 1;
+            width = section_end(render_tile_x) - start_x;
+            height = 4;
+            break;
+        }
+        break;
+
+      case DoorPrioritySpan::kHighRange:
+        switch (render_direction) {
+          case DoorDirection::North:
+            start_y = section_start(render_tile_y);
+            width = 4;
+            height = render_tile_y - start_y;
+            break;
+          case DoorDirection::South:
+            start_y = render_tile_y + 3;
+            width = 4;
+            height = section_end(render_tile_y) - start_y;
+            break;
+          case DoorDirection::West:
+            start_x = section_start(render_tile_x);
+            width = render_tile_x - start_x;
+            height = 4;
+            break;
+          case DoorDirection::East:
+            // The visible raster starts one column right of the USDASM table
+            // anchor and spans three columns. Priority begins at anchor+4.
+            start_x = render_tile_x + 3;
+            width = section_end(render_tile_x) - start_x;
+            height = 4;
+            break;
+        }
+        break;
+    }
+
+    if (width > 0 && height > 0) {
+      promote_upper_priority_rect(start_x, start_y, width, height);
+    }
+  };
+
+  // Door markers update room-transition metadata in USDASM; they do not
+  // stamp tiles. In real room streams they commonly follow a physical door
+  // at the same position, so treating them as art overwrites that door with
+  // the marker table's mirrored shutter tiles.
+  const bool is_nonvisual_marker = door.type == DoorType::DungeonSwapMarker ||
+                                   door.type == DoorType::LayerSwapMarker ||
+                                   (door.type == DoorType::ExitMarker &&
+                                    (door.direction == DoorDirection::North ||
+                                     door.direction == DoorDirection::South));
+  if (is_nonvisual_marker) {
+    return;
+  }
+
+  // Type $06 only promotes existing upper-layer wall tiles in USDASM. It
+  // neither looks up nor stamps door graphics.
+  if (door.type == DoorType::UnusedCaveExit) {
+    promote_door_priority(door.direction, tile_x, tile_y,
+                          DoorPrioritySpan::kLowerLayerOnly);
+    return;
+  }
+
+  // South has several dedicated routines that bypass the ordinary 4x3 door
+  // tables. Their coordinates begin at the raw USDASM tilemap anchor rather
+  // than the generic South render anchor one row below it.
+  if (door.direction == DoorDirection::South) {
+    const auto [raw_tile_x, raw_tile_y] =
+        DoorPositionManager::PositionToTileCoords(door.position,
+                                                  door.direction);
+    const int fancy_data_addr =
+        kRoomDrawObjectDataBase + kFancyDungeonExitObjectOffset;
+    const int cave_light_data_addr =
+        kRoomDrawObjectDataBase + kCaveExitLightObjectOffset;
+    const auto has_object_words = [&](int address, int word_count) {
+      return address >= 0 &&
+             address + word_count * 2 <= static_cast<int>(rom_->size());
+    };
+
+    switch (door.type) {
+      case DoorType::FancyDungeonExit:
+        if (!has_object_words(fancy_data_addr, 80)) {
+          DrawDoorIndicator(bg1, raw_tile_x - 3, raw_tile_y - 4,
+                            /*width=*/10, /*height=*/8, door.type,
+                            door.direction);
+          return;
+        }
+        draw_from_object_data_row_major(bg1, raw_tile_x - 3, raw_tile_y - 4,
+                                        /*width=*/10, /*height=*/8,
+                                        fancy_data_addr);
+        return;
+
+      case DoorType::FancyDungeonExitLower:
+        if (!has_object_words(fancy_data_addr, 80)) {
+          DrawDoorIndicator(bg2, raw_tile_x - 3, raw_tile_y - 4,
+                            /*width=*/10, /*height=*/8, door.type,
+                            door.direction);
+          return;
+        }
+        draw_from_object_data_row_major(bg2, raw_tile_x - 3, raw_tile_y - 4,
+                                        /*width=*/10, /*height=*/8,
+                                        fancy_data_addr);
+        // RoomDraw_NormalRangedDoors_South copies the final lower-layer row
+        // back to the upper tilemap and forces high priority.
+        for (int dx = 0; dx < 10; ++dx) {
+          (void)draw_object_data_tile(
+              bg1, raw_tile_x - 3 + dx, raw_tile_y + 3, fancy_data_addr,
+              /*tile_idx=*/70 + dx, /*word_mask=*/0x2000);
+        }
+        return;
+
+      case DoorType::ExitLower:
+        if (!has_object_words(cave_light_data_addr, 16)) {
+          DrawDoorIndicator(bg2, raw_tile_x, raw_tile_y, /*width=*/4,
+                            /*height=*/4, door.type, door.direction);
+          return;
+        }
+        promote_lower_priority_rect(raw_tile_x, raw_tile_y + 4,
+                                    /*width_tiles=*/4, /*height_tiles=*/7);
+        draw_from_object_data(bg2, raw_tile_x, raw_tile_y, /*width=*/4,
+                              /*height=*/4, cave_light_data_addr);
+        for (int dx = 0; dx < 4; ++dx) {
+          (void)draw_object_data_tile(
+              bg1, raw_tile_x + dx, raw_tile_y + 3, cave_light_data_addr,
+              /*tile_idx=*/dx * 4 + 3, /*word_mask=*/0x2000);
+        }
+        return;
+
+      case DoorType::CaveExit:
+        if (!has_object_words(cave_light_data_addr, 16)) {
+          DrawDoorIndicator(bg1, raw_tile_x, raw_tile_y, /*width=*/4,
+                            /*height=*/4, door.type, door.direction);
+          return;
+        }
+        draw_from_object_data(bg1, raw_tile_x, raw_tile_y, /*width=*/4,
+                              /*height=*/4, cave_light_data_addr);
+        return;
+
+      case DoorType::LitCaveExitLower:
+        if (!has_object_words(cave_light_data_addr, 16)) {
+          DrawDoorIndicator(bg1, raw_tile_x, raw_tile_y, /*width=*/4,
+                            /*height=*/4, door.type, door.direction);
+          return;
+        }
+        promote_upper_priority_rect(raw_tile_x, raw_tile_y + 4,
+                                    /*width_tiles=*/4, /*height_tiles=*/7);
+        draw_from_object_data(bg1, raw_tile_x, raw_tile_y, /*width=*/4,
+                              /*height=*/4, cave_light_data_addr);
+        return;
+
+      default:
+        break;
+    }
+  }
+
   auto resolve_render_type = [](DoorDirection render_direction,
                                 DoorType render_type) {
     switch (render_type) {
+      case DoorType::BigKeyDoor:
+        // South's closed big-key door is coerced to the normal-door table
+        // entry by RoomDraw_OneSidedShutters_South.
+        return render_direction == DoorDirection::South ? DoorType::NormalDoor
+                                                        : render_type;
       case DoorType::BottomSidedShutter:
         return (render_direction == DoorDirection::North ||
                 render_direction == DoorDirection::West)
@@ -1682,9 +1980,9 @@ void ObjectDrawer::DrawDoor(const DoorDef& door, int door_index,
     }
   };
 
-  auto draw_table_door = [&](gfx::BackgroundBuffer& target,
-                             DoorDirection render_direction, int start_tile_x,
-                             int start_tile_y, DoorType render_type) -> bool {
+  auto resolve_table_door_data = [&](DoorDirection render_direction,
+                                     DoorType render_type,
+                                     int* tile_data_addr) -> bool {
     int offset_table_addr = 0;
     switch (render_direction) {
       case DoorDirection::North:
@@ -1712,17 +2010,99 @@ void ObjectDrawer::DrawDoor(const DoorDef& door, int door_index,
 
     const uint16_t tile_offset =
         rom_data[table_entry_addr] | (rom_data[table_entry_addr + 1] << 8);
-    const int tile_data_addr = kRoomDrawObjectDataBase + tile_offset;
+    *tile_data_addr = kRoomDrawObjectDataBase + tile_offset;
     const auto dims = GetDoorDimensions(render_direction);
     const int data_size = dims.width_tiles * dims.height_tiles * 2;
-    if (tile_data_addr < 0 ||
-        tile_data_addr + data_size > static_cast<int>(rom_->size())) {
+    if (*tile_data_addr < 0 ||
+        *tile_data_addr + data_size > static_cast<int>(rom_->size())) {
       return false;
     }
 
-    draw_from_object_data(target, start_tile_x, start_tile_y, dims.width_tiles,
-                          dims.height_tiles, tile_data_addr);
     return true;
+  };
+
+  auto draw_table_door = [&](gfx::BackgroundBuffer& target,
+                             DoorDirection render_direction, int start_tile_x,
+                             int start_tile_y, DoorType render_type) -> bool {
+    int tile_data_addr = 0;
+    if (!resolve_table_door_data(render_direction, render_type,
+                                 &tile_data_addr)) {
+      return false;
+    }
+
+    const auto render_dims = GetDoorDimensions(render_direction);
+    draw_from_object_data(target, start_tile_x, start_tile_y,
+                          render_dims.width_tiles, render_dims.height_tiles,
+                          tile_data_addr);
+    return true;
+  };
+
+  auto draw_high_range_table_door = [&](DoorDirection render_direction,
+                                        int start_tile_x, int start_tile_y,
+                                        DoorType render_type) -> bool {
+    int tile_data_addr = 0;
+    if (!resolve_table_door_data(render_direction, render_type,
+                                 &tile_data_addr)) {
+      return false;
+    }
+
+    const auto dims = GetDoorDimensions(render_direction);
+    int tile_idx = 0;
+    for (int dx = 0; dx < dims.width_tiles; ++dx) {
+      for (int dy = 0; dy < dims.height_tiles; ++dy) {
+        // RoomDraw_OneSidedLowerShutters_* splits one logical door across
+        // the upper ($7E2000/BG1) and lower ($7E4000/BG2) tilemaps.
+        bool writes_upper = false;
+        switch (render_direction) {
+          case DoorDirection::North:
+            writes_upper = dy == 0;
+            break;
+          case DoorDirection::South:
+            writes_upper = dy == dims.height_tiles - 1;
+            break;
+          case DoorDirection::West:
+            writes_upper = dx == 0;
+            break;
+          case DoorDirection::East:
+            writes_upper = dx == dims.width_tiles - 1;
+            break;
+        }
+        gfx::BackgroundBuffer& target = writes_upper ? bg1 : bg2;
+        if (!draw_object_data_tile(target, start_tile_x + dx, start_tile_y + dy,
+                                   tile_data_addr, tile_idx++)) {
+          return false;
+        }
+      }
+    }
+    return true;
+  };
+
+  auto draw_ranged_door = [&](DoorDirection render_direction, int start_tile_x,
+                              int start_tile_y, DoorType render_type) -> bool {
+    if (render_type == DoorType::NormalDoorLower) {
+      // Type $02 stamps the ordinary door art after promoting the fixed wall
+      // rectangle selected by RoomDraw_MakeDoorPartsHighPriority_*.
+      promote_door_priority(render_direction, start_tile_x, start_tile_y,
+                            DoorPrioritySpan::kNormalLower);
+    }
+
+    const int render_type_value = static_cast<int>(render_type);
+    const bool is_high_range =
+        render_type_value >= 0x40 && render_type_value <= 0x66;
+    if (is_high_range) {
+      const bool drew = draw_high_range_table_door(
+          render_direction, start_tile_x, start_tile_y, render_type);
+      // North type $46 deliberately skips RoomDraw_MakeDoorHighPriority_North;
+      // every other high-range direction/type promotes the adjacent upper wall.
+      if (drew && !(render_direction == DoorDirection::North &&
+                    render_type == DoorType::ExplicitRoomDoor)) {
+        promote_door_priority(render_direction, start_tile_x, start_tile_y,
+                              DoorPrioritySpan::kHighRange);
+      }
+      return drew;
+    }
+    return draw_table_door(bg1, render_direction, start_tile_x, start_tile_y,
+                           render_type);
   };
 
   // USDASM has special north-door branches that do not follow the generic 4x3
@@ -1847,27 +2227,50 @@ void ObjectDrawer::DrawDoor(const DoorDef& door, int door_index,
     return;
   }
 
+  // Closed North lower-layer key stairs ($24/$26) use the ordinary 4x3 table
+  // layout, but every tile is written to $7E4000/BG2 and no middle-door
+  // counterpart is emitted.
+  const bool is_north_lower_key_stairs =
+      door.direction == DoorDirection::North &&
+      (door.type == DoorType::SmallKeyStairsUpLower ||
+       door.type == DoorType::SmallKeyStairsDownLower);
+  if (is_north_lower_key_stairs) {
+    if (is_door_open) {
+      return;
+    }
+    if (!draw_table_door(bg2, door.direction, tile_x, tile_y, door.type)) {
+      DrawDoorIndicator(bg2, tile_x, tile_y, door_width, door_height, door.type,
+                        door.direction);
+    }
+    return;
+  }
+
   // Door graphics use an indirect addressing scheme:
   // 1. kDoorGfxUp/Down/Left/Right point to offset tables (DoorGFXDataOffset_*)
   // 2. Each table entry is a 16-bit offset into RoomDrawObjectData
   // 3. RoomDrawObjectData base is at PC 0x1B52 (SNES $00:9B52)
   // 4. Actual tile data = 0x1B52 + offset_from_table
+  const bool north_explicit_door = door.direction == DoorDirection::North &&
+                                   door.type == DoorType::ExplicitRoomDoor;
   if ((door.direction == DoorDirection::North ||
        door.direction == DoorDirection::West) &&
-      position_index >= 6 && door.type != DoorType::ExplicitRoomDoor) {
+      position_index >= 6 && !north_explicit_door) {
     const DoorDirection counterpart_direction =
         door.direction == DoorDirection::North ? DoorDirection::South
                                                : DoorDirection::East;
-    const int counterpart_tile_x =
-        tile_x + (counterpart_direction == DoorDirection::East ? 1 : 0);
-    const int counterpart_tile_y =
-        tile_y + (counterpart_direction == DoorDirection::South ? 1 : 0);
-    (void)draw_table_door(bg1, counterpart_direction, counterpart_tile_x,
-                          counterpart_tile_y, door.type);
+    // USDASM indexes the table immediately following NorthMiddle/WestMiddle
+    // with the original 6..11 position offset. That lands on counterpart
+    // positions 0..5; the two rasters are separated by the middle wall rather
+    // than overlapping at the current anchor.
+    const auto [counterpart_tile_x, counterpart_tile_y] =
+        DoorPositionManager::PositionToRenderTileCoords(
+            static_cast<uint8_t>(position_index - 6), counterpart_direction);
+    (void)draw_ranged_door(counterpart_direction, counterpart_tile_x,
+                           counterpart_tile_y, door.type);
   }
 
   const bool drew_current =
-      draw_table_door(bg1, door.direction, tile_x, tile_y, door.type);
+      draw_ranged_door(door.direction, tile_x, tile_y, door.type);
   if (!drew_current) {
     LOG_DEBUG("ObjectDrawer",
               "DrawDoor: INVALID ADDRESS - falling back to indicator");

--- a/src/zelda3/dungeon/object_drawer.cc
+++ b/src/zelda3/dungeon/object_drawer.cc
@@ -77,6 +77,27 @@ void SyncModifiedBitmapToSurface(gfx::Bitmap& bitmap, const char* layer_name) {
   SDL_UnlockSurface(surface);
 }
 
+void PromoteTilePriorityOnly(gfx::BackgroundBuffer& target, int tile_x,
+                             int tile_y) {
+  for (int py = 0; py < 8; ++py) {
+    for (int px = 0; px < 8; ++px) {
+      target.SetPriorityAt(tile_x * 8 + px, tile_y * 8 + py, 1);
+    }
+  }
+}
+
+void PromoteTilePriorityOnOwners(gfx::BackgroundBuffer& object_owner,
+                                 gfx::BackgroundBuffer* layout_owner,
+                                 int tile_x, int tile_y) {
+  // The SNES mutates one physical tilemap. Yaze temporarily splits that map
+  // between layout and object buffers, so update both possible pixel owners
+  // without writing bitmap pixels, coverage, or a new tile word.
+  PromoteTilePriorityOnly(object_owner, tile_x, tile_y);
+  if (layout_owner != nullptr && layout_owner != &object_owner) {
+    PromoteTilePriorityOnly(*layout_owner, tile_x, tile_y);
+  }
+}
+
 }  // namespace
 
 ObjectDrawer::ObjectDrawer(Rom* rom, int room_id,
@@ -217,7 +238,7 @@ absl::Status ObjectDrawer::DrawObject(
     const RoomObject& object, gfx::BackgroundBuffer& bg1,
     gfx::BackgroundBuffer& bg2, const gfx::PaletteGroup& palette_group,
     [[maybe_unused]] const DungeonState* state,
-    gfx::BackgroundBuffer* layout_bg1) {
+    gfx::BackgroundBuffer* layout_bg1, gfx::BackgroundBuffer* layout_bg2) {
   if (!rom_ || !rom_->is_loaded()) {
     return absl::FailedPreconditionError("ROM not loaded");
   }
@@ -355,11 +376,7 @@ absl::Status ObjectDrawer::DrawObject(
   } else if (!is_both_bg && routine_id == DrawRoutineIds::kAutoStairs) {
     registry_secondary_bg_ = &other_bg;
   } else if (!is_both_bg &&
-             (routine_id == DrawRoutineIds::kStraightInterRoomStairs ||
-              routine_id == DrawRoutineIds::kSpiralStairsGoingUpUpper ||
-              routine_id == DrawRoutineIds::kSpiralStairsGoingDownUpper ||
-              routine_id == DrawRoutineIds::kSpiralStairsGoingUpLower ||
-              routine_id == DrawRoutineIds::kSpiralStairsGoingDownLower)) {
+             routine_id == DrawRoutineIds::kStraightInterRoomStairs) {
     dispatch_bg = &bg1;
     registry_secondary_bg_ = &bg2;
     registry_primary_layer_ = RoomObject::LayerType::BG1;
@@ -388,6 +405,23 @@ absl::Status ObjectDrawer::DrawObject(
                                state);
   }
 
+  const bool is_upper_spiral =
+      routine_id == DrawRoutineIds::kSpiralStairsGoingUpUpper ||
+      routine_id == DrawRoutineIds::kSpiralStairsGoingDownUpper;
+  const bool is_lower_spiral =
+      routine_id == DrawRoutineIds::kSpiralStairsGoingUpLower ||
+      routine_id == DrawRoutineIds::kSpiralStairsGoingDownLower;
+  if (!trace_only_ && (is_upper_spiral || is_lower_spiral)) {
+    auto& priority_object_owner = is_upper_spiral ? bg1 : bg2;
+    auto* priority_layout_owner = is_upper_spiral ? layout_bg1 : layout_bg2;
+    // USDASM ORs $2000 into the tile immediately left of the 4x3 raster and
+    // the tile immediately right of it.
+    for (const int tile_x : {object.x_ - 1, object.x_ + 4}) {
+      PromoteTilePriorityOnOwners(priority_object_owner, priority_layout_owner,
+                                  tile_x, object.y_);
+    }
+  }
+
   if (trace_hook_active) {
     DrawRoutineUtils::ClearTraceHook();
   }
@@ -399,10 +433,12 @@ absl::Status ObjectDrawer::DrawObject(
 
   // BG2 mask propagation is deferred to compositing so raw BG1 stays intact.
   //
-  // Ordinary BG2 overlay objects now mask per-pixel as they draw, which keeps
+  // Ordinary BG2 overlay objects mask per-pixel as they draw, which keeps
   // transparent cutouts intact for platforms/statues/stairs. Full-rect masking
   // remains only for true pit/ceiling mask families that intentionally clear an
-  // area larger than their opaque tile pixels.
+  // area larger than their opaque tile pixels. Layer mode 6 ignores these legacy
+  // cross-BG masks because its upper-main/lower-sub PPU setup is resolved by
+  // transparency instead.
   if (use_rectangular_bg1_mask) {
     // Route through DimensionService so the mask rect comes from the same
     // source as selection bounds (ObjectGeometry if available, then
@@ -447,7 +483,8 @@ absl::Status ObjectDrawer::DrawObjectList(
     const std::vector<RoomObject>& objects, gfx::BackgroundBuffer& bg1,
     gfx::BackgroundBuffer& bg2, const gfx::PaletteGroup& palette_group,
     [[maybe_unused]] const DungeonState* state,
-    gfx::BackgroundBuffer* layout_bg1, bool reset_room_event_indices) {
+    gfx::BackgroundBuffer* layout_bg1, bool reset_room_event_indices,
+    gfx::BackgroundBuffer* layout_bg2) {
   if (reset_room_event_indices) {
     ResetChestIndex();
   }
@@ -471,7 +508,8 @@ absl::Status ObjectDrawer::DrawObjectList(
         break;
     }
 
-    auto s = DrawObject(object, bg1, bg2, palette_group, state, layout_bg1);
+    auto s = DrawObject(object, bg1, bg2, palette_group, state, layout_bg1,
+                        layout_bg2);
     if (!s.ok() && status.ok()) {
       status = s;
     }
@@ -1534,6 +1572,10 @@ void ObjectDrawer::DrawDoor(const DoorDef& door, int door_index,
     return;
   }
 
+  // DungeonState intentionally exposes the editor's logical door index. The
+  // runtime derives a separate marker-aware physical slot from $0460 before it
+  // probes $068C; reproducing that slot aliasing belongs in the state adapter,
+  // not in this renderer's vector-index contract.
   const bool is_door_open = state && state->IsDoorOpen(room_id_, door_index);
 
   // Get door position from DoorPositionManager
@@ -1553,6 +1595,38 @@ void ObjectDrawer::DrawDoor(const DoorDef& door, int door_index,
   constexpr int kFancyDungeonExitObjectOffset = 0x2656;
   constexpr int kCaveExitLightObjectOffset = 0x26F6;
   const auto& rom_data = rom_->data();
+
+  auto resolve_effective_door_type = [&]() -> uint16_t {
+    const auto stored_type = static_cast<uint16_t>(door.type);
+    if (!is_door_open) {
+      return stored_type;
+    }
+
+    // RoomDraw_FlagDoorsAndGetFinalType leaves shutter graphics closed while
+    // the room's shutter controller ($0468) is active, even when the persistent
+    // door-open bit is set.
+    const bool is_controlled_shutter =
+        door.type == DoorType::DoubleSidedShutter ||
+        door.type == DoorType::DoubleSidedShutterLower;
+    if (is_controlled_shutter && state->IsDoorSwitchActive(room_id_)) {
+      return stored_type;
+    }
+
+    // USDASM performs a 16-bit read from DoorwayReplacementDoorGFX using the
+    // original even-valued door type as a byte offset. Keep the bounds check on
+    // both bytes so malformed or undersized ROMs fall back to the stored type.
+    const int replacement_addr =
+        kDoorwayReplacementDoorGfxBase + static_cast<int>(door.type);
+    if (replacement_addr < 0 ||
+        replacement_addr + 1 >= static_cast<int>(rom_->size())) {
+      return stored_type;
+    }
+
+    return static_cast<uint16_t>(rom_data[replacement_addr] |
+                                 (rom_data[replacement_addr + 1] << 8));
+  };
+
+  const uint16_t effective_door_type = resolve_effective_door_type();
 
   auto draw_tile_word = [&](gfx::BackgroundBuffer& target, int tile_x,
                             int tile_y, uint16_t tile_word) {
@@ -1948,40 +2022,41 @@ void ObjectDrawer::DrawDoor(const DoorDef& door, int door_index,
   }
 
   auto resolve_render_type = [](DoorDirection render_direction,
-                                DoorType render_type) {
+                                uint16_t render_type) -> uint16_t {
     switch (render_type) {
-      case DoorType::BigKeyDoor:
+      case static_cast<uint16_t>(DoorType::BigKeyDoor):
         // South's closed big-key door is coerced to the normal-door table
         // entry by RoomDraw_OneSidedShutters_South.
-        return render_direction == DoorDirection::South ? DoorType::NormalDoor
-                                                        : render_type;
-      case DoorType::BottomSidedShutter:
+        return render_direction == DoorDirection::South
+                   ? static_cast<uint16_t>(DoorType::NormalDoor)
+                   : render_type;
+      case static_cast<uint16_t>(DoorType::BottomSidedShutter):
         return (render_direction == DoorDirection::North ||
                 render_direction == DoorDirection::West)
-                   ? DoorType::DoubleSidedShutter
-                   : DoorType::NormalDoor;
-      case DoorType::TopSidedShutter:
+                   ? static_cast<uint16_t>(DoorType::DoubleSidedShutter)
+                   : static_cast<uint16_t>(DoorType::NormalDoor);
+      case static_cast<uint16_t>(DoorType::TopSidedShutter):
         return (render_direction == DoorDirection::North ||
                 render_direction == DoorDirection::West)
-                   ? DoorType::NormalDoor
-                   : DoorType::DoubleSidedShutter;
-      case DoorType::BottomShutterLower:
+                   ? static_cast<uint16_t>(DoorType::NormalDoor)
+                   : static_cast<uint16_t>(DoorType::DoubleSidedShutter);
+      case static_cast<uint16_t>(DoorType::BottomShutterLower):
         return (render_direction == DoorDirection::North ||
                 render_direction == DoorDirection::West)
-                   ? DoorType::DoubleSidedShutterLower
-                   : DoorType::NormalDoorOneSidedShutter;
-      case DoorType::TopShutterLower:
+                   ? static_cast<uint16_t>(DoorType::DoubleSidedShutterLower)
+                   : static_cast<uint16_t>(DoorType::NormalDoorOneSidedShutter);
+      case static_cast<uint16_t>(DoorType::TopShutterLower):
         return (render_direction == DoorDirection::North ||
                 render_direction == DoorDirection::West)
-                   ? DoorType::NormalDoorOneSidedShutter
-                   : DoorType::DoubleSidedShutterLower;
+                   ? static_cast<uint16_t>(DoorType::NormalDoorOneSidedShutter)
+                   : static_cast<uint16_t>(DoorType::DoubleSidedShutterLower);
       default:
         return render_type;
     }
   };
 
   auto resolve_table_door_data = [&](DoorDirection render_direction,
-                                     DoorType render_type,
+                                     uint16_t render_type,
                                      int* tile_data_addr) -> bool {
     int offset_table_addr = 0;
     switch (render_direction) {
@@ -1999,11 +2074,12 @@ void ObjectDrawer::DrawDoor(const DoorDef& door, int door_index,
         break;
     }
 
-    const DoorType resolved_type =
+    const uint16_t resolved_type =
         resolve_render_type(render_direction, render_type);
-    const int render_type_value = static_cast<int>(resolved_type);
-    const int type_index = render_type_value / 2;
-    const int table_entry_addr = offset_table_addr + (type_index * 2);
+    // DoorGFXDataOffset_* is an absolute-indexed word table and Y is already
+    // the byte offset. Do not divide/re-multiply: hacked replacement tables may
+    // intentionally supply an odd or wider offset.
+    const int table_entry_addr = offset_table_addr + resolved_type;
     if (table_entry_addr + 1 >= static_cast<int>(rom_->size())) {
       return false;
     }
@@ -2023,7 +2099,7 @@ void ObjectDrawer::DrawDoor(const DoorDef& door, int door_index,
 
   auto draw_table_door = [&](gfx::BackgroundBuffer& target,
                              DoorDirection render_direction, int start_tile_x,
-                             int start_tile_y, DoorType render_type) -> bool {
+                             int start_tile_y, uint16_t render_type) -> bool {
     int tile_data_addr = 0;
     if (!resolve_table_door_data(render_direction, render_type,
                                  &tile_data_addr)) {
@@ -2039,7 +2115,7 @@ void ObjectDrawer::DrawDoor(const DoorDef& door, int door_index,
 
   auto draw_high_range_table_door = [&](DoorDirection render_direction,
                                         int start_tile_x, int start_tile_y,
-                                        DoorType render_type) -> bool {
+                                        uint16_t render_type) -> bool {
     int tile_data_addr = 0;
     if (!resolve_table_door_data(render_direction, render_type,
                                  &tile_data_addr)) {
@@ -2078,31 +2154,35 @@ void ObjectDrawer::DrawDoor(const DoorDef& door, int door_index,
   };
 
   auto draw_ranged_door = [&](DoorDirection render_direction, int start_tile_x,
-                              int start_tile_y, DoorType render_type) -> bool {
-    if (render_type == DoorType::NormalDoorLower) {
+                              int start_tile_y, DoorType original_type,
+                              uint16_t table_type) -> bool {
+    if (original_type == DoorType::NormalDoorLower) {
       // Type $02 stamps the ordinary door art after promoting the fixed wall
       // rectangle selected by RoomDraw_MakeDoorPartsHighPriority_*.
       promote_door_priority(render_direction, start_tile_x, start_tile_y,
                             DoorPrioritySpan::kNormalLower);
     }
 
-    const int render_type_value = static_cast<int>(render_type);
+    // The dispatcher selects the normal/high-range writer before
+    // RoomDraw_FlagDoorsAndGetFinalType substitutes open-door graphics. Keep
+    // that choice tied to the stored type while looking up art by final type.
+    const int render_type_value = static_cast<int>(original_type);
     const bool is_high_range =
         render_type_value >= 0x40 && render_type_value <= 0x66;
     if (is_high_range) {
       const bool drew = draw_high_range_table_door(
-          render_direction, start_tile_x, start_tile_y, render_type);
+          render_direction, start_tile_x, start_tile_y, table_type);
       // North type $46 deliberately skips RoomDraw_MakeDoorHighPriority_North;
       // every other high-range direction/type promotes the adjacent upper wall.
       if (drew && !(render_direction == DoorDirection::North &&
-                    render_type == DoorType::ExplicitRoomDoor)) {
+                    original_type == DoorType::ExplicitRoomDoor)) {
         promote_door_priority(render_direction, start_tile_x, start_tile_y,
                               DoorPrioritySpan::kHighRange);
       }
       return drew;
     }
     return draw_table_door(bg1, render_direction, start_tile_x, start_tile_y,
-                           render_type);
+                           table_type);
   };
 
   // USDASM has special north-door branches that do not follow the generic 4x3
@@ -2133,17 +2213,8 @@ void ObjectDrawer::DrawDoor(const DoorDef& door, int door_index,
 
   if (door.direction == DoorDirection::North &&
       door.type == DoorType::CurtainDoor && is_door_open) {
-    const int replacement_type_addr =
-        kDoorwayReplacementDoorGfxBase + static_cast<int>(door.type);
-    if (replacement_type_addr < 0 ||
-        replacement_type_addr >= static_cast<int>(rom_->size())) {
-      DrawDoorIndicator(bg1, tile_x, tile_y, /*width=*/4, /*height=*/4,
-                        door.type, door.direction);
-      return;
-    }
-
-    const int replacement_type = rom_data[replacement_type_addr];
-    const int table_entry_addr = kDoorGfxUp + replacement_type;
+    const int table_entry_addr =
+        kDoorGfxUp + static_cast<int>(effective_door_type);
     if (table_entry_addr < 0 ||
         table_entry_addr + 1 >= static_cast<int>(rom_->size())) {
       DrawDoorIndicator(bg1, tile_x, tile_y, /*width=*/4, /*height=*/4,
@@ -2227,6 +2298,19 @@ void ObjectDrawer::DrawDoor(const DoorDef& door, int door_index,
     return;
   }
 
+  // RoomDraw_North treats all four key-stair types ($20/$22/$24/$26) as
+  // stateful stair records. Once their persistent bit is open, USDASM returns
+  // without drawing replacement art.
+  const bool is_north_key_stairs =
+      door.direction == DoorDirection::North &&
+      (door.type == DoorType::SmallKeyStairsUp ||
+       door.type == DoorType::SmallKeyStairsDown ||
+       door.type == DoorType::SmallKeyStairsUpLower ||
+       door.type == DoorType::SmallKeyStairsDownLower);
+  if (is_north_key_stairs && is_door_open) {
+    return;
+  }
+
   // Closed North lower-layer key stairs ($24/$26) use the ordinary 4x3 table
   // layout, but every tile is written to $7E4000/BG2 and no middle-door
   // counterpart is emitted.
@@ -2235,13 +2319,23 @@ void ObjectDrawer::DrawDoor(const DoorDef& door, int door_index,
       (door.type == DoorType::SmallKeyStairsUpLower ||
        door.type == DoorType::SmallKeyStairsDownLower);
   if (is_north_lower_key_stairs) {
-    if (is_door_open) {
-      return;
-    }
-    if (!draw_table_door(bg2, door.direction, tile_x, tile_y, door.type)) {
+    if (!draw_table_door(bg2, door.direction, tile_x, tile_y,
+                         static_cast<uint16_t>(door.type))) {
       DrawDoorIndicator(bg2, tile_x, tile_y, door_width, door_height, door.type,
                         door.direction);
     }
+    return;
+  }
+
+  // The normal ranged-door callers treat curtain and waterfall final types as
+  // metadata-only results (carry clear from FlagDoorsAndGetFinalType). North
+  // curtain and lower key stairs have already taken their dedicated branches.
+  const bool uses_normal_ranged_writer =
+      static_cast<int>(door.type) <
+      static_cast<int>(DoorType::NormalDoorOneSidedShutter);
+  if (uses_normal_ranged_writer &&
+      (effective_door_type == static_cast<uint16_t>(DoorType::CurtainDoor) ||
+       effective_door_type == static_cast<uint16_t>(DoorType::WaterfallDoor))) {
     return;
   }
 
@@ -2266,11 +2360,11 @@ void ObjectDrawer::DrawDoor(const DoorDef& door, int door_index,
         DoorPositionManager::PositionToRenderTileCoords(
             static_cast<uint8_t>(position_index - 6), counterpart_direction);
     (void)draw_ranged_door(counterpart_direction, counterpart_tile_x,
-                           counterpart_tile_y, door.type);
+                           counterpart_tile_y, door.type, effective_door_type);
   }
 
-  const bool drew_current =
-      draw_ranged_door(door.direction, tile_x, tile_y, door.type);
+  const bool drew_current = draw_ranged_door(door.direction, tile_x, tile_y,
+                                             door.type, effective_door_type);
   if (!drew_current) {
     LOG_DEBUG("ObjectDrawer",
               "DrawDoor: INVALID ADDRESS - falling back to indicator");
@@ -2280,8 +2374,10 @@ void ObjectDrawer::DrawDoor(const DoorDef& door, int door_index,
   }
 
   LOG_DEBUG("ObjectDrawer",
-            "DrawDoor: type=%s dir=%s pos=%d at tile(%d,%d) size=%dx%d",
+            "DrawDoor: type=%s effective=0x%04X dir=%s pos=%d at tile(%d,%d) "
+            "size=%dx%d",
             std::string(GetDoorTypeName(door.type)).c_str(),
+            static_cast<unsigned int>(effective_door_type),
             std::string(GetDoorDirectionName(door.direction)).c_str(),
             door.position, tile_x, tile_y, door_width, door_height);
 }

--- a/src/zelda3/dungeon/object_drawer.cc
+++ b/src/zelda3/dungeon/object_drawer.cc
@@ -1,5 +1,6 @@
 #include "object_drawer.h"
 
+#include <array>
 #include <cstdio>
 #include <cstring>
 #include <filesystem>
@@ -218,6 +219,7 @@ void ObjectDrawer::DrawUsingRegistryRoutine(
       .room_id = room_id_,
       .room_gfx_buffer = room_gfx_buffer_,
       .secondary_bg = registry_secondary_bg_,
+      .target_layout_bg = registry_primary_layout_bg_,
   };
   info->function(ctx);
 
@@ -267,9 +269,7 @@ absl::Status ObjectDrawer::DrawObject(
 
   // Check for custom object override first (guarded by feature flag).
   // We check this BEFORE routine lookup to allow overriding vanilla objects.
-  bool is_custom_object = false;
   if (HasActiveCustomObjectOverride(object, allow_track_corner_aliases_)) {
-    is_custom_object = true;
     // Custom objects default to drawing on the target layer only, unless all_bgs_ is set
     // Mask propagation is difficult without dimensions, so we rely on explicit transparency in the custom object tiles if needed
 
@@ -287,8 +287,26 @@ absl::Status ObjectDrawer::DrawObject(
     return absl::OkStatus();
   }
 
+  std::array<gfx::TileInfo, 8> room_floor_tiles;
+  std::span<const gfx::TileInfo> render_tiles = mutable_obj.tiles();
+  if (has_room_floor_graphics_ &&
+      (object.id_ == 0x00C4 || object.id_ == 0x00DB)) {
+    const uint8_t floor_graphics =
+        object.id_ == 0x00C4 ? floor1_graphics_ : floor2_graphics_;
+    const auto decoded = gfx::DecodeDungeonFloorTilePattern(
+        rom_->vector(), kRoomObjectTileAddress, kRoomObjectTileAddressFloor,
+        floor_graphics);
+    if (!decoded.has_value()) {
+      return absl::DataLossError(
+          absl::StrFormat("Object 0x%03X cannot read room floor pattern %d",
+                          object.id_, static_cast<int>(floor_graphics)));
+    }
+    room_floor_tiles = *decoded;
+    render_tiles = room_floor_tiles;
+  }
+
   // Skip objects that don't have tiles loaded
-  if (!is_custom_object && mutable_obj.tiles().empty()) {
+  if (render_tiles.empty()) {
     LOG_DEBUG("ObjectDrawer",
               "Object 0x%03X at (%d,%d) has NO TILES - skipping", object.id_,
               object.x_, object.y_);
@@ -302,15 +320,15 @@ absl::Status ObjectDrawer::DrawObject(
   LOG_DEBUG("ObjectDrawer",
             "Object 0x%03X at (%d,%d) size=%d -> routine=%d tiles=%zu",
             object.id_, object.x_, object.y_, object.size_, routine_id,
-            mutable_obj.tiles().size());
+            render_tiles.size());
 
   if (routine_id < 0 || routine_id >= static_cast<int>(draw_routines_.size())) {
     LOG_DEBUG("ObjectDrawer",
               "Object 0x%03X: NO ROUTINE (id=%d, max=%zu) - using fallback 1x1",
               object.id_, routine_id, draw_routines_.size());
     // Fallback to simple 1x1 drawing using first 8x8 tile
-    if (!mutable_obj.tiles().empty()) {
-      const auto& tile_info = mutable_obj.tiles()[0];
+    if (!render_tiles.empty()) {
+      const auto& tile_info = render_tiles[0];
       SetTraceContext(object, use_bg2 ? RoomObject::LayerType::BG2
                                       : RoomObject::LayerType::BG1);
       WriteTile8(target_bg, object.x_, object.y_, tile_info);
@@ -324,15 +342,15 @@ absl::Status ObjectDrawer::DrawObject(
   const DrawRoutineInfo* routine_info =
       DrawRoutineRegistry::Get().GetRoutineInfo(routine_id);
   if (routine_info && routine_info->min_tiles > 0 &&
-      static_cast<int>(mutable_obj.tiles().size()) < routine_info->min_tiles) {
+      static_cast<int>(render_tiles.size()) < routine_info->min_tiles) {
     LOG_WARN("ObjectDrawer",
              "Object 0x%03X at (%d,%d): tile payload too small "
              "(%zu < %d required by routine '%s') - skipping",
-             object.id_, object.x_, object.y_, mutable_obj.tiles().size(),
+             object.id_, object.x_, object.y_, render_tiles.size(),
              routine_info->min_tiles, routine_info->name.c_str());
     // Fall through to 1x1 fallback if any tiles are present
-    if (!mutable_obj.tiles().empty()) {
-      const auto& tile_info = mutable_obj.tiles()[0];
+    if (!render_tiles.empty()) {
+      const auto& tile_info = render_tiles[0];
       SetTraceContext(object, use_bg2 ? RoomObject::LayerType::BG2
                                       : RoomObject::LayerType::BG1);
       WriteTile8(target_bg, object.x_, object.y_, tile_info);
@@ -359,6 +377,9 @@ absl::Status ObjectDrawer::DrawObject(
                                   !is_both_bg && !use_rectangular_bg1_mask;
 
   registry_secondary_bg_ = nullptr;
+  registry_primary_layout_bg_ =
+      use_bg2 ? static_cast<const gfx::BackgroundBuffer*>(layout_bg2)
+              : static_cast<const gfx::BackgroundBuffer*>(layout_bg1);
   registry_primary_layer_ =
       use_bg2 ? RoomObject::LayerType::BG2 : RoomObject::LayerType::BG1;
   registry_secondary_layer_ =
@@ -393,16 +414,21 @@ absl::Status ObjectDrawer::DrawObject(
     // Draw to both background layers
     registry_secondary_bg_ = nullptr;
     registry_primary_layer_ = RoomObject::LayerType::BG1;
+    registry_primary_layout_bg_ = layout_bg1;
     SetTraceContext(object, RoomObject::LayerType::BG1);
-    draw_routines_[routine_id](this, object, bg1, mutable_obj.tiles(), state);
+    draw_routines_[routine_id](this, object, bg1, render_tiles, state);
     registry_primary_layer_ = RoomObject::LayerType::BG2;
+    registry_primary_layout_bg_ = layout_bg2;
     SetTraceContext(object, RoomObject::LayerType::BG2);
-    draw_routines_[routine_id](this, object, bg2, mutable_obj.tiles(), state);
+    draw_routines_[routine_id](this, object, bg2, render_tiles, state);
   } else {
     // Execute the appropriate draw routine on target buffer only
+    registry_primary_layout_bg_ =
+        dispatch_bg == &bg2
+            ? static_cast<const gfx::BackgroundBuffer*>(layout_bg2)
+            : static_cast<const gfx::BackgroundBuffer*>(layout_bg1);
     SetTraceContext(object, registry_primary_layer_);
-    draw_routines_[routine_id](this, object, *dispatch_bg, mutable_obj.tiles(),
-                               state);
+    draw_routines_[routine_id](this, object, *dispatch_bg, render_tiles, state);
   }
 
   const bool is_upper_spiral =
@@ -422,6 +448,19 @@ absl::Status ObjectDrawer::DrawObject(
     }
   }
 
+  if (!trace_only_ &&
+      object_render_routing::IsMixedStraightInterroomObject(object.id_)) {
+    // USDASM promotes a fixed BG1 column outside the lower staircase raster.
+    // North variants touch y-4..y-1; south variants touch y+4..y+7.
+    const int priority_y =
+        object_render_routing::IsNorthMixedStraightInterroomObject(object.id_)
+            ? object.y_ - 4
+            : object.y_ + 4;
+    for (int row = 0; row < 4; ++row) {
+      PromoteTilePriorityOnOwners(bg1, layout_bg1, object.x_, priority_y + row);
+    }
+  }
+
   if (trace_hook_active) {
     DrawRoutineUtils::ClearTraceHook();
   }
@@ -430,6 +469,7 @@ absl::Status ObjectDrawer::DrawObject(
   active_layout_bg1_mask_ = nullptr;
   active_mask_source_bg_ = nullptr;
   registry_secondary_bg_ = nullptr;
+  registry_primary_layout_bg_ = nullptr;
 
   // BG2 mask propagation is deferred to compositing so raw BG1 stays intact.
   //
@@ -2722,6 +2762,10 @@ void ObjectDrawer::WriteTile8(gfx::BackgroundBuffer& bg, int tile_x, int tile_y,
   if (trace_only_) {
     return;
   }
+  // Keep the logical tilemap synchronized with the bitmap/coverage owner.
+  // Conditional edge routines query this word after coverage selects whether
+  // the object or layout half owns the effective physical BG entry.
+  bg.SetTileAt(tile_x, tile_y, gfx::TileInfoToWord(tile_info));
   // Draw directly to bitmap instead of tile buffer to avoid being overwritten
   auto& bitmap = bg.bitmap();
   if (!bitmap.is_active() || bitmap.width() == 0) {
@@ -2989,833 +3033,7 @@ void ObjectDrawer::DrawLargeCanvasObject(const RoomObject& obj,
 
 std::pair<int, int> yaze::zelda3::ObjectDrawer::CalculateObjectDimensions(
     const RoomObject& object) {
-  if (!routines_initialized_) {
-    InitializeDrawRoutines();
-  }
-
-  // Default size 16x16 (2x2 tiles)
-  int width = 16;
-  int height = 16;
-
-  int routine_id = GetDrawRoutineId(object.id_);
-  int size = object.size_;
-
-  // Based on routine ID, calculate dimensions
-  // This logic must match the draw routines
-  switch (routine_id) {
-    case 0:   // DrawRightwards2x2_1to15or32
-    case 4:   // DrawRightwards2x2_1to16
-    case 7:   // DrawDownwards2x2_1to15or32
-    case 11:  // DrawDownwards2x2_1to16
-      // 2x2 tiles repeated
-      if (routine_id == 0 || routine_id == 7) {
-        if (size == 0)
-          size = 32;
-      } else {
-        size = size & 0x0F;
-        if (size == 0)
-          size = 16;  // 0 usually means 16 for 1to16 routines
-      }
-
-      if (routine_id == 0 || routine_id == 4) {
-        // Rightwards: size * 2 tiles width, 2 tiles height
-        width = size * 16;
-        height = 16;
-      } else {
-        // Downwards: 2 tiles width, size * 2 tiles height
-        width = 16;
-        height = size * 16;
-      }
-      break;
-
-    case 1:  // RoomDraw_Rightwards2x4_1to15or26 (layout walls 0x01-0x02)
-    {
-      // ASM: GetSize_1to15or26 - defaults to 26 when size is 0
-      int effective_size = (size == 0) ? 26 : (size & 0x0F);
-      // Draws 2x4 tiles repeated 'effective_size' times horizontally
-      width = effective_size * 16;  // 2 tiles wide per repetition
-      height = 32;                  // 4 tiles tall
-      break;
-    }
-    case DrawRoutineIds::kWeird2x4_1to16: {  // Archery curtains (object 0xB5)
-      const int count = (size & 0x0F) + 1;
-      width = count * 16;
-      height = 32;
-      break;
-    }
-
-    case 2:  // RoomDraw_Rightwards2x4spaced4_1to16 (objects 0x03-0x04)
-    case 3:  // RoomDraw_Rightwards2x4spaced4_1to16_BothBG (objects 0x05-0x06)
-    {
-      // ASM: GetSize_1to16, so both routines repeat size + 1 times.
-      size = size & 0x0F;
-      int count = size + 1;
-      width = count * 16;  // 2 tiles wide per repetition (adjacent)
-      height = 32;         // 4 tiles tall
-      break;
-    }
-
-    case 5:  // DrawDiagonalAcute_1to16
-    case 6:  // DrawDiagonalGrave_1to16
-    {
-      // ASM: RoomDraw_DiagonalAcute/Grave_1to16
-      // Uses LDA #$0007; JSR RoomDraw_GetSize_1to16_timesA
-      // count = size + 7
-      // Each iteration draws 5 tiles vertically (RoomDraw_2x2and1 pattern)
-      // Width = count tiles, Height = 5 tiles base + (count-1) diagonal offset
-      size = size & 0x0F;
-      int count = size + 7;
-      width = count * 8;
-      height = (count + 4) * 8;  // 5 tiles + (count-1) = count + 4
-      break;
-    }
-    case 17:  // DrawDiagonalAcute_1to16_BothBG
-    case 18:  // DrawDiagonalGrave_1to16_BothBG
-    {
-      // ASM: RoomDraw_DiagonalAcute/Grave_1to16_BothBG
-      // Uses LDA #$0006; JSR RoomDraw_GetSize_1to16_timesA
-      // count = size + 6 (one less than non-BothBG)
-      size = size & 0x0F;
-      int count = size + 6;
-      width = count * 8;
-      height = (count + 4) * 8;  // 5 tiles + (count-1) = count + 4
-      break;
-    }
-
-    case 8:  // RoomDraw_Downwards4x2_1to15or26 (layout walls 0x61-0x62)
-    {
-      // ASM: GetSize_1to15or26 - defaults to 26 when size is 0
-      int effective_size = (size == 0) ? 26 : (size & 0x0F);
-      // Draws 4x2 tiles repeated 'effective_size' times vertically
-      width = 32;                    // 4 tiles wide
-      height = effective_size * 16;  // 2 tiles tall per repetition
-      break;
-    }
-    case 9:   // RoomDraw_Downwards4x2_1to16_BothBG (objects 0x63-0x64)
-    case 10:  // RoomDraw_DownwardsDecor4x2spaced4_1to16 (objects 0x65-0x66)
-    {
-      // ASM: GetSize_1to16, draws 4x2 tiles with spacing
-      size = size & 0x0F;
-      int count = size + 1;
-      width = 32;           // 4 tiles wide
-      height = count * 16;  // 2 tiles tall per repetition (adjacent)
-      break;
-    }
-
-    case 12:  // RoomDraw_DownwardsHasEdge1x1_1to16_plus3
-      // ASM ($01:8EC3) uses GetSize_1to16_timesA with A=2, giving
-      // count = size + 2 middle tiles. Total span (corner + middles + end) =
-      // size + 4 tiles, matching the horizontal counterpart 0x22 (case 21).
-      size = size & 0x0F;
-      width = 8;
-      height = (size + 4) * 8;
-      break;
-    case 13:  // RoomDraw_DownwardsEdge1x1_1to16
-      size = size & 0x0F;
-      width = 8;
-      height = (size + 1) * 8;
-      break;
-    case 14:  // RoomDraw_DownwardsLeftCorners2x1_1to16_plus12
-    case 15:  // RoomDraw_DownwardsRightCorners2x1_1to16_plus12
-      size = size & 0x0F;
-      width = 16;
-      height = (size + 14) * 8;
-      break;
-
-    case 16:  // DrawRightwards4x4_1to16 (Routine 16)
-    {
-      // 4x4 block repeated horizontally based on size
-      // ASM: GetSize_1to16, count = (size & 0x0F) + 1
-      int count = (size & 0x0F) + 1;
-      width = 32 * count;  // 4 tiles * 8 pixels * count
-      height = 32;         // 4 tiles * 8 pixels
-      break;
-    }
-    case DrawRoutineIds::kWaterHopStairsA:
-    case DrawRoutineIds::kWaterHopStairsB:
-      width = 32;
-      height = 16;
-      break;
-    case DrawRoutineIds::kDamFloodGate:
-      width = 80;
-      height = 32;
-      break;
-    case 19:  // DrawCorner4x4 (Type 2 corners 0x100-0x103)
-    case 34:  // Water Face (4x4)
-    case 35:  // 4x4 Corner BothBG
-    case 36:  // Weird Corner Bottom
-    case 37:  // Weird Corner Top
-      // 4x4 tiles (32x32 pixels) - fixed size, no repetition
-      width = 32;
-      height = 32;
-      break;
-    case 39: {  // Chest routine (small or big)
-      // Infer size from tile span: big chests provide >=16 tiles
-      int tile_count = object.tiles().size();
-      if (tile_count >= 16) {
-        width = height = 32;  // Big chest 4x4
-      } else {
-        width = height = 16;  // Small chest 2x2
-      }
-      break;
-    }
-
-    case 20:  // Edge 1x2 (RoomDraw_Rightwards1x2_1to16_plus2)
-    {
-      // ZScream: width = size * 2 + 4, height = 3 tiles
-      size = size & 0x0F;
-      width = (size * 2 + 4) * 8;
-      height = 24;
-      break;
-    }
-
-    case 21:  // RoomDraw_RightwardsHasEdge1x1_1to16_plus3 (small rails 0x22)
-    {
-      // ZScream: count = size + 2 (corner + middle*count + end)
-      size = size & 0x0F;
-      width = (size + 4) * 8;
-      height = 8;
-      break;
-    }
-    case 22:  // RoomDraw_RightwardsHasEdge1x1_1to16_plus2 (carpet trim 0x23-0x2E)
-    {
-      // ASM: GetSize_1to16, count = size + 1
-      // Plus corner (1) + end (1) = count + 2 total width
-      size = size & 0x0F;
-      int count = size + 1;
-      width = (count + 2) * 8;  // corner + middle*count + end
-      height = 8;
-      break;
-    }
-    case 118:  // RoomDraw_RightwardsHasEdge1x1_1to16_plus23 (long rails 0x5F)
-    {
-      size = size & 0x0F;
-      width = (size + 23) * 8;
-      height = 8;
-      break;
-    }
-    case DrawRoutineIds::kDownwardsHasEdge1x1_1to16_plus23:
-      size = size & 0x0F;
-      width = 8;
-      height = (size + 23) * 8;
-      break;
-    case DrawRoutineIds::kDownwardsEdge1x1_1to16plus7:
-      size = size & 0x0F;
-      width = 8;
-      height = (size + 8) * 8;
-      break;
-    case 25:  // RoomDraw_Rightwards1x1Solid_1to16_plus3
-    {
-      // ASM: GetSize_1to16_timesA(4), so count = size + 4
-      size = size & 0x0F;
-      width = (size + 4) * 8;
-      height = 8;
-      break;
-    }
-
-    case 23:  // RightwardsTopCorners1x2_1to16_plus13
-    case 24:  // RightwardsBottomCorners1x2_1to16_plus13
-      size = size & 0x0F;
-      width = 8 + size * 8;
-      height = 16;
-      break;
-
-    case 26:  // Door Switcher
-      width = 32;
-      height = 32;
-      break;
-
-    case 27:  // RoomDraw_RightwardsDecor4x4spaced2_1to16
-    {
-      // 4x4 tiles with 6-tile X spacing per repetition
-      // ASM: s * 6 spacing, count = size + 1
-      size = size & 0x0F;
-      int count = size + 1;
-      // Total width = (count - 1) * 6 (spacing) + 4 (last block)
-      width = ((count - 1) * 6 + 4) * 8;
-      height = 32;  // 4 tiles
-      break;
-    }
-
-    case 28:  // RoomDraw_RightwardsStatue2x3spaced2_1to16
-    {
-      // 2x3 tiles with 4-tile X spacing per repetition
-      // ASM: s * 4 spacing, count = size + 1
-      size = size & 0x0F;
-      int count = size + 1;
-      // Total width = (count - 1) * 4 (spacing) + 2 (last block)
-      width = ((count - 1) * 4 + 2) * 8;
-      height = 24;  // 3 tiles
-      break;
-    }
-
-    case 29:  // RoomDraw_RightwardsPillar2x4spaced4_1to16
-    {
-      // 2x4 tiles with 4-tile X spacing per repetition
-      // ASM: ADC #$0008 = 4 tiles between starts
-      size = size & 0x0F;
-      int count = size + 1;
-      // Total width = (count - 1) * 4 (spacing) + 2 (last block)
-      width = ((count - 1) * 4 + 2) * 8;
-      height = 32;  // 4 tiles
-      break;
-    }
-
-    case 30:  // RoomDraw_RightwardsDecor4x3spaced4_1to16
-    {
-      // 4x3 tiles with 8-tile X spacing per repetition
-      // ASM: ADC #$0008 = 8-byte advance = 4 tiles gap between 4-tile objects
-      size = size & 0x0F;
-      int count = size + 1;
-      // Total width = (count - 1) * 8 (spacing) + 4 (last block)
-      width = ((count - 1) * 8 + 4) * 8;
-      height = 24;  // 3 tiles
-      break;
-    }
-
-    case 31:  // RoomDraw_RightwardsDoubled2x2spaced2_1to16
-    {
-      // 4x2 tiles (doubled 2x2) with 6-tile X spacing
-      // ASM: s * 6 spacing, count = size + 1
-      size = size & 0x0F;
-      int count = size + 1;
-      // Total width = (count - 1) * 6 (spacing) + 4 (last block)
-      width = ((count - 1) * 6 + 4) * 8;
-      height = 16;  // 2 tiles
-      break;
-    }
-    case 32:  // RoomDraw_RightwardsDecor2x2spaced12_1to16
-    {
-      // 2x2 tiles with 14-tile X spacing per repetition
-      // ASM: s * 14 spacing, count = size + 1
-      size = size & 0x0F;
-      int count = size + 1;
-      // Total width = (count - 1) * 14 (spacing) + 2 (last block)
-      width = ((count - 1) * 14 + 2) * 8;
-      height = 16;  // 2 tiles
-      break;
-    }
-
-    case 33:  // Somaria Line
-      // Each subtype-3 path piece is one 8x8 tile.
-      width = 8;
-      height = 8;
-      break;
-
-    case 38:  // Nothing (RoomDraw_Nothing)
-      width = 8;
-      height = 8;
-      break;
-
-    case 40:  // Rightwards 4x2 (FloorTile)
-    {
-      // 4 cols x 2 rows, GetSize_1to16
-      size = size & 0x0F;
-      int count = size + 1;
-      width = count * 4 * 8;  // 4 tiles per repetition
-      height = 16;            // 2 tiles
-      break;
-    }
-
-    case 41:  // Rightwards Decor 4x2 spaced 12 (wall torches 0x55-0x56)
-    {
-      // ASM: 4 columns x 2 rows with 12-tile horizontal spacing.
-      size = size & 0x0F;
-      int count = size + 1;
-      width = ((count - 1) * 12 + 4) * 8;
-      height = 16;
-      break;
-    }
-
-    case 42:  // Rightwards Cannon Hole 4x3
-    {
-      // 4x3 tiles, GetSize_1to16
-      size = size & 0x0F;
-      int count = size + 1;
-      width = count * 4 * 8;
-      height = 24;
-      break;
-    }
-
-    case 43:  // Downwards Floor 4x4
-    {
-      // 4x4 tiles, GetSize_1to16
-      size = size & 0x0F;
-      int count = size + 1;
-      width = 32;
-      height = count * 4 * 8;
-      break;
-    }
-
-    case 44:  // Downwards 1x1 Solid +3
-    {
-      size = size & 0x0F;
-      width = 8;
-      height = (size + 4) * 8;
-      break;
-    }
-
-    case 45:  // Downwards Decor 4x4 spaced 2
-    {
-      size = size & 0x0F;
-      int count = size + 1;
-      width = 32;
-      height = ((count - 1) * 6 + 4) * 8;
-      break;
-    }
-
-    case 46:  // Downwards Pillar 2x4 spaced 2
-    {
-      size = size & 0x0F;
-      int count = size + 1;
-      width = 16;
-      height = ((count - 1) * 6 + 4) * 8;
-      break;
-    }
-
-    case 47:  // Downwards Decor 3x4 spaced 4
-    {
-      size = size & 0x0F;
-      int count = size + 1;
-      width = 24;
-      height = ((count - 1) * 6 + 4) * 8;
-      break;
-    }
-
-    case 48:  // Downwards Decor 2x2 spaced 12
-    {
-      size = size & 0x0F;
-      int count = size + 1;
-      width = 16;
-      height = ((count - 1) * 14 + 2) * 8;
-      break;
-    }
-
-    case 49:  // Downwards Line 1x1 +1
-    {
-      size = size & 0x0F;
-      width = 8;
-      height = (size + 2) * 8;
-      break;
-    }
-
-    case 50:  // Downwards Decor 2x4 spaced 8
-    {
-      size = size & 0x0F;
-      int count = size + 1;
-      width = 16;
-      height = ((count - 1) * 12 + 4) * 8;
-      break;
-    }
-
-    case 51:  // Rightwards Line 1x1 +1
-    {
-      size = size & 0x0F;
-      width = (size + 2) * 8;
-      height = 8;
-      break;
-    }
-
-    case 52:  // Rightwards Bar 4x3
-    {
-      size = size & 0x0F;
-      int count = size + 1;
-      width = ((count - 1) * 6 + 4) * 8;
-      height = 24;
-      break;
-    }
-
-    case 53:  // Rightwards Shelf 4x4
-    {
-      size = size & 0x0F;
-      int count = size + 1;
-      width = ((count - 1) * 6 + 4) * 8;
-      height = 32;
-      break;
-    }
-
-    case 54:  // Rightwards Big Rail 1x3 +5
-    {
-      size = size & 0x0F;
-      width = (size + 6) * 8;
-      height = 24;
-      break;
-    }
-
-    case 55:  // Rightwards Block 2x2 spaced 2
-    {
-      size = size & 0x0F;
-      int count = size + 1;
-      width = ((count - 1) * 4 + 2) * 8;
-      height = 16;
-      break;
-    }
-
-    // Routines 56-64: SuperSquare patterns
-    // ASM: Type1/Type3 objects pack 2-bit X/Y sizes into a 4-bit size:
-    //   size = (x_size << 2) | y_size, where x_size/y_size are 0..3 (meaning 1..4).
-    // Each super square unit is 4 tiles (32 pixels) in each dimension.
-    case 56:  // 4x4BlocksIn4x4SuperSquare
-    case 57:  // 3x3FloorIn4x4SuperSquare
-    case 58:  // 4x4FloorIn4x4SuperSquare
-    case 59:  // 4x4FloorOneIn4x4SuperSquare
-    case 60:  // 4x4FloorTwoIn4x4SuperSquare
-    case 62:  // Spike2x2In4x4SuperSquare
-    {
-      int size_x = ((size >> 2) & 0x03) + 1;
-      int size_y = (size & 0x03) + 1;
-      width = size_x * 32;   // 4 tiles per super square
-      height = size_y * 32;  // 4 tiles per super square
-      break;
-    }
-    case 61:  // BigHole4x4
-    case 63:  // TableRock4x4
-    case 64:  // WaterOverlay8x8
-      width = 32;
-      height = 32;
-      break;
-
-    // Routines 65-74: Various downwards/rightwards patterns
-    case 65:  // DownwardsDecor3x4spaced2
-    {
-      size = size & 0x0F;
-      int count = size + 1;
-      width = 24;
-      height = ((count - 1) * 5 + 4) * 8;
-      break;
-    }
-
-    case 66:  // DownwardsBigRail3x1 +5
-    {
-      // Top cap (2x2) + Middle (2x1 x count) + Bottom cap (2x3)
-      // Total: 2 tiles wide, 2 + (size+1) + 3 = size + 6 tiles tall
-      size = size & 0x0F;
-      width = 16;  // 2 tiles wide
-      height = (size + 6) * 8;
-      break;
-    }
-
-    case 67:  // DownwardsBlock2x2spaced2
-    {
-      size = size & 0x0F;
-      int count = size + 1;
-      width = 16;
-      height = ((count - 1) * 4 + 2) * 8;
-      break;
-    }
-
-    case 68:  // DownwardsCannonHole3x4
-    {
-      size = size & 0x0F;
-      width = 24;
-      // Height = repeated 3x2 segment (size+1) + final 3x2 edge segment.
-      // => (2 * (size + 2)) tiles.
-      height = (2 * (size + 2)) * 8;
-      break;
-    }
-
-    case 69:  // DownwardsBar2x5
-    {
-      size = size & 0x0F;
-      width = 16;
-      // 1 top row + 2*(size+2) body rows.
-      height = (2 * size + 5) * 8;
-      break;
-    }
-
-    case 70:  // DownwardsPots2x2
-    case 71:  // DownwardsHammerPegs2x2
-    {
-      size = size & 0x0F;
-      int count = size + 1;
-      width = 16;
-      height = count * 2 * 8;
-      break;
-    }
-
-    case 72:  // RightwardsEdge1x1 +7
-    {
-      size = size & 0x0F;
-      width = (size + 8) * 8;
-      height = 8;
-      break;
-    }
-
-    case 73:  // RightwardsPots2x2
-    case 74:  // RightwardsHammerPegs2x2
-    {
-      size = size & 0x0F;
-      int count = size + 1;
-      width = count * 2 * 8;
-      height = 16;
-      break;
-    }
-
-    // Diagonal ceilings (75-78) - TRIANGLE shapes
-    // Draw uses count = (size & 0x0F) + 4
-    // Outline uses smaller size since triangle only fills half the square area
-    case 75:  // DiagonalCeilingTopLeft - triangle at origin
-    case 76:  // DiagonalCeilingBottomLeft - triangle at origin
-    {
-      // Smaller outline for triangle - use half the drawn area
-      int count = (size & 0x0F) + 2;
-      width = count * 8;
-      height = count * 8;
-      break;
-    }
-    case 77:  // DiagonalCeilingTopRight - triangle shifts diagonally
-    case 78:  // DiagonalCeilingBottomRight - triangle shifts diagonally
-    {
-      // Smaller outline for diagonal triangles
-      int count = (size & 0x0F) + 2;
-      width = count * 8;
-      height = count * 8;
-      break;
-    }
-
-    case 79: {  // ClosedChestPlatform
-      int size_x = (size >> 2) & 0x03;
-      int size_y = size & 0x03;
-      width = (size_x * 2 + 14) * 8;
-      height = (size_y * 2 + 8) * 8;
-      break;
-    }
-
-    // Special platform routines (80-82)
-    case 80:  // MovingWallWest
-    case 81:  // MovingWallEast
-      return DimensionService::Get().GetPixelDimensions(object);
-
-    case 82: {  // OpenChestPlatform
-      int size_x = (size >> 2) & 0x03;
-      int size_y = size & 0x03;
-      width = (size_x * 2 + 10) * 8;
-      height = (size_y * 2 + 7) * 8;
-      break;
-    }
-
-    // Stair routines - different sizes for different types
-
-    // 4x4 stair patterns (32x32 pixels)
-    case 83:        // InterRoomFatStairsUp (0x12D)
-    case 84:        // InterRoomFatStairsDownA (0x12E)
-    case 85:        // InterRoomFatStairsDownB (0x12F)
-    case 86:        // AutoStairs (0x130-0x133)
-    case 87:        // StraightInterroomStairs (0xF9E-0xFA9)
-      width = 32;   // 4 tiles
-      height = 32;  // 4 tiles (4x4 pattern)
-      break;
-
-    // 4x3 stair patterns (32x24 pixels)
-    case 88:  // SpiralStairsGoingUpUpper (0x138)
-    case 89:  // SpiralStairsGoingDownUpper (0x139)
-    case 90:  // SpiralStairsGoingUpLower (0x13A)
-    case 91:  // SpiralStairsGoingDownLower (0x13B)
-      // ASM: RoomDraw_1x3N_rightwards with A=4 -> 4 columns x 3 rows
-      width = 32;   // 4 tiles
-      height = 24;  // 3 tiles
-      break;
-
-    case 92:  // BigKeyLock
-      width = 16;
-      height = 16;
-      break;
-
-    case 93:  // BombableFloor
-      width = 32;
-      height = 32;
-      break;
-
-    case 94:  // EmptyWaterFace
-      width = 32;
-      // Report the larger stateful footprint so editor bounds do not
-      // undershoot the active 4x5 branch.
-      height = 40;
-      break;
-
-    case 95:  // SpittingWaterFace
-      width = 32;
-      height = 40;
-      break;
-
-    case 96:  // DrenchingWaterFace
-      width = 32;
-      height = 56;
-      break;
-
-    case 97:        // PrisonCell
-      width = 128;  // 16 tiles
-      height = 32;  // 4 tiles
-      break;
-
-    case 98:  // Bed4x5
-      width = 32;
-      height = 40;
-      break;
-
-    case 99:        // Rightwards3x6
-      width = 48;   // 6 tiles
-      height = 24;  // 3 tiles
-      break;
-
-    case 100:  // Utility6x3
-      width = 48;
-      height = 24;
-      break;
-
-    case 101:  // Utility3x5
-      width = 24;
-      height = 40;
-      break;
-
-    case 102:  // VerticalTurtleRockPipe
-      width = 32;
-      height = 48;
-      break;
-
-    case 103:  // HorizontalTurtleRockPipe
-      width = 48;
-      height = 32;
-      break;
-
-    case 104:      // LightBeam
-      width = 32;  // 4 tiles
-      height = 80;
-      break;
-
-    case 105:  // BigLightBeam
-      width = 64;
-      height = 64;
-      break;
-
-    case DrawRoutineIds::kFloorLight:
-      width = 64;
-      height = 64;
-      break;
-
-    case 106:  // BossShell4x4
-      width = 32;
-      height = 32;
-      break;
-
-    case DrawRoutineIds::kVitreousGooDamage:
-      width = 160;
-      height = 64;
-      break;
-
-    case 107:  // SolidWallDecor3x4
-      width = 24;
-      height = 32;
-      break;
-
-    case 108:  // ArcheryGameTargetDoor
-      width = 24;
-      height = 48;
-      break;
-
-    case 109:  // GanonTriforceFloorDecor
-      width = 64;
-      height = 64;
-      break;
-
-    case 110:  // Single2x2
-      width = 16;
-      height = 16;
-      break;
-
-    case 111:  // Waterfall47 (object 0x47)
-    {
-      // ASM: count = (size+1)*2, draws 1x5 columns
-      // Width = first column + middle columns + last column = 2 + count tiles
-      size = size & 0x0F;
-      int count = (size + 1) * 2;
-      width = (2 + count) * 8;
-      height = 40;  // 5 tiles
-      break;
-    }
-    case 112:  // Waterfall48 (object 0x48)
-    {
-      // ASM: count = (size+1)*2, draws 1x3 columns
-      // Width = first column + middle columns + last column = 2 + count tiles
-      size = size & 0x0F;
-      int count = (size + 1) * 2;
-      width = (2 + count) * 8;
-      height = 24;  // 3 tiles
-      break;
-    }
-
-    case 113:  // Single4x4 (no repetition) - 4x4 TILE16 = 8x8 TILE8
-      // ASM RoomDraw_4x4 = 4x4 tile8.
-      width = 32;
-      height = 32;
-      break;
-
-    case 114:  // Single4x3 (no repetition)
-      // 4 tiles wide x 3 tiles tall = 32x24 pixels
-      width = 32;
-      height = 24;
-      break;
-
-    case 115:  // RupeeFloor (special pattern)
-      // Columns at x + 0, +2, +4 bound a 5x8-tile area = 40x64 pixels.
-      width = 40;
-      height = 64;
-      break;
-
-    case 116:  // Actual4x4 (true 4x4 tile8 pattern, no repetition)
-      // 4 tile8s x 4 tile8s = 32x32 pixels
-      width = 32;
-      height = 32;
-      break;
-
-    case DrawRoutineIds::kBigWallDecor:
-      width = 64;
-      height = 24;
-      break;
-
-    case DrawRoutineIds::kTableBowl:
-      width = 32;
-      height = 16;
-      break;
-
-    case DrawRoutineIds::kSmithyFurnace:
-      width = 48;
-      height = 64;
-      break;
-
-    case DrawRoutineIds::kBigGrayRock:
-      width = 32;
-      height = 32;
-      break;
-
-    case DrawRoutineIds::kAgahnimsAltar:
-      width = 112;
-      height = 112;
-      break;
-
-    case DrawRoutineIds::kFortuneTellerRoom:
-      width = 112;
-      height = 112;
-      break;
-
-    case DrawRoutineIds::kMagicBatAltar:
-      width = 64;
-      height = 56;
-      break;
-
-    default:
-      // Fallback to naive calculation if not handled
-      // Matches DungeonCanvasViewer::DrawRoomObjects logic
-      {
-        int size_h = (object.size_ & 0x0F);
-        int size_v = (object.size_ >> 4) & 0x0F;
-        width = (size_h + 1) * 8;
-        height = (size_v + 1) * 8;
-      }
-      break;
-  }
-
-  return {width, height};
+  return DimensionService::Get().GetPixelDimensions(object);
 }
 
 void yaze::zelda3::ObjectDrawer::DrawCustomObject(

--- a/src/zelda3/dungeon/object_drawer.h
+++ b/src/zelda3/dungeon/object_drawer.h
@@ -83,6 +83,13 @@ class ObjectDrawer {
   void SetBG1RevealMaskSource(gfx::BG1RevealMaskSource source) {
     bg1_reveal_mask_source_ = source;
   }
+  // Room objects 0xC4/0xDB copy the active Floor 1/Floor 2 pattern rather than
+  // reading a normal object tile payload.
+  void SetRoomFloorGraphics(uint8_t floor1, uint8_t floor2) {
+    floor1_graphics_ = floor1 & 0x0F;
+    floor2_graphics_ = floor2 & 0x0F;
+    has_room_floor_graphics_ = true;
+  }
 
   /**
    * @brief Draw a door to background buffers
@@ -303,7 +310,11 @@ class ObjectDrawer {
   mutable int current_chest_index_ = 0;
   mutable int current_room_event_index_ = 0;
   bool allow_track_corner_aliases_ = true;
+  bool has_room_floor_graphics_ = false;
+  uint8_t floor1_graphics_ = 0;
+  uint8_t floor2_graphics_ = 0;
   gfx::BackgroundBuffer* registry_secondary_bg_ = nullptr;
+  const gfx::BackgroundBuffer* registry_primary_layout_bg_ = nullptr;
   RoomObject::LayerType registry_primary_layer_ = RoomObject::LayerType::BG1;
   RoomObject::LayerType registry_secondary_layer_ = RoomObject::LayerType::BG2;
   gfx::BackgroundBuffer* active_object_bg1_mask_ = nullptr;

--- a/src/zelda3/dungeon/object_drawer.h
+++ b/src/zelda3/dungeon/object_drawer.h
@@ -85,12 +85,17 @@ class ObjectDrawer {
   /**
    * @brief Draw a door to background buffers
    * @param door Door definition (type, direction, position)
-   * @param bg1 Background layer 1 buffer
-   * @param bg2 Background layer 2 buffer
+   * @param bg1 Background layer 1 object buffer
+   * @param bg2 Background layer 2 object buffer
+   * @param layout_bg1 Optional upper-layer layout buffer. Door priority
+   *        promotion is applied to both BG1 owners without repainting pixels.
+   * @param layout_bg2 Optional lower-layer layout buffer for door routines that
+   *        mutate existing BG2 priority.
    */
   void DrawDoor(const DoorDef& door, int door_index, gfx::BackgroundBuffer& bg1,
-                gfx::BackgroundBuffer& bg2,
-                const DungeonState* state = nullptr);
+                gfx::BackgroundBuffer& bg2, const DungeonState* state = nullptr,
+                gfx::BackgroundBuffer* layout_bg1 = nullptr,
+                gfx::BackgroundBuffer* layout_bg2 = nullptr);
 
   /**
    * @brief Draw a pot item visualization

--- a/src/zelda3/dungeon/object_drawer.h
+++ b/src/zelda3/dungeon/object_drawer.h
@@ -44,14 +44,16 @@ class ObjectDrawer {
    * @param bg1 Background layer 1 buffer (object buffer)
    * @param bg2 Background layer 2 buffer (object buffer)
    * @param palette_group Current palette group for color mapping
-   * @param layout_bg1 Optional second BG1 target for room-object reveal masks
+   * @param layout_bg1 Optional upper layout owner for fixed-tilemap mutations
+   * @param layout_bg2 Optional lower layout owner for fixed-tilemap mutations
    * @return Status of the drawing operation
    */
   absl::Status DrawObject(const RoomObject& object, gfx::BackgroundBuffer& bg1,
                           gfx::BackgroundBuffer& bg2,
                           const gfx::PaletteGroup& palette_group,
                           const DungeonState* state = nullptr,
-                          gfx::BackgroundBuffer* layout_bg1 = nullptr);
+                          gfx::BackgroundBuffer* layout_bg1 = nullptr,
+                          gfx::BackgroundBuffer* layout_bg2 = nullptr);
 
   struct DoorDef {
     DoorType type;
@@ -112,10 +114,13 @@ class ObjectDrawer {
    * @param bg1 Background layer 1 buffer (object buffer)
    * @param bg2 Background layer 2 buffer (object buffer)
    * @param palette_group Current palette group for color mapping
-   * @param layout_bg1 Optional second BG1 target for room-object reveal masks
+   * @param layout_bg1 Optional upper layout owner for fixed-tilemap mutations
    * @param reset_room_event_indices If true, reset the chest-only and shared
    *        chest/lock counters before drawing (set false on subsequent USDASM
    *        list passes; see Room::RenderObjectsToBackground)
+   * @param layout_bg2 Optional lower layout owner for fixed-tilemap mutations.
+   *        Kept after reset_room_event_indices for source compatibility with
+   *        existing positional callers.
    * @return Status of the drawing operation
    */
   absl::Status DrawObjectList(const std::vector<RoomObject>& objects,
@@ -124,7 +129,8 @@ class ObjectDrawer {
                               const gfx::PaletteGroup& palette_group,
                               const DungeonState* state = nullptr,
                               gfx::BackgroundBuffer* layout_bg1 = nullptr,
-                              bool reset_room_event_indices = true);
+                              bool reset_room_event_indices = true,
+                              gfx::BackgroundBuffer* layout_bg2 = nullptr);
 
   /**
    * @brief Get draw routine ID for an object

--- a/src/zelda3/dungeon/object_layer_semantics.h
+++ b/src/zelda3/dungeon/object_layer_semantics.h
@@ -88,18 +88,9 @@ inline ObjectLayerSemantics GetObjectLayerSemantics(const RoomObject& object) {
   }
 
   if (out.routine_id == DrawRoutineIds::kAgahnimsAltar ||
-      out.routine_id == DrawRoutineIds::kFortuneTellerRoom ||
-      out.routine_id == DrawRoutineIds::kSpiralStairsGoingUpUpper ||
-      out.routine_id == DrawRoutineIds::kSpiralStairsGoingDownUpper) {
+      out.routine_id == DrawRoutineIds::kFortuneTellerRoom) {
     out.effective_bg_layer = EffectiveBgLayer::kBg1;
     out.render_routing = ObjectRenderRouting::kFixedBg1;
-    return out;
-  }
-
-  if (out.routine_id == DrawRoutineIds::kSpiralStairsGoingUpLower ||
-      out.routine_id == DrawRoutineIds::kSpiralStairsGoingDownLower) {
-    out.effective_bg_layer = EffectiveBgLayer::kBg2;
-    out.render_routing = ObjectRenderRouting::kFixedBg2;
     return out;
   }
 

--- a/src/zelda3/dungeon/object_layer_semantics.h
+++ b/src/zelda3/dungeon/object_layer_semantics.h
@@ -1,8 +1,12 @@
 #ifndef YAZE_ZELDA3_DUNGEON_OBJECT_LAYER_SEMANTICS_H_
 #define YAZE_ZELDA3_DUNGEON_OBJECT_LAYER_SEMANTICS_H_
 
+#include <algorithm>
 #include <cstdint>
+#include <span>
 
+#include "core/features.h"
+#include "zelda3/dungeon/custom_object.h"
 #include "zelda3/dungeon/draw_routines/draw_routine_registry.h"
 #include "zelda3/dungeon/object_render_routing.h"
 #include "zelda3/dungeon/room_object.h"
@@ -18,6 +22,7 @@ enum class EffectiveBgLayer {
 
 struct ObjectLayerSemantics {
   int routine_id = -1;
+  bool custom_override_active = false;
   // Compatibility field for the legacy all_bgs_/routine-metadata decision.
   // Object-ID-specific routing (for example auto and straight stairs) is
   // represented by render_routing instead.
@@ -34,6 +39,28 @@ inline bool UsesRoomObjectStream(const RoomObject& object) {
 
 inline bool UsesSpecialLayerSelector(const RoomObject& object) {
   return !UsesRoomObjectStream(object);
+}
+
+inline bool IsTrackCornerAliasObjectId(int object_id) {
+  return object_id >= 0x100 && object_id <= 0x103;
+}
+
+inline bool RoomAllowsTrackCornerAliases(
+    std::span<const RoomObject> room_objects) {
+  return std::any_of(
+      room_objects.begin(), room_objects.end(),
+      [](const RoomObject& object) { return object.id_ == 0x31; });
+}
+
+inline bool HasActiveCustomObjectOverride(const RoomObject& object,
+                                          bool allow_track_corner_aliases) {
+  if (!core::FeatureFlags::get().kEnableCustomObjects ||
+      (IsTrackCornerAliasObjectId(object.id_) && !allow_track_corner_aliases)) {
+    return false;
+  }
+
+  const int subtype = object.size_ & 0x1F;
+  return CustomObjectManager::Get().GetObjectInternal(object.id_, subtype).ok();
 }
 
 // Reports built-in routine routing. A project custom-object override can
@@ -91,6 +118,29 @@ inline ObjectLayerSemantics GetObjectLayerSemantics(const RoomObject& object) {
   out.effective_bg_layer = (object.layer_ == RoomObject::LayerType::BG2)
                                ? EffectiveBgLayer::kBg2
                                : EffectiveBgLayer::kBg1;
+  return out;
+}
+
+// Reports the route actually used by ObjectDrawer after custom overrides have
+// had their chance to preempt the built-in routine.
+inline ObjectLayerSemantics GetEffectiveObjectLayerSemantics(
+    const RoomObject& object, bool allow_track_corner_aliases) {
+  if (!HasActiveCustomObjectOverride(object, allow_track_corner_aliases)) {
+    return GetObjectLayerSemantics(object);
+  }
+
+  ObjectLayerSemantics out;
+  out.custom_override_active = true;
+  out.draws_to_both_bgs = object.all_bgs_;
+  if (object.all_bgs_) {
+    out.effective_bg_layer = EffectiveBgLayer::kBothBg1Bg2;
+    out.render_routing = ObjectRenderRouting::kFullBothBg1Bg2;
+  } else {
+    out.effective_bg_layer = object.layer_ == RoomObject::LayerType::BG2
+                                 ? EffectiveBgLayer::kBg2
+                                 : EffectiveBgLayer::kBg1;
+    out.render_routing = ObjectRenderRouting::kStoredPlacement;
+  }
   return out;
 }
 

--- a/src/zelda3/dungeon/object_render_routing.h
+++ b/src/zelda3/dungeon/object_render_routing.h
@@ -31,6 +31,10 @@ inline constexpr bool IsMixedStraightInterroomObject(int object_id) {
   return object_id >= 0xFA6 && object_id <= 0xFA9;
 }
 
+inline constexpr bool IsNorthMixedStraightInterroomObject(int object_id) {
+  return object_id == 0xFA6 || object_id == 0xFA7;
+}
+
 inline constexpr bool IsSouthMixedStraightInterroomObject(int object_id) {
   return object_id == 0xFA8 || object_id == 0xFA9;
 }

--- a/src/zelda3/dungeon/object_tile_editor.cc
+++ b/src/zelda3/dungeon/object_tile_editor.cc
@@ -275,6 +275,7 @@ absl::StatusOr<ObjectTileLayout> ObjectTileEditor::CaptureObjectLayout(
 
   // Create drawer and set up trace collection
   ObjectDrawer drawer(rom_, room.id(), room.get_gfx_buffer().data());
+  drawer.SetRoomFloorGraphics(room.floor1(), room.floor2());
 
   std::vector<ObjectDrawer::TileTrace> traces;
   traces.reserve(256);

--- a/src/zelda3/dungeon/room.cc
+++ b/src/zelda3/dungeon/room.cc
@@ -1290,7 +1290,8 @@ void Room::LoadLayoutTilesToBuffer() {
 
   // Draw layout objects using proper draw routines via RoomLayout
   auto status = layout_.Draw(room_id_, current_gfx16_.data(), bg1_buffer_,
-                             bg2_buffer_, palette_group, dungeon_state_.get());
+                             bg2_buffer_, palette_group, dungeon_state_.get(),
+                             floor1_graphics_, floor2_graphics_);
 
   if (!status.ok()) {
     LOG_DEBUG(
@@ -1348,6 +1349,7 @@ void Room::RenderObjectsToBackground() {
   // Pass the room-specific graphics buffer (current_gfx16_) so objects use
   // correct tiles
   ObjectDrawer drawer(rom_, room_id_, current_gfx16_.data());
+  drawer.SetRoomFloorGraphics(floor1_graphics_, floor2_graphics_);
   drawer.SetAllowTrackCornerAliases(
       RoomAllowsTrackCornerAliases(tile_objects_));
   drawer.SetBG1RevealMaskSource(gfx::BG1RevealMaskSource::kBG2Objects);
@@ -1364,19 +1366,18 @@ void Room::RenderObjectsToBackground() {
   object_bg1_buffer_.bitmap().Fill(255);
   object_bg2_buffer_.bitmap().Fill(255);
 
-  // IMPORTANT: Clear priority buffers when clearing object buffers
-  // Otherwise, old priority values persist and cause incorrect Z-ordering
+  // Clear object-owned tile words, priority, and coverage. Conditional edge
+  // routines use coverage to select between this object owner and the matching
+  // layout owner, so none of those buffers may remain stale.
+  object_bg1_buffer_.ClearTileBuffer();
+  object_bg2_buffer_.ClearTileBuffer();
   object_bg1_buffer_.ClearPriorityBuffer();
   object_bg2_buffer_.ClearPriorityBuffer();
-
-  // IMPORTANT: Clear coverage buffers when clearing object buffers.
-  // Coverage distinguishes "no draw" vs "drew transparent", so stale values
-  // can cause objects to incorrectly clear the layout.
   object_bg1_buffer_.ClearCoverageBuffer();
   object_bg2_buffer_.ClearCoverageBuffer();
 
-  // Room-object masks target both raw BG1 stacks. Clear only their source bit
-  // so layout-owned reveals survive an object-only rerender.
+  // Room-object masks target both raw BG1 stacks. Clear their source bit on
+  // both owners so layout-owned reveals survive an object-only rerender.
   object_bg1_buffer_.ClearBG1RevealMask(gfx::BG1RevealMaskSource::kBG2Objects);
   bg1_buffer_.ClearBG1RevealMask(gfx::BG1RevealMaskSource::kBG2Objects);
 

--- a/src/zelda3/dungeon/room.cc
+++ b/src/zelda3/dungeon/room.cc
@@ -42,11 +42,6 @@ namespace zelda3 {
 
 namespace {
 
-bool RoomUsesTrackCornerAliases(const std::vector<RoomObject>& objects) {
-  return std::any_of(objects.begin(), objects.end(),
-                     [](const RoomObject& obj) { return obj.id_ == 0x31; });
-}
-
 uint8_t Layer2ModeFromHeaderByte(uint8_t byte0) {
   return static_cast<uint8_t>((byte0 >> 5) & 0x07);
 }
@@ -1353,7 +1348,8 @@ void Room::RenderObjectsToBackground() {
   // Pass the room-specific graphics buffer (current_gfx16_) so objects use
   // correct tiles
   ObjectDrawer drawer(rom_, room_id_, current_gfx16_.data());
-  drawer.SetAllowTrackCornerAliases(RoomUsesTrackCornerAliases(tile_objects_));
+  drawer.SetAllowTrackCornerAliases(
+      RoomAllowsTrackCornerAliases(tile_objects_));
   drawer.SetBG1RevealMaskSource(gfx::BG1RevealMaskSource::kBG2Objects);
   // NOTE: Routines marked draws_to_both_bgs explicitly write both tilemaps.
   // Object-specific stair routing is handled inside the registered routines.
@@ -1468,11 +1464,12 @@ void Room::RenderObjectsToBackground() {
     // Draw doors to object buffers (not layout buffers) so they remain visible
     // when BG1_Layout is hidden. Doors are objects, not layout tiles.
     drawer.DrawDoor(door_def, i, object_bg1_buffer_, object_bg2_buffer_,
-                    dungeon_state_.get());
+                    dungeon_state_.get(), &bg1_buffer_, &bg2_buffer_);
   }
   // Mark object buffer as modified so texture gets updated
   if (!doors_.empty()) {
     object_bg1_buffer_.bitmap().set_modified(true);
+    object_bg2_buffer_.bitmap().set_modified(true);
   }
 
   // Render pot items

--- a/src/zelda3/dungeon/room.cc
+++ b/src/zelda3/dungeon/room.cc
@@ -1409,9 +1409,10 @@ void Room::RenderObjectsToBackground() {
   // `tile_objects_[].layer_` holds the list index (0/1/2) for save/load, not
   // the buffer name. Map with MapRoomObjectListIndexToDrawLayer before drawing.
   // BothBG routines still fan out to both buffers via DrawRoutineRegistry.
-  // Pass bg1_buffer_ as the second raw BG1 target. BG2 room objects record
-  // deferred reveal bits on both layout and object targets without mutating
-  // either bitmap.
+  // Pass both layout buffers because USDASM priority-only writes target one
+  // physical tilemap, while Yaze temporarily splits that tilemap between its
+  // layout and object owners. BG2 room objects also record deferred upper-map
+  // reveal bits without mutating either bitmap.
   //
   // Three DrawObjectList passes match USDASM list order; the shared chest/
   // big-key-lock event index continues across passes (reset only on the first
@@ -1445,7 +1446,8 @@ void Room::RenderObjectsToBackground() {
     }
     auto chunk_status = drawer.DrawObjectList(
         by_list[pass], object_bg1_buffer_, object_bg2_buffer_, palette_group,
-        dungeon_state_.get(), &bg1_buffer_, reset_room_events_for_next_chunk);
+        dungeon_state_.get(), &bg1_buffer_, reset_room_events_for_next_chunk,
+        &bg2_buffer_);
     reset_room_events_for_next_chunk = false;
     if (!chunk_status.ok() && status.ok()) {
       status = chunk_status;

--- a/src/zelda3/dungeon/room.h
+++ b/src/zelda3/dungeon/room.h
@@ -1017,6 +1017,7 @@ class Room {
   bool IsCompositeDirty() const { return dirty_state_.composite; }
 
   DungeonState* GetDungeonState() { return dungeon_state_.get(); }
+  const DungeonState* GetDungeonState() const { return dungeon_state_.get(); }
 
  private:
   Rom* rom_;

--- a/src/zelda3/dungeon/room.h
+++ b/src/zelda3/dungeon/room.h
@@ -655,9 +655,27 @@ class Room {
 
   // Public setters for LoadRoomFromRom function
   void SetBg2(background2 bg2) {
-    if (bg2_ != bg2) {
-      bg2_ = bg2;
+    const uint8_t raw_value = static_cast<uint8_t>(bg2);
+    const uint8_t normalized_value = raw_value <= 8 ? raw_value : 0;
+    const bool dark_room = normalized_value == 8;
+    const uint8_t next_layer2_mode =
+        dark_room ? static_cast<uint8_t>(layer2_mode_ & 0x07)
+                  : normalized_value;
+    const LayerMergeType& next_merge =
+        kLayerMergeTypeList[dark_room ? 8 : next_layer2_mode];
+    const background2 normalized_bg2 =
+        static_cast<background2>(normalized_value);
+
+    if (bg2_ != normalized_bg2 || layer2_mode_ != next_layer2_mode ||
+        layer_merging_ != next_merge || is_dark_ != dark_room ||
+        is_light_ != dark_room) {
+      bg2_ = normalized_bg2;
+      layer2_mode_ = next_layer2_mode;
+      layer_merging_ = next_merge;
+      is_dark_ = dark_room;
+      is_light_ = dark_room;
       MarkHeaderDirty();
+      MarkGraphicsDirty();
     }
   }
   void SetCollision(CollisionKey collision) {
@@ -760,15 +778,22 @@ class Room {
     }
   }
   void SetLayer2Mode(uint8_t mode) {
-    if (layer2_mode_ != mode) {
-      layer2_mode_ = mode;
+    const uint8_t normalized_mode = mode & 0x07;
+    if (layer2_mode_ != normalized_mode) {
+      layer2_mode_ = normalized_mode;
+      if (bg2_ != background2::DarkRoom) {
+        bg2_ = static_cast<background2>(normalized_mode);
+        layer_merging_ = kLayerMergeTypeList[normalized_mode];
+      }
       MarkHeaderDirty();
+      MarkGraphicsDirty();
     }
   }
   void SetLayerMerging(LayerMergeType merging) {
     if (layer_merging_ != merging) {
       layer_merging_ = merging;
       MarkHeaderDirty();
+      MarkGraphicsDirty();
     }
   }
   void SetIsDark(bool is_dark) {
@@ -890,6 +915,7 @@ class Room {
   TagKey tag2() const { return tag2_; }
   CollisionKey collision() const { return collision_; }
   const LayerMergeType& layer_merging() const { return layer_merging_; }
+  uint8_t layer2_mode() const { return layer2_mode_; }
   uint8_t staircase_plane(int index) const {
     return (index >= 0 && index < 4) ? staircase_plane_[index] : 0;
   }

--- a/src/zelda3/dungeon/room_layer_manager.cc
+++ b/src/zelda3/dungeon/room_layer_manager.cc
@@ -217,7 +217,8 @@ void RoomLayerManager::CompositeToOutput(Room& room,
     }
 
     // Check if BG2 uses translucent blending (water rooms, color math effects).
-    // When translucent, overlapping BG1+BG2 pixels are averaged in RGB space.
+    // The editor approximates half-add color math by averaging overlapping
+    // BG1+BG2 RGB values and mapping the result back into the indexed palette.
     const bool bg2_translucent = (GetLayerBlendMode(LayerType::BG2_Layout) ==
                                   LayerBlendMode::Translucent) ||
                                  (GetLayerBlendMode(LayerType::BG2_Objects) ==
@@ -420,9 +421,8 @@ void RoomLayerManager::CompositeToOutput(Room& room,
             break;
 
           case LayerBlendMode::Translucent:
-            // 50% alpha blend: only overwrite if destination is transparent,
-            // otherwise blend colors using palette index averaging (simplified)
-            // For indexed color mode, we can't truly blend - use alpha threshold
+            // Fallback alpha approximation for paths without the palette-aware
+            // priority compositor above. This is not a pixel-exact SNES model.
             if (IsTransparent(dst_data[idx]) || layer_alpha > 180) {
               dst_data[idx] = src_pixel;
             }

--- a/src/zelda3/dungeon/room_layer_manager.cc
+++ b/src/zelda3/dungeon/room_layer_manager.cc
@@ -132,7 +132,67 @@ void RoomLayerManager::CompositeToOutput(Room& room,
     }
   };
 
-  if (use_priority_compositing_) {
+  if (room.layer2_mode() == 0x06) {
+    // Header layer mode 6 uses the upper dungeon tilemap on the SNES main
+    // screen and the lower tilemap on the sub screen. Ignoring OBJ/BG3, an
+    // opaque upper pixel wins regardless of either tile's priority bit; the
+    // lower pixel is visible only where the upper tilemap is transparent.
+    //
+    // Yaze's historic BG1/BG2 names describe semantic editor layers here:
+    // BG1_* is the upper tilemap ($7E2000 / hardware BG2), while BG2_* is the
+    // lower tilemap ($7E4000 / hardware BG1).
+    if (bg1_layout_on) {
+      CopyPaletteIfNeeded(bg1_layout.bitmap());
+    }
+    if (bg1_obj_on) {
+      CopyPaletteIfNeeded(bg1_objects.bitmap());
+    }
+    if (bg2_layout_on) {
+      CopyPaletteIfNeeded(bg2_layout.bitmap());
+    }
+    if (bg2_obj_on) {
+      CopyPaletteIfNeeded(bg2_objects.bitmap());
+    }
+
+    const auto& upper_layout_px = bg1_layout.bitmap().data();
+    const auto& upper_object_px = bg1_objects.bitmap().data();
+    const auto& lower_layout_px = bg2_layout.bitmap().data();
+    const auto& lower_object_px = bg2_objects.bitmap().data();
+    const auto& upper_object_coverage = bg1_objects.coverage_data();
+    const auto& lower_object_coverage = bg2_objects.coverage_data();
+
+    auto resolve_tilemap_pixel =
+        [&](bool layout_on, bool objects_on, const uint8_t* layout_pixels,
+            const uint8_t* object_pixels,
+            const std::vector<uint8_t>& object_coverage, int index) -> uint8_t {
+      if (objects_on) {
+        const bool object_wrote =
+            (index < static_cast<int>(object_coverage.size()) &&
+             object_coverage[index] != 0) ||
+            !IsTransparent(object_pixels[index]);
+        if (object_wrote) {
+          return object_pixels[index];
+        }
+      }
+      return layout_on ? layout_pixels[index] : 255;
+    };
+
+    auto& dst_data = output.mutable_data();
+    for (int idx = 0; idx < kPixelCount; ++idx) {
+      const uint8_t upper_pixel =
+          resolve_tilemap_pixel(bg1_layout_on, bg1_obj_on, upper_layout_px,
+                                upper_object_px, upper_object_coverage, idx);
+      const uint8_t lower_pixel =
+          resolve_tilemap_pixel(bg2_layout_on, bg2_obj_on, lower_layout_px,
+                                lower_object_px, lower_object_coverage, idx);
+
+      if (!IsTransparent(upper_pixel)) {
+        dst_data[idx] = upper_pixel;
+      } else if (!IsTransparent(lower_pixel)) {
+        dst_data[idx] = lower_pixel;
+      }
+    }
+  } else if (use_priority_compositing_) {
     // Priority compositing (SNES Mode 1):
     // - BG2 priority=0 is behind BG1 priority=0.
     // - BG2 priority=1 can appear above BG1 priority=0.

--- a/src/zelda3/dungeon/room_layer_manager.h
+++ b/src/zelda3/dungeon/room_layer_manager.h
@@ -91,7 +91,8 @@ class RoomLayerManager {
     bg2_on_top_ = false;
     layers_merged_ = false;
     current_merge_type_id_ = 0;
-    use_priority_compositing_ = true;  // Default to accurate SNES behavior
+    use_priority_compositing_ =
+        true;  // Default to SNES-informed priority order
   }
 
   // Priority compositing control

--- a/src/zelda3/dungeon/room_layer_manager.h
+++ b/src/zelda3/dungeon/room_layer_manager.h
@@ -56,8 +56,8 @@ struct ObjectTranslucency {
  */
 struct ObjectPriority {
   size_t object_index = 0;
-  int layer = 0;          // Object's layer (0=BG1, 1=BG2, 2=BG1 priority)
-  int priority = 0;       // Object layer value (not visual Z-order)
+  int layer = 0;               // Object's layer (0=BG1, 1=BG2, 2=BG1 priority)
+  int priority = 0;            // Object layer value (not visual Z-order)
   bool is_bg2_object = false;  // True if object renders to BG2 buffer
 };
 
@@ -97,8 +97,12 @@ class RoomLayerManager {
   // Priority compositing control
   // When enabled (default): Uses SNES Mode 1 per-tile priority for Z-ordering
   // When disabled: Simple back-to-front layer order (BG2 behind, BG1 in front)
-  void SetPriorityCompositing(bool enabled) { use_priority_compositing_ = enabled; }
-  bool IsPriorityCompositingEnabled() const { return use_priority_compositing_; }
+  void SetPriorityCompositing(bool enabled) {
+    use_priority_compositing_ = enabled;
+  }
+  bool IsPriorityCompositingEnabled() const {
+    return use_priority_compositing_;
+  }
 
   // Layer visibility
   void SetLayerVisible(LayerType layer, bool visible) {
@@ -180,7 +184,7 @@ class RoomLayerManager {
   // effects like transparency and additive blending.
   void SetBG2ColorMathEnabled(bool enabled) { bg2_on_top_ = enabled; }
   bool IsBG2ColorMathEnabled() const { return bg2_on_top_; }
-  
+
   // Legacy aliases for compatibility
   void SetBG2OnTop(bool on_top) { bg2_on_top_ = on_top; }
   bool IsBG2OnTop() const { return bg2_on_top_; }
@@ -231,8 +235,7 @@ class RoomLayerManager {
         // SNES uses HDMA-driven color math to blend water layer.
         if (GetLayerBlendMode(LayerType::BG2_Layout) ==
             LayerBlendMode::Normal) {
-          SetLayerBlendMode(LayerType::BG2_Layout,
-                            LayerBlendMode::Translucent);
+          SetLayerBlendMode(LayerType::BG2_Layout, LayerBlendMode::Translucent);
         }
         if (GetLayerBlendMode(LayerType::BG2_Objects) ==
             LayerBlendMode::Normal) {
@@ -264,8 +267,7 @@ class RoomLayerManager {
         // the Triforce floor pattern showing through.
         if (GetLayerBlendMode(LayerType::BG2_Layout) ==
             LayerBlendMode::Normal) {
-          SetLayerBlendMode(LayerType::BG2_Layout,
-                            LayerBlendMode::Translucent);
+          SetLayerBlendMode(LayerType::BG2_Layout, LayerBlendMode::Translucent);
         }
         break;
 
@@ -359,10 +361,8 @@ class RoomLayerManager {
    * @param object_layer The object's layer value (0, 1, 2)
    * @return Layer value (same as input - used for buffer routing)
    */
-  int GetObjectLayerValue(int object_layer) const {
-    return object_layer;
-  }
-  
+  int GetObjectLayerValue(int object_layer) const { return object_layer; }
+
   // Legacy function - kept for API compatibility
   // No longer affects visual order since SNES Mode 1 is fixed (BG1 > BG2)
   int CalculateObjectPriority(int object_layer) const {
@@ -489,7 +489,8 @@ class RoomLayerManager {
    * @param surface The SDL surface to apply modulation to
    */
   void ApplySurfaceColorMod(SDL_Surface* surface) const {
-    if (!surface) return;
+    if (!surface)
+      return;
 
     if (current_merge_type_id_ == 0x08) {
       // DarkRoom: 50% brightness
@@ -507,8 +508,10 @@ class RoomLayerManager {
   /**
    * @brief Composite all visible layers into a single output bitmap
    *
-   * Implements SNES Mode 1 per-tile priority compositing. Each tile's priority
-   * bit affects its effective Z-order:
+   * Implements room-header-aware dungeon compositing. Layer mode 6 uses the
+   * upper tilemap on the main screen and reveals the lower tilemap only through
+   * transparent upper pixels. Other modes currently use the SNES Mode 1
+   * per-tile priority model below:
    *
    * | Layer | Priority | Effective Order |
    * |-------|----------|-----------------|
@@ -549,15 +552,13 @@ class RoomLayerManager {
    * - Actual colors are at indices 1-15 within each 16-color bank
    * - Buffers should be initialized to 255, not 0
    */
-  static bool IsTransparent(uint8_t pixel) {
-    return pixel == 255;
-  }
+  static bool IsTransparent(uint8_t pixel) { return pixel == 255; }
 
   std::array<bool, 4> layer_visible_;
   std::array<LayerBlendMode, 4> layer_blend_mode_;
   std::array<uint8_t, 4> layer_alpha_;
   std::vector<ObjectTranslucency> object_translucency_;
-  
+
   // Color math participation flag (from ROM's Layer2OnTop)
   // NOTE: Does NOT affect draw order - BG1 is always above BG2 per SNES Mode 1.
   // This controls whether BG2 participates in sub-screen color math effects.
@@ -566,7 +567,7 @@ class RoomLayerManager {
   // Merge state tracking
   bool layers_merged_ = false;
   uint8_t current_merge_type_id_ = 0;
-  
+
   // When enabled, CompositeToOutput uses per-pixel priority buffers to emulate
   // SNES Mode 1 ordering (BG2 pri=1 can appear above BG1 pri=0).
   bool use_priority_compositing_ = true;

--- a/src/zelda3/dungeon/room_layout.cc
+++ b/src/zelda3/dungeon/room_layout.cc
@@ -8,34 +8,6 @@
 
 namespace yaze::zelda3 {
 
-namespace {
-
-// Returns true if the object ID is a pit or layer mask that should be on BG2.
-// These objects create transparency holes in BG1 to show BG2 content through.
-// Based on ALTTP object IDs and draw routine analysis.
-bool IsPitOrMaskObject(int16_t id) {
-  // Pit and layer-2 masks that rely on BG1 transparency to reveal BG2.
-  //
-  // Source of truth for names: RoomObjectNames in room_object.h.
-  // USDASM: These are "layer 2 mask" objects that operate by clearing BG1.
-  if (id == 0xA4)
-    return true;  // Pit
-  if (id >= 0xA5 && id <= 0xAC)
-    return true;  // Diagonal layer 2 masks
-  if (id == 0xC2 || id == 0xC3)
-    return true;  // Layer 2 pit masks (large/medium)
-  if (id == 0xC6 || id == 0xD7 || id == 0xD9)
-    return true;  // Layer 2 masks (large/medium/swim)
-  if (id == 0xFE6)
-    return true;  // Type 3 pit
-  if (id == 0xFF3)
-    return true;  // Type 3 layer 2 mask (full)
-
-  return false;
-}
-
-}  // namespace
-
 absl::StatusOr<int> RoomLayout::GetLayoutAddress(int layout_id) const {
   if (!rom_ || !rom_->is_loaded()) {
     return absl::FailedPreconditionError("ROM not loaded");
@@ -94,14 +66,6 @@ absl::Status RoomLayout::LoadLayout(int layout_id) {
     RoomObject obj = RoomObject::DecodeObjectFromBytes(
         b1, b2, b3, static_cast<uint8_t>(layer));
 
-    // Pit/mask objects should be on BG2 layer to create transparency holes.
-    // This allows them to show through BG1 content (walls, floor).
-    if (IsPitOrMaskObject(obj.id_)) {
-      obj.layer_ = RoomObject::LayerType::BG2;
-      LOG_DEBUG("RoomLayout", "Pit/mask object 0x%03X assigned to BG2 layer",
-                obj.id_);
-    }
-
     obj.SetRom(rom_);
     obj.EnsureTilesLoaded();
     objects_.push_back(obj);
@@ -139,15 +103,13 @@ absl::Status RoomLayout::Draw(int room_id, const uint8_t* gfx_data,
 
   std::vector<RoomObject> render_objects = objects_;
   for (auto& obj : render_objects) {
-    if (!IsPitOrMaskObject(obj.id_)) {
-      obj.layer_ = RoomObject::LayerType::BG1;
-    }
+    obj.layer_ = RoomObject::LayerType::BG1;
   }
 
-  // Layout objects render through the room-layout stream, which in ALTTP uses the
-  // upper-layer tilemap pointer set for the visible room shell. Keep track-corner
-  // aliases disabled so vanilla wall corners survive, but preserve BG2 routing for
-  // pit/mask objects that intentionally reveal the lower layer.
+  // ALTTP enters the room-layout stream with the upper tilemap pointer active.
+  // Object IDs do not reroute the destination tilemap; their draw routines use
+  // the current stream pointer. Keep track-corner aliases disabled so vanilla
+  // structural wall corners survive.
   return drawer.DrawObjectList(render_objects, bg1, bg2, palette_group, state);
 }
 

--- a/src/zelda3/dungeon/room_layout.cc
+++ b/src/zelda3/dungeon/room_layout.cc
@@ -88,7 +88,8 @@ absl::Status RoomLayout::Draw(int room_id, const uint8_t* gfx_data,
                               gfx::BackgroundBuffer& bg1,
                               gfx::BackgroundBuffer& bg2,
                               const gfx::PaletteGroup& palette_group,
-                              DungeonState* state) const {
+                              DungeonState* state, uint8_t floor1_graphics,
+                              uint8_t floor2_graphics) const {
   if (!rom_ || !rom_->is_loaded()) {
     return absl::FailedPreconditionError("ROM not loaded");
   }
@@ -100,6 +101,7 @@ absl::Status RoomLayout::Draw(int room_id, const uint8_t* gfx_data,
   ObjectDrawer drawer(rom_, room_id, gfx_data);
   drawer.SetAllowTrackCornerAliases(false);
   drawer.SetBG1RevealMaskSource(gfx::BG1RevealMaskSource::kBG2Layout);
+  drawer.SetRoomFloorGraphics(floor1_graphics, floor2_graphics);
 
   std::vector<RoomObject> render_objects = objects_;
   for (auto& obj : render_objects) {

--- a/src/zelda3/dungeon/room_layout.h
+++ b/src/zelda3/dungeon/room_layout.h
@@ -25,8 +25,8 @@ class RoomLayout {
   // Render the layout objects into the provided buffers
   absl::Status Draw(int room_id, const uint8_t* gfx_data,
                     gfx::BackgroundBuffer& bg1, gfx::BackgroundBuffer& bg2,
-                    const gfx::PaletteGroup& palette_group,
-                    DungeonState* state) const;
+                    const gfx::PaletteGroup& palette_group, DungeonState* state,
+                    uint8_t floor1_graphics, uint8_t floor2_graphics) const;
 
   const std::vector<RoomObject>& GetObjects() const { return objects_; }
 

--- a/src/zelda3/dungeon/room_object.cc
+++ b/src/zelda3/dungeon/room_object.cc
@@ -36,27 +36,6 @@ SubtypeTableInfo GetSubtypeTable(int object_id) {
   }
 }
 
-bool IsAllBgsObjectId(int object_id) {
-  // Objects that should be treated as drawing to both BG1 and BG2.
-  //
-  // NOTE: This is editor/runtime metadata for our renderer, not a ROM field.
-  // Keep this list in sync with DecodeObjectFromBytes behavior and any
-  // special-cased BothBG handling in ObjectDrawer.
-  const int id = object_id;
-  // USDASM: Rightwards2x4spaced4_1to16 writes to both tilemaps.
-  if ((id >= 0x03 && id <= 0x04) ||
-      (id >= 0x63 && id <= 0x64) ||  // Routine 9 objects
-      // Routine 17 (Acute Diagonals)
-      id == 0x0C || id == 0x0D || id == 0x10 || id == 0x11 || id == 0x14 ||
-      id == 0x15 || id == 0x18 || id == 0x19 || id == 0x1C || id == 0x1D ||
-      id == 0x20 ||
-      // Routine 18 (Grave Diagonals)
-      id == 0x0E || id == 0x0F || id == 0x12 || id == 0x13 || id == 0x16 ||
-      id == 0x17 || id == 0x1A || id == 0x1B || id == 0x1E || id == 0x1F) {
-    return true;
-  }
-  return false;
-}
 }  // namespace
 
 ObjectOption operator|(ObjectOption lhs, ObjectOption rhs) {
@@ -199,16 +178,14 @@ void RoomObject::MarkTileCacheUntracked() {
   tile_cache_tracked_ = false;
 }
 
-void RoomObject::RefreshDerivedFlagsFromId() {
-  all_bgs_ = IsAllBgsObjectId(id_);
-}
-
 void RoomObject::set_id(int16_t id) {
   if (id_ == id) {
     return;
   }
   id_ = id;
-  RefreshDerivedFlagsFromId();
+  // A manual/custom routing override belongs to the old object identity.
+  // Built-in routing for the new ID is resolved through DrawRoutineRegistry.
+  all_bgs_ = false;
   InvalidateTileCache();
 }
 
@@ -325,10 +302,7 @@ RoomObject RoomObject::DecodeObjectFromBytes(uint8_t b1, uint8_t b2, uint8_t b3,
               b2, b3, id, x, y, size);
   }
 
-  auto obj = RoomObject(static_cast<int16_t>(id), x, y, size, layer);
-  obj.RefreshDerivedFlagsFromId();
-
-  return obj;
+  return RoomObject(static_cast<int16_t>(id), x, y, size, layer);
 }
 
 RoomObject::ObjectBytes RoomObject::EncodeObjectToBytes() const {

--- a/src/zelda3/dungeon/room_object.h
+++ b/src/zelda3/dungeon/room_object.h
@@ -73,9 +73,7 @@ class RoomObject {
         oy_(y),
         width_(16),
         height_(16),
-        rom_(nullptr) {
-    RefreshDerivedFlagsFromId();
-  }
+        rom_(nullptr) {}
 
   void SetRom(Rom* rom) { rom_ = rom; }
   Rom* rom() const { return rom_; }
@@ -188,6 +186,8 @@ class RoomObject {
     return copy;
   }
 
+  // Explicit editor/custom-object override. Built-in objects derive their
+  // layer routing from DrawRoutineRegistry instead of duplicating ID lists.
   bool all_bgs_ = false;
   bool lit_ = false;
 
@@ -243,7 +243,6 @@ class RoomObject {
   Rom* rom_;
 
  private:
-  void RefreshDerivedFlagsFromId();
   void InvalidateTileCache();
   bool IsTrackedTileCacheCurrent() const;
   void MarkTileCacheCurrent();

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -214,6 +214,7 @@ if(YAZE_BUILD_TESTS)
     unit/gfx/usdasm_palette_loading_test.cc
     unit/gfx/bpp_conversion_test.cc
     unit/gfx/sheet_role_palette_table_test.cc
+    unit/gfx/arena_retirement_test.cc
     unit/palette_json_test.cc
     unit/snes_color_test.cc
     unit/gui/tile_selector_widget_test.cc
@@ -555,6 +556,7 @@ if(YAZE_BUILD_TESTS)
     unit/emu/emulator_test.cc
     unit/emu/mesen_socket_client_test.cc
     unit/gfx/sheet_role_palette_table_test.cc
+    unit/gfx/arena_retirement_test.cc
     unit/gui/canvas_context_menu_role_test.cc
     unit/zelda3/resource_labels_test.cc
     unit/zelda3/sprite_render_preview_test.cc

--- a/test/README.md
+++ b/test/README.md
@@ -490,9 +490,9 @@ ctest --test-dir build --verbose
 
 ## Dungeon Object Parity Tests
 
-The dungeon object parity test suite validates that the editor's drawing pipeline matches SNES behavior for all vanilla dungeon objects. Located at `test/unit/zelda3/dungeon/object_drawing_comprehensive_test.cc`.
+The dungeon object comprehensive suite validates registry coverage and selected renderer invariants across the vanilla object ID space. It is an internal regression layer, not proof that every object matches SNES pixels. The suite is located at `test/unit/zelda3/dungeon/object_drawing_comprehensive_test.cc`; ROM-backed and independent Mesen evidence live in separate suites.
 
-**What it validates (19 tests):**
+**Representative checks:**
 
 | Test | Coverage |
 |------|----------|
@@ -522,8 +522,9 @@ ctest --test-dir build -R "ObjectDrawingComprehensive" --output-on-failure
 ```
 
 **Related docs:**
-- Plan: `docs/internal/agents/dungeon-object-parity-plan.md`
-- Spec: `docs/internal/agents/dungeon-object-rendering-spec.md`
+- Active spec and evidence matrix: `docs/internal/agents/dungeon-object-rendering-spec.md`
+- Historical plan: `docs/internal/plans/dungeon-object-rendering-parity-2026-04.md`
+- Independent fixtures: `test/fixtures/visual/dungeon/README.md`
 - Architecture: `docs/internal/architecture/dungeon_editor_system.md` (Room Layer Manager section)
 
 ## Adding New Tests

--- a/test/fixtures/visual/dungeon/README.md
+++ b/test/fixtures/visual/dungeon/README.md
@@ -89,8 +89,8 @@ fixture.
 - Fixture SHA-256:
   `4d09ab115a859f5afc6cf159501f9323beb1244474d60b8c2be93cfded3f4c1c`.
 
-This is the first independent Mesen ROI for a visual-parity gap object family
-(TableRock). Rails, BigHole, water overlays, and doors remain uncovered.
+This was the first independent Mesen ROI for a visual-parity gap object family
+(TableRock). Later sections record BigHole, rails, and one west door ROI.
 
 ## `vanilla_room_031_mesen_bighole_32x32.png`
 
@@ -330,11 +330,11 @@ they do **not** replace Mesen ROI baselines for these families.
 | Long horizontal rail (`_plus23`) | `0x5F` | `0x007`, `0x02A`, `0x07D`, `0x0C2` | **`0x007` tile `(20,14)` has a committed Mesen ROI** |
 | Long vertical rail (`_plus23`) | `0x8A` | `0x007`, `0x03A`, `0x081`, `0x0C2` | **`0x007` tile `(14,20)` has a committed Mesen ROI** |
 | BigHole 4x4 | `0xA4` | `0x031`, `0x017`, `0x054`, `0x09B` | 24 rooms; **`0x031` tile `(44,44)` has a committed Mesen ROI** |
-| Water overlay A | `0xD8` | `0x076` | **BG2 structural test** (HDMA in-game; no pixel ROI) |
-| Water overlay B | `0xDA` | `0x035`, `0x037` | Same draw routine as `0xD8`; covered by routine+parse |
+| Water overlay A | `0xD8` | `0x076` | **BG2 structural editor-preview test**; vanilla tilemap/HDMA behavior is stateful and has no committed Mesen ROI |
+| Water overlay B | `0xDA` | `0x035`, `0x037` | Shares the stateful family with `0xD8`; routine mapping is covered, runtime-state pixels are not |
 | TableRock 4x4 | `0xDD` | `0x065`, `0x02F`, `0x080` | 38 rooms; **`0x065` has a committed Mesen ROI** at tile `(41,52)` |
 | Door-heavy | (doors) | `0x024`, `0x0B2`, `0x0BC`, `0x0C1`, `0x0C2` | ≥8 door records; **`0x076` West door has a committed Mesen ROI** |
 
-Suggested next captures: additional door types (key/shutter/bombable) in
-door-heavy rooms; `0xDA` rooms share the water structural path with `0xD8`.
-Long rails in `0x007` are covered.
+Suggested next captures: additional door types (key/shutter/bombable/exploding)
+in door-heavy rooms, then state-labeled `0xD8`/`0xDA` captures. Long rails in
+`0x007` are covered.

--- a/test/fixtures/visual/dungeon/README.md
+++ b/test/fixtures/visual/dungeon/README.md
@@ -151,18 +151,23 @@ ROI — see below).
 - Fixture SHA-256:
   `e36ac2ab54fd94cae6e7523d241b69a76ffe05f0432b56f24a016b16f0f83b1b`.
 
-## Water overlay `0xD8` / `0xDA` (no Mesen pixel ROI)
+## Water overlay `0xD8` / `0xDA` (Tier-4 incomplete)
 
-Vanilla `RoomDraw_WaterOverlayA8x8_1to16` / `…B…` (`$0195D6`) is an **HDMA
-control object** — it does not stamp tiles in-game. Yaze draws a BG2 editor
-indicator so authors can see the overlay footprint. Therefore:
+Vanilla `RoomDraw_WaterOverlayA8x8_1to16` / `…B…` is stateful. The routines set
+HDMA geometry **and stamp tilemap patterns**; the exact pattern and destination
+can change with saved water state, and the routines can also change the active
+layer mode. The earlier claim that these objects never stamp tiles in-game was
+incorrect.
 
-- Exact RGBA Mesen↔yaze ROI is **not** a valid Tier-4 proof for these IDs.
-- Coverage is the structural test
-  `Room076WaterOverlayWritesBg2ObjectBuffer`: parse `0xD8` @ `(38,13)` on the
-  BG2 stream in room `0x076`, assert non-backdrop pixels in the object BG2
-  buffer ROI, and assert the composite changes when BG2 is enabled.
-- Rooms `0x035` / `0x037` carry `0xDA` with the same draw routine.
+- `Room076WaterOverlayWritesBg2ObjectBuffer` is a structural guard for Yaze's
+  currently modeled `0xD8` state: it parses `0xD8` @ `(38,13)` from the BG2
+  stream, checks coverage/opaque pixels using `255` as the transparent fill,
+  and toggles only BG2-object visibility in the comparison.
+- That structural test is **not** independent Mesen parity and does not prove
+  the alternate saved state or the layer-mode side effects.
+- Honest Tier-4 closure requires state-labeled Mesen captures for the relevant
+  `0xD8` and `0xDA` paths. Rooms `0x035` / `0x037` are useful `0xDA`
+  candidates.
 
 The regression test explicitly selects the intact/bombed preview through
 `EditorDungeonState::SetFloorBombable`. It removes room-object list 1 from its

--- a/test/integration/interaction_delegation_test.cc
+++ b/test/integration/interaction_delegation_test.cc
@@ -19,6 +19,7 @@
 #include "app/gui/canvas/canvas.h"
 #include "imgui/imgui.h"
 #include "zelda3/dungeon/dungeon_object_editor.h"
+#include "zelda3/dungeon/object_layer_semantics.h"
 #include "zelda3/dungeon/room.h"
 #include "zelda3/dungeon/room_object.h"
 #include "zelda3/sprite/sprite.h"
@@ -315,7 +316,7 @@ TEST_F(InteractionDelegationTest, UpdateObjectIdInvalidatesCache) {
   EXPECT_EQ(objects[0].id_, 0x42);
   EXPECT_FALSE(objects[0].tiles_loaded_);  // Cache should be invalidated
   EXPECT_FALSE(objects[0].all_bgs_)
-      << "Derived flags should refresh on ID change";
+      << "ID changes must not create a manual BothBG override";
 }
 
 TEST_F(InteractionDelegationTest, UpdateObjectSizeInvalidatesCache) {
@@ -349,7 +350,7 @@ TEST_F(InteractionDelegationTest, UpdateObjectLayerMovesBothBgObject) {
 
   // Fixture index 2 is id=0x03, which is treated as a structural BothBG object.
   ASSERT_EQ(objects[2].layer_, zelda3::RoomObject::LayerType::BG1);
-  ASSERT_TRUE(objects[2].all_bgs_);
+  ASSERT_TRUE(zelda3::GetObjectLayerSemantics(objects[2]).draws_to_both_bgs);
 
   tile_handler.UpdateObjectsLayer(0, {2}, 1);
   EXPECT_EQ(objects[2].layer_, zelda3::RoomObject::LayerType::BG2);

--- a/test/integration/zelda3/dungeon_room_regression_fixtures.h
+++ b/test/integration/zelda3/dungeon_room_regression_fixtures.h
@@ -37,7 +37,8 @@ struct DungeonRoomRegressionFixture {
 
 // Fixed vanilla-room fixtures (US 1.0). Room ids verified via
 // DungeonRoomRegressionFixturesTest.ScanAllRoomsForFixtureCandidates.
-// Golden checksums regenerated 2026-09-10 against canonical US ROM
+// Golden checksums regenerated 2026-09-10 against canonical US ROM after the
+// floor-copy, thin-strip origin, diagonal, and single-layer routing fixes.
 // SHA-1 6d4f10a8b10e10dbe624cb23cf03b88bb8252973 (roms/zelda3.sfc; first 1 MiB
 // of padded alttp_vanilla.sfc). The fixture renderer now loads each room header
 // before drawing and applies the same merge/effect configuration as the editor
@@ -59,13 +60,14 @@ inline constexpr DungeonRoomRegressionFixture kDungeonRoomRegressionFixtures[] =
                 "streams with BG2 overlay platform objects 0x033/0x034/0x071.",
             .required_object_id = 0x108,
             .expected_layer_merge_id = 6,
-            .composite_checksum = 18079800016860863152ull,
+            // The BG2 0x034/0x071 strips now begin at their encoded origin.
+            .composite_checksum = 14126997594749283512ull,
             .object_bg1_checksum = 16473803172668162085ull,
-            .object_bg2_checksum = 2272669664059805342ull,
+            .object_bg2_checksum = 9560400034495958298ull,
             .layout_bg1_checksum = 16155382640141831219ull,
             .composite_non_backdrop_pixels = 262144,
             .object_bg1_non_backdrop_pixels = 57088,
-            .object_bg2_non_backdrop_pixels = 39168,
+            .object_bg2_non_backdrop_pixels = 38656,
         },
         {
             .room_id = 0x050,
@@ -77,30 +79,33 @@ inline constexpr DungeonRoomRegressionFixture kDungeonRoomRegressionFixtures[] =
                      "streams.",
             .required_object_id = 0x034,
             .expected_layer_merge_id = 6,
-            .composite_checksum = 16835019496338994218ull,
+            // The BG2 0x034/0x071 strips now begin at their encoded origin.
+            .composite_checksum = 12705092217259824174ull,
             .object_bg1_checksum = 12090658100540583468ull,
-            .object_bg2_checksum = 15343382323770861576ull,
+            .object_bg2_checksum = 14942757394939352408ull,
             .layout_bg1_checksum = 14374714413720404755ull,
             .composite_non_backdrop_pixels = 262144,
             .object_bg1_non_backdrop_pixels = 52608,
-            .object_bg2_non_backdrop_pixels = 46464,
+            .object_bg2_non_backdrop_pixels = 46720,
         },
         {
             .room_id = 0x00E,
             .category = DungeonRoomRegressionCategory::kOpaqueBg2Control,
             .name = "EasternPalace_OpaqueMerge",
-            .notes = "Layer merge off (id 0) — BG2 must not apply spurious "
-                     "translucency; "
-                     "wall/corner objects with no moving-water effect.",
+            .notes = "Layer merge off (id 0); the primary stream's diagonal "
+                     "walls are single-layer, so the object BG2 buffer must "
+                     "remain empty.",
             .required_object_id = 0x100,
             .expected_layer_merge_id = 0,
-            .composite_checksum = 6950119620544630590ull,
-            .object_bg1_checksum = 2789486847902414902ull,
-            .object_bg2_checksum = 7686508337355327995ull,
+            // IDs 0x0D-0x10 use USDASM's single-layer diagonal routines;
+            // their old duplicated BG2 raster was an editor-only artifact.
+            .composite_checksum = 18354950681794196905ull,
+            .object_bg1_checksum = 11901466281411276978ull,
+            .object_bg2_checksum = 11028269878064776067ull,
             .layout_bg1_checksum = 7897614742461255965ull,
             .composite_non_backdrop_pixels = 262144,
-            .object_bg1_non_backdrop_pixels = 75456,
-            .object_bg2_non_backdrop_pixels = 11520,
+            .object_bg1_non_backdrop_pixels = 77824,
+            .object_bg2_non_backdrop_pixels = 0,
         },
         {
             .room_id = 0x016,
@@ -113,13 +118,13 @@ inline constexpr DungeonRoomRegressionFixture kDungeonRoomRegressionFixtures[] =
             .expected_layer_merge_id = 4,
             // FF1 now honors the inactive room-0x065 bombed-floor state, so
             // the default room render correctly omits the big light beam.
-            .composite_checksum = 17351781091166995936ull,
-            .object_bg1_checksum = 18256671800728123299ull,
-            .object_bg2_checksum = 2709826818660264417ull,
+            .composite_checksum = 16184705480853915451ull,
+            .object_bg1_checksum = 10182215693742640491ull,
+            .object_bg2_checksum = 10480448132206945203ull,
             .layout_bg1_checksum = 10260335362238553655ull,
             .composite_non_backdrop_pixels = 231372,
-            .object_bg1_non_backdrop_pixels = 150848,
-            .object_bg2_non_backdrop_pixels = 37324,
+            .object_bg1_non_backdrop_pixels = 152256,
+            .object_bg2_non_backdrop_pixels = 26572,
         },
         {
             .room_id = 0x004,

--- a/test/integration/zelda3/dungeon_room_regression_fixtures.h
+++ b/test/integration/zelda3/dungeon_room_regression_fixtures.h
@@ -37,11 +37,11 @@ struct DungeonRoomRegressionFixture {
 
 // Fixed vanilla-room fixtures (US 1.0). Room ids verified via
 // DungeonRoomRegressionFixturesTest.ScanAllRoomsForFixtureCandidates.
-// Golden checksums regenerated 2026-09-08 against canonical US ROM
+// Golden checksums regenerated 2026-09-09 against canonical US ROM
 // SHA-1 6d4f10a8b10e10dbe624cb23cf03b88bb8252973 (roms/zelda3.sfc; first 1 MiB
-// of padded alttp_vanilla.sfc). Drift vs 2026-07-22 goldens is limited to
-// object BG2 (rooms 0x001/0x050) and object BG1 (room 0x016) after post-July
-// fixed-payload / overlay-stream parity fixes. Layout checksums unchanged.
+// of padded alttp_vanilla.sfc). Drift vs 2026-09-08 is limited to object
+// layers and composites after USDASM-backed door split, priority, middle-seam,
+// and South fancy-exit fixes. Layout checksums remain unchanged.
 // These self-fingerprints are drift guards only — not independent visual 1:1.
 // Independent truth comes from Mesen ROI fixtures for rooms 0x007, 0x012,
 // 0x031, 0x065, and 0x076.
@@ -57,9 +57,9 @@ inline constexpr DungeonRoomRegressionFixture kDungeonRoomRegressionFixtures[] =
                 "streams with BG2 overlay platform objects 0x033/0x034/0x071.",
             .required_object_id = 0x108,
             .expected_layer_merge_id = 6,
-            .composite_checksum = 23780482654574992ull,
-            .object_bg1_checksum = 7942374673971519889ull,
-            .object_bg2_checksum = 10287929610757281366ull,
+            .composite_checksum = 17587705441275982428ull,
+            .object_bg1_checksum = 16473803172668162085ull,
+            .object_bg2_checksum = 2272669664059805342ull,
             .layout_bg1_checksum = 16155382640141831219ull,
             .composite_non_backdrop_pixels = 262144,
             .object_bg1_non_backdrop_pixels = 262144,
@@ -75,9 +75,9 @@ inline constexpr DungeonRoomRegressionFixture kDungeonRoomRegressionFixtures[] =
                      "streams.",
             .required_object_id = 0x034,
             .expected_layer_merge_id = 6,
-            .composite_checksum = 11416175861626265506ull,
-            .object_bg1_checksum = 12203971081140519348ull,
-            .object_bg2_checksum = 1568926056972221297ull,
+            .composite_checksum = 10391518055730100830ull,
+            .object_bg1_checksum = 12090658100540583468ull,
+            .object_bg2_checksum = 15343382323770861576ull,
             .layout_bg1_checksum = 14374714413720404755ull,
             .composite_non_backdrop_pixels = 262144,
             .object_bg1_non_backdrop_pixels = 262144,
@@ -92,8 +92,8 @@ inline constexpr DungeonRoomRegressionFixture kDungeonRoomRegressionFixtures[] =
                      "wall/corner objects with no moving-water effect.",
             .required_object_id = 0x100,
             .expected_layer_merge_id = 0,
-            .composite_checksum = 7928503047124983480ull,
-            .object_bg1_checksum = 10501821798088277057ull,
+            .composite_checksum = 15546560354129968140ull,
+            .object_bg1_checksum = 17240403903712956186ull,
             .object_bg2_checksum = 14741702422515376347ull,
             .layout_bg1_checksum = 3904745168084633499ull,
             .composite_non_backdrop_pixels = 262144,
@@ -111,8 +111,8 @@ inline constexpr DungeonRoomRegressionFixture kDungeonRoomRegressionFixtures[] =
             .expected_layer_merge_id = 4,
             // FF1 now honors the inactive room-0x065 bombed-floor state, so
             // the default room render correctly omits the big light beam.
-            .composite_checksum = 2251720105443116807ull,
-            .object_bg1_checksum = 15680809605901349847ull,
+            .composite_checksum = 4811588923815197718ull,
+            .object_bg1_checksum = 2627692379214606145ull,
             .object_bg2_checksum = 9908005591592637895ull,
             .layout_bg1_checksum = 6452462266518031539ull,
             .composite_non_backdrop_pixels = 208440,
@@ -130,8 +130,8 @@ inline constexpr DungeonRoomRegressionFixture kDungeonRoomRegressionFixtures[] =
             .expected_layer_merge_id = 0,
             // Room 0x004 contains six F92 rupee-floor objects. Their
             // USDASM-accurate sparse five-by-eight pattern changes BG1.
-            .composite_checksum = 11931349271745880540ull,
-            .object_bg1_checksum = 3494573777721387843ull,
+            .composite_checksum = 2000104977467415466ull,
+            .object_bg1_checksum = 3172523571313953129ull,
             .object_bg2_checksum = 11028269878064776067ull,
             .layout_bg1_checksum = 8128105348724780643ull,
             .composite_non_backdrop_pixels = 262144,

--- a/test/integration/zelda3/dungeon_room_regression_fixtures.h
+++ b/test/integration/zelda3/dungeon_room_regression_fixtures.h
@@ -37,11 +37,13 @@ struct DungeonRoomRegressionFixture {
 
 // Fixed vanilla-room fixtures (US 1.0). Room ids verified via
 // DungeonRoomRegressionFixturesTest.ScanAllRoomsForFixtureCandidates.
-// Golden checksums regenerated 2026-09-09 against canonical US ROM
+// Golden checksums regenerated 2026-09-10 against canonical US ROM
 // SHA-1 6d4f10a8b10e10dbe624cb23cf03b88bb8252973 (roms/zelda3.sfc; first 1 MiB
-// of padded alttp_vanilla.sfc). Drift vs 2026-09-08 is limited to object
-// layers and composites after USDASM-backed door split, priority, middle-seam,
-// and South fancy-exit fixes. Layout checksums remain unchanged.
+// of padded alttp_vanilla.sfc). The fixture renderer now loads each room header
+// before drawing and applies the same merge/effect configuration as the editor
+// canvas. Raw object counts treat palette index 255 as transparent instead of
+// counting the entire initialized buffer. Layout-stream pit/mask objects remain
+// on the upper tilemap selected by the stream, matching USDASM pointer routing.
 // These self-fingerprints are drift guards only — not independent visual 1:1.
 // Independent truth comes from Mesen ROI fixtures for rooms 0x007, 0x012,
 // 0x031, 0x065, and 0x076.
@@ -57,13 +59,13 @@ inline constexpr DungeonRoomRegressionFixture kDungeonRoomRegressionFixtures[] =
                 "streams with BG2 overlay platform objects 0x033/0x034/0x071.",
             .required_object_id = 0x108,
             .expected_layer_merge_id = 6,
-            .composite_checksum = 17587705441275982428ull,
+            .composite_checksum = 18079800016860863152ull,
             .object_bg1_checksum = 16473803172668162085ull,
             .object_bg2_checksum = 2272669664059805342ull,
             .layout_bg1_checksum = 16155382640141831219ull,
             .composite_non_backdrop_pixels = 262144,
-            .object_bg1_non_backdrop_pixels = 262144,
-            .object_bg2_non_backdrop_pixels = 262144,
+            .object_bg1_non_backdrop_pixels = 57088,
+            .object_bg2_non_backdrop_pixels = 39168,
         },
         {
             .room_id = 0x050,
@@ -75,13 +77,13 @@ inline constexpr DungeonRoomRegressionFixture kDungeonRoomRegressionFixtures[] =
                      "streams.",
             .required_object_id = 0x034,
             .expected_layer_merge_id = 6,
-            .composite_checksum = 10391518055730100830ull,
+            .composite_checksum = 16835019496338994218ull,
             .object_bg1_checksum = 12090658100540583468ull,
             .object_bg2_checksum = 15343382323770861576ull,
             .layout_bg1_checksum = 14374714413720404755ull,
             .composite_non_backdrop_pixels = 262144,
-            .object_bg1_non_backdrop_pixels = 262144,
-            .object_bg2_non_backdrop_pixels = 262144,
+            .object_bg1_non_backdrop_pixels = 52608,
+            .object_bg2_non_backdrop_pixels = 46464,
         },
         {
             .room_id = 0x00E,
@@ -92,13 +94,13 @@ inline constexpr DungeonRoomRegressionFixture kDungeonRoomRegressionFixtures[] =
                      "wall/corner objects with no moving-water effect.",
             .required_object_id = 0x100,
             .expected_layer_merge_id = 0,
-            .composite_checksum = 15546560354129968140ull,
-            .object_bg1_checksum = 17240403903712956186ull,
-            .object_bg2_checksum = 14741702422515376347ull,
-            .layout_bg1_checksum = 3904745168084633499ull,
+            .composite_checksum = 6950119620544630590ull,
+            .object_bg1_checksum = 2789486847902414902ull,
+            .object_bg2_checksum = 7686508337355327995ull,
+            .layout_bg1_checksum = 7897614742461255965ull,
             .composite_non_backdrop_pixels = 262144,
-            .object_bg1_non_backdrop_pixels = 262144,
-            .object_bg2_non_backdrop_pixels = 262144,
+            .object_bg1_non_backdrop_pixels = 75456,
+            .object_bg2_non_backdrop_pixels = 11520,
         },
         {
             .room_id = 0x016,
@@ -111,13 +113,13 @@ inline constexpr DungeonRoomRegressionFixture kDungeonRoomRegressionFixtures[] =
             .expected_layer_merge_id = 4,
             // FF1 now honors the inactive room-0x065 bombed-floor state, so
             // the default room render correctly omits the big light beam.
-            .composite_checksum = 4811588923815197718ull,
-            .object_bg1_checksum = 2627692379214606145ull,
-            .object_bg2_checksum = 9908005591592637895ull,
-            .layout_bg1_checksum = 6452462266518031539ull,
-            .composite_non_backdrop_pixels = 208440,
-            .object_bg1_non_backdrop_pixels = 262144,
-            .object_bg2_non_backdrop_pixels = 262144,
+            .composite_checksum = 17351781091166995936ull,
+            .object_bg1_checksum = 18256671800728123299ull,
+            .object_bg2_checksum = 2709826818660264417ull,
+            .layout_bg1_checksum = 10260335362238553655ull,
+            .composite_non_backdrop_pixels = 231372,
+            .object_bg1_non_backdrop_pixels = 150848,
+            .object_bg2_non_backdrop_pixels = 37324,
         },
         {
             .room_id = 0x004,
@@ -130,13 +132,13 @@ inline constexpr DungeonRoomRegressionFixture kDungeonRoomRegressionFixtures[] =
             .expected_layer_merge_id = 0,
             // Room 0x004 contains six F92 rupee-floor objects. Their
             // USDASM-accurate sparse five-by-eight pattern changes BG1.
-            .composite_checksum = 2000104977467415466ull,
-            .object_bg1_checksum = 3172523571313953129ull,
+            .composite_checksum = 2845038811880130538ull,
+            .object_bg1_checksum = 5024287954780586053ull,
             .object_bg2_checksum = 11028269878064776067ull,
-            .layout_bg1_checksum = 8128105348724780643ull,
+            .layout_bg1_checksum = 10084805582793809819ull,
             .composite_non_backdrop_pixels = 262144,
-            .object_bg1_non_backdrop_pixels = 262144,
-            .object_bg2_non_backdrop_pixels = 262144,
+            .object_bg1_non_backdrop_pixels = 60096,
+            .object_bg2_non_backdrop_pixels = 0,
         },
 };
 

--- a/test/integration/zelda3/dungeon_room_regression_fixtures_test.cc
+++ b/test/integration/zelda3/dungeon_room_regression_fixtures_test.cc
@@ -1,6 +1,7 @@
 #include <gtest/gtest.h>
 
 #include <algorithm>
+#include <array>
 #include <cstdint>
 #include <cstdlib>
 #if defined(YAZE_HAS_VISUAL_DIFF_ENGINE)
@@ -20,6 +21,7 @@
 #include "util/rom_hash.h"
 #endif
 #include "zelda3/dungeon/editor_dungeon_state.h"
+#include "zelda3/dungeon/object_drawer.h"
 #include "zelda3/dungeon/room.h"
 #include "zelda3/dungeon/room_layer_manager.h"
 #include "zelda3/game_data.h"
@@ -49,6 +51,19 @@ int CountNonBackdropPixels(const gfx::Bitmap& bitmap) {
   return count;
 }
 
+int CountOpaqueLayerPixels(const gfx::Bitmap& bitmap) {
+  if (!bitmap.is_active()) {
+    return 0;
+  }
+  int count = 0;
+  for (size_t i = 0; i < bitmap.size(); ++i) {
+    if (bitmap.data()[i] != 255) {
+      ++count;
+    }
+  }
+  return count;
+}
+
 struct RoomLayerFingerprints {
   uint64_t layout_bg1_checksum = 0;
   uint64_t layout_bg2_checksum = 0;
@@ -61,14 +76,14 @@ struct RoomLayerFingerprints {
   int composite_non_backdrop = 0;
 };
 
-constexpr int kRoom001ObjectOverlapX = 45;
-constexpr int kRoom001ObjectOverlapY = 120;
-constexpr int kRoom001ObjectOverlapIndex = 61485;
-constexpr uint8_t kRoom001ObjectOverlapBg1Pixel = 41;
-constexpr uint8_t kRoom001ObjectOverlapBg2Pixel = 42;
-constexpr uint8_t kRoom001ObjectOverlapBg1Priority = 1;
-constexpr uint8_t kRoom001ObjectOverlapBg2Priority = 0;
-constexpr uint8_t kRoom001ObjectOverlapCompositePixel = 41;
+constexpr int kRoom001DoorY = 120;
+constexpr int kRoom001DoorHeight = 32;
+constexpr int kRoom001WestDoorEdgeX = 40;
+constexpr int kRoom001WestDoorBodyX = 48;
+constexpr int kRoom001EastDoorBodyX = 448;
+constexpr int kRoom001EastDoorEdgeX = 464;
+constexpr int kRoom001DoorEdgeWidth = 8;
+constexpr int kRoom001DoorBodyWidth = 16;
 
 // Room 0x076 water-overlay coverage is structural and does not depend on the
 // libpng-backed visual diff engine. Keep these constants available on every
@@ -173,13 +188,16 @@ constexpr int kRoom076WestDoorRoiHeight = 32;
 RoomLayerFingerprints CaptureRoomLayerFingerprints(Rom* rom,
                                                    GameData* game_data,
                                                    int room_id) {
-  Room room(room_id, rom, game_data);
+  Room room = LoadRoomFromRom(rom, room_id);
+  room.SetGameData(game_data);
   room.LoadRoomGraphics();
   room.LoadObjects();
   room.CopyRoomGraphicsToBuffer();
   room.RenderRoomGraphics();
 
   RoomLayerManager layer_manager;
+  layer_manager.ApplyLayerMerging(room.layer_merging());
+  layer_manager.ApplyRoomEffect(room.effect());
   auto& composite = room.GetCompositeBitmap(layer_manager);
 
   const auto& layout_bg1 = room.bg1_buffer().bitmap();
@@ -203,9 +221,9 @@ RoomLayerFingerprints CaptureRoomLayerFingerprints(Rom* rom,
       .composite_checksum = composite.is_active()
                                 ? Fnv1a64(composite.data(), composite.size())
                                 : 0,
-      .layout_bg1_non_backdrop = CountNonBackdropPixels(layout_bg1),
-      .object_bg1_non_backdrop = CountNonBackdropPixels(object_bg1),
-      .object_bg2_non_backdrop = CountNonBackdropPixels(object_bg2),
+      .layout_bg1_non_backdrop = CountOpaqueLayerPixels(layout_bg1),
+      .object_bg1_non_backdrop = CountOpaqueLayerPixels(object_bg1),
+      .object_bg2_non_backdrop = CountOpaqueLayerPixels(object_bg2),
       .composite_non_backdrop = CountNonBackdropPixels(composite),
   };
 }
@@ -283,6 +301,8 @@ TEST_F(DungeonRoomRegressionFixturesTest, DumpBg1OnlyRoomRoiForCapture) {
   room.RenderRoomGraphics();
 
   RoomLayerManager layer_manager;
+  layer_manager.ApplyLayerMerging(room.layer_merging());
+  layer_manager.ApplyRoomEffect(room.effect());
   if (!include_bg2) {
     layer_manager.SetLayerVisible(LayerType::BG2_Layout, false);
     layer_manager.SetLayerVisible(LayerType::BG2_Objects, false);
@@ -417,21 +437,42 @@ TEST_F(DungeonRoomRegressionFixturesTest, FixtureRoomsHaveThreeStreamCoverage) {
 }
 
 TEST_F(DungeonRoomRegressionFixturesTest,
-       Room001ObjectOverlapPixelMatchesPriorityWinner) {
-  // Broad checksums catch drift but do not explain *where* compositing changed.
-  // Pin one sparse golden overlap pixel from room 0x001, which exercises
-  // primary, BG2-overlay, and BG1-overlay object streams. The sampled pixel is
-  // BG1 high-priority object pixel 0x29 over BG2 low-priority object pixel
-  // 0x2A, so SNES Mode 1 compositing must leave palette index 0x29 on top.
-  Room room(0x001, &rom_, &game_data_);
+       Room001ExplicitDoorBodiesReplaceGuidanceWallTiles) {
+  Room room = LoadRoomFromRom(&rom_, 0x001);
+  room.SetGameData(&game_data_);
   room.LoadRoomGraphics();
   room.LoadObjects();
   room.CopyRoomGraphicsToBuffer();
   room.RenderRoomGraphics();
-  ASSERT_FALSE(room.layer_merging().Layer2Translucent)
-      << "This sparse ordering assertion assumes opaque compositing.";
+  ASSERT_EQ(room.layer_merging().ID, LayerMerge06.ID);
+
+  bool saw_west_door = false;
+  bool saw_east_door = false;
+  for (const auto& door : room.GetDoors()) {
+    saw_west_door |= door.type == DoorType::ExplicitRoomDoor &&
+                     door.direction == DoorDirection::West &&
+                     door.position == 3;
+    saw_east_door |= door.type == DoorType::ExplicitRoomDoor &&
+                     door.direction == DoorDirection::East &&
+                     door.position == 9;
+  }
+  EXPECT_TRUE(saw_west_door);
+  EXPECT_TRUE(saw_east_door);
+
+  bool saw_west_guidance_wall = false;
+  bool saw_east_guidance_wall = false;
+  for (const auto& object : room.GetTileObjects()) {
+    saw_west_guidance_wall |=
+        object.id_ == 0x63 && object.x_ == 5 && object.y_ == 14;
+    saw_east_guidance_wall |=
+        object.id_ == 0x64 && object.x_ == 55 && object.y_ == 14;
+  }
+  EXPECT_TRUE(saw_west_guidance_wall);
+  EXPECT_TRUE(saw_east_guidance_wall);
 
   RoomLayerManager layer_manager;
+  layer_manager.ApplyLayerMerging(room.layer_merging());
+  layer_manager.ApplyRoomEffect(room.effect());
   const auto& composite = room.GetCompositeBitmap(layer_manager);
   const auto& bg1_objects = room.object_bg1_buffer();
   const auto& bg2_objects = room.object_bg2_buffer();
@@ -442,26 +483,99 @@ TEST_F(DungeonRoomRegressionFixturesTest,
   ASSERT_TRUE(composite.is_active());
   ASSERT_EQ(bg2_bitmap.width(), bg1_bitmap.width());
   ASSERT_EQ(composite.width(), bg1_bitmap.width());
-  ASSERT_LT(kRoom001ObjectOverlapX, bg1_bitmap.width());
-  ASSERT_LT(kRoom001ObjectOverlapY, bg1_bitmap.height());
-  const int sample_index =
-      kRoom001ObjectOverlapY * bg1_bitmap.width() + kRoom001ObjectOverlapX;
-  ASSERT_EQ(sample_index, kRoom001ObjectOverlapIndex);
-  ASSERT_LT(sample_index, static_cast<int>(bg1_bitmap.size()));
-  ASSERT_LT(sample_index, static_cast<int>(bg2_bitmap.size()));
-  ASSERT_LT(sample_index, static_cast<int>(composite.size()));
-  ASSERT_LT(sample_index, static_cast<int>(bg1_objects.priority_data().size()));
-  ASSERT_LT(sample_index, static_cast<int>(bg2_objects.priority_data().size()));
-  EXPECT_EQ(bg1_bitmap.data()[sample_index], kRoom001ObjectOverlapBg1Pixel);
-  EXPECT_EQ(bg2_bitmap.data()[sample_index], kRoom001ObjectOverlapBg2Pixel);
-  EXPECT_EQ(bg1_objects.priority_data()[sample_index],
-            kRoom001ObjectOverlapBg1Priority);
-  EXPECT_EQ(bg2_objects.priority_data()[sample_index],
-            kRoom001ObjectOverlapBg2Priority);
-  EXPECT_EQ(composite.data()[sample_index], kRoom001ObjectOverlapCompositePixel)
-      << "Room 0x001 overlap pixel (" << kRoom001ObjectOverlapX << ","
-      << kRoom001ObjectOverlapY << ") should preserve the golden BG1-over-BG2 "
-      << "priority winner";
+
+  auto expect_lower_door_body = [&](int start_x, const char* label) {
+    for (int y = kRoom001DoorY; y < kRoom001DoorY + kRoom001DoorHeight; ++y) {
+      for (int x = start_x; x < start_x + kRoom001DoorBodyWidth; ++x) {
+        const int index = y * composite.width() + x;
+        ASSERT_EQ(bg1_objects.coverage_data()[index], 1)
+            << label << " " << x << "," << y;
+        EXPECT_EQ(bg1_bitmap.data()[index], 255)
+            << label << " " << x << "," << y;
+        ASSERT_NE(bg2_bitmap.data()[index], 255)
+            << label << " " << x << "," << y;
+        EXPECT_EQ(composite.data()[index], bg2_bitmap.data()[index])
+            << label << " guidance wall covered door body at " << x << "," << y;
+      }
+    }
+  };
+
+  auto expect_upper_door_edge = [&](int start_x, const char* label) {
+    for (int y = kRoom001DoorY; y < kRoom001DoorY + kRoom001DoorHeight; ++y) {
+      for (int x = start_x; x < start_x + kRoom001DoorEdgeWidth; ++x) {
+        const int index = y * composite.width() + x;
+        ASSERT_NE(bg1_bitmap.data()[index], 255)
+            << label << " " << x << "," << y;
+        EXPECT_EQ(composite.data()[index], bg1_bitmap.data()[index])
+            << label << " upper edge lost at " << x << "," << y;
+      }
+    }
+  };
+
+  expect_lower_door_body(kRoom001WestDoorBodyX, "west door");
+  expect_lower_door_body(kRoom001EastDoorBodyX, "east door");
+  expect_upper_door_edge(kRoom001WestDoorEdgeX, "west door");
+  expect_upper_door_edge(kRoom001EastDoorEdgeX, "east door");
+}
+
+TEST_F(DungeonRoomRegressionFixturesTest,
+       Room077SpiralStairRastersFollowStoredBg2Stream) {
+  Room room = LoadRoomFromRom(&rom_, 0x077);
+  room.SetGameData(&game_data_);
+  room.LoadObjects();
+
+  struct SpiralWitness {
+    int object_id;
+    int x;
+    int y;
+  };
+  constexpr std::array<SpiralWitness, 3> kWitnesses = {{
+      {0x138, 44, 41},
+      {0x139, 16, 41},
+      {0x13B, 14, 7},
+  }};
+
+  gfx::PaletteGroup palette_group;
+  for (const auto& witness : kWitnesses) {
+    SCOPED_TRACE(::testing::Message()
+                 << "object=0x" << std::hex << witness.object_id << " at ("
+                 << std::dec << witness.x << "," << witness.y << ")");
+    const auto& objects = room.GetTileObjects();
+    const auto object_it = std::find_if(
+        objects.begin(), objects.end(), [&](const RoomObject& object) {
+          return object.id_ == witness.object_id && object.x_ == witness.x &&
+                 object.y_ == witness.y;
+        });
+    ASSERT_NE(object_it, objects.end());
+    ASSERT_EQ(object_it->GetLayerValue(), 1)
+        << "Room 0x077 witness moved out of the lower object-list stream.";
+
+    RoomObject object = *object_it;
+    object.SetRom(&rom_);
+    object.EnsureTilesLoaded();
+    ASSERT_GE(object.tiles().size(), 12u);
+
+    gfx::BackgroundBuffer upper(512, 512);
+    gfx::BackgroundBuffer lower(512, 512);
+    ObjectDrawer drawer(&rom_, /*room_id=*/0x077,
+                        /*room_gfx_buffer=*/nullptr);
+    std::vector<ObjectDrawer::TileTrace> trace;
+    drawer.SetTraceCollector(&trace, /*trace_only=*/true);
+    ASSERT_TRUE(drawer.DrawObject(object, upper, lower, palette_group).ok());
+    ASSERT_EQ(trace.size(), 12u);
+
+    for (int column = 0; column < 4; ++column) {
+      for (int row = 0; row < 3; ++row) {
+        const int index = column * 3 + row;
+        EXPECT_EQ(trace[index].layer,
+                  static_cast<uint8_t>(RoomObject::LayerType::BG2));
+        EXPECT_EQ(trace[index].x_tile, witness.x + column);
+        EXPECT_EQ(trace[index].y_tile, witness.y + row);
+        EXPECT_EQ(trace[index].tile_id, object.tiles()[index].id_)
+            << "The real ROM tile payload must stay column-major.";
+      }
+    }
+  }
 }
 
 TEST_F(DungeonRoomRegressionFixturesTest,
@@ -1081,50 +1195,67 @@ TEST_F(DungeonRoomRegressionFixturesTest,
   ASSERT_GE(object_bg2.width(), kOverlayPixelX + kOverlayPixelW);
   ASSERT_GE(object_bg2.height(), kOverlayPixelY + kOverlayPixelH);
 
-  int non_backdrop = 0;
+  const auto& object_bg2_coverage = room.object_bg2_buffer().coverage_data();
+  int covered_pixels = 0;
+  int opaque_pixels = 0;
   for (int py = 0; py < kOverlayPixelH; ++py) {
     for (int px = 0; px < kOverlayPixelW; ++px) {
       const int index =
           (kOverlayPixelY + py) * object_bg2.width() + (kOverlayPixelX + px);
-      if (object_bg2.data()[index] != 0) {
-        ++non_backdrop;
+      if (object_bg2_coverage[index] != 0) {
+        ++covered_pixels;
+      }
+      if (object_bg2.data()[index] != 255) {
+        ++opaque_pixels;
       }
     }
   }
-  EXPECT_GT(non_backdrop, 1000)
-      << "Editor water-overlay indicator must stamp visible BG2 object pixels "
-         "in the 0xD8 ROI (vanilla HDMA does not draw these tiles in-game)";
+  EXPECT_GT(covered_pixels, 1000)
+      << "Water overlay 0xD8 must write tilemap coverage in its BG2 stream ROI";
+  EXPECT_GT(opaque_pixels, 1000)
+      << "Yaze's currently modeled water state must stamp visible BG2 pixels";
 
-  // Hiding BG2 must remove the indicator from the composite (proves layering).
+  // Hold BG2 layout visibility constant and toggle only BG2 objects. This
+  // isolates the modeled 0xD8 stamp instead of attributing unrelated lower
+  // layout pixels to the object.
   // GetCompositeBitmap returns a reference to one mutable buffer — snapshot
-  // BG1-only before requesting the full composite.
-  RoomLayerManager bg1_only;
-  bg1_only.SetLayerVisible(LayerType::BG2_Layout, false);
-  bg1_only.SetLayerVisible(LayerType::BG2_Objects, false);
-  RoomLayerManager with_bg2;
-  const auto& bg1_composite = room.GetCompositeBitmap(bg1_only);
-  ASSERT_TRUE(bg1_composite.is_active());
-  std::vector<uint8_t> bg1_snapshot(
-      bg1_composite.data(),
-      bg1_composite.data() + static_cast<size_t>(bg1_composite.size()));
+  // object-hidden state before requesting the object-visible composite.
+  RoomLayerManager without_bg2_objects;
+  without_bg2_objects.ApplyLayerMerging(room.layer_merging());
+  without_bg2_objects.ApplyRoomEffect(room.effect());
+  without_bg2_objects.SetLayerVisible(LayerType::BG2_Layout, false);
+  without_bg2_objects.SetLayerVisible(LayerType::BG2_Objects, false);
+  RoomLayerManager with_bg2_objects;
+  with_bg2_objects.ApplyLayerMerging(room.layer_merging());
+  with_bg2_objects.ApplyRoomEffect(room.effect());
+  with_bg2_objects.SetLayerVisible(LayerType::BG2_Layout, false);
+  const auto& without_objects_composite =
+      room.GetCompositeBitmap(without_bg2_objects);
+  ASSERT_TRUE(without_objects_composite.is_active());
+  std::vector<uint8_t> without_objects_snapshot(
+      without_objects_composite.data(),
+      without_objects_composite.data() +
+          static_cast<size_t>(without_objects_composite.size()));
 
-  const auto& full_composite = room.GetCompositeBitmap(with_bg2);
+  const auto& full_composite = room.GetCompositeBitmap(with_bg2_objects);
   ASSERT_TRUE(full_composite.is_active());
-  ASSERT_EQ(bg1_snapshot.size(), static_cast<size_t>(full_composite.size()));
+  ASSERT_EQ(without_objects_snapshot.size(),
+            static_cast<size_t>(full_composite.size()));
 
   int differing = 0;
   for (int py = 0; py < kOverlayPixelH; ++py) {
     for (int px = 0; px < kOverlayPixelW; ++px) {
       const int index = (kOverlayPixelY + py) * full_composite.width() +
                         (kOverlayPixelX + px);
-      if (bg1_snapshot[static_cast<size_t>(index)] !=
+      if (without_objects_snapshot[static_cast<size_t>(index)] !=
           full_composite.data()[index]) {
         ++differing;
       }
     }
   }
-  EXPECT_GT(differing, 100)
-      << "BG2 water-overlay indicator must change the composite vs BG1-only";
+  EXPECT_GT(differing, 100) << "The modeled 0xD8 BG2 object stamp must change "
+                               "the composite when only "
+                               "BG2 object visibility is toggled";
 }
 
 TEST_F(DungeonRoomRegressionFixturesTest, PerLayerFingerprintsMatchGolden) {

--- a/test/integration/zelda3/dungeon_room_render_parity_test.cc
+++ b/test/integration/zelda3/dungeon_room_render_parity_test.cc
@@ -37,13 +37,16 @@ struct RoomRenderFingerprint {
 
 RoomRenderFingerprint CaptureRoomFingerprint(Rom* rom, GameData* game_data,
                                              int room_id) {
-  Room room(room_id, rom, game_data);
+  Room room = LoadRoomFromRom(rom, room_id);
+  room.SetGameData(game_data);
   room.LoadRoomGraphics();
   room.LoadObjects();
   room.CopyRoomGraphicsToBuffer();
   room.RenderRoomGraphics();
 
   RoomLayerManager layer_manager;
+  layer_manager.ApplyLayerMerging(room.layer_merging());
+  layer_manager.ApplyRoomEffect(room.effect());
   auto& composite = room.GetCompositeBitmap(layer_manager);
   return {
       .checksum = Fnv1a64(composite.data(), composite.size()),
@@ -70,13 +73,10 @@ class DungeonRoomRenderParityTest : public ::testing::Test {
 
 TEST_F(DungeonRoomRenderParityTest, Room00FingerprintSmoke) {
   const auto fingerprint = CaptureRoomFingerprint(&rom_, &game_data_, 0x00);
-  EXPECT_EQ(fingerprint.checksum, 11412267139571907076ull);
-  EXPECT_EQ(fingerprint.non_backdrop_pixels, 261888);
-}
-
-TEST_F(DungeonRoomRenderParityTest, Room01FingerprintSmoke) {
-  const auto fingerprint = CaptureRoomFingerprint(&rom_, &game_data_, 0x01);
-  EXPECT_EQ(fingerprint.checksum, 3925581144764392225ull);
+  // Self-fingerprint drift guard recorded from the canonical US ROM after the
+  // test began loading the real room header and applying canvas merge/effect
+  // settings. Independent visual truth remains in the Mesen ROI suite.
+  EXPECT_EQ(fingerprint.checksum, 9478994322329370003ull);
   EXPECT_EQ(fingerprint.non_backdrop_pixels, 262144);
 }
 

--- a/test/integration/zelda3/dungeon_room_render_parity_test.cc
+++ b/test/integration/zelda3/dungeon_room_render_parity_test.cc
@@ -76,7 +76,9 @@ TEST_F(DungeonRoomRenderParityTest, Room00FingerprintSmoke) {
   // Self-fingerprint drift guard recorded from the canonical US ROM after the
   // test began loading the real room header and applying canvas merge/effect
   // settings. Independent visual truth remains in the Mesen ROI suite.
-  EXPECT_EQ(fingerprint.checksum, 9478994322329370003ull);
+  // Floor-copy object 0xC4 now resolves its effective tile payload from this
+  // room's Floor1 header value, matching the vanilla room-draw path.
+  EXPECT_EQ(fingerprint.checksum, 14786764279995352503ull);
   EXPECT_EQ(fingerprint.non_backdrop_pixels, 262144);
 }
 

--- a/test/unit/editor/dungeon_canvas_viewer_navigation_test.cc
+++ b/test/unit/editor/dungeon_canvas_viewer_navigation_test.cc
@@ -37,6 +37,17 @@ struct PendingScrollFrameSnapshot {
 
 class DungeonCanvasViewerTestPeer {
  public:
+  static void UpdateRoomCanvasShortcutFocus(DungeonCanvasViewer& viewer,
+                                            bool hovered, bool pointer_pressed,
+                                            int frame_index) {
+    viewer.UpdateRoomCanvasShortcutFocus(hovered, pointer_pressed, frame_index);
+  }
+
+  static bool HasRoomCanvasShortcutFocusForFrame(
+      const DungeonCanvasViewer& viewer, int frame_index) {
+    return viewer.HasRoomCanvasShortcutFocusForFrame(frame_index);
+  }
+
   static absl::Status PrepareIssueReportPopup(
       DungeonCanvasViewer& viewer, const std::string& title,
       const std::string& summary, const std::string& kind_label,
@@ -344,6 +355,31 @@ TEST(DungeonCanvasViewerNavigationTest, ScrollToTileStoresPendingTarget) {
   ASSERT_TRUE(viewer.GetPendingScrollTarget().has_value());
   EXPECT_EQ(viewer.GetPendingScrollTarget()->first, 12);
   EXPECT_EQ(viewer.GetPendingScrollTarget()->second, 34);
+}
+
+TEST(DungeonCanvasViewerShortcutFocusTest,
+     DeleteEligibilityFollowsCanvasFocusAndCurrentDrawFrame) {
+  DungeonCanvasViewer viewer;
+
+  DungeonCanvasViewerTestPeer::UpdateRoomCanvasShortcutFocus(
+      viewer, /*hovered=*/true, /*pointer_pressed=*/false,
+      /*frame_index=*/10);
+  EXPECT_FALSE(DungeonCanvasViewerTestPeer::HasRoomCanvasShortcutFocusForFrame(
+      viewer, 10));
+
+  DungeonCanvasViewerTestPeer::UpdateRoomCanvasShortcutFocus(
+      viewer, /*hovered=*/true, /*pointer_pressed=*/true,
+      /*frame_index=*/11);
+  EXPECT_TRUE(DungeonCanvasViewerTestPeer::HasRoomCanvasShortcutFocusForFrame(
+      viewer, 11));
+  EXPECT_FALSE(DungeonCanvasViewerTestPeer::HasRoomCanvasShortcutFocusForFrame(
+      viewer, 12));
+
+  DungeonCanvasViewerTestPeer::UpdateRoomCanvasShortcutFocus(
+      viewer, /*hovered=*/false, /*pointer_pressed=*/true,
+      /*frame_index=*/12);
+  EXPECT_FALSE(DungeonCanvasViewerTestPeer::HasRoomCanvasShortcutFocusForFrame(
+      viewer, 12));
 }
 
 TEST(DungeonCanvasViewerNavigationTest,
@@ -860,8 +896,17 @@ TEST(DungeonCanvasViewerConnectedGraphTest,
      CollectDungeonConnectedRoomLinksSkipsExitDoorsAndUnusedStairHeaders) {
   zelda3::Room room;
   ClearRoomLinks(&room);
-  room.AddDoor(MakeDoor(zelda3::DoorDirection::East,
-                        zelda3::DoorType::FancyDungeonExit));
+  for (const auto type : {
+           zelda3::DoorType::ExitLower,
+           zelda3::DoorType::FancyDungeonExit,
+           zelda3::DoorType::FancyDungeonExitLower,
+           zelda3::DoorType::CaveExit,
+           zelda3::DoorType::LitCaveExitLower,
+           zelda3::DoorType::DungeonSwapMarker,
+           zelda3::DoorType::LayerSwapMarker,
+       }) {
+    room.AddDoor(MakeDoor(zelda3::DoorDirection::East, type));
+  }
   room.AddDoor(
       MakeDoor(zelda3::DoorDirection::South, zelda3::DoorType::NormalDoor));
   room.SetStaircaseRoom(0, 0);

--- a/test/unit/editor/dungeon_canvas_viewer_navigation_test.cc
+++ b/test/unit/editor/dungeon_canvas_viewer_navigation_test.cc
@@ -12,6 +12,7 @@
 #include "app/editor/dungeon/dungeon_canvas_transform.h"
 #include "app/editor/dungeon/ui_constants.h"
 #include "app/gfx/core/bitmap.h"
+#include "app/gfx/resource/arena.h"
 #include "app/gfx/types/snes_tile.h"
 #include "app/gui/canvas/canvas_pipelines.h"
 #include "core/project.h"
@@ -59,6 +60,10 @@ class DungeonCanvasViewerTestPeer {
 
   static const std::string& last_log_path(const DungeonCanvasViewer& viewer) {
     return viewer.issue_report_popup_last_log_path_;
+  }
+
+  static absl::Status SaveIssueReport(DungeonCanvasViewer& viewer) {
+    return viewer.EnsureIssueReportPersisted();
   }
 
   static std::string BuildDrawIssueReport(const DungeonCanvasViewer& viewer,
@@ -117,6 +122,13 @@ class DungeonCanvasViewerTestPeer {
       labels.push_back(item.label);
     }
     return labels;
+  }
+
+  static std::vector<gui::CanvasMenuItem> SelectionContextMenuItems(
+      DungeonCanvasViewer& viewer, int room_id,
+      std::optional<zelda3::RoomObject> context_object) {
+    return viewer.BuildSelectionContextMenuItems(room_id,
+                                                 std::move(context_object));
   }
 
   static bool InvokeSelectionContextMenuItem(DungeonCanvasViewer& viewer,
@@ -419,7 +431,7 @@ TEST(DungeonCanvasViewerNavigationTest,
   EXPECT_EQ(snapshot.background_origin_room_pixel, std::make_pair(0, 0));
 }
 
-TEST(DungeonCanvasViewerContextMenuTest, DirectActionsPrecedeInsertSubmenu) {
+TEST(DungeonCanvasViewerContextMenuTest, RootActionsUseStableSubmenus) {
   ScopedImGuiContext imgui;
   DungeonCanvasViewer viewer;
   viewer.SetShowObjectPanelCallback([]() {});
@@ -429,11 +441,42 @@ TEST(DungeonCanvasViewerContextMenuTest, DirectActionsPrecedeInsertSubmenu) {
   const auto labels =
       DungeonCanvasViewerTestPeer::InteractionContextMenuLabels(viewer, 0);
 
-  ASSERT_GE(labels.size(), 4u);
-  EXPECT_EQ(labels[0], "Paste");
-  EXPECT_EQ(labels[1], "Delete");
-  EXPECT_EQ(labels[2], "Delete All");
-  EXPECT_EQ(labels[3], "Insert");
+  ASSERT_EQ(labels.size(), 2u);
+  EXPECT_EQ(labels[0], "Selection");
+  EXPECT_EQ(labels[1], "Insert");
+}
+
+TEST(DungeonCanvasViewerContextMenuTest,
+     ObjectBrushActionKeepsItsSlotAndUsesCapturedObject) {
+  ScopedImGuiContext imgui;
+  DungeonCanvasViewer viewer;
+
+  auto items = DungeonCanvasViewerTestPeer::SelectionContextMenuItems(
+      viewer, 0, std::nullopt);
+  auto brush = std::find_if(items.begin(), items.end(), [](const auto& item) {
+    return item.label == "Use Object as Brush";
+  });
+  ASSERT_NE(brush, items.end());
+  EXPECT_FALSE(brush->enabled_condition());
+
+  const zelda3::RoomObject captured_object{0x34, 12, 9, 0x05, 1};
+  items = DungeonCanvasViewerTestPeer::SelectionContextMenuItems(
+      viewer, 0, captured_object);
+  brush = std::find_if(items.begin(), items.end(), [](const auto& item) {
+    return item.label == "Use Object as Brush";
+  });
+  ASSERT_NE(brush, items.end());
+  ASSERT_TRUE(brush->enabled_condition());
+  ASSERT_TRUE(brush->callback);
+  brush->callback();
+
+  EXPECT_TRUE(viewer.object_interaction().IsObjectLoaded());
+  const auto& preview =
+      viewer.object_interaction().mode_manager().GetModeState().preview_object;
+  ASSERT_TRUE(preview.has_value());
+  EXPECT_EQ(preview->id_, captured_object.id_);
+  EXPECT_EQ(preview->size_, captured_object.size_);
+  EXPECT_EQ(preview->layer_, captured_object.layer_);
 }
 
 TEST(DungeonCanvasViewerContextMenuTest,
@@ -645,7 +688,7 @@ TEST(DungeonCanvasViewerNavigationTest, EntranceRenderContextRoundTrips) {
 }
 
 TEST(DungeonCanvasViewerNavigationTest,
-     OpeningIssueReportPersistsInitialDraft) {
+     OpeningIssueReportKeepsDraftLocalUntilExplicitSave) {
   const std::filesystem::path temp_home = MakeTempHomeRoot();
   ASSERT_TRUE(std::filesystem::create_directories(temp_home));
   ScopedEnvVar scoped_home("HOME", temp_home.string());
@@ -656,6 +699,11 @@ TEST(DungeonCanvasViewerNavigationTest,
       "Dungeon Palette Issue Report", "Room 0x001\nBG sheets: [1,2,3,4]", 0x01,
       0);
   ASSERT_TRUE(status.ok()) << status;
+
+  EXPECT_TRUE(DungeonCanvasViewerTestPeer::last_log_path(viewer).empty());
+
+  const auto save_status = DungeonCanvasViewerTestPeer::SaveIssueReport(viewer);
+  ASSERT_TRUE(save_status.ok()) << save_status;
 
   const std::filesystem::path log_path =
       DungeonCanvasViewerTestPeer::last_log_path(viewer);
@@ -718,15 +766,159 @@ TEST(DungeonCanvasViewerNavigationTest,
   const std::string report =
       DungeonCanvasViewerTestPeer::BuildDrawIssueReport(viewer, room, 0x72);
 
-  EXPECT_NE(report.find("Object tiles: count=8"), std::string::npos);
+  EXPECT_NE(report.find("Descriptor tiles: count=8"), std::string::npos);
   EXPECT_NE(report.find("Object geometry: selection_bounds_px="),
             std::string::npos);
   EXPECT_NE(report.find("Drawer trace: status=ok"), std::string::npos);
+  EXPECT_NE(report.find("context=room-stream-prefix+layout-tilewords"),
+            std::string::npos);
   EXPECT_NE(report.find("bounds_tiles="), std::string::npos);
   EXPECT_NE(report.find("layer_counts BG1="), std::string::npos);
   EXPECT_NE(report.find("write[0] BG1 tile="), std::string::npos);
 
   zelda3::PaletteDebugger::Get().Clear();
+}
+
+TEST(DungeonCanvasViewerNavigationTest,
+     DrawIssueReportReplaysConditionalEdgeAgainstRoomLayout) {
+  std::vector<uint8_t> rom_data(1024 * 1024, 0);
+  Rom rom;
+  ASSERT_TRUE(rom.LoadFromData(rom_data).ok());
+
+  DungeonCanvasViewer viewer(&rom);
+  zelda3::Room room;
+  zelda3::RoomObject edge(/*id=*/0x22, /*x=*/4, /*y=*/5, /*size=*/0,
+                          /*layer=*/0);
+  edge.tiles_loaded_ = true;
+  edge.tiles_ = MakeObjectTiles(3);
+  room.GetTileObjects().push_back(edge);
+  room.bg1_buffer().SetTileAt(4, 5, 0x00E2);
+  viewer.object_interaction().SetSelectedObjects({0});
+
+  const std::string report =
+      DungeonCanvasViewerTestPeer::BuildDrawIssueReport(viewer, room, 0x72);
+
+  EXPECT_NE(report.find("context=room-stream-prefix+layout-tilewords writes=3"),
+            std::string::npos);
+  EXPECT_NE(report.find("write[0] BG1 tile=(5,5) id=0x121"), std::string::npos);
+  EXPECT_EQ(report.find("write[0] BG1 tile=(4,5) id=0x120"), std::string::npos);
+}
+
+TEST(DungeonCanvasViewerNavigationTest,
+     DrawIssueReportPriorObjectCoverageOverridesMatchingLayout) {
+  std::vector<uint8_t> rom_data(1024 * 1024, 0);
+  Rom rom;
+  ASSERT_TRUE(rom.LoadFromData(rom_data).ok());
+
+  DungeonCanvasViewer viewer(&rom);
+  zelda3::Room room;
+  zelda3::RoomObject prior(/*id=*/0x11F, /*x=*/4, /*y=*/5, /*size=*/0,
+                           /*layer=*/0);
+  prior.tiles_loaded_ = true;
+  prior.tiles_ = MakeObjectTiles(4);
+  prior.tiles_[0].id_ = 0x0320;
+  room.GetTileObjects().push_back(prior);
+
+  zelda3::RoomObject edge(/*id=*/0x22, /*x=*/4, /*y=*/5, /*size=*/0,
+                          /*layer=*/0);
+  edge.tiles_loaded_ = true;
+  edge.tiles_ = MakeObjectTiles(3);
+  room.GetTileObjects().push_back(edge);
+  room.bg1_buffer().SetTileAt(4, 5, 0x00E2);
+  viewer.object_interaction().SetSelectedObjects({1});
+
+  const std::string report =
+      DungeonCanvasViewerTestPeer::BuildDrawIssueReport(viewer, room, 0x72);
+
+  EXPECT_NE(report.find("context=room-stream-prefix+layout-tilewords writes=4"),
+            std::string::npos);
+  EXPECT_NE(report.find("write[0] BG1 tile=(4,5) id=0x120"), std::string::npos);
+}
+
+TEST(DungeonCanvasViewerNavigationTest,
+     RepeatedDrawIssueReportsReuseRetiredTraceSurfaces) {
+  std::vector<uint8_t> rom_data(1024 * 1024, 0);
+  Rom rom;
+  ASSERT_TRUE(rom.LoadFromData(rom_data).ok());
+
+  DungeonCanvasViewer viewer(&rom);
+  zelda3::Room room;
+  zelda3::RoomObject object(/*id=*/0x34, /*x=*/4, /*y=*/5, /*size=*/0,
+                            /*layer=*/0);
+  object.tiles_loaded_ = true;
+  object.tiles_ = MakeObjectTiles(8);
+  room.GetTileObjects().push_back(object);
+  viewer.object_interaction().SetSelectedObjects({0});
+
+  auto& arena = gfx::Arena::Get();
+  arena.ClearTextureQueue();
+  const size_t active_surfaces_before =
+      arena.GetSurfaceCount() - arena.GetPooledSurfaceCount();
+  const std::string first_report =
+      DungeonCanvasViewerTestPeer::BuildDrawIssueReport(viewer, room, 0x72);
+  ASSERT_NE(first_report.find("Drawer trace: status=ok"), std::string::npos);
+  ASSERT_EQ(arena.GetSurfaceCount() - arena.GetPooledSurfaceCount(),
+            active_surfaces_before);
+  const size_t surfaces_after_first_report = arena.GetSurfaceCount();
+
+  for (int iteration = 0; iteration < 8; ++iteration) {
+    const std::string report =
+        DungeonCanvasViewerTestPeer::BuildDrawIssueReport(viewer, room, 0x72);
+    ASSERT_NE(report.find("Drawer trace: status=ok"), std::string::npos);
+    ASSERT_EQ(arena.GetSurfaceCount() - arena.GetPooledSurfaceCount(),
+              active_surfaces_before);
+  }
+
+  EXPECT_EQ(arena.GetSurfaceCount(), surfaces_after_first_report)
+      << "Trace-only reports should reuse the two explicitly retired object "
+         "surfaces instead of retaining two more per capture";
+  EXPECT_EQ(arena.texture_command_queue_size(), 0u);
+  EXPECT_EQ(arena.retired_texture_handle_count(), 0u);
+}
+
+TEST(DungeonCanvasViewerNavigationTest,
+     DrawIssueReportDistinguishesFloorCopyDescriptorsAndEffectiveTiles) {
+  std::vector<uint8_t> rom_data(1024 * 1024, 0);
+  Rom rom;
+  ASSERT_TRUE(rom.LoadFromData(rom_data).ok());
+
+  DungeonCanvasViewer viewer(&rom);
+  viewer.object_interaction().SetSelectedObjects({0});
+
+  auto build_report = [&](int16_t object_id) {
+    zelda3::Room room;
+    room.set_floor1(6);
+    room.set_floor2(11);
+    zelda3::RoomObject object(object_id, /*x=*/4, /*y=*/5, /*size=*/0,
+                              /*layer=*/0);
+    object.tiles_loaded_ = true;
+    object.tiles_ = MakeObjectTiles(8);
+    room.GetTileObjects().push_back(object);
+    return DungeonCanvasViewerTestPeer::BuildDrawIssueReport(viewer, room,
+                                                             0x72);
+  };
+
+  const std::string floor1_report = build_report(0x00C4);
+  EXPECT_NE(floor1_report.find("Floor1:6 Floor2:11"), std::string::npos);
+  EXPECT_NE(floor1_report.find("Descriptor tiles: count=8 [0]=0x120"),
+            std::string::npos);
+  EXPECT_NE(
+      floor1_report.find("Floor copy source: Floor 1 (room.floor1) pattern=6"),
+      std::string::npos);
+  EXPECT_NE(floor1_report.find("Effective floor-copy tiles: count=8 "
+                               "[0]=0x000"),
+            std::string::npos);
+
+  const std::string floor2_report = build_report(0x00DB);
+  EXPECT_NE(floor2_report.find("Floor1:6 Floor2:11"), std::string::npos);
+  EXPECT_NE(floor2_report.find("Descriptor tiles: count=8 [0]=0x120"),
+            std::string::npos);
+  EXPECT_NE(
+      floor2_report.find("Floor copy source: Floor 2 (room.floor2) pattern=11"),
+      std::string::npos);
+  EXPECT_NE(floor2_report.find("Effective floor-copy tiles: count=8 "
+                               "[0]=0x000"),
+            std::string::npos);
 }
 
 TEST(DungeonCanvasViewerNavigationTest,
@@ -808,11 +1000,11 @@ TEST(DungeonCanvasViewerNavigationTest,
       DungeonCanvasViewerTestPeer::BuildSelectionIssueReport(viewer, room,
                                                              0x59);
 
-  EXPECT_NE(report.find("geometry: selection_bounds_px=(232,136,8,64) "
+  EXPECT_NE(report.find("geometry: selection_bounds_px=(232,112,8,64) "
                         "object_origin_px=(232,112)"),
             std::string::npos);
   EXPECT_NE(report.find("trace: writes=8 unique_cells=8 "
-                        "bounds_px=(232,136,8,64) "
+                        "bounds_px=(232,112,8,64) "
                         "delta_vs_selection_px=(+0,+0,+0,+0)"),
             std::string::npos);
 }

--- a/test/unit/editor/dungeon_layout_defaults_test.cc
+++ b/test/unit/editor/dungeon_layout_defaults_test.cc
@@ -1,7 +1,6 @@
 #include "app/editor/layout/layout_presets.h"
 
 #include <algorithm>
-#include <iterator>
 #include <vector>
 
 #include "gtest/gtest.h"
@@ -14,49 +13,41 @@ bool ContainsPanel(const std::vector<std::string>& panels,
   return std::find(panels.begin(), panels.end(), panel_id) != panels.end();
 }
 
-int IndexOfPanel(const std::vector<std::string>& panels, const char* panel_id) {
-  const auto it = std::find(panels.begin(), panels.end(), panel_id);
-  return it == panels.end()
-             ? -1
-             : static_cast<int>(std::distance(panels.begin(), it));
-}
-
-TEST(DungeonLayoutDefaultsTest, WorkbenchDefaultUsesRightSideToolStacks) {
+TEST(DungeonLayoutDefaultsTest, WorkbenchIsSoleDefaultSurface) {
   auto preset = LayoutPresets::GetDefaultPreset(EditorType::kDungeon);
 
+  ASSERT_EQ(preset.default_visible_panels.size(), 1U);
   EXPECT_TRUE(ContainsPanel(preset.default_visible_panels,
                             LayoutPresets::Panels::kDungeonWorkbench));
+  EXPECT_TRUE(preset.dock_only_default_visible_panels);
+
   EXPECT_FALSE(ContainsPanel(preset.default_visible_panels,
                              LayoutPresets::Panels::kDungeonRoomSelector));
-  EXPECT_TRUE(ContainsPanel(preset.default_visible_panels,
-                            LayoutPresets::Panels::kDungeonObjectSelector));
+  EXPECT_FALSE(ContainsPanel(preset.default_visible_panels,
+                             LayoutPresets::Panels::kDungeonObjectSelector));
   EXPECT_FALSE(ContainsPanel(preset.default_visible_panels,
                              LayoutPresets::Panels::kDungeonObjectEditor));
-  EXPECT_TRUE(ContainsPanel(preset.default_visible_panels,
-                            LayoutPresets::Panels::kDungeonRoomGraphics));
-  EXPECT_TRUE(ContainsPanel(preset.default_visible_panels,
-                            LayoutPresets::Panels::kDungeonRoomMatrix));
-  EXPECT_TRUE(ContainsPanel(preset.default_visible_panels,
-                            LayoutPresets::Panels::kDungeonDoorEditor));
-  EXPECT_TRUE(ContainsPanel(preset.default_visible_panels,
-                            LayoutPresets::Panels::kDungeonPaletteEditor));
+  EXPECT_FALSE(ContainsPanel(preset.default_visible_panels,
+                             LayoutPresets::Panels::kDungeonRoomGraphics));
+  EXPECT_FALSE(ContainsPanel(preset.default_visible_panels,
+                             LayoutPresets::Panels::kDungeonRoomMatrix));
+  EXPECT_FALSE(ContainsPanel(preset.default_visible_panels,
+                             LayoutPresets::Panels::kDungeonDoorEditor));
+  EXPECT_FALSE(ContainsPanel(preset.default_visible_panels,
+                             LayoutPresets::Panels::kDungeonPaletteEditor));
 
-  EXPECT_LT(IndexOfPanel(preset.default_visible_panels,
-                         LayoutPresets::Panels::kDungeonObjectSelector),
-            IndexOfPanel(preset.default_visible_panels,
-                         LayoutPresets::Panels::kDungeonRoomGraphics));
-  EXPECT_LT(IndexOfPanel(preset.default_visible_panels,
-                         LayoutPresets::Panels::kDungeonRoomGraphics),
-            IndexOfPanel(preset.default_visible_panels,
-                         LayoutPresets::Panels::kDungeonRoomMatrix));
-  EXPECT_LT(IndexOfPanel(preset.default_visible_panels,
-                         LayoutPresets::Panels::kDungeonRoomMatrix),
-            IndexOfPanel(preset.default_visible_panels,
-                         LayoutPresets::Panels::kDungeonDoorEditor));
-  EXPECT_LT(IndexOfPanel(preset.default_visible_panels,
-                         LayoutPresets::Panels::kDungeonDoorEditor),
-            IndexOfPanel(preset.default_visible_panels,
-                         LayoutPresets::Panels::kDungeonPaletteEditor));
+  EXPECT_TRUE(ContainsPanel(preset.optional_panels,
+                            LayoutPresets::Panels::kDungeonRoomSelector));
+  EXPECT_TRUE(ContainsPanel(preset.optional_panels,
+                            LayoutPresets::Panels::kDungeonObjectSelector));
+  EXPECT_TRUE(ContainsPanel(preset.optional_panels,
+                            LayoutPresets::Panels::kDungeonRoomGraphics));
+  EXPECT_TRUE(ContainsPanel(preset.optional_panels,
+                            LayoutPresets::Panels::kDungeonRoomMatrix));
+  EXPECT_TRUE(ContainsPanel(preset.optional_panels,
+                            LayoutPresets::Panels::kDungeonDoorEditor));
+  EXPECT_TRUE(ContainsPanel(preset.optional_panels,
+                            LayoutPresets::Panels::kDungeonPaletteEditor));
 
   auto selector_pos = preset.panel_positions.find(
       LayoutPresets::Panels::kDungeonObjectSelector);

--- a/test/unit/editor/dungeon_object_selector_palette_test.cc
+++ b/test/unit/editor/dungeon_object_selector_palette_test.cc
@@ -4,7 +4,10 @@
 #include <vector>
 
 #include "app/editor/dungeon/ui/window/object_tile_editor_panel.h"
+#include "app/gfx/resource/arena.h"
 #include "app/gfx/types/snes_palette.h"
+#include "framework/mock_renderer.h"
+#include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
 namespace yaze {
@@ -19,15 +22,52 @@ struct DungeonObjectSelectorTestAccess {
     return selector.OpenNewCustomObjectEditor(width, height, filename,
                                               object_id, room_id);
   }
+
+  static void SynchronizePreviewCacheRoomContext(
+      DungeonObjectSelector& selector, const zelda3::Room& room) {
+    selector.SynchronizePreviewCacheRoomContext(room);
+  }
+
+  static uint32_t MakeLayoutCacheKey(int object_id, uint8_t preview_size,
+                                     const zelda3::Room* room) {
+    return DungeonObjectSelector::MakeLayoutCacheKey(object_id, preview_size,
+                                                     room);
+  }
+
+  static void SeedPreviewCache(DungeonObjectSelector& selector,
+                               uint64_t cache_key) {
+    selector.preview_cache_[cache_key] =
+        std::make_unique<gfx::BackgroundBuffer>(8, 8);
+  }
+
+  static size_t PreviewCacheSize(const DungeonObjectSelector& selector) {
+    return selector.preview_cache_.size();
+  }
+
+  static gfx::Bitmap* SeedInitializedPreviewCache(
+      DungeonObjectSelector& selector, uint64_t cache_key) {
+    auto preview = std::make_unique<gfx::BackgroundBuffer>(8, 8);
+    preview->EnsureBitmapInitialized();
+    gfx::Bitmap* bitmap = &preview->bitmap();
+    selector.preview_cache_[cache_key] = std::move(preview);
+    return bitmap;
+  }
 };
 
 namespace {
 
+size_t ActiveArenaSurfaceCount() {
+  const auto& arena = gfx::Arena::Get();
+  return arena.GetSurfaceCount() - arena.GetPooledSurfaceCount();
+}
+
 // Pins the cache-invalidation contract for DungeonObjectSelector's preview
 // cache.
 //
-// The cache is keyed on (object_id, subtype, room.blockset(), room.palette()).
-// None of those keys capture the *contents* of the active palette group, so
+// The cache entry key covers object/subtype and compact room-header fields;
+// room ID, entrance graphics, and palette-group swaps invalidate the complete
+// cache before lookup. None of those fields capture the *contents* of the
+// active palette group, so
 // switching dungeon palette banks (which the editor does via
 // SetCurrentPaletteGroup, not by changing the slot value on the room) used
 // to leave the cache holding entries whose colors were silently stale.
@@ -72,12 +112,147 @@ TEST(DungeonObjectSelectorPaletteTest,
   EXPECT_EQ(selector.preview_cache_invalidations_for_testing(), 2u);
 }
 
+TEST(DungeonObjectSelectorPaletteTest,
+     InvalidationCancelsPendingCreateAndRetiresCachedTexture) {
+  gfx::Arena& arena = gfx::Arena::Get();
+  arena.ClearTextureQueue();
+  const size_t active_surfaces_before = ActiveArenaSurfaceCount();
+  DungeonObjectSelector selector;
+  gfx::Bitmap* bitmap =
+      DungeonObjectSelectorTestAccess::SeedInitializedPreviewCache(selector,
+                                                                   0x1234);
+  int texture_storage = 0;
+  const gfx::TextureHandle texture = &texture_storage;
+  bitmap->set_texture(texture);
+  ASSERT_EQ(ActiveArenaSurfaceCount(), active_surfaces_before + 1);
+  arena.QueueTextureCommand(gfx::Arena::TextureCommandType::CREATE, bitmap);
+  ASSERT_EQ(arena.texture_command_queue_size(), 1u);
+
+  selector.InvalidatePreviewCache();
+
+  EXPECT_EQ(DungeonObjectSelectorTestAccess::PreviewCacheSize(selector), 0u);
+  EXPECT_EQ(ActiveArenaSurfaceCount(), active_surfaces_before);
+  EXPECT_EQ(arena.texture_command_queue_size(), 0u);
+  EXPECT_EQ(arena.retired_texture_handle_count(), 1u);
+
+  ::testing::NiceMock<test::MockRenderer> renderer;
+  EXPECT_CALL(renderer, DestroyTexture(texture)).Times(1);
+  EXPECT_EQ(arena.DrainRetiredBitmaps(&renderer), 1u);
+}
+
+TEST(DungeonObjectSelectorPaletteTest,
+     DestructionCancelsPendingCreateBeforePreviewOwnerDisappears) {
+  gfx::Arena& arena = gfx::Arena::Get();
+  arena.ClearTextureQueue();
+  {
+    DungeonObjectSelector selector;
+    gfx::Bitmap* bitmap =
+        DungeonObjectSelectorTestAccess::SeedInitializedPreviewCache(selector,
+                                                                     0x1234);
+    arena.QueueTextureCommand(gfx::Arena::TextureCommandType::CREATE, bitmap);
+    ASSERT_EQ(arena.texture_command_queue_size(), 1u);
+  }
+
+  EXPECT_EQ(arena.texture_command_queue_size(), 0u);
+}
+
 TEST(DungeonObjectSelectorPaletteTest, InitialInvalidationCountIsZero) {
   // Defensive: a freshly-constructed selector must report no invalidations,
   // so a test asserting "+1" can rely on baseline 0 without an explicit
   // setup-phase reset.
   DungeonObjectSelector selector;
   EXPECT_EQ(selector.preview_cache_invalidations_for_testing(), 0u);
+}
+
+TEST(DungeonObjectSelectorPaletteTest,
+     FloorHeaderChangesInvalidateRoomDependentPreviews) {
+  DungeonObjectSelector selector;
+  selector.set_current_room_id(7);
+  zelda3::Room room;
+  room.SetBlockset(2);
+  room.SetPalette(3);
+  room.set_floor1(4);
+  room.set_floor2(5);
+
+  DungeonObjectSelectorTestAccess::SynchronizePreviewCacheRoomContext(selector,
+                                                                      room);
+  EXPECT_EQ(selector.preview_cache_invalidations_for_testing(), 1u);
+
+  DungeonObjectSelectorTestAccess::SynchronizePreviewCacheRoomContext(selector,
+                                                                      room);
+  EXPECT_EQ(selector.preview_cache_invalidations_for_testing(), 1u)
+      << "An unchanged room context must keep its cached previews";
+
+  room.set_floor1(6);
+  DungeonObjectSelectorTestAccess::SynchronizePreviewCacheRoomContext(selector,
+                                                                      room);
+  EXPECT_EQ(selector.preview_cache_invalidations_for_testing(), 2u);
+
+  room.set_floor2(7);
+  DungeonObjectSelectorTestAccess::SynchronizePreviewCacheRoomContext(selector,
+                                                                      room);
+  EXPECT_EQ(selector.preview_cache_invalidations_for_testing(), 3u);
+}
+
+TEST(DungeonObjectSelectorPaletteTest,
+     EntranceBlocksetChangeEvictsRoomGraphicsPreviews) {
+  DungeonObjectSelector selector;
+  selector.set_current_room_id(7);
+  zelda3::Room room;
+  room.SetBlockset(2);
+  room.SetPalette(3);
+  room.SetRenderEntranceBlockset(0x10);
+
+  DungeonObjectSelectorTestAccess::SynchronizePreviewCacheRoomContext(selector,
+                                                                      room);
+  EXPECT_EQ(selector.preview_cache_invalidations_for_testing(), 1u);
+
+  DungeonObjectSelectorTestAccess::SeedPreviewCache(selector, 0x1234);
+  DungeonObjectSelectorTestAccess::SynchronizePreviewCacheRoomContext(selector,
+                                                                      room);
+  EXPECT_EQ(DungeonObjectSelectorTestAccess::PreviewCacheSize(selector), 1u)
+      << "An unchanged entrance graphics context must retain its previews";
+
+  room.SetRenderEntranceBlockset(0x11);
+  DungeonObjectSelectorTestAccess::SynchronizePreviewCacheRoomContext(selector,
+                                                                      room);
+  EXPECT_EQ(selector.preview_cache_invalidations_for_testing(), 2u);
+  EXPECT_EQ(DungeonObjectSelectorTestAccess::PreviewCacheSize(selector), 0u)
+      << "A new entrance Main GFX group must evict thumbnails rendered from "
+         "the prior room graphics buffer";
+}
+
+TEST(DungeonObjectSelectorPaletteTest,
+     FloorObjectTooltipKeysIncludeTheirRoomHeaderSource) {
+  zelda3::Room room;
+  room.set_floor1(4);
+  room.set_floor2(5);
+
+  const uint32_t floor_one_key =
+      DungeonObjectSelectorTestAccess::MakeLayoutCacheKey(
+          0xC4, /*preview_size=*/2, &room);
+  const uint32_t floor_two_key =
+      DungeonObjectSelectorTestAccess::MakeLayoutCacheKey(
+          0xDB, /*preview_size=*/2, &room);
+  const uint32_t unrelated_key =
+      DungeonObjectSelectorTestAccess::MakeLayoutCacheKey(
+          0x34, /*preview_size=*/2, &room);
+
+  room.set_floor1(6);
+  EXPECT_NE(DungeonObjectSelectorTestAccess::MakeLayoutCacheKey(
+                0xC4, /*preview_size=*/2, &room),
+            floor_one_key);
+  EXPECT_EQ(DungeonObjectSelectorTestAccess::MakeLayoutCacheKey(
+                0xDB, /*preview_size=*/2, &room),
+            floor_two_key);
+  EXPECT_EQ(DungeonObjectSelectorTestAccess::MakeLayoutCacheKey(
+                0x34, /*preview_size=*/2, &room),
+            unrelated_key);
+
+  room.set_floor2(7);
+  EXPECT_NE(DungeonObjectSelectorTestAccess::MakeLayoutCacheKey(
+                0xDB, /*preview_size=*/2, &room),
+            floor_two_key);
 }
 
 TEST(DungeonObjectSelectorPaletteTest, ObjectPreviewsDefaultOn) {

--- a/test/unit/editor/dungeon_workbench_content_test.cc
+++ b/test/unit/editor/dungeon_workbench_content_test.cc
@@ -14,6 +14,7 @@
 #include "app/editor/dungeon/dungeon_project_labels.h"
 #include "app/editor/dungeon/workspace/dungeon_pit_damage_view_model.h"
 #include "app/editor/dungeon/workspace/dungeon_workbench_inspector_helpers.h"
+#include "core/features.h"
 #include "core/project.h"
 #include "imgui/imgui.h"
 #include "zelda3/dungeon/pit_damage_table.h"
@@ -148,6 +149,37 @@ TEST(DungeonWorkbenchContentLayoutTest,
       699.0f, kMinCanvasWidth, kMinSidebarWidth, kSplitterWidth, true, true);
   EXPECT_FALSE(hide_both.show_left);
   EXPECT_FALSE(hide_both.show_right);
+}
+
+TEST(DungeonWorkbenchApplyScopeTest, SelectAllAndNoneIncludeEntrances) {
+  auto& flags = core::FeatureFlags::get().dungeon;
+  const auto previous = flags;
+  int current_room_id = 0;
+  const std::deque<int> recent_rooms;
+  auto content = MakeWorkbenchForToolStateTests(current_room_id, recent_rooms);
+
+  flags.kSaveWaterFillZones = true;
+  content.SetAllSaveFlagsForTesting(false);
+  EXPECT_FALSE(flags.kSaveObjects);
+  EXPECT_FALSE(flags.kSaveSprites);
+  EXPECT_FALSE(flags.kSaveRoomHeaders);
+  EXPECT_FALSE(flags.kSaveChests);
+  EXPECT_FALSE(flags.kSavePotItems);
+  EXPECT_FALSE(flags.kSaveEntrances);
+  EXPECT_FALSE(flags.kSavePalettes);
+  EXPECT_FALSE(flags.kSaveCollision);
+  EXPECT_FALSE(flags.kSaveBlocks);
+  EXPECT_FALSE(flags.kSaveTorches);
+  EXPECT_FALSE(flags.kSavePits);
+  EXPECT_TRUE(flags.kSaveWaterFillZones);
+
+  flags.kSaveWaterFillZones = false;
+  content.SetAllSaveFlagsForTesting(true);
+  EXPECT_TRUE(flags.kSaveEntrances);
+  EXPECT_TRUE(flags.kSaveObjects);
+  EXPECT_FALSE(flags.kSaveWaterFillZones);
+
+  flags = previous;
 }
 
 TEST(DungeonWorkbenchContentLayoutTest,

--- a/test/unit/editor/editor_activator_test.cc
+++ b/test/unit/editor/editor_activator_test.cc
@@ -1,12 +1,98 @@
 #include "app/editor/system/workspace/editor_activator.h"
+
+#include "app/editor/layout/layout_manager.h"
+#include "app/editor/layout/layout_presets.h"
 #include "app/editor/overworld/overworld_editor.h"
 #include "app/editor/session_types.h"
 #include "app/editor/shell/feedback/toast_manager.h"
+#include "app/editor/system/workspace/workspace_window_manager.h"
+#include "imgui/imgui.h"
+#include "imgui/imgui_internal.h"
 
 #include <gtest/gtest.h>
 
+#include <vector>
+
 namespace yaze::editor {
 namespace {
+
+class EditorActivatorLayoutTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    imgui_context_ = ImGui::CreateContext();
+    ImGui::SetCurrentContext(imgui_context_);
+
+    ImGuiIO& io = ImGui::GetIO();
+    io.DisplaySize = ImVec2(1280.0f, 720.0f);
+    io.DeltaTime = 1.0f / 60.0f;
+    io.ConfigFlags |= ImGuiConfigFlags_DockingEnable;
+    unsigned char* pixels = nullptr;
+    int width = 0;
+    int height = 0;
+    io.Fonts->GetTexDataAsRGBA32(&pixels, &width, &height);
+    ImGui::NewFrame();
+
+    window_manager_.RegisterSession(0);
+    window_manager_.SetActiveSession(0);
+    layout_manager_.SetWindowManager(&window_manager_);
+
+    EditorActivator::Dependencies deps;
+    deps.window_manager = &window_manager_;
+    deps.layout_manager = &layout_manager_;
+    deps.get_current_editor_set = [this]() {
+      return &editor_set_;
+    };
+    deps.get_current_session_id = [this]() {
+      return window_manager_.GetActiveSessionId();
+    };
+    deps.queue_deferred_action = [this](std::function<void()> action) {
+      if (defer_layout_actions_) {
+        deferred_layout_actions_.push_back(std::move(action));
+      } else {
+        action();
+      }
+    };
+    activator_.Initialize(deps);
+  }
+
+  void TearDown() override {
+    ImGui::DockBuilderRemoveNode(ImGui::GetID("MainDockSpace"));
+    ImGui::EndFrame();
+    ImGui::DestroyContext(imgui_context_);
+    imgui_context_ = nullptr;
+  }
+
+  void RegisterDungeonPanel(size_t session_id, const char* panel_id,
+                            bool* visible) {
+    RegisterPanel(session_id, panel_id, "Dungeon", visible);
+  }
+
+  void RegisterPanel(size_t session_id, const char* panel_id,
+                     const char* category, bool* visible) {
+    WindowDescriptor descriptor{};
+    descriptor.card_id = panel_id;
+    descriptor.display_name = panel_id;
+    descriptor.icon = "ICON_MD_ACCOUNT_TREE";
+    descriptor.category = category;
+    descriptor.priority = 1;
+    descriptor.visibility_flag = visible;
+    window_manager_.RegisterWindow(session_id, descriptor);
+  }
+
+  ImGuiContext* imgui_context_ = nullptr;
+  bool session_zero_workbench_visible_ = false;
+  bool session_one_workbench_visible_ = false;
+  bool session_one_object_selector_visible_ = false;
+  bool overworld_canvas_visible_ = false;
+  bool overworld_tile_selector_visible_ = false;
+  bool overworld_properties_visible_ = false;
+  bool defer_layout_actions_ = false;
+  std::vector<std::function<void()>> deferred_layout_actions_;
+  WorkspaceWindowManager window_manager_;
+  LayoutManager layout_manager_;
+  EditorSet editor_set_{nullptr, nullptr, nullptr, 0, nullptr};
+  EditorActivator activator_;
+};
 
 TEST(EditorActivatorTest, RejectsInvalidOverworldMapJumpTargets) {
   EditorSet editor_set(nullptr, nullptr, nullptr, 0, nullptr);
@@ -49,6 +135,106 @@ TEST(EditorActivatorTest, AppliesValidOverworldMapJumpTargets) {
 
   EXPECT_EQ(overworld_editor->current_map_id(), 0x7F);
   EXPECT_TRUE(toast_manager.GetHistory().empty());
+}
+
+TEST_F(EditorActivatorLayoutTest,
+       RepeatedDungeonActivationRefreshesLazyDockingForActiveSession) {
+  RegisterDungeonPanel(0, LayoutPresets::Panels::kDungeonWorkbench,
+                       &session_zero_workbench_visible_);
+  Editor* dungeon_editor = editor_set_.GetEditor(EditorType::kDungeon);
+  ASSERT_NE(dungeon_editor, nullptr);
+
+  activator_.SwitchToEditor(EditorType::kDungeon, true);
+  ASSERT_TRUE(layout_manager_.IsLayoutInitialized(EditorType::kDungeon));
+
+  window_manager_.RegisterSession(1);
+  RegisterDungeonPanel(1, LayoutPresets::Panels::kDungeonWorkbench,
+                       &session_one_workbench_visible_);
+  RegisterDungeonPanel(1, LayoutPresets::Panels::kDungeonObjectSelector,
+                       &session_one_object_selector_visible_);
+  window_manager_.SetActiveSession(1);
+
+  activator_.SwitchToEditor(EditorType::kDungeon, true);
+
+  EXPECT_TRUE(layout_manager_.DockDefaultPositionOnFirstOpen(
+      1, LayoutPresets::Panels::kDungeonObjectSelector));
+}
+
+TEST_F(EditorActivatorLayoutTest,
+       DeactivatingForegroundEditorRefreshesFallbackLayoutContext) {
+  RegisterDungeonPanel(0, LayoutPresets::Panels::kDungeonWorkbench,
+                       &session_zero_workbench_visible_);
+  RegisterPanel(0, LayoutPresets::Panels::kOverworldCanvas, "Overworld",
+                &overworld_canvas_visible_);
+  RegisterPanel(0, LayoutPresets::Panels::kOverworldTile16Selector, "Overworld",
+                &overworld_tile_selector_visible_);
+  RegisterPanel(0, LayoutPresets::Panels::kOverworldMapProperties, "Overworld",
+                &overworld_properties_visible_);
+
+  auto* dungeon_editor = editor_set_.GetDungeonEditor();
+  auto* overworld_editor = editor_set_.GetOverworldEditor();
+  ASSERT_NE(dungeon_editor, nullptr);
+  ASSERT_NE(overworld_editor, nullptr);
+
+  activator_.SwitchToEditor(EditorType::kDungeon, true);
+  activator_.SwitchToEditor(EditorType::kOverworld, true);
+  ASSERT_EQ(window_manager_.GetActiveCategory(), "Overworld");
+
+  window_manager_.RegisterSession(1);
+  RegisterDungeonPanel(1, LayoutPresets::Panels::kDungeonWorkbench,
+                       &session_one_workbench_visible_);
+  RegisterDungeonPanel(1, LayoutPresets::Panels::kDungeonObjectSelector,
+                       &session_one_object_selector_visible_);
+  window_manager_.SetActiveSession(1);
+
+  activator_.SwitchToEditor(EditorType::kOverworld);
+
+  EXPECT_EQ(window_manager_.GetActiveCategory(), "Dungeon");
+  EXPECT_TRUE(layout_manager_.DockDefaultPositionOnFirstOpen(
+      1, LayoutPresets::Panels::kDungeonObjectSelector));
+}
+
+TEST_F(EditorActivatorLayoutTest,
+       DeferredLayoutInitializationDoesNotCrossRomSessions) {
+  RegisterDungeonPanel(0, LayoutPresets::Panels::kDungeonWorkbench,
+                       &session_zero_workbench_visible_);
+  ASSERT_NE(editor_set_.GetDungeonEditor(), nullptr);
+
+  defer_layout_actions_ = true;
+  activator_.SwitchToEditor(EditorType::kDungeon, true);
+  ASSERT_EQ(deferred_layout_actions_.size(), 1u);
+  EXPECT_FALSE(layout_manager_.IsLayoutInitialized(EditorType::kDungeon));
+
+  window_manager_.RegisterSession(1);
+  window_manager_.SetActiveSession(1);
+  auto action = std::move(deferred_layout_actions_.front());
+  deferred_layout_actions_.clear();
+  action();
+
+  EXPECT_FALSE(layout_manager_.IsLayoutInitialized(EditorType::kDungeon));
+}
+
+TEST_F(EditorActivatorLayoutTest, DeferredEditorSwitchDoesNotCrossRomSessions) {
+  RegisterDungeonPanel(0, LayoutPresets::Panels::kDungeonWorkbench,
+                       &session_zero_workbench_visible_);
+  Editor* dungeon_editor = editor_set_.GetEditor(EditorType::kDungeon);
+  ASSERT_NE(dungeon_editor, nullptr);
+  dungeon_editor->set_active(false);
+
+  ImGui::EndFrame();
+  defer_layout_actions_ = true;
+  activator_.SwitchToEditor(EditorType::kDungeon, true);
+  ASSERT_EQ(deferred_layout_actions_.size(), 1u);
+
+  window_manager_.RegisterSession(1);
+  window_manager_.SetActiveSession(1);
+  ImGui::NewFrame();
+  auto action = std::move(deferred_layout_actions_.front());
+  deferred_layout_actions_.clear();
+  action();
+
+  EXPECT_FALSE(*dungeon_editor->active());
+  EXPECT_FALSE(layout_manager_.IsLayoutInitialized(EditorType::kDungeon));
 }
 
 }  // namespace

--- a/test/unit/editor/editor_manager_test.cc
+++ b/test/unit/editor/editor_manager_test.cc
@@ -1,6 +1,10 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include <filesystem>
+#include <fstream>
+#include <string>
+
 #include "app/editor/editor_manager.h"
 #include "app/editor/registry/content_registry.h"
 #include "app/gfx/backend/irenderer.h"
@@ -11,6 +15,16 @@
 
 namespace yaze {
 namespace editor {
+
+class EditorManagerLayoutTestPeer {
+ public:
+  static void RestoreEditorLayoutAfterAssets(EditorManager* manager,
+                                             RomSession* session,
+                                             EditorType type) {
+    manager->RestoreEditorLayoutAfterAssets(session, type);
+  }
+};
+
 namespace {
 
 class EditorManagerTest : public ::testing::Test {
@@ -72,6 +86,169 @@ TEST_F(EditorManagerTest, PublicAPISurface) {
   // We can't easily test DrawMainMenuBar without a full ImGui setup,
   // but we can verify it compiles.
   // editor_manager_->DrawMainMenuBar();
+}
+
+TEST_F(EditorManagerTest,
+       TargetedDungeonDefaultsMigrationPreservesWorkspaceAndWidths) {
+  const std::filesystem::path settings_path =
+      std::filesystem::temp_directory_path() /
+      ("yaze_editor_manager_targeted_layout_" + std::to_string(::getpid()) +
+       ".json");
+  {
+    std::ofstream settings_file(settings_path);
+    ASSERT_TRUE(settings_file.is_open());
+    settings_file << R"({
+      "layouts": {
+        "defaults_revision": 21,
+        "panel_visibility": {
+          "Dungeon": {
+            "dungeon.workbench": false,
+            "dungeon.object_selector": true,
+            "dungeon.door_editor": true
+          }
+        },
+        "pinned_panels": {"dungeon.object_selector": true},
+        "right_panel_widths": {
+          "agent_chat": 777.0,
+          "dungeon.workbench": 444.0
+        },
+        "saved_layouts": {
+          "custom": {"dungeon.object_selector": true}
+        },
+        "named_layouts": {
+          "favorite": {
+            "schema_version": 2,
+            "name": "favorite",
+            "root": {
+              "id": 1,
+              "type": "leaf",
+              "active_tab_index": 0,
+              "panels": [
+                {"panel_id": "dungeon.object_selector"}
+              ]
+            }
+          }
+        }
+      },
+      "sidebar": {
+        "active_category": "Dungeon",
+        "visible": true,
+        "panel_expanded": true
+      }
+    })";
+  }
+
+  editor_manager_->user_settings().SetSettingsFilePathForTesting(
+      settings_path.string());
+  static constexpr char kSentinelIni[] =
+      "[Window][MigrationSentinel]\n"
+      "Pos=11,22\n"
+      "Size=333,222\n"
+      "Collapsed=0\n\n";
+  ImGui::LoadIniSettingsFromMemory(kSentinelIni, sizeof(kSentinelIni) - 1);
+
+  editor_manager_->Initialize(renderer_.get(), "");
+
+  const auto& prefs = editor_manager_->user_settings().prefs();
+  EXPECT_EQ(prefs.panel_layout_defaults_revision,
+            UserSettings::kLatestPanelLayoutDefaultsRevision);
+  EXPECT_FALSE(prefs.sidebar_panel_expanded);
+  EXPECT_TRUE(
+      prefs.panel_visibility_state.at("Dungeon").at("dungeon.workbench"));
+  EXPECT_FALSE(
+      prefs.panel_visibility_state.at("Dungeon").at("dungeon.object_selector"));
+  EXPECT_FALSE(
+      prefs.panel_visibility_state.at("Dungeon").at("dungeon.door_editor"));
+  EXPECT_TRUE(prefs.pinned_panels.at("dungeon.object_selector"));
+  EXPECT_TRUE(prefs.saved_layouts.at("custom").at("dungeon.object_selector"));
+  EXPECT_NE(prefs.named_layouts.at("favorite").find("dungeon.object_selector"),
+            std::string::npos);
+  EXPECT_FLOAT_EQ(prefs.right_panel_widths.at("agent_chat"), 777.0f);
+  EXPECT_FLOAT_EQ(prefs.right_panel_widths.at("dungeon.workbench"), 444.0f);
+
+  EXPECT_FALSE(editor_manager_->window_manager().IsSidebarExpanded());
+
+  size_t ini_size = 0;
+  const char* ini_data = ImGui::SaveIniSettingsToMemory(&ini_size);
+  ASSERT_NE(ini_data, nullptr);
+  EXPECT_NE(std::string(ini_data, ini_size).find("MigrationSentinel"),
+            std::string::npos);
+
+  std::error_code ec;
+  std::filesystem::remove(settings_path, ec);
+}
+
+TEST_F(EditorManagerTest,
+       PostRegistrationRestoreAppliesLazySecondSessionPanelVisibility) {
+  editor_manager_->Initialize(renderer_.get(), "");
+
+  constexpr size_t kSecondSessionId = 7;
+  RomSession second_session(&editor_manager_->user_settings(),
+                            kSecondSessionId);
+  second_session.editor_initialized[EditorTypeIndex(EditorType::kDungeon)] =
+      true;
+
+  bool object_selector_visible = false;
+  WindowDescriptor descriptor{};
+  descriptor.card_id = LayoutPresets::Panels::kDungeonObjectSelector;
+  descriptor.display_name = "Object Selector";
+  descriptor.icon = "ICON_MD_ACCOUNT_TREE";
+  descriptor.category = "Dungeon";
+  descriptor.priority = 1;
+  descriptor.visibility_flag = &object_selector_visible;
+
+  auto& window_manager = editor_manager_->window_manager();
+  window_manager.RegisterSession(kSecondSessionId);
+  window_manager.SetActiveSession(kSecondSessionId);
+  window_manager.SetActiveCategory("Dungeon");
+  window_manager.RegisterWindow(kSecondSessionId, descriptor);
+  editor_manager_->user_settings()
+      .prefs()
+      .panel_visibility_state["Dungeon"]
+                             [LayoutPresets::Panels::kDungeonObjectSelector] =
+      true;
+
+  EditorManagerLayoutTestPeer::RestoreEditorLayoutAfterAssets(
+      editor_manager_.get(), &second_session, EditorType::kDungeon);
+
+  EXPECT_TRUE(object_selector_visible);
+}
+
+TEST_F(EditorManagerTest,
+       RepeatedEnsureDoesNotReplayStaleVisibilityAfterPanelClose) {
+  editor_manager_->Initialize(renderer_.get(), "");
+  editor_manager_->CreateNewSession();
+
+  auto& window_manager = editor_manager_->window_manager();
+  RomSession* active_session =
+      editor_manager_->session_coordinator()->GetActiveRomSession();
+  ASSERT_NE(active_session, nullptr);
+  const size_t session_id = window_manager.GetActiveSessionId();
+  window_manager.SetActiveCategory("Assembly");
+  editor_manager_->user_settings()
+      .prefs()
+      .panel_visibility_state["Assembly"]
+                             [LayoutPresets::Panels::kAssemblyEditor] = true;
+
+  ASSERT_TRUE(
+      editor_manager_->EnsureEditorAssetsLoaded(EditorType::kAssembly).ok());
+  const WindowDescriptor* descriptor = window_manager.GetWindowDescriptor(
+      session_id, LayoutPresets::Panels::kAssemblyEditor);
+  ASSERT_NE(descriptor, nullptr);
+  ASSERT_NE(descriptor->visibility_flag, nullptr);
+  ASSERT_TRUE(*descriptor->visibility_flag);
+
+  // Model an ImGui title-bar X close. That path changes the live visibility
+  // flag before the debounced settings snapshot catches up.
+  *descriptor->visibility_flag = false;
+  ASSERT_TRUE(editor_manager_->user_settings()
+                  .prefs()
+                  .panel_visibility_state.at("Assembly")
+                  .at(LayoutPresets::Panels::kAssemblyEditor));
+
+  ASSERT_TRUE(
+      editor_manager_->EnsureEditorAssetsLoaded(EditorType::kAssembly).ok());
+  EXPECT_FALSE(*descriptor->visibility_flag);
 }
 
 // Regression: ~EditorManager must clear the static singletons that hold

--- a/test/unit/editor/layout/layout_manager_dock_tree_test.cc
+++ b/test/unit/editor/layout/layout_manager_dock_tree_test.cc
@@ -6,6 +6,7 @@
 #include "app/editor/layout/layout_designer/dock_tree.h"
 #include "app/editor/layout/layout_designer/dock_tree_json.h"
 #include "app/editor/layout/layout_manager.h"
+#include "app/editor/layout/layout_presets.h"
 #include "app/editor/system/session/user_settings.h"
 #include "app/editor/system/workspace/workspace_window_manager.h"
 #include "imgui/imgui.h"
@@ -79,6 +80,25 @@ class LayoutManagerDockTreeTest : public ::testing::Test {
     }
   }
 
+  void RegisterPanel(const char* id, bool* visible, size_t session_id = 0) {
+    WindowDescriptor desc{};
+    desc.card_id = id;
+    desc.display_name = id;
+    desc.icon = "ICON_MD_ACCOUNT_TREE";
+    desc.category = "Dungeon";
+    desc.priority = 1;
+    desc.visibility_flag = visible;
+    window_manager_.RegisterWindow(session_id, desc);
+  }
+
+  ImGuiID GetPanelDockId(const char* id, size_t session_id = 0) const {
+    const std::string title =
+        window_manager_.GetWorkspaceWindowName(session_id, id);
+    const ImGuiWindowSettings* settings =
+        ImGui::FindWindowSettingsByID(ImHashStr(title.c_str()));
+    return settings ? settings->DockId : 0;
+  }
+
   ImGuiContext* imgui_context_ = nullptr;
   bool always_true_ = true;
   WorkspaceWindowManager window_manager_;
@@ -108,6 +128,218 @@ TEST_F(LayoutManagerDockTreeTest, ApplyEmptyLeafSucceeds) {
   ImGuiDockNode* node = ImGui::DockBuilderGetNode(kDockspaceId);
   ASSERT_NE(node, nullptr);
   EXPECT_TRUE(node->IsLeafNode());
+}
+
+TEST_F(LayoutManagerDockTreeTest, DungeonDefaultBuildsSingleDockLeaf) {
+  layout_manager_.InitializeEditorLayout(EditorType::kDungeon, kDockspaceId);
+
+  ImGuiDockNode* root = ImGui::DockBuilderGetNode(kDockspaceId);
+  ASSERT_NE(root, nullptr);
+  EXPECT_TRUE(root->IsLeafNode())
+      << "Workbench-only startup must not reserve empty side docks for "
+         "optional tools";
+}
+
+TEST_F(LayoutManagerDockTreeTest,
+       DungeonOptionalPanelsCreatePresetRegionsOnFirstOpen) {
+  bool workbench_visible = false;
+  bool object_selector_visible = false;
+  bool door_editor_visible = false;
+  bool palette_editor_visible = false;
+  RegisterPanel(LayoutPresets::Panels::kDungeonWorkbench, &workbench_visible);
+  RegisterPanel(LayoutPresets::Panels::kDungeonObjectSelector,
+                &object_selector_visible);
+  RegisterPanel(LayoutPresets::Panels::kDungeonDoorEditor,
+                &door_editor_visible);
+  RegisterPanel(LayoutPresets::Panels::kDungeonPaletteEditor,
+                &palette_editor_visible);
+
+  layout_manager_.InitializeEditorLayout(EditorType::kDungeon, kDockspaceId);
+  ImGuiDockNode* root = ImGui::DockBuilderGetNode(kDockspaceId);
+  ASSERT_NE(root, nullptr);
+  ASSERT_TRUE(root->IsLeafNode());
+
+  ASSERT_TRUE(layout_manager_.DockDefaultPositionOnFirstOpen(
+      0, LayoutPresets::Panels::kDungeonObjectSelector));
+  root = ImGui::DockBuilderGetNode(kDockspaceId);
+  ASSERT_TRUE(root->IsSplitNode());
+  ASSERT_EQ(root->SplitAxis, ImGuiAxis_X);
+  ImGuiDockNode* right = root->ChildNodes[1];
+  ASSERT_NE(right, nullptr);
+  EXPECT_EQ(GetPanelDockId(LayoutPresets::Panels::kDungeonObjectSelector),
+            right->ID);
+
+  ASSERT_TRUE(layout_manager_.DockDefaultPositionOnFirstOpen(
+      0, LayoutPresets::Panels::kDungeonDoorEditor));
+  right = ImGui::DockBuilderGetNode(right->ID);
+  ASSERT_NE(right, nullptr);
+  ASSERT_TRUE(right->IsSplitNode());
+  ASSERT_EQ(right->SplitAxis, ImGuiAxis_Y);
+  ASSERT_NE(right->ChildNodes[0], nullptr);
+  ASSERT_NE(right->ChildNodes[1], nullptr);
+  EXPECT_EQ(GetPanelDockId(LayoutPresets::Panels::kDungeonObjectSelector),
+            right->ChildNodes[0]->ID);
+  EXPECT_EQ(GetPanelDockId(LayoutPresets::Panels::kDungeonDoorEditor),
+            right->ChildNodes[1]->ID);
+
+  ASSERT_TRUE(layout_manager_.DockDefaultPositionOnFirstOpen(
+      0, LayoutPresets::Panels::kDungeonPaletteEditor));
+  EXPECT_EQ(GetPanelDockId(LayoutPresets::Panels::kDungeonPaletteEditor),
+            GetPanelDockId(LayoutPresets::Panels::kDungeonDoorEditor));
+}
+
+TEST_F(LayoutManagerDockTreeTest,
+       DungeonOptionalRegionsAreStableWhenBottomOpensFirst) {
+  bool workbench_visible = false;
+  bool object_selector_visible = false;
+  bool door_editor_visible = false;
+  RegisterPanel(LayoutPresets::Panels::kDungeonWorkbench, &workbench_visible);
+  RegisterPanel(LayoutPresets::Panels::kDungeonObjectSelector,
+                &object_selector_visible);
+  RegisterPanel(LayoutPresets::Panels::kDungeonDoorEditor,
+                &door_editor_visible);
+
+  layout_manager_.InitializeEditorLayout(EditorType::kDungeon, kDockspaceId);
+  ASSERT_TRUE(layout_manager_.DockDefaultPositionOnFirstOpen(
+      0, LayoutPresets::Panels::kDungeonDoorEditor));
+  ASSERT_TRUE(layout_manager_.DockDefaultPositionOnFirstOpen(
+      0, LayoutPresets::Panels::kDungeonObjectSelector));
+
+  ImGuiDockNode* root = ImGui::DockBuilderGetNode(kDockspaceId);
+  ASSERT_NE(root, nullptr);
+  ASSERT_TRUE(root->IsSplitNode());
+  ImGuiDockNode* right = root->ChildNodes[1];
+  ASSERT_NE(right, nullptr);
+  ASSERT_TRUE(right->IsSplitNode());
+  EXPECT_EQ(GetPanelDockId(LayoutPresets::Panels::kDungeonObjectSelector),
+            right->ChildNodes[0]->ID);
+  EXPECT_EQ(GetPanelDockId(LayoutPresets::Panels::kDungeonDoorEditor),
+            right->ChildNodes[1]->ID);
+}
+
+TEST_F(LayoutManagerDockTreeTest,
+       DungeonLazyDockingRefreshesAfterOverworldActivation) {
+  bool dungeon_workbench_visible = false;
+  bool dungeon_door_editor_visible = false;
+  bool overworld_canvas_visible = false;
+  bool overworld_tile_selector_visible = false;
+  bool overworld_properties_visible = false;
+  RegisterPanel(LayoutPresets::Panels::kDungeonWorkbench,
+                &dungeon_workbench_visible);
+  RegisterPanel(LayoutPresets::Panels::kDungeonDoorEditor,
+                &dungeon_door_editor_visible);
+  RegisterPanel(LayoutPresets::Panels::kOverworldCanvas,
+                &overworld_canvas_visible);
+  RegisterPanel(LayoutPresets::Panels::kOverworldTile16Selector,
+                &overworld_tile_selector_visible);
+  RegisterPanel(LayoutPresets::Panels::kOverworldMapProperties,
+                &overworld_properties_visible);
+
+  layout_manager_.InitializeEditorLayout(EditorType::kDungeon, kDockspaceId);
+  ASSERT_TRUE(layout_manager_.DockDefaultPositionOnFirstOpen(
+      0, LayoutPresets::Panels::kDungeonDoorEditor));
+  ASSERT_NE(GetPanelDockId(LayoutPresets::Panels::kDungeonWorkbench), 0u);
+  ASSERT_NE(GetPanelDockId(LayoutPresets::Panels::kDungeonDoorEditor), 0u);
+
+  layout_manager_.InitializeEditorLayout(EditorType::kOverworld, kDockspaceId);
+  dungeon_door_editor_visible = true;
+  layout_manager_.InitializeEditorLayout(EditorType::kDungeon, kDockspaceId);
+
+  EXPECT_NE(GetPanelDockId(LayoutPresets::Panels::kDungeonWorkbench), 0u);
+  EXPECT_NE(GetPanelDockId(LayoutPresets::Panels::kDungeonDoorEditor), 0u);
+  EXPECT_FALSE(layout_manager_.DockDefaultPositionOnFirstOpen(
+      0, LayoutPresets::Panels::kDungeonDoorEditor));
+}
+
+TEST_F(LayoutManagerDockTreeTest,
+       HiddenDefaultPanelRebindsWhenReopenedAfterSharedTreeReplacement) {
+  bool dungeon_workbench_visible = true;
+  bool overworld_canvas_visible = true;
+  bool overworld_tile_selector_visible = true;
+  bool overworld_properties_visible = true;
+  RegisterPanel(LayoutPresets::Panels::kDungeonWorkbench,
+                &dungeon_workbench_visible);
+  RegisterPanel(LayoutPresets::Panels::kOverworldCanvas,
+                &overworld_canvas_visible);
+  RegisterPanel(LayoutPresets::Panels::kOverworldTile16Selector,
+                &overworld_tile_selector_visible);
+  RegisterPanel(LayoutPresets::Panels::kOverworldMapProperties,
+                &overworld_properties_visible);
+
+  layout_manager_.InitializeEditorLayout(EditorType::kDungeon, kDockspaceId);
+  dungeon_workbench_visible = false;
+  layout_manager_.InitializeEditorLayout(EditorType::kOverworld, kDockspaceId);
+  layout_manager_.InitializeEditorLayout(EditorType::kDungeon, kDockspaceId);
+
+  const ImGuiID stale_dock_id =
+      GetPanelDockId(LayoutPresets::Panels::kDungeonWorkbench);
+  EXPECT_TRUE(stale_dock_id == 0 ||
+              ImGui::DockBuilderGetNode(stale_dock_id) == nullptr);
+
+  dungeon_workbench_visible = true;
+  ASSERT_TRUE(layout_manager_.DockPresetPositionOnPanelOpen(
+      0, LayoutPresets::Panels::kDungeonWorkbench));
+  const ImGuiID rebound_dock_id =
+      GetPanelDockId(LayoutPresets::Panels::kDungeonWorkbench);
+  EXPECT_NE(rebound_dock_id, 0u);
+  EXPECT_NE(ImGui::DockBuilderGetNode(rebound_dock_id), nullptr);
+}
+
+TEST_F(LayoutManagerDockTreeTest,
+       DungeonLazyDockingRefreshesForSecondRomSession) {
+  bool session_zero_workbench_visible = false;
+  bool session_one_workbench_visible = true;
+  bool session_one_object_selector_visible = true;
+  RegisterPanel(LayoutPresets::Panels::kDungeonWorkbench,
+                &session_zero_workbench_visible, 0);
+  layout_manager_.InitializeEditorLayout(EditorType::kDungeon, kDockspaceId);
+
+  window_manager_.RegisterSession(1);
+  window_manager_.SetActiveSession(1);
+  RegisterPanel(LayoutPresets::Panels::kDungeonWorkbench,
+                &session_one_workbench_visible, 1);
+  RegisterPanel(LayoutPresets::Panels::kDungeonObjectSelector,
+                &session_one_object_selector_visible, 1);
+  layout_manager_.InitializeEditorLayout(EditorType::kDungeon, kDockspaceId);
+
+  EXPECT_NE(GetPanelDockId(LayoutPresets::Panels::kDungeonWorkbench, 1), 0u);
+  EXPECT_NE(GetPanelDockId(LayoutPresets::Panels::kDungeonObjectSelector, 1),
+            0u);
+}
+
+TEST_F(LayoutManagerDockTreeTest,
+       DungeonOptionalDockingIsOneShotAndYieldsToCustomTrees) {
+  bool workbench_visible = false;
+  bool object_selector_visible = false;
+  bool door_editor_visible = false;
+  RegisterPanel(LayoutPresets::Panels::kDungeonWorkbench, &workbench_visible);
+  RegisterPanel(LayoutPresets::Panels::kDungeonObjectSelector,
+                &object_selector_visible);
+  RegisterPanel(LayoutPresets::Panels::kDungeonDoorEditor,
+                &door_editor_visible);
+
+  layout_manager_.InitializeEditorLayout(EditorType::kDungeon, kDockspaceId);
+  ASSERT_TRUE(layout_manager_.DockDefaultPositionOnFirstOpen(
+      0, LayoutPresets::Panels::kDungeonObjectSelector));
+
+  const std::string object_title = window_manager_.GetWorkspaceWindowName(
+      0, LayoutPresets::Panels::kDungeonObjectSelector);
+  ImGuiWindowSettings* object_settings =
+      ImGui::FindWindowSettingsByID(ImHashStr(object_title.c_str()));
+  ASSERT_NE(object_settings, nullptr);
+  object_settings->DockId = 0;
+  EXPECT_FALSE(layout_manager_.DockDefaultPositionOnFirstOpen(
+      0, LayoutPresets::Panels::kDungeonObjectSelector));
+  EXPECT_EQ(GetPanelDockId(LayoutPresets::Panels::kDungeonObjectSelector), 0u);
+
+  DockTree custom_tree;
+  ASSERT_TRUE(layout_manager_.ApplyDockTree(custom_tree, kDockspaceId).ok());
+  ImGuiDockNode* root = ImGui::DockBuilderGetNode(kDockspaceId);
+  ASSERT_NE(root, nullptr);
+  ASSERT_TRUE(root->IsLeafNode());
+  EXPECT_FALSE(layout_manager_.DockDefaultPositionOnFirstOpen(
+      0, LayoutPresets::Panels::kDungeonDoorEditor));
+  EXPECT_TRUE(root->IsLeafNode());
 }
 
 TEST_F(LayoutManagerDockTreeTest, ApplyLeftSplitUsesHorizontalAxis) {

--- a/test/unit/editor/layout_manager_persistence_test.cc
+++ b/test/unit/editor/layout_manager_persistence_test.cc
@@ -5,13 +5,17 @@
 #include <string>
 
 #include "app/editor/layout/layout_manager.h"
+#include "app/editor/layout/layout_presets.h"
 #include "app/editor/system/workspace/workspace_window_manager.h"
 #include "imgui/imgui.h"
+#include "imgui/imgui_internal.h"
 #include "util/json.h"
 #include "util/platform_paths.h"
 
 namespace yaze::editor {
 namespace {
+
+constexpr ImGuiID kDockspaceId = 0x41594C54u;
 
 class LayoutManagerPersistenceTest : public ::testing::Test {
  protected:
@@ -19,10 +23,14 @@ class LayoutManagerPersistenceTest : public ::testing::Test {
     imgui_context_ = ImGui::CreateContext();
     ImGui::SetCurrentContext(imgui_context_);
     ImGuiIO& io = ImGui::GetIO();
+    io.DisplaySize = ImVec2(1280.0f, 720.0f);
+    io.DeltaTime = 1.0f / 60.0f;
+    io.ConfigFlags |= ImGuiConfigFlags_DockingEnable;
     unsigned char* pixels = nullptr;
     int width = 0;
     int height = 0;
     io.Fonts->GetTexDataAsRGBA32(&pixels, &width, &height);
+    ImGui::NewFrame();
 
     window_manager_.RegisterSession(0);
     window_manager_.SetActiveSession(0);
@@ -37,6 +45,19 @@ class LayoutManagerPersistenceTest : public ::testing::Test {
     descriptor.priority = 1;
     window_manager_.RegisterWindow(0, descriptor);
 
+    WindowDescriptor workbench = descriptor;
+    workbench.card_id = LayoutPresets::Panels::kDungeonWorkbench;
+    workbench.display_name = "Dungeon Workbench";
+    workbench.category = "Dungeon";
+    workbench.visibility_flag = &dungeon_workbench_visible_;
+    window_manager_.RegisterWindow(0, workbench);
+
+    WindowDescriptor object_selector = workbench;
+    object_selector.card_id = LayoutPresets::Panels::kDungeonObjectSelector;
+    object_selector.display_name = "Object Selector";
+    object_selector.visibility_flag = &dungeon_object_selector_visible_;
+    window_manager_.RegisterWindow(0, object_selector);
+
     layout_manager_.SetWindowManager(&window_manager_);
 
     project_key_ = "layout-manager-window-schema-test";
@@ -49,6 +70,8 @@ class LayoutManagerPersistenceTest : public ::testing::Test {
     std::error_code ec;
     std::filesystem::remove(layout_path_, ec);
     if (imgui_context_) {
+      ImGui::DockBuilderRemoveNode(kDockspaceId);
+      ImGui::EndFrame();
       ImGui::DestroyContext(imgui_context_);
       imgui_context_ = nullptr;
     }
@@ -69,6 +92,8 @@ class LayoutManagerPersistenceTest : public ::testing::Test {
   WorkspaceWindowManager window_manager_;
   LayoutManager layout_manager_;
   bool visible_ = false;
+  bool dungeon_workbench_visible_ = false;
+  bool dungeon_object_selector_visible_ = false;
   std::string project_key_;
   std::filesystem::path layout_path_;
 };
@@ -131,6 +156,46 @@ TEST_F(LayoutManagerPersistenceTest, PrefersWindowsKeyWhenBothSchemasExist) {
 
   layout_manager_.LoadLayout("Precedence");
   EXPECT_TRUE(visible_);
+}
+
+TEST_F(LayoutManagerPersistenceTest,
+       VisibilityOnlyLayoutPreservesLazyDefaultDocking) {
+  yaze::Json root;
+  root["version"] = 2;
+  root["layouts"]["Visibility Only"]["windows"] =
+      yaze::Json{{"test.demo", true}};
+
+  std::ofstream file(layout_path_);
+  ASSERT_TRUE(file.is_open());
+  file << root.dump(2);
+  file.close();
+
+  layout_manager_.SetProjectLayoutKey(project_key_);
+  layout_manager_.InitializeEditorLayout(EditorType::kDungeon, kDockspaceId);
+  layout_manager_.LoadLayout("Visibility Only");
+
+  EXPECT_TRUE(layout_manager_.DockDefaultPositionOnFirstOpen(
+      0, LayoutPresets::Panels::kDungeonObjectSelector));
+}
+
+TEST_F(LayoutManagerPersistenceTest,
+       DockingLayoutBeforeFirstEditorArmsDefaultRebuildProtection) {
+  yaze::Json root;
+  root["version"] = 2;
+  root["layouts"]["Docking"]["windows"] = yaze::Json{{"test.demo", true}};
+  root["layouts"]["Docking"]["imgui_ini"] =
+      "[Window][Demo]\nPos=10,10\nSize=320,240\nCollapsed=0\n\n";
+
+  std::ofstream file(layout_path_);
+  ASSERT_TRUE(file.is_open());
+  file << root.dump(2);
+  file.close();
+
+  layout_manager_.SetProjectLayoutKey(project_key_);
+  ASSERT_FALSE(layout_manager_.startup_reapply_pending_protection_for_test());
+  layout_manager_.LoadLayout("Docking");
+
+  EXPECT_TRUE(layout_manager_.startup_reapply_pending_protection_for_test());
 }
 
 }  // namespace

--- a/test/unit/editor/layout_presets_test.cc
+++ b/test/unit/editor/layout_presets_test.cc
@@ -94,19 +94,39 @@ TEST(LayoutPresetsTest,
   EXPECT_EQ(debug_pos->second, DockPosition::RightBottom);
 }
 
-TEST(LayoutPresetsTest, DungeonWorkbenchDefaultHidesStandaloneRoomSelector) {
+TEST(LayoutPresetsTest, DungeonWorkbenchDefaultKeepsStandaloneToolsOptional) {
   auto preset = LayoutPresets::GetDefaultPreset(EditorType::kDungeon);
 
+  ASSERT_EQ(preset.default_visible_panels.size(), 1U);
+  EXPECT_TRUE(ContainsPanel(preset.default_visible_panels,
+                            LayoutPresets::Panels::kDungeonWorkbench));
+  EXPECT_TRUE(preset.dock_only_default_visible_panels);
   EXPECT_FALSE(ContainsPanel(preset.default_visible_panels,
                              LayoutPresets::Panels::kDungeonRoomSelector));
   EXPECT_TRUE(ContainsPanel(preset.optional_panels,
                             LayoutPresets::Panels::kDungeonRoomSelector));
-  EXPECT_TRUE(ContainsPanel(preset.default_visible_panels,
+  EXPECT_FALSE(ContainsPanel(preset.default_visible_panels,
+                             LayoutPresets::Panels::kDungeonRoomMatrix));
+  EXPECT_TRUE(ContainsPanel(preset.optional_panels,
                             LayoutPresets::Panels::kDungeonRoomMatrix));
   EXPECT_FALSE(ContainsPanel(preset.default_visible_panels,
+                             LayoutPresets::Panels::kDungeonObjectSelector));
+  EXPECT_TRUE(ContainsPanel(preset.optional_panels,
+                            LayoutPresets::Panels::kDungeonObjectSelector));
+  EXPECT_FALSE(ContainsPanel(preset.default_visible_panels,
                              LayoutPresets::Panels::kDungeonObjectEditor));
-  EXPECT_TRUE(ContainsPanel(preset.default_visible_panels,
+  EXPECT_FALSE(ContainsPanel(preset.default_visible_panels,
+                             LayoutPresets::Panels::kDungeonDoorEditor));
+  EXPECT_TRUE(ContainsPanel(preset.optional_panels,
                             LayoutPresets::Panels::kDungeonDoorEditor));
+  EXPECT_FALSE(ContainsPanel(preset.default_visible_panels,
+                             LayoutPresets::Panels::kDungeonRoomGraphics));
+  EXPECT_TRUE(ContainsPanel(preset.optional_panels,
+                            LayoutPresets::Panels::kDungeonRoomGraphics));
+  EXPECT_FALSE(ContainsPanel(preset.default_visible_panels,
+                             LayoutPresets::Panels::kDungeonPaletteEditor));
+  EXPECT_TRUE(ContainsPanel(preset.optional_panels,
+                            LayoutPresets::Panels::kDungeonPaletteEditor));
 }
 
 TEST(LayoutPresetsTest, WorkspaceAliasesMirrorWindowTerminology) {

--- a/test/unit/editor/minecart_track_editor_panel_test.cc
+++ b/test/unit/editor/minecart_track_editor_panel_test.cc
@@ -841,6 +841,8 @@ TEST(MinecartTrackEditorPanelTest,
 
   auto renderer = std::make_unique<gfx::NullRenderer>();
   auto manager = std::make_unique<EditorManager>();
+  manager->user_settings().SetSettingsFilePathForTesting(
+      fixture.Path("settings.json").string());
   manager->Initialize(renderer.get(), "");
   manager->SetAssetLoadMode(AssetLoadMode::kLazy);
   ASSERT_TRUE(manager->OpenRomOrProject(fixture.project_path().string()).ok());

--- a/test/unit/editor/shortcut_configurator_test.cc
+++ b/test/unit/editor/shortcut_configurator_test.cc
@@ -1,7 +1,12 @@
 #include <gtest/gtest.h>
 
+#include <deque>
 #include <memory>
+#include <optional>
+#include <vector>
 
+#include "app/editor/dungeon/dungeon_editor_v2.h"
+#include "app/editor/dungeon/workspace/dungeon_workbench_content.h"
 #include "app/editor/editor_manager.h"
 #include "app/editor/system/shortcut_configurator.h"
 #include "app/editor/system/shortcut_manager.h"
@@ -10,6 +15,27 @@
 #include "imgui/imgui.h"
 
 namespace yaze::editor {
+
+class DungeonEditorV2ShortcutTestPeer {
+ public:
+  static bool HasQueuedDelete(const DungeonEditorV2& editor) {
+    return editor.room_canvas_delete_shortcut_frame_.has_value();
+  }
+
+  static std::optional<int> QueuedDeleteFrame(const DungeonEditorV2& editor) {
+    return editor.room_canvas_delete_shortcut_frame_;
+  }
+
+  static bool ConsumeQueuedDelete(DungeonEditorV2& editor,
+                                  DungeonCanvasViewer& viewer) {
+    return editor.ConsumeRoomCanvasDeleteShortcut(viewer);
+  }
+
+  static void ExpireStaleDelete(DungeonEditorV2& editor) {
+    editor.ExpireStaleRoomCanvasDeleteShortcut();
+  }
+};
+
 namespace {
 
 class ShortcutConfiguratorTest : public ::testing::Test {
@@ -18,6 +44,8 @@ class ShortcutConfiguratorTest : public ::testing::Test {
     imgui_context_ = ImGui::CreateContext();
     ImGui::SetCurrentContext(imgui_context_);
     ImGuiIO& io = ImGui::GetIO();
+    io.DisplaySize = ImVec2(1400.0f, 1000.0f);
+    io.DeltaTime = 1.0f / 60.0f;
     unsigned char* pixels = nullptr;
     int width = 0;
     int height = 0;
@@ -159,6 +187,101 @@ TEST_F(ShortcutConfiguratorTest,
   shortcuts.ExecuteShortcut("view.toggle.test.demo");
   EXPECT_FALSE(test_window_visible_);
   EXPECT_FALSE(second_window_visible_);
+}
+
+TEST_F(ShortcutConfiguratorTest,
+       DungeonDeleteRequestExpiresWhenItsFramePassesWithoutCanvasOwnership) {
+  DungeonEditorV2 dungeon_editor;
+
+  ImGui::NewFrame();
+  dungeon_editor.QueueRoomCanvasDeleteShortcut();
+  const int queued_frame = ImGui::GetFrameCount();
+  EXPECT_TRUE(DungeonEditorV2ShortcutTestPeer::HasQueuedDelete(dungeon_editor));
+  EXPECT_EQ(DungeonEditorV2ShortcutTestPeer::QueuedDeleteFrame(dungeon_editor),
+            queued_frame);
+  EXPECT_TRUE(dungeon_editor.Update().ok());
+  EXPECT_TRUE(DungeonEditorV2ShortcutTestPeer::HasQueuedDelete(dungeon_editor));
+  ImGui::Render();
+
+  ImGui::NewFrame();
+  EXPECT_TRUE(dungeon_editor.Update().ok());
+  EXPECT_FALSE(
+      DungeonEditorV2ShortcutTestPeer::HasQueuedDelete(dungeon_editor));
+  ImGui::Render();
+}
+
+TEST_F(ShortcutConfiguratorTest,
+       DungeonDeleteWaitsForDetachedWorkbenchCanvasInTheSameFrame) {
+  Rom rom;
+  ASSERT_TRUE(rom.LoadFromData(std::vector<uint8_t>(0x200000, 0)).ok());
+
+  DungeonEditorV2 dungeon_editor;
+  DungeonCanvasViewer viewer(&rom);
+  DungeonRoomSelector room_selector(&rom);
+  int current_room_id = 0;
+  const std::deque<int> recent_rooms{current_room_id};
+  DungeonWorkbenchContent workbench(
+      &room_selector, &current_room_id, [](int) {},
+      [](int, RoomSelectionIntent) {}, [](int) {}, []() {},
+      [&viewer]() { return &viewer; },
+      [](int) -> DungeonCanvasViewer* { return nullptr; },
+      [&recent_rooms]() -> const std::deque<int>& { return recent_rooms; },
+      [](int) {}, [](bool) {}, &rom);
+
+  bool delete_consumed = false;
+  workbench.SetPrimaryCanvasDrawnCallback(
+      [&](DungeonCanvasViewer& drawn_viewer) {
+        delete_consumed = DungeonEditorV2ShortcutTestPeer::ConsumeQueuedDelete(
+                              dungeon_editor, drawn_viewer) ||
+                          delete_consumed;
+      });
+
+  auto draw_workbench = [&]() {
+    ImGui::SetNextWindowPos(ImVec2(20.0f, 20.0f), ImGuiCond_Always);
+    ImGui::SetNextWindowSize(ImVec2(1200.0f, 850.0f), ImGuiCond_Always);
+    ImGui::Begin("##DetachedWorkbenchShortcutHost", nullptr,
+                 ImGuiWindowFlags_NoSavedSettings);
+    workbench.Draw(nullptr);
+    ImGui::End();
+  };
+
+  ImGuiIO& io = ImGui::GetIO();
+  io.AddMousePosEvent(-1000.0f, -1000.0f);
+  io.AddMouseButtonEvent(ImGuiMouseButton_Left, false);
+  ImGui::NewFrame();
+  draw_workbench();
+  const ImVec2 canvas_origin = viewer.canvas().zero_point();
+  const ImVec2 canvas_size = viewer.canvas().canvas_size();
+  ASSERT_GT(canvas_size.x, 0.0f);
+  ASSERT_GT(canvas_size.y, 0.0f);
+  ImGui::Render();
+
+  // Give the detached canvas shortcut ownership in the preceding frame.
+  io.AddMousePosEvent(canvas_origin.x + canvas_size.x * 0.5f,
+                      canvas_origin.y + canvas_size.y * 0.5f);
+  io.AddMouseButtonEvent(ImGuiMouseButton_Left, true);
+  ImGui::NewFrame();
+  draw_workbench();
+  EXPECT_TRUE(viewer.CanHandleRoomCanvasShortcut());
+  ImGui::Render();
+
+  // ShortcutManager queues before DungeonEditorV2::Update. The detached
+  // Workbench canvas draws later, so the request must survive Update and be
+  // consumed only after that canvas refreshes its ownership for this frame.
+  io.AddMouseButtonEvent(ImGuiMouseButton_Left, false);
+  ImGui::NewFrame();
+  dungeon_editor.QueueRoomCanvasDeleteShortcut();
+  const int queued_frame = ImGui::GetFrameCount();
+  DungeonEditorV2ShortcutTestPeer::ExpireStaleDelete(dungeon_editor);
+  EXPECT_EQ(DungeonEditorV2ShortcutTestPeer::QueuedDeleteFrame(dungeon_editor),
+            queued_frame);
+  EXPECT_FALSE(delete_consumed);
+
+  draw_workbench();
+  EXPECT_TRUE(delete_consumed);
+  EXPECT_FALSE(
+      DungeonEditorV2ShortcutTestPeer::HasQueuedDelete(dungeon_editor));
+  ImGui::Render();
 }
 
 }  // namespace

--- a/test/unit/editor/shortcut_manager_test.cc
+++ b/test/unit/editor/shortcut_manager_test.cc
@@ -44,7 +44,8 @@ class ShortcutManagerTest : public ::testing::Test {
     ImGui::SetNextWindowFocus();
     ImGui::Begin("##ShortcutHost", nullptr,
                  ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_NoMove |
-                     ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoSavedSettings);
+                     ImGuiWindowFlags_NoResize |
+                     ImGuiWindowFlags_NoSavedSettings);
     if (frame_body) {
       frame_body();
     }
@@ -63,8 +64,8 @@ TEST_F(ShortcutManagerTest, PrefersMoreSpecificShortcut) {
   int save_as_called = 0;
 
   shortcuts.RegisterShortcut(
-      "Save", {ImGuiMod_Ctrl, ImGuiKey_S},
-      [&]() { ++save_called; }, Shortcut::Scope::kGlobal);
+      "Save", {ImGuiMod_Ctrl, ImGuiKey_S}, [&]() { ++save_called; },
+      Shortcut::Scope::kGlobal);
   shortcuts.RegisterShortcut(
       "Save As", {ImGuiMod_Ctrl, ImGuiMod_Shift, ImGuiKey_S},
       [&]() { ++save_as_called; }, Shortcut::Scope::kGlobal);
@@ -109,14 +110,15 @@ TEST_F(ShortcutManagerTest, DoesNotGateOnWantCaptureKeyboard) {
   EXPECT_EQ(palette_called, 1);
 }
 
-TEST_F(ShortcutManagerTest, WantTextInputBlocksPlainKeysButAllowsModifiedChords) {
+TEST_F(ShortcutManagerTest,
+       WantTextInputBlocksPlainKeysButAllowsModifiedChords) {
   ShortcutManager shortcuts;
   int space_called = 0;
   int palette_called = 0;
 
   shortcuts.RegisterShortcut(
-      "Play/Pause", {ImGuiKey_Space},
-      [&]() { ++space_called; }, Shortcut::Scope::kEditor);
+      "Play/Pause", {ImGuiKey_Space}, [&]() { ++space_called; },
+      Shortcut::Scope::kEditor);
   shortcuts.RegisterShortcut(
       "Command Palette", {ImGuiMod_Ctrl, ImGuiMod_Shift, ImGuiKey_P},
       [&]() { ++palette_called; }, Shortcut::Scope::kGlobal);
@@ -124,14 +126,11 @@ TEST_F(ShortcutManagerTest, WantTextInputBlocksPlainKeysButAllowsModifiedChords)
   RunFrame(nullptr, [&]() { ExecuteShortcuts(shortcuts); });
 
   // Plain keys are ignored while typing.
-  RunFrame(
-      [](ImGuiIO& io) {
-        io.AddKeyEvent(ImGuiKey_Space, true);
-      },
-      [&]() {
-        ImGui::GetIO().WantTextInput = true;
-        ExecuteShortcuts(shortcuts);
-      });
+  RunFrame([](ImGuiIO& io) { io.AddKeyEvent(ImGuiKey_Space, true); },
+           [&]() {
+             ImGui::GetIO().WantTextInput = true;
+             ExecuteShortcuts(shortcuts);
+           });
 
   // Modified chords still work while typing.
   RunFrame(
@@ -149,6 +148,27 @@ TEST_F(ShortcutManagerTest, WantTextInputBlocksPlainKeysButAllowsModifiedChords)
 
   EXPECT_EQ(space_called, 0);
   EXPECT_EQ(palette_called, 1);
+}
+
+TEST_F(ShortcutManagerTest, PlainShortcutDoesNotMatchModifiedChord) {
+  ShortcutManager shortcuts;
+  int plain_delete_tool_called = 0;
+
+  shortcuts.RegisterShortcut(
+      "Delete Tool", {ImGuiKey_D}, [&]() { ++plain_delete_tool_called; },
+      Shortcut::Scope::kEditor);
+
+  RunFrame(nullptr, [&]() { ExecuteShortcuts(shortcuts); });
+  RunFrame(
+      [](ImGuiIO& io) {
+        const ImGuiKey primary =
+            io.ConfigMacOSXBehaviors ? ImGuiMod_Super : ImGuiMod_Ctrl;
+        io.AddKeyEvent(primary, true);
+        io.AddKeyEvent(ImGuiKey_D, true);
+      },
+      [&]() { ExecuteShortcuts(shortcuts); });
+
+  EXPECT_EQ(plain_delete_tool_called, 0);
 }
 
 }  // namespace

--- a/test/unit/editor/sprite_door_handler_test.cc
+++ b/test/unit/editor/sprite_door_handler_test.cc
@@ -480,6 +480,30 @@ TEST_F(DoorInteractionHandlerTest,
 }
 
 TEST_F(DoorInteractionHandlerTest,
+       HitTestingUsesSouthFancyExitOffsetAndFullFootprint) {
+  zelda3::Room::Door door;
+  door.position = 8;
+  door.type = zelda3::DoorType::FancyDungeonExit;
+  door.direction = zelda3::DoorDirection::South;
+  rooms_[0].AddDoor(door);
+
+  EXPECT_EQ(handler_.GetEntityAtPosition(348, 436), 0u);
+  EXPECT_FALSE(handler_.GetEntityAtPosition(343, 436).has_value());
+  EXPECT_FALSE(handler_.GetEntityAtPosition(348, 431).has_value());
+}
+
+TEST_F(DoorInteractionHandlerTest, HitTestingUsesSouthFourByFourExitFootprint) {
+  zelda3::Room::Door door;
+  door.position = 8;
+  door.type = zelda3::DoorType::ExitLower;
+  door.direction = zelda3::DoorDirection::South;
+  rooms_[0].AddDoor(door);
+
+  EXPECT_EQ(handler_.GetEntityAtPosition(372, 468), 0u);
+  EXPECT_FALSE(handler_.GetEntityAtPosition(372, 463).has_value());
+}
+
+TEST_F(DoorInteractionHandlerTest,
        DragReleaseMovesDoorAndMarksObjectStreamDirty) {
   zelda3::Room::Door door;
   door.position = 0;
@@ -493,15 +517,74 @@ TEST_F(DoorInteractionHandlerTest,
 
   const auto [door_x, door_y, door_w, door_h] =
       rooms_[0].GetDoors()[0].GetEditorBounds();
-  ASSERT_TRUE(handler_.HandleClick(door_x + door_w / 2, door_y + door_h / 2));
+  const auto [source_anchor_x, source_anchor_y] =
+      rooms_[0].GetDoors()[0].GetPixelCoords();
+  const int grab_x = door_x + door_w / 2;
+  const int grab_y = door_y + door_h / 2;
+  ASSERT_TRUE(handler_.HandleClick(grab_x, grab_y));
 
-  handler_.HandleDrag(ImVec2(30.0f * 8.0f, static_cast<float>(door_y)),
-                      ImVec2(0.0f, 0.0f));
+  const auto [target_anchor_x, target_anchor_y] =
+      zelda3::DoorPositionManager::PositionToPixelCoords(
+          /*position=*/1, zelda3::DoorDirection::North);
+  handler_.HandleDrag(
+      ImVec2(static_cast<float>(target_anchor_x + grab_x - source_anchor_x),
+             static_cast<float>(target_anchor_y + grab_y - source_anchor_y)),
+      ImVec2(0.0f, 0.0f));
   handler_.HandleRelease();
 
   const auto& moved = rooms_[0].GetDoors()[0];
   EXPECT_EQ(moved.position, 1);
   EXPECT_EQ(moved.direction, zelda3::DoorDirection::North);
+  const auto [expected_b1, expected_b2] = moved.EncodeBytes();
+  EXPECT_EQ(moved.byte1, expected_b1);
+  EXPECT_EQ(moved.byte2, expected_b2);
+  EXPECT_TRUE(rooms_[0].object_stream_dirty());
+  EXPECT_EQ(mutation_count_, 1);
+  EXPECT_EQ(invalidate_count_, 1);
+}
+
+TEST_F(DoorInteractionHandlerTest,
+       DraggingSouthFancyExitFromExpandedTopRowsPreservesAnchorOffset) {
+  zelda3::Room::Door door;
+  door.position = 8;
+  door.type = zelda3::DoorType::FancyDungeonExit;
+  door.direction = zelda3::DoorDirection::South;
+  auto [byte1, byte2] = door.EncodeBytes();
+  door.byte1 = byte1;
+  door.byte2 = byte2;
+  rooms_[0].AddDoor(door);
+  rooms_[0].ClearObjectStreamDirty();
+
+  const auto [door_x, door_y, door_w, door_h] =
+      rooms_[0].GetDoors()[0].GetEditorBounds();
+  const auto [source_anchor_x, source_anchor_y] =
+      rooms_[0].GetDoors()[0].GetPixelCoords();
+  ASSERT_EQ(door_w, 80);
+  ASSERT_EQ(door_h, 64);
+
+  // Grab the expanded art four pixels from its top-left corner. This point is
+  // above the South wall-classification threshold and used to produce no move.
+  const int grab_x = door_x + 4;
+  const int grab_y = door_y + 4;
+  ASSERT_LT(grab_y, (zelda3::DoorPositionManager::kRoomHeightTiles -
+                     zelda3::DoorPositionManager::kWallDetectionThreshold) *
+                        zelda3::DoorPositionManager::kTileSize);
+  ASSERT_TRUE(handler_.HandleClick(grab_x, grab_y));
+
+  const auto [target_anchor_x, target_anchor_y] =
+      zelda3::DoorPositionManager::PositionToPixelCoords(
+          /*position=*/7, zelda3::DoorDirection::South);
+  const int grab_offset_x = grab_x - source_anchor_x;
+  const int grab_offset_y = grab_y - source_anchor_y;
+  handler_.HandleDrag(
+      ImVec2(static_cast<float>(target_anchor_x + grab_offset_x),
+             static_cast<float>(target_anchor_y + grab_offset_y)),
+      ImVec2(0.0f, 0.0f));
+  handler_.HandleRelease();
+
+  const auto& moved = rooms_[0].GetDoors()[0];
+  EXPECT_EQ(moved.position, 7);
+  EXPECT_EQ(moved.direction, zelda3::DoorDirection::South);
   const auto [expected_b1, expected_b2] = moved.EncodeBytes();
   EXPECT_EQ(moved.byte1, expected_b1);
   EXPECT_EQ(moved.byte2, expected_b2);
@@ -598,6 +681,77 @@ TEST_F(DoorInteractionHandlerTest, PairBadgeClickNavigatesToNeighborDoor) {
       rooms_[1].GetDoors()[0].GetTileCoords();
   EXPECT_EQ(target_tile_x, expected_tile_x);
   EXPECT_EQ(target_tile_y, expected_tile_y);
+}
+
+TEST_F(DoorInteractionHandlerTest,
+       ExitAndControlMarkersDoNotExposeReciprocalPairBadges) {
+  ctx_.current_room_id = 0;
+
+  zelda3::Room::Door neighbor_door;
+  neighbor_door.position = 8;
+  neighbor_door.type = zelda3::DoorType::NormalDoor;
+  neighbor_door.direction = zelda3::DoorDirection::North;
+  rooms_[0x10].AddDoor(neighbor_door);
+
+  int navigation_count = 0;
+  ctx_.on_door_pair_navigation = [&](int, std::optional<size_t>, int, int) {
+    ++navigation_count;
+  };
+  handler_.SetContext(&ctx_);
+
+  for (const auto type : {
+           zelda3::DoorType::FancyDungeonExit,
+           zelda3::DoorType::DungeonSwapMarker,
+           zelda3::DoorType::LayerSwapMarker,
+       }) {
+    zelda3::Room::Door source;
+    source.position = 8;
+    source.type = type;
+    source.direction = zelda3::DoorDirection::South;
+    rooms_[0].GetDoors().clear();
+    rooms_[0].AddDoor(source);
+    handler_.SelectDoor(0);
+
+    const auto [door_x, door_y, door_w, door_h] =
+        rooms_[0].GetDoors()[0].GetEditorBounds();
+    EXPECT_FALSE(handler_.HandleOverlayClick(door_x + 4, door_y + door_h + 4))
+        << zelda3::GetDoorTypeName(type);
+  }
+  EXPECT_EQ(navigation_count, 0);
+}
+
+TEST_F(DoorInteractionHandlerTest,
+       ReciprocalPairSearchSkipsControlMarkerTargets) {
+  ctx_.current_room_id = 0;
+
+  zelda3::Room::Door source;
+  source.position = 0;
+  source.type = zelda3::DoorType::NormalDoor;
+  source.direction = zelda3::DoorDirection::East;
+  rooms_[0].AddDoor(source);
+
+  zelda3::Room::Door marker;
+  marker.position = source.position;
+  marker.type = zelda3::DoorType::DungeonSwapMarker;
+  marker.direction = zelda3::DoorDirection::West;
+  rooms_[1].AddDoor(marker);
+
+  int navigation_count = 0;
+  std::optional<size_t> navigated_door = 99;
+  ctx_.on_door_pair_navigation = [&](int, std::optional<size_t> door_index, int,
+                                     int) {
+    ++navigation_count;
+    navigated_door = door_index;
+  };
+  handler_.SetContext(&ctx_);
+  handler_.SelectDoor(0);
+
+  const auto [door_x, door_y, door_w, door_h] =
+      rooms_[0].GetDoors()[0].GetEditorBounds();
+  ASSERT_TRUE(
+      handler_.HandleOverlayClick(door_x + door_w + 8, door_y + door_h / 2));
+  EXPECT_EQ(navigation_count, 1);
+  EXPECT_FALSE(navigated_door.has_value());
 }
 
 TEST_F(DoorInteractionHandlerTest, DeleteAllClearsDoorsAndFiresCallbacks) {

--- a/test/unit/editor/tile_object_handler_test.cc
+++ b/test/unit/editor/tile_object_handler_test.cc
@@ -1645,12 +1645,12 @@ TEST_F(TileObjectHandlerTest,
   ScopedCustomObjectSelectionState custom_state;
   ASSERT_TRUE(custom_state.WriteOneTileObject("override.bin"));
   zelda3::CustomObjectManager::Get().SetObjectFileMap(
-      {{0x138, {"override.bin"}}});
+      {{0xFAD, {"override.bin"}}});
 
   AddTestObjects({CreateLayeredTestObject(10, 10, zelda3::RoomObject::BG2,
-                                          /*size=*/0, /*id=*/0x138)});
+                                          /*size=*/0, /*id=*/0xFAD)});
   ASSERT_TRUE(zelda3::CustomObjectManager::Get()
-                  .GetObjectInternal(/*object_id=*/0x138, /*subtype=*/0)
+                  .GetObjectInternal(/*object_id=*/0xFAD, /*subtype=*/0)
                   .ok());
 
   DungeonCanvasViewer viewer;
@@ -1664,9 +1664,9 @@ TEST_F(TileObjectHandlerTest,
   ASSERT_GT(width, 0);
   ASSERT_GT(height, 0);
 
-  // Vanilla 0x138 is fixed to BG1, but its active custom override returns
-  // early through ObjectDrawer and therefore follows this object's stored BG2
-  // placement.
+  // Vanilla 0xFAD writes its facade to the fixed upper tilemap, but an active
+  // custom override is a complete replacement and follows the object's stored
+  // lower placement.
   viewer.SetLayerVisible(0, zelda3::LayerType::BG2_Objects, false);
   EXPECT_FALSE(
       tile_handler.GetEntityAtPosition(tile_x * 8, tile_y * 8).has_value());

--- a/test/unit/editor/tile_object_handler_test.cc
+++ b/test/unit/editor/tile_object_handler_test.cc
@@ -9,14 +9,21 @@
 
 #include <algorithm>
 #include <array>
+#include <chrono>
+#include <filesystem>
+#include <fstream>
 #include <vector>
 
 #include <gtest/gtest.h>
 
 #include "app/editor/dungeon/dungeon_room_store.h"
 #include "app/editor/dungeon/interaction/interaction_context.h"
+#include "core/features.h"
 #include "rom/rom.h"
 #include "rom/snes.h"
+#include "zelda3/dungeon/custom_object.h"
+#include "zelda3/dungeon/dimension_service.h"
+#include "zelda3/dungeon/draw_routines/draw_routine_registry.h"
 #include "zelda3/dungeon/dungeon_block_codec.h"
 #include "zelda3/dungeon/dungeon_rom_addresses.h"
 #include "zelda3/dungeon/room.h"
@@ -39,6 +46,51 @@ zelda3::RoomObject CreateLayeredTestObject(uint8_t x, uint8_t y,
   object.layer_ = layer;
   return object;
 }
+
+class ScopedCustomObjectSelectionState {
+ public:
+  ScopedCustomObjectSelectionState()
+      : previous_state_(zelda3::CustomObjectManager::Get().SnapshotState()),
+        previous_enabled_(core::FeatureFlags::get().kEnableCustomObjects) {
+    const auto nonce =
+        std::chrono::steady_clock::now().time_since_epoch().count();
+    directory_ = std::filesystem::temp_directory_path() /
+                 ("yaze_tile_object_selection_" + std::to_string(nonce));
+    std::error_code error;
+    std::filesystem::create_directories(directory_, error);
+
+    zelda3::CustomObjectManager::Get().Initialize(directory_.string());
+    core::FeatureFlags::get().kEnableCustomObjects = true;
+    zelda3::DrawRoutineRegistry::Get().RefreshFeatureFlagMappings();
+  }
+
+  ~ScopedCustomObjectSelectionState() {
+    core::FeatureFlags::get().kEnableCustomObjects = previous_enabled_;
+    zelda3::DrawRoutineRegistry::Get().RefreshFeatureFlagMappings();
+    zelda3::CustomObjectManager::Get().RestoreState(previous_state_);
+    std::error_code error;
+    std::filesystem::remove_all(directory_, error);
+  }
+
+  bool WriteOneTileObject(const std::string& filename) const {
+    const std::array<uint8_t, 6> bytes = {
+        0x01, 0x00,  // one tile, no row jump
+        0x40, 0x08,  // tile word 0x0840
+        0x00, 0x00,  // terminator
+    };
+    std::ofstream output(directory_ / filename, std::ios::binary);
+    if (!output.good()) {
+      return false;
+    }
+    output.write(reinterpret_cast<const char*>(bytes.data()), bytes.size());
+    return output.good();
+  }
+
+ private:
+  zelda3::CustomObjectManager::State previous_state_;
+  bool previous_enabled_ = false;
+  std::filesystem::path directory_;
+};
 
 class TestableTileObjectHandler : public TileObjectHandler {
  public:
@@ -1514,6 +1566,117 @@ TEST_F(TileObjectHandlerTest, GetEntityAtPositionPrioritizesTopmost) {
   if (result.has_value()) {
     EXPECT_EQ(result.value(), 1);  // Should return topmost (last) object
   }
+}
+
+TEST_F(TileObjectHandlerTest,
+       HiddenObjectLayerDoesNotInterceptHitTestOrReplaceLayerFilter) {
+  AddTestObjects({
+      CreateLayeredTestObject(10, 10, zelda3::RoomObject::BG2, 0x05, 0x21),
+      CreateLayeredTestObject(10, 10, zelda3::RoomObject::BG1, 0x05, 0x22),
+  });
+  DungeonCanvasViewer viewer;
+  viewer.SetRooms(&rooms_);
+  auto& interaction = viewer.object_interaction();
+  interaction.SetCurrentRoom(&rooms_, 0);
+  viewer.SetLayerVisible(0, zelda3::LayerType::BG1_Objects, false);
+  auto& tile_handler = interaction.entity_coordinator().tile_handler();
+
+  const auto visible_hit = tile_handler.GetEntityAtPosition(80, 80);
+  ASSERT_TRUE(visible_hit.has_value());
+  EXPECT_EQ(*visible_hit, 0u);
+
+  interaction.SetLayerFilter(ObjectSelection::kLayer1);
+  EXPECT_FALSE(tile_handler.GetEntityAtPosition(80, 80).has_value());
+
+  interaction.SetLayerFilter(ObjectSelection::kLayer2);
+  const auto filtered_hit = tile_handler.GetEntityAtPosition(80, 80);
+  ASSERT_TRUE(filtered_hit.has_value());
+  EXPECT_EQ(*filtered_hit, 0u);
+}
+
+TEST_F(TileObjectHandlerTest, MarqueeSelectionSkipsObjectsOnHiddenLayers) {
+  AddTestObjects({
+      CreateLayeredTestObject(5, 5, zelda3::RoomObject::BG1, 0x05, 0x21),
+      CreateLayeredTestObject(20, 20, zelda3::RoomObject::BG2, 0x05, 0x22),
+  });
+  DungeonCanvasViewer viewer;
+  viewer.SetRooms(&rooms_);
+  auto& interaction = viewer.object_interaction();
+  interaction.SetCurrentRoom(&rooms_, 0);
+  viewer.SetLayerVisible(0, zelda3::LayerType::BG1_Objects, false);
+  auto& tile_handler = interaction.entity_coordinator().tile_handler();
+
+  tile_handler.BeginMarqueeSelection(ImVec2(0.0f, 0.0f));
+  tile_handler.HandleMarqueeSelection(
+      ImVec2(240.0f, 240.0f), /*mouse_left_down=*/false,
+      /*mouse_left_released=*/true, /*shift_down=*/false,
+      /*toggle_down=*/false, /*alt_down=*/false, /*draw_box=*/false);
+
+  EXPECT_FALSE(interaction.IsObjectSelected(0));
+  EXPECT_TRUE(interaction.IsObjectSelected(1));
+}
+
+TEST_F(TileObjectHandlerTest,
+       BothBackgroundObjectRemainsSelectableUntilBothLayersAreHidden) {
+  AddTestObjects(
+      {CreateLayeredTestObject(10, 10, zelda3::RoomObject::BG1, 0x00, 0x108)});
+  DungeonCanvasViewer viewer;
+  viewer.SetRooms(&rooms_);
+  auto& interaction = viewer.object_interaction();
+  interaction.SetCurrentRoom(&rooms_, 0);
+  auto& tile_handler = interaction.entity_coordinator().tile_handler();
+  const auto [tile_x, tile_y, width, height] =
+      zelda3::DimensionService::Get().GetHitTestBounds(
+          rooms_[0].GetTileObjects().front());
+  ASSERT_GT(width, 0);
+  ASSERT_GT(height, 0);
+
+  viewer.SetLayerVisible(0, zelda3::LayerType::BG1_Objects, false);
+  EXPECT_TRUE(
+      tile_handler.GetEntityAtPosition(tile_x * 8, tile_y * 8).has_value());
+
+  viewer.SetLayerVisible(0, zelda3::LayerType::BG2_Objects, false);
+  EXPECT_FALSE(
+      tile_handler.GetEntityAtPosition(tile_x * 8, tile_y * 8).has_value());
+}
+
+TEST_F(TileObjectHandlerTest,
+       ActiveCustomOverrideUsesStoredLayerForSelectionVisibility) {
+  ScopedCustomObjectSelectionState custom_state;
+  ASSERT_TRUE(custom_state.WriteOneTileObject("override.bin"));
+  zelda3::CustomObjectManager::Get().SetObjectFileMap(
+      {{0x138, {"override.bin"}}});
+
+  AddTestObjects({CreateLayeredTestObject(10, 10, zelda3::RoomObject::BG2,
+                                          /*size=*/0, /*id=*/0x138)});
+  ASSERT_TRUE(zelda3::CustomObjectManager::Get()
+                  .GetObjectInternal(/*object_id=*/0x138, /*subtype=*/0)
+                  .ok());
+
+  DungeonCanvasViewer viewer;
+  viewer.SetRooms(&rooms_);
+  auto& interaction = viewer.object_interaction();
+  interaction.SetCurrentRoom(&rooms_, 0);
+  auto& tile_handler = interaction.entity_coordinator().tile_handler();
+  const auto [tile_x, tile_y, width, height] =
+      zelda3::DimensionService::Get().GetHitTestBounds(
+          rooms_[0].GetTileObjects().front());
+  ASSERT_GT(width, 0);
+  ASSERT_GT(height, 0);
+
+  // Vanilla 0x138 is fixed to BG1, but its active custom override returns
+  // early through ObjectDrawer and therefore follows this object's stored BG2
+  // placement.
+  viewer.SetLayerVisible(0, zelda3::LayerType::BG2_Objects, false);
+  EXPECT_FALSE(
+      tile_handler.GetEntityAtPosition(tile_x * 8, tile_y * 8).has_value());
+
+  viewer.SetLayerVisible(0, zelda3::LayerType::BG2_Objects, true);
+  viewer.SetLayerVisible(0, zelda3::LayerType::BG1_Objects, false);
+  const auto stored_layer_hit =
+      tile_handler.GetEntityAtPosition(tile_x * 8, tile_y * 8);
+  ASSERT_TRUE(stored_layer_hit.has_value());
+  EXPECT_EQ(*stored_layer_hit, 0u);
 }
 
 // ============================================================================

--- a/test/unit/editor/tile_object_handler_test.cc
+++ b/test/unit/editor/tile_object_handler_test.cc
@@ -250,7 +250,7 @@ TEST_F(TileObjectHandlerTest,
 }
 
 TEST_F(TileObjectHandlerTest,
-       MarqueeAndUpLeftPlacementGhostShareCanvasTransform) {
+       MarqueeAndUpwardPlacementGhostShareCanvasTransform) {
   constexpr std::array<float, 3> kScales = {0.5f, 1.0f, 2.0f};
   constexpr std::array<ImVec2, 2> kScrolling = {ImVec2(48.0f, 24.0f),
                                                 ImVec2(-56.0f, -32.0f)};
@@ -259,7 +259,7 @@ TEST_F(TileObjectHandlerTest,
   const auto preview = CreateTestObject(0, 0, 0x12, 0xA3);
   const auto preview_geometry =
       TileObjectHandler::CalculateGhostPreviewGeometry(preview);
-  ASSERT_LT(preview_geometry.offset_x_tiles, 0);
+  ASSERT_EQ(preview_geometry.offset_x_tiles, 0);
   ASSERT_LT(preview_geometry.offset_y_tiles, 0);
   handler_.SetPreviewObject(preview);
   handler_.BeginPlacement();
@@ -461,13 +461,15 @@ TEST_F(TileObjectHandlerTest,
     int offset_y;
   };
 
-  // The first two need negative-axis headroom; 0x33 is the ordinary baseline,
-  // and 0x34 starts three tiles to the right of its encoded origin.
-  constexpr std::array<TestCase, 4> kCases{{
-      {0x09, 0x12, 0, 8, 0, -8},
-      {0xA3, 0x12, 5, 5, -5, -5},
+  // Acute diagonals and bottom-right diagonal ceilings need upward headroom;
+  // moving wall west needs leftward headroom. Straight objects remain anchored
+  // at their encoded origin.
+  constexpr std::array<TestCase, 5> kCases{{
+      {0x09, 0x12, 0, 7, 0, -7},
+      {0xA3, 0x12, 0, 5, 0, -5},
+      {0xCD, 0x00, 8, 0, -8, 0},
       {0x33, 0x12, 0, 0, 0, 0},
-      {0x34, 0x12, 0, 0, 3, 0},
+      {0x34, 0x12, 0, 0, 0, 0},
   }};
 
   for (const auto& test_case : kCases) {
@@ -498,7 +500,7 @@ TEST_F(TileObjectHandlerTest,
 }
 
 TEST_F(TileObjectHandlerTest,
-       GhostPreviewBitmapRendersPositiveOffsetWithoutClipping) {
+       GhostPreviewBitmapRendersOriginAlignedObjectWithoutClipping) {
   Rom rom;
   ASSERT_TRUE(rom.LoadFromData(std::vector<uint8_t>(0x200000, 0)).ok());
   rooms_.SetRom(&rom);
@@ -514,7 +516,7 @@ TEST_F(TileObjectHandlerTest,
 
   const auto geometry =
       TileObjectHandler::CalculateGhostPreviewGeometry(object);
-  ASSERT_EQ(geometry.offset_x_tiles, 3);
+  ASSERT_EQ(geometry.offset_x_tiles, 0);
   handler_.SetPreviewObject(object);
   handler_.BeginPlacement();
 
@@ -528,10 +530,6 @@ TEST_F(TileObjectHandlerTest,
   const auto& coverage = buffer->coverage_data();
   ASSERT_EQ(coverage.size(),
             static_cast<size_t>(bitmap.width() * bitmap.height()));
-  const int first_drawn_x = geometry.offset_x_tiles * 8;
-  for (int y = 0; y < bitmap.height(); ++y) {
-    EXPECT_EQ(coverage[y * bitmap.width() + first_drawn_x - 1], 0);
-  }
   const auto column_has_coverage = [&](int x) {
     for (int y = 0; y < bitmap.height(); ++y) {
       if (coverage[y * bitmap.width() + x] != 0) {
@@ -540,7 +538,7 @@ TEST_F(TileObjectHandlerTest,
     }
     return false;
   };
-  EXPECT_TRUE(column_has_coverage(first_drawn_x));
+  EXPECT_TRUE(column_has_coverage(0));
   EXPECT_TRUE(column_has_coverage(geometry.buffer_width_pixels - 1));
 }
 

--- a/test/unit/editor/user_settings_layout_defaults_test.cc
+++ b/test/unit/editor/user_settings_layout_defaults_test.cc
@@ -1,5 +1,6 @@
 #include "app/editor/system/session/user_settings.h"
 
+#include <array>
 #include <cstdio>
 #include <filesystem>
 #include <string>
@@ -44,7 +45,7 @@ TEST(UserSettingsLayoutDefaultsTest, AppliesRevisionAndResetsPanelLayoutState) {
 
   EXPECT_EQ(prefs.panel_layout_defaults_revision, kTargetRevision);
   EXPECT_TRUE(prefs.sidebar_visible);
-  EXPECT_TRUE(prefs.sidebar_panel_expanded);
+  EXPECT_FALSE(prefs.sidebar_panel_expanded);
   EXPECT_FLOAT_EQ(prefs.sidebar_panel_width, 0.0f);
   EXPECT_FLOAT_EQ(prefs.panel_browser_category_width, 260.0f);
   EXPECT_TRUE(prefs.sidebar_active_category.empty());
@@ -220,20 +221,20 @@ TEST(UserSettingsLayoutDefaultsTest,
   EXPECT_EQ(prefs.panel_layout_defaults_revision,
             UserSettings::kLatestPanelLayoutDefaultsRevision);
   EXPECT_TRUE(prefs.panel_visibility_state["Dungeon"]["dungeon.workbench"]);
-  // Rev-13 closes `dungeon.room_selector`; Rev-21 (Layout C) re-opens it as
-  // part of the ZScream-style left-stack so a first-run user lands on the
-  // browser/entrances surface without hunting through a menu.
-  EXPECT_TRUE(prefs.panel_visibility_state["Dungeon"]["dungeon.room_selector"]);
-  EXPECT_TRUE(
+  // Revision 23 leaves the Workbench as the sole live Dungeon surface while
+  // preserving the user's saved custom layout.
+  EXPECT_FALSE(
+      prefs.panel_visibility_state["Dungeon"]["dungeon.room_selector"]);
+  EXPECT_FALSE(
       prefs.panel_visibility_state["Dungeon"]["dungeon.object_selector"]);
-  EXPECT_TRUE(prefs.panel_visibility_state["Dungeon"]["dungeon.room_matrix"]);
+  EXPECT_FALSE(prefs.panel_visibility_state["Dungeon"]["dungeon.room_matrix"]);
   EXPECT_EQ(
       prefs.panel_visibility_state["Dungeon"].count("dungeon.object_editor"),
       0U);
   EXPECT_FALSE(prefs.panel_visibility_state["Dungeon"]["dungeon.door_editor"]);
   EXPECT_FALSE(
       prefs.panel_visibility_state["Dungeon"]["dungeon.room_graphics"]);
-  EXPECT_TRUE(
+  EXPECT_FALSE(
       prefs.panel_visibility_state["Dungeon"]["dungeon.palette_editor"]);
   EXPECT_TRUE(prefs.saved_layouts["custom"]["dungeon.room_selector"]);
 }
@@ -262,7 +263,7 @@ TEST(UserSettingsLayoutDefaultsTest,
             0U);
   EXPECT_EQ(
       prefs.panel_visibility_state["Dungeon"].count("dungeon.dungeon_map"), 0U);
-  EXPECT_TRUE(prefs.panel_visibility_state["Dungeon"]["dungeon.room_matrix"]);
+  EXPECT_FALSE(prefs.panel_visibility_state["Dungeon"]["dungeon.room_matrix"]);
   EXPECT_EQ(prefs.saved_layouts["custom"].count("dungeon.settings"), 0U);
 }
 
@@ -275,10 +276,8 @@ TEST(UserSettingsLayoutDefaultsTest,
   prefs.panel_visibility_state["Dungeon"]["dungeon.object_selector"] = false;
   prefs.panel_visibility_state["Dungeon"]["dungeon.room_graphics"] = true;
 
-  EXPECT_TRUE(settings.ApplyPanelLayoutDefaultsRevision(
-      UserSettings::kLatestPanelLayoutDefaultsRevision));
-  EXPECT_EQ(prefs.panel_layout_defaults_revision,
-            UserSettings::kLatestPanelLayoutDefaultsRevision);
+  EXPECT_TRUE(settings.ApplyPanelLayoutDefaultsRevision(15));
+  EXPECT_EQ(prefs.panel_layout_defaults_revision, 15);
   EXPECT_TRUE(
       prefs.panel_visibility_state["Dungeon"]["dungeon.object_selector"]);
   EXPECT_FALSE(
@@ -298,10 +297,8 @@ TEST(UserSettingsLayoutDefaultsTest,
   prefs.pinned_panels["dungeon.room_98"] = true;
   prefs.pinned_panels["layout.designer"] = true;
 
-  EXPECT_TRUE(settings.ApplyPanelLayoutDefaultsRevision(
-      UserSettings::kLatestPanelLayoutDefaultsRevision));
-  EXPECT_EQ(prefs.panel_layout_defaults_revision,
-            UserSettings::kLatestPanelLayoutDefaultsRevision);
+  EXPECT_TRUE(settings.ApplyPanelLayoutDefaultsRevision(18));
+  EXPECT_EQ(prefs.panel_layout_defaults_revision, 18);
   EXPECT_EQ(prefs.panel_visibility_state["Dungeon"].count("dungeon.room_98"),
             0U);
   EXPECT_EQ(prefs.panel_visibility_state["Dungeon"].count("dungeon.room_165"),
@@ -333,10 +330,8 @@ TEST(UserSettingsLayoutDefaultsTest,
   prefs.named_layouts["custom"] =
       R"({"schema_version":2,"name":"custom","root":{"id":1,"type":"leaf","active_tab_index":2,"panels":[{"panel_id":"dungeon.object_editor"},{"panel_id":"dungeon.room_matrix"},{"panel_id":"dungeon.dungeon_map"}]}})";
 
-  EXPECT_TRUE(settings.ApplyPanelLayoutDefaultsRevision(
-      UserSettings::kLatestPanelLayoutDefaultsRevision));
-  EXPECT_EQ(prefs.panel_layout_defaults_revision,
-            UserSettings::kLatestPanelLayoutDefaultsRevision);
+  EXPECT_TRUE(settings.ApplyPanelLayoutDefaultsRevision(19));
+  EXPECT_EQ(prefs.panel_layout_defaults_revision, 19);
   EXPECT_TRUE(prefs.panel_visibility_state["Dungeon"]["dungeon.workbench"]);
   EXPECT_TRUE(
       prefs.panel_visibility_state["Dungeon"]["dungeon.object_selector"]);
@@ -380,10 +375,8 @@ TEST(UserSettingsLayoutDefaultsTest,
   // ctor leaves it as "right" — this is the only knob we need to set.)
   prefs.dungeon_inspector_side.clear();
 
-  EXPECT_TRUE(settings.ApplyPanelLayoutDefaultsRevision(
-      UserSettings::kLatestPanelLayoutDefaultsRevision));
-  EXPECT_EQ(prefs.panel_layout_defaults_revision,
-            UserSettings::kLatestPanelLayoutDefaultsRevision);
+  EXPECT_TRUE(settings.ApplyPanelLayoutDefaultsRevision(21));
+  EXPECT_EQ(prefs.panel_layout_defaults_revision, 21);
 
   EXPECT_TRUE(prefs.panel_visibility_state["Dungeon"]["dungeon.workbench"]);
   EXPECT_TRUE(
@@ -411,10 +404,96 @@ TEST(UserSettingsLayoutDefaultsTest,
   prefs.panel_layout_defaults_revision = 20;
   prefs.dungeon_inspector_side = "left";
 
-  EXPECT_TRUE(settings.ApplyPanelLayoutDefaultsRevision(
-      UserSettings::kLatestPanelLayoutDefaultsRevision));
+  EXPECT_TRUE(settings.ApplyPanelLayoutDefaultsRevision(21));
   EXPECT_EQ(prefs.dungeon_inspector_side, "left");
   EXPECT_EQ(settings.GetDungeonInspectorSide(), "left");
+}
+
+TEST(UserSettingsLayoutDefaultsTest,
+     RevisionTwentyTwoClosesWorkbenchDuplicatePanels) {
+  UserSettings settings;
+  auto& prefs = settings.prefs();
+
+  prefs.panel_layout_defaults_revision = 21;
+  prefs.panel_visibility_state["Dungeon"]["dungeon.workbench"] = false;
+  constexpr std::array<const char*, 10> kDuplicatePanels = {
+      "dungeon.room_selector",   "dungeon.room_matrix",
+      "dungeon.object_selector", "dungeon.sprite_editor",
+      "dungeon.item_editor",     "dungeon.room_graphics",
+      "dungeon.door_editor",     "dungeon.palette_editor",
+      "dungeon.entrance_list",   "dungeon.entrance_properties",
+  };
+  for (const char* panel_id : kDuplicatePanels) {
+    prefs.panel_visibility_state["Dungeon"][panel_id] = true;
+  }
+
+  prefs.dungeon_inspector_side = "left";
+  prefs.right_panel_widths["dungeon.workbench"] = 444.0f;
+  prefs.pinned_panels["dungeon.object_selector"] = true;
+  prefs.saved_layouts["custom"]["dungeon.object_selector"] = true;
+  prefs.named_layouts["custom"] =
+      R"({"schema_version":2,"name":"custom","root":{"id":1,"type":"leaf","active_tab_index":0,"panels":[{"panel_id":"dungeon.object_selector"}]}})";
+
+  EXPECT_TRUE(settings.ApplyPanelLayoutDefaultsRevision(22));
+  EXPECT_EQ(prefs.panel_layout_defaults_revision, 22);
+  EXPECT_TRUE(prefs.panel_visibility_state["Dungeon"]["dungeon.workbench"]);
+  for (const char* panel_id : kDuplicatePanels) {
+    EXPECT_FALSE(prefs.panel_visibility_state["Dungeon"][panel_id]) << panel_id;
+  }
+
+  EXPECT_EQ(prefs.dungeon_inspector_side, "left");
+  EXPECT_FLOAT_EQ(prefs.right_panel_widths["dungeon.workbench"], 444.0f);
+  EXPECT_TRUE(prefs.pinned_panels["dungeon.object_selector"]);
+  EXPECT_TRUE(prefs.saved_layouts["custom"]["dungeon.object_selector"]);
+  EXPECT_NE(prefs.named_layouts["custom"].find("dungeon.object_selector"),
+            std::string::npos);
+}
+
+TEST(UserSettingsLayoutDefaultsTest,
+     RevisionTwentyThreeCollapsesDungeonToolCatalogAndReassertsWorkbench) {
+  UserSettings settings;
+  auto& prefs = settings.prefs();
+
+  prefs.panel_layout_defaults_revision = 22;
+  prefs.sidebar_visible = true;
+  prefs.sidebar_panel_expanded = true;
+  prefs.sidebar_active_category = "Dungeon";
+  prefs.sidebar_panel_width = 412.0f;
+  prefs.panel_visibility_state["Dungeon"]["dungeon.workbench"] = false;
+  prefs.panel_visibility_state["Dungeon"]["dungeon.object_selector"] = true;
+  prefs.panel_visibility_state["Dungeon"]["dungeon.door_editor"] = true;
+  prefs.pinned_panels["dungeon.object_selector"] = true;
+  prefs.saved_layouts["custom"]["dungeon.object_selector"] = true;
+
+  EXPECT_TRUE(settings.ApplyPanelLayoutDefaultsRevision(
+      UserSettings::kLatestPanelLayoutDefaultsRevision));
+
+  EXPECT_EQ(prefs.panel_layout_defaults_revision, 23);
+  EXPECT_TRUE(prefs.sidebar_visible);
+  EXPECT_FALSE(prefs.sidebar_panel_expanded);
+  EXPECT_FLOAT_EQ(prefs.sidebar_panel_width, 412.0f);
+  EXPECT_TRUE(prefs.panel_visibility_state["Dungeon"]["dungeon.workbench"]);
+  EXPECT_FALSE(
+      prefs.panel_visibility_state["Dungeon"]["dungeon.object_selector"]);
+  EXPECT_FALSE(prefs.panel_visibility_state["Dungeon"]["dungeon.door_editor"]);
+  EXPECT_TRUE(prefs.pinned_panels["dungeon.object_selector"]);
+  EXPECT_TRUE(prefs.saved_layouts["custom"]["dungeon.object_selector"]);
+}
+
+TEST(UserSettingsLayoutDefaultsTest,
+     RevisionTwentyThreePreservesExpandedCatalogOutsideDungeon) {
+  UserSettings settings;
+  auto& prefs = settings.prefs();
+
+  prefs.panel_layout_defaults_revision = 22;
+  prefs.sidebar_panel_expanded = true;
+  prefs.sidebar_active_category = "Graphics";
+
+  EXPECT_TRUE(settings.ApplyPanelLayoutDefaultsRevision(
+      UserSettings::kLatestPanelLayoutDefaultsRevision));
+
+  EXPECT_EQ(prefs.panel_layout_defaults_revision, 23);
+  EXPECT_TRUE(prefs.sidebar_panel_expanded);
 }
 
 // Default ctor seeds "right". Setter normalizes unrecognized values back to

--- a/test/unit/gfx/arena_retirement_test.cc
+++ b/test/unit/gfx/arena_retirement_test.cc
@@ -1,0 +1,90 @@
+#include "app/gfx/resource/arena.h"
+
+#include <stdexcept>
+#include <vector>
+
+#include "framework/mock_renderer.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+namespace yaze::gfx {
+namespace {
+
+using ::testing::NiceMock;
+
+size_t ActiveSurfaceCount(const Arena& arena) {
+  return arena.GetSurfaceCount() - arena.GetPooledSurfaceCount();
+}
+
+TEST(ArenaRetirementTest,
+     DetachesSurfaceCancelsCommandsAndDefersOpaqueHandleDestruction) {
+  Arena& arena = Arena::Get();
+  arena.ClearTextureQueue();
+  const size_t active_surfaces_before = ActiveSurfaceCount(arena);
+
+  Bitmap retiring_bitmap(8, 8, 8, std::vector<uint8_t>(64, 1));
+  Bitmap surviving_bitmap(8, 8, 8, std::vector<uint8_t>(64, 2));
+  ASSERT_EQ(ActiveSurfaceCount(arena), active_surfaces_before + 2);
+  int texture_storage = 0;
+  const TextureHandle texture = &texture_storage;
+  retiring_bitmap.set_texture(texture);
+
+  arena.QueueTextureCommand(Arena::TextureCommandType::CREATE,
+                            &retiring_bitmap);
+  arena.QueueTextureCommand(Arena::TextureCommandType::UPDATE,
+                            &retiring_bitmap);
+  arena.QueueTextureCommand(Arena::TextureCommandType::DESTROY,
+                            &retiring_bitmap);
+  arena.QueueTextureCommand(Arena::TextureCommandType::UPDATE,
+                            &surviving_bitmap);
+  ASSERT_EQ(arena.texture_command_queue_size(), 4u);
+
+  arena.RetireBitmap(retiring_bitmap);
+
+  EXPECT_EQ(retiring_bitmap.surface(), nullptr);
+  EXPECT_EQ(retiring_bitmap.texture(), nullptr);
+  EXPECT_FALSE(retiring_bitmap.is_active());
+  EXPECT_EQ(ActiveSurfaceCount(arena), active_surfaces_before + 1);
+  EXPECT_EQ(arena.texture_command_queue_size(), 1u)
+      << "Only commands for the retired Bitmap address should be removed";
+  EXPECT_EQ(arena.retired_texture_handle_count(), 1u);
+
+  arena.RetireBitmap(retiring_bitmap);
+  EXPECT_EQ(ActiveSurfaceCount(arena), active_surfaces_before + 1);
+  EXPECT_EQ(arena.texture_command_queue_size(), 1u);
+  EXPECT_EQ(arena.retired_texture_handle_count(), 1u)
+      << "Retiring the same detached Bitmap twice must be a no-op";
+
+  NiceMock<test::MockRenderer> renderer;
+  EXPECT_CALL(renderer, DestroyTexture(texture)).Times(1);
+  EXPECT_EQ(arena.DrainRetiredBitmaps(&renderer), 1u);
+  EXPECT_EQ(arena.retired_texture_handle_count(), 0u);
+
+  arena.RetireBitmap(surviving_bitmap);
+  EXPECT_EQ(arena.texture_command_queue_size(), 0u);
+  EXPECT_EQ(ActiveSurfaceCount(arena), active_surfaces_before);
+}
+
+TEST(ArenaRetirementTest, FailedHandleDestroyRemainsQueuedForRetry) {
+  Arena& arena = Arena::Get();
+  arena.ClearTextureQueue();
+
+  Bitmap bitmap(8, 8, 8, std::vector<uint8_t>(64, 1));
+  int texture_storage = 0;
+  const TextureHandle texture = &texture_storage;
+  bitmap.set_texture(texture);
+  arena.RetireBitmap(bitmap);
+
+  NiceMock<test::MockRenderer> renderer;
+  EXPECT_CALL(renderer, DestroyTexture(texture))
+      .WillOnce(::testing::Throw(std::runtime_error("destroy failed")))
+      .WillOnce(::testing::Return());
+
+  EXPECT_EQ(arena.DrainRetiredBitmaps(&renderer), 0u);
+  EXPECT_EQ(arena.retired_texture_handle_count(), 1u);
+  EXPECT_EQ(arena.DrainRetiredBitmaps(&renderer), 1u);
+  EXPECT_EQ(arena.retired_texture_handle_count(), 0u);
+}
+
+}  // namespace
+}  // namespace yaze::gfx

--- a/test/unit/zelda3/dungeon/custom_object_room_render_test.cc
+++ b/test/unit/zelda3/dungeon/custom_object_room_render_test.cc
@@ -232,6 +232,20 @@ TEST_F(CustomObjectRoomRenderTest, EmptyLayoutClearsOnlyLayoutOwnedRevealBits) {
 }
 
 TEST_F(CustomObjectRoomRenderTest,
+       LayoutPitAndMaskObjectsRemainOnUpperStreamTilemap) {
+  WriteLayoutObjects(
+      /*layout_id=*/0,
+      {RoomObject(/*id=*/0xA4, /*x=*/4, /*y=*/5, /*size=*/0, /*layer=*/0),
+       RoomObject(/*id=*/0xC2, /*x=*/8, /*y=*/9, /*size=*/0, /*layer=*/0)});
+
+  RoomLayout layout(rom_.get());
+  ASSERT_TRUE(layout.LoadLayout(/*layout_id=*/0).ok());
+  ASSERT_EQ(layout.GetObjects().size(), 2U);
+  EXPECT_EQ(layout.GetObjects()[0].layer_, RoomObject::LayerType::BG1);
+  EXPECT_EQ(layout.GetObjects()[1].layer_, RoomObject::LayerType::BG1);
+}
+
+TEST_F(CustomObjectRoomRenderTest,
        MissingCustomObjectBinDrawsDiagnosticPlaceholderOnRoomCanvas) {
   EnableCustomObjects({"missing_track.bin"});
 
@@ -330,7 +344,7 @@ TEST_F(CustomObjectRoomRenderTest,
          "not disappear into BG2 behind the floor.";
 }
 
-TEST_F(CustomObjectRoomRenderTest, LayoutPitMasksStayOnBg2Path) {
+TEST_F(CustomObjectRoomRenderTest, LayoutPitMasksUseCurrentUpperStreamTilemap) {
   WriteLayoutObjects(
       /*layout_id=*/0,
       {RoomObject(/*id=*/0x0A4, /*x=*/6, /*y=*/7, /*size=*/0, /*layer=*/0)});
@@ -350,11 +364,12 @@ TEST_F(CustomObjectRoomRenderTest, LayoutPitMasksStayOnBg2Path) {
   const int bg2_covered_pixels =
       static_cast<int>(std::count(bg2_coverage.begin(), bg2_coverage.end(), 1));
 
-  EXPECT_GT(bg2_covered_pixels, 0)
-      << "Layout pit/mask objects should still render into BG2 to reveal the "
-         "lower layer.";
-  EXPECT_LT(bg1_covered_pixels, bg2_covered_pixels)
-      << "Pit/mask layout objects should not be forced wholesale onto BG1.";
+  EXPECT_GT(bg1_covered_pixels, 0) << "Layout objects use the upper tilemap "
+                                      "pointer active when ALTTP enters "
+                                      "the layout stream.";
+  EXPECT_EQ(bg2_covered_pixels, 0)
+      << "A pit/mask object ID does not reroute the layout stream to the lower "
+         "tilemap.";
 }
 
 TEST_F(CustomObjectRoomRenderTest,

--- a/test/unit/zelda3/dungeon/dimension_service_test.cc
+++ b/test/unit/zelda3/dungeon/dimension_service_test.cc
@@ -53,7 +53,7 @@ TEST(DimensionServiceTest, GetSelectionBoundsPixelsUsesPixelUnits) {
 }
 
 TEST(DimensionServiceTest,
-     DiagonalCeilingSelectionBoundsUseAnchorAwareOffsets) {
+     DiagonalCeilingSelectionBoundsMatchFullRenderedFootprint) {
   RoomObject obj(/*id=*/0xA3, /*x=*/10, /*y=*/12, /*size=*/0);
 
   auto [hit_x, hit_y, hit_w, hit_h] =
@@ -61,11 +61,13 @@ TEST(DimensionServiceTest,
   auto [sel_x_px, sel_y_px, sel_w_px, sel_h_px] =
       DimensionService::Get().GetSelectionBoundsPixels(obj);
 
-  // Bottom-right diagonal ceilings extend up-left from the origin. Hit testing
-  // and selection should honor those negative offsets rather than clamping to
-  // the object origin.
-  EXPECT_LT(hit_x, obj.x_);
-  EXPECT_LT(hit_y, obj.y_);
+  // Bottom-right diagonal ceilings extend upward from the origin. At size zero
+  // the USDASM loop draws a 4x4 footprint whose lowest-left tile is the object
+  // anchor, so there is no negative X offset or shrunken selection rectangle.
+  EXPECT_EQ(hit_x, obj.x_);
+  EXPECT_EQ(hit_y, obj.y_ - 3);
+  EXPECT_EQ(hit_w, 4);
+  EXPECT_EQ(hit_h, 4);
   EXPECT_EQ(sel_x_px, hit_x * 8);
   EXPECT_EQ(sel_y_px, hit_y * 8);
   EXPECT_EQ(sel_w_px, hit_w * 8);

--- a/test/unit/zelda3/dungeon/door_position_test.cc
+++ b/test/unit/zelda3/dungeon/door_position_test.cc
@@ -1,6 +1,8 @@
 #include "zelda3/dungeon/door_position.h"
 
+#include <algorithm>
 #include <array>
+#include <iomanip>
 #include <utility>
 
 #include "gtest/gtest.h"
@@ -65,6 +67,68 @@ TEST(DoorPositionManagerTest, SouthRenderBoundsStartBelowUsdasmAnchor) {
   EXPECT_EQ(y, 59 * DoorPositionManager::kTileSize);
   EXPECT_EQ(width, 4 * DoorPositionManager::kTileSize);
   EXPECT_EQ(height, 3 * DoorPositionManager::kTileSize);
+}
+
+TEST(DoorPositionManagerTest, SouthExitEditorBoundsMatchUsdasmFootprints) {
+  struct ExpectedBounds {
+    DoorType type;
+    int tile_x;
+    int tile_y;
+    int width_tiles;
+    int height_tiles;
+  };
+
+  constexpr std::array<ExpectedBounds, 5> kCases = {{
+      {DoorType::ExitLower, 46, 58, 4, 4},
+      {DoorType::FancyDungeonExit, 43, 54, 10, 8},
+      {DoorType::FancyDungeonExitLower, 43, 54, 10, 8},
+      {DoorType::CaveExit, 46, 58, 4, 4},
+      {DoorType::LitCaveExitLower, 46, 58, 4, 4},
+  }};
+
+  for (const auto& expected : kCases) {
+    const auto [x, y, width, height] = DoorPositionManager::GetDoorEditorBounds(
+        /*position=*/8, DoorDirection::South, expected.type);
+    EXPECT_EQ(x, expected.tile_x * DoorPositionManager::kTileSize)
+        << GetDoorTypeName(expected.type);
+    EXPECT_EQ(y, expected.tile_y * DoorPositionManager::kTileSize)
+        << GetDoorTypeName(expected.type);
+    EXPECT_EQ(width, expected.width_tiles * DoorPositionManager::kTileSize)
+        << GetDoorTypeName(expected.type);
+    EXPECT_EQ(height, expected.height_tiles * DoorPositionManager::kTileSize)
+        << GetDoorTypeName(expected.type);
+  }
+}
+
+TEST(DoorPositionManagerTest,
+     SouthExitOverridesAreDirectionalAndPreserveGenericDoors) {
+  EXPECT_EQ(DoorPositionManager::GetDoorEditorBounds(
+                /*position=*/8, DoorDirection::South, DoorType::NormalDoor),
+            (std::tuple<int, int, int, int>{46 * 8, 59 * 8, 4 * 8, 3 * 8}));
+  EXPECT_EQ(DoorPositionManager::GetDoorEditorBounds(
+                /*position=*/8, DoorDirection::South, DoorType::BigKeyDoor),
+            (std::tuple<int, int, int, int>{46 * 8, 59 * 8, 4 * 8, 3 * 8}));
+  EXPECT_EQ(
+      DoorPositionManager::GetDoorEditorBounds(
+          /*position=*/8, DoorDirection::North, DoorType::FancyDungeonExit),
+      (std::tuple<int, int, int, int>{46 * 8, 36 * 8, 4 * 8, 3 * 8}));
+}
+
+TEST(DoorPositionManagerTest, EastRenderBoundsStartRightOfUsdasmAnchor) {
+  // RoomDraw_OneSidedShutters_East increments the table address by one word
+  // before writing, just as the South routine skips its anchor row.
+  EXPECT_EQ(DoorPositionManager::PositionToTileCoords(9, DoorDirection::East),
+            (std::pair<int, int>{55, 15}));
+  EXPECT_EQ(
+      DoorPositionManager::PositionToRenderTileCoords(9, DoorDirection::East),
+      (std::pair<int, int>{56, 15}));
+
+  const auto [x, y, width, height] = DoorPositionManager::GetDoorEditorBounds(
+      /*position=*/9, DoorDirection::East, DoorType::NormalDoor);
+  EXPECT_EQ(x, 56 * DoorPositionManager::kTileSize);
+  EXPECT_EQ(y, 15 * DoorPositionManager::kTileSize);
+  EXPECT_EQ(width, 3 * DoorPositionManager::kTileSize);
+  EXPECT_EQ(height, 4 * DoorPositionManager::kTileSize);
 }
 
 TEST(DoorPositionManagerTest, VerticalSnapPositionsMatchUsdasmRows) {
@@ -149,6 +213,69 @@ TEST(DoorPositionManagerTest,
   EXPECT_EQ(y, 4 * DoorPositionManager::kTileSize);
   EXPECT_EQ(width, 4 * DoorPositionManager::kTileSize);
   EXPECT_EQ(height, 3 * DoorPositionManager::kTileSize);
+}
+
+TEST(DoorTypesTest, PlaceableCatalogCoversSupportedRomHackVariants) {
+  constexpr auto types = GetPlaceableDoorTypes();
+  EXPECT_EQ(types.size(), 32U);
+
+  for (size_t i = 0; i < types.size(); ++i) {
+    EXPECT_EQ(std::count(types.begin(), types.end(), types[i]), 1)
+        << "duplicate door type 0x" << std::hex << static_cast<int>(types[i]);
+  }
+
+  for (DoorType supported : {
+           DoorType::ExitLower,
+           DoorType::FancyDungeonExitLower,
+           DoorType::LitCaveExitLower,
+           DoorType::SmallKeyStairsUpLower,
+           DoorType::SmallKeyStairsDownLower,
+           DoorType::BombableCaveExit,
+           DoorType::UnopenableBigKeyDoor,
+           DoorType::NormalDoorOneSidedShutter,
+           DoorType::DoubleSidedShutterLower,
+           DoorType::ExplicitRoomDoor,
+           DoorType::BottomShutterLower,
+           DoorType::TopShutterLower,
+       }) {
+    EXPECT_NE(std::find(types.begin(), types.end(), supported), types.end())
+        << "missing supported door type 0x" << std::hex
+        << static_cast<int>(supported);
+  }
+
+  for (DoorType unsafe : {
+           DoorType::UnusedCaveExit,
+           DoorType::UnusableBottomShutter,
+           DoorType::UnusedDoubleSidedShutter,
+           DoorType::UnusableNormalDoor4C,
+           DoorType::UnusableGlitchyDoor54,
+           DoorType::UnusableGlitchyStairsDown66,
+       }) {
+    EXPECT_EQ(std::find(types.begin(), types.end(), unsafe), types.end())
+        << "unsafe door type exposed in placement UI: 0x" << std::hex
+        << static_cast<int>(unsafe);
+  }
+}
+
+TEST(DoorTypesTest, RoomConnectionPredicateRejectsExitsAndControlMarkers) {
+  EXPECT_TRUE(IsRoomConnectionDoorType(DoorType::NormalDoor));
+  EXPECT_TRUE(IsRoomConnectionDoorType(DoorType::BigKeyDoor));
+
+  for (const auto type : {
+           DoorType::ExitLower,
+           DoorType::FancyDungeonExit,
+           DoorType::FancyDungeonExitLower,
+           DoorType::CaveExit,
+           DoorType::LitCaveExitLower,
+           DoorType::ExitMarker,
+           DoorType::DungeonSwapMarker,
+           DoorType::LayerSwapMarker,
+       }) {
+    EXPECT_FALSE(IsRoomConnectionDoorType(type)) << GetDoorTypeName(type);
+  }
+
+  EXPECT_FALSE(IsExitDoorType(DoorType::DungeonSwapMarker));
+  EXPECT_FALSE(IsExitDoorType(DoorType::LayerSwapMarker));
 }
 
 }  // namespace

--- a/test/unit/zelda3/dungeon/draw_routine_mapping_test.cc
+++ b/test/unit/zelda3/dungeon/draw_routine_mapping_test.cc
@@ -1,51 +1,5 @@
-// Phase 4 Routine Mappings (0x80-0xFF range)
-//
-// Steps 1, 2, 3, 4, 5 completed - 83 routines total (0-82)
-//
-// Step 1 Quick Fixes:
-// - 0x8D-0x8E: 25 -> 13 (DownwardsEdge1x1_1to16)
-// - 0x92-0x93: 11 -> 7 (Downwards2x2_1to15or32)
-// - 0x94: 16 -> 43 (DownwardsFloor4x4_1to16)
-// - 0xB6-0xB7: 8 -> 1 (Rightwards2x4_1to15or26)
-// - 0xB8-0xB9: 11 -> 0 (Rightwards2x2_1to15or32)
-// - 0xBB: 11 -> 55 (RightwardsBlock2x2spaced2_1to16)
-//
-// Step 2 Simple Variant Routines (IDs 65-74):
-// - 0x81-0x84: routine 65 (DrawDownwardsDecor3x4spaced2_1to16)
-// - 0x88: routine 66 (DrawDownwardsBigRail3x1_1to16plus5)
-// - 0x89: routine 67 (DrawDownwardsBlock2x2spaced2_1to16)
-// - 0x85-0x86: routine 68 (DrawDownwardsCannonHole3x4_1to16)
-// - 0x8F: routine 69 (DrawDownwardsBar2x5_1to16)
-// - 0x95: routine 70 (DrawDownwardsPots2x2_1to16)
-// - 0x96: routine 71 (DrawDownwardsHammerPegs2x2_1to16)
-// - 0xB0-0xB1: routine 72 (DrawRightwardsEdge1x1_1to16plus7)
-// - 0xBC: routine 73 (DrawRightwardsPots2x2_1to16)
-// - 0xBD: routine 74 (DrawRightwardsHammerPegs2x2_1to16)
-// - 0x8B-0x8C: routine 122 (DrawDownwardsEdge1x1_1to16plus7)
-//
-// Step 3 Diagonal Ceiling Routines (IDs 75-78):
-// - 0xA0, 0xA5, 0xA9: routine 75 (DrawDiagonalCeilingTopLeft)
-// - 0xA1, 0xA6, 0xAA: routine 76 (DrawDiagonalCeilingBottomLeft)
-// - 0xA2, 0xA7, 0xAB: routine 77 (DrawDiagonalCeilingTopRight)
-// - 0xA3, 0xA8, 0xAC: routine 78 (DrawDiagonalCeilingBottomRight)
-//
-// Step 4 SuperSquare Routines (IDs 56-64):
-// - 0xC0, 0xC2: routine 56 (Draw4x4BlocksIn4x4SuperSquare)
-// - 0xC3, 0xD7: routine 57 (Draw3x3FloorIn4x4SuperSquare)
-// - 0xC5-0xCA, 0xD1-0xD2, 0xD9, 0xDF-0xE8: routine 58 (Draw4x4FloorIn4x4SuperSquare)
-// - 0xC4: routine 59 (Draw4x4FloorOneIn4x4SuperSquare)
-// - 0xDB: routine 60 (Draw4x4FloorTwoIn4x4SuperSquare)
-// - 0xA4: routine 61 (DrawBigHole4x4_1to16)
-// - 0xDE: routine 62 (DrawSpike2x2In4x4SuperSquare)
-// - 0xDD: routine 63 (DrawTableRock4x4_1to16)
-// - 0xD8, 0xDA: routine 64 (DrawWaterOverlay8x8_1to16)
-//
-// Step 5 Special Routines (IDs 79-82):
-// - 0xC1: routine 79 (DrawClosedChestPlatform)
-// - 0xCD: routine 80 (DrawMovingWallWest)
-// - 0xCE: routine 81 (DrawMovingWallEast)
-// - 0xDC: routine 82 (DrawOpenChestPlatform)
-// - 0xD3-0xD6: routine 38 (DrawNothing - logic-only objects)
+// Object-to-routine mapping and focused draw-behavior regressions. Independent
+// pixel evidence lives in dungeon_room_regression_fixtures_test.cc.
 
 #include <algorithm>
 #include <vector>
@@ -451,6 +405,165 @@ TEST_F(DrawRoutineMappingTest,
   }
 }
 
+TEST_F(DrawRoutineMappingTest, SolidPlus3RoutinesExtendFromTheObjectOrigin) {
+  auto& reg = DrawRoutineRegistry::Get();
+  const DrawRoutineInfo* horizontal =
+      reg.GetRoutineInfo(DrawRoutineIds::kRightwards1x1Solid_1to16_plus3);
+  const DrawRoutineInfo* vertical =
+      reg.GetRoutineInfo(DrawRoutineIds::kDownwards1x1Solid_1to16_plus3);
+  ASSERT_NE(horizontal, nullptr);
+  ASSERT_NE(vertical, nullptr);
+
+  const std::vector<gfx::TileInfo> tiles = {MakeTile(0x0310, 3)};
+  constexpr int kAnchorX = 9;
+  constexpr int kAnchorY = 6;
+
+  for (uint8_t size : {uint8_t{0}, uint8_t{5}, uint8_t{15}}) {
+    SCOPED_TRACE(::testing::Message() << "size=" << static_cast<int>(size));
+    const int expected_count = static_cast<int>(size) + 4;
+
+    auto draw = [&](const DrawRoutineInfo& info, const RoomObject& object) {
+      gfx::BackgroundBuffer bg;
+      DrawContext ctx{bg,
+                      object,
+                      std::span<const gfx::TileInfo>(tiles),
+                      /*state=*/nullptr,
+                      rom_.get(),
+                      /*room_id=*/0,
+                      /*room_gfx_buffer=*/nullptr,
+                      /*secondary_bg=*/nullptr};
+      info.function(ctx);
+      return bg;
+    };
+
+    const auto horizontal_bg =
+        draw(*horizontal, RoomObject(0x34, kAnchorX, kAnchorY, size, 0));
+    const auto horizontal_points = CollectNonZeroTiles(horizontal_bg);
+    ASSERT_EQ(static_cast<int>(horizontal_points.size()), expected_count);
+    for (int x = kAnchorX; x < kAnchorX + expected_count; ++x) {
+      EXPECT_TRUE(ContainsPoint(horizontal_points, x, kAnchorY));
+    }
+
+    const auto vertical_bg =
+        draw(*vertical, RoomObject(0x71, kAnchorX, kAnchorY, size, 0));
+    const auto vertical_points = CollectNonZeroTiles(vertical_bg);
+    ASSERT_EQ(static_cast<int>(vertical_points.size()), expected_count);
+    for (int y = kAnchorY; y < kAnchorY + expected_count; ++y) {
+      EXPECT_TRUE(ContainsPoint(vertical_points, kAnchorX, y));
+    }
+  }
+}
+
+TEST_F(DrawRoutineMappingTest,
+       HorizontalCornerRoutinesUseUsdasmCapsAndObjectOrigin) {
+  auto& reg = DrawRoutineRegistry::Get();
+  const std::vector<gfx::TileInfo> tiles = {
+      MakeTile(0x0300, 0), MakeTile(0x0301, 1), MakeTile(0x0302, 2),
+      MakeTile(0x0303, 3), MakeTile(0x0304, 4), MakeTile(0x0305, 5)};
+  constexpr int kAnchorX = 6;
+  constexpr int kAnchorY = 8;
+  constexpr int kBodyCount = 10;
+
+  struct Case {
+    int routine_id;
+    int object_id;
+    bool top_corner;
+  };
+  for (const auto& tc :
+       {Case{DrawRoutineIds::kRightwardsTopCorners1x2_1to16_plus13, 0x2F, true},
+        Case{DrawRoutineIds::kRightwardsBottomCorners1x2_1to16_plus13, 0x30,
+             false}}) {
+    SCOPED_TRACE(::testing::Message() << "routine=" << tc.routine_id);
+    const DrawRoutineInfo* info = reg.GetRoutineInfo(tc.routine_id);
+    ASSERT_NE(info, nullptr);
+
+    gfx::BackgroundBuffer bg;
+    const RoomObject object(tc.object_id, kAnchorX, kAnchorY, 0, 0);
+    DrawContext ctx{bg,
+                    object,
+                    std::span<const gfx::TileInfo>(tiles),
+                    /*state=*/nullptr,
+                    rom_.get(),
+                    /*room_id=*/0,
+                    /*room_gfx_buffer=*/nullptr,
+                    /*secondary_bg=*/nullptr};
+    info->function(ctx);
+
+    const int edge_y = tc.top_corner ? kAnchorY : kAnchorY + 1;
+    const int fill_y = tc.top_corner ? kAnchorY + 1 : kAnchorY;
+    EXPECT_EQ(DrawRoutineUtils::TileIdAt(bg, kAnchorX, edge_y), tiles[1].id_);
+    EXPECT_EQ(DrawRoutineUtils::TileIdAt(bg, kAnchorX + 1, edge_y),
+              tiles[2].id_);
+    for (int x = kAnchorX; x < kAnchorX + kBodyCount + 4; ++x) {
+      EXPECT_EQ(DrawRoutineUtils::TileIdAt(bg, x, fill_y), tiles[0].id_)
+          << "x=" << x;
+    }
+    for (int x = kAnchorX + 2; x < kAnchorX + 2 + kBodyCount; ++x) {
+      EXPECT_EQ(DrawRoutineUtils::TileIdAt(bg, x, edge_y), tiles[3].id_)
+          << "x=" << x;
+    }
+    EXPECT_EQ(DrawRoutineUtils::TileIdAt(bg, kAnchorX + kBodyCount + 2, edge_y),
+              tiles[4].id_);
+    EXPECT_EQ(DrawRoutineUtils::TileIdAt(bg, kAnchorX + kBodyCount + 3, edge_y),
+              tiles[5].id_);
+  }
+}
+
+TEST_F(DrawRoutineMappingTest,
+       DownwardsCornerRoutinesUseUsdasmCapsAndObjectOrigin) {
+  auto& reg = DrawRoutineRegistry::Get();
+  const std::vector<gfx::TileInfo> tiles = {
+      MakeTile(0x0300, 0), MakeTile(0x0301, 1), MakeTile(0x0302, 2),
+      MakeTile(0x0303, 3), MakeTile(0x0304, 4), MakeTile(0x0305, 5)};
+  constexpr int kAnchorX = 6;
+  constexpr int kAnchorY = 8;
+  constexpr int kBodyCount = 10;
+
+  struct Case {
+    int routine_id;
+    int object_id;
+    bool left_corner;
+  };
+  for (const auto& tc :
+       {Case{DrawRoutineIds::kDownwardsLeftCorners2x1_1to16_plus12, 0x6C, true},
+        Case{DrawRoutineIds::kDownwardsRightCorners2x1_1to16_plus12, 0x6D,
+             false}}) {
+    SCOPED_TRACE(::testing::Message() << "routine=" << tc.routine_id);
+    const DrawRoutineInfo* info = reg.GetRoutineInfo(tc.routine_id);
+    ASSERT_NE(info, nullptr);
+
+    gfx::BackgroundBuffer bg;
+    const RoomObject object(tc.object_id, kAnchorX, kAnchorY, 0, 0);
+    DrawContext ctx{bg,
+                    object,
+                    std::span<const gfx::TileInfo>(tiles),
+                    /*state=*/nullptr,
+                    rom_.get(),
+                    /*room_id=*/0,
+                    /*room_gfx_buffer=*/nullptr,
+                    /*secondary_bg=*/nullptr};
+    info->function(ctx);
+
+    const int edge_x = tc.left_corner ? kAnchorX : kAnchorX + 1;
+    const int fill_x = tc.left_corner ? kAnchorX + 1 : kAnchorX;
+    EXPECT_EQ(DrawRoutineUtils::TileIdAt(bg, edge_x, kAnchorY), tiles[1].id_);
+    EXPECT_EQ(DrawRoutineUtils::TileIdAt(bg, edge_x, kAnchorY + 1),
+              tiles[2].id_);
+    for (int y = kAnchorY; y < kAnchorY + kBodyCount + 4; ++y) {
+      EXPECT_EQ(DrawRoutineUtils::TileIdAt(bg, fill_x, y), tiles[0].id_)
+          << "y=" << y;
+    }
+    for (int y = kAnchorY + 2; y < kAnchorY + 2 + kBodyCount; ++y) {
+      EXPECT_EQ(DrawRoutineUtils::TileIdAt(bg, edge_x, y), tiles[3].id_)
+          << "y=" << y;
+    }
+    EXPECT_EQ(DrawRoutineUtils::TileIdAt(bg, edge_x, kAnchorY + kBodyCount + 2),
+              tiles[4].id_);
+    EXPECT_EQ(DrawRoutineUtils::TileIdAt(bg, edge_x, kAnchorY + kBodyCount + 3),
+              tiles[5].id_);
+  }
+}
+
 TEST_F(DrawRoutineMappingTest,
        DownwardsEdgePlus7RepeatsOneTileForSizePlusEightRows) {
   auto& reg = DrawRoutineRegistry::Get();
@@ -510,9 +623,9 @@ TEST_F(DrawRoutineMappingTest,
 
   const std::vector<Case> cases = {
       {DrawRoutineIds::kDownwardsLeftCorners2x1_1to16_plus12,
-       RoomObject(0x6C, 6, 8, 0, 0), 18, 8, 18, 8, 19, 8, 18, 18},
+       RoomObject(0x6C, 6, 8, 0, 0), 6, 8, 6, 8, 7, 8, 6, 6},
       {DrawRoutineIds::kDownwardsRightCorners2x1_1to16_plus12,
-       RoomObject(0x6D, 6, 8, 0, 0), 19, 8, 19, 8, 18, 8, 19, 19},
+       RoomObject(0x6D, 6, 8, 0, 0), 7, 8, 7, 8, 6, 8, 7, 7},
   };
 
   for (const auto& tc : cases) {
@@ -570,10 +683,9 @@ TEST_F(DrawRoutineMappingTest, VerifiesSubtype1Mappings) {
   EXPECT_EQ(drawer.GetDrawRoutineId(0x33), 16);
 }
 
-TEST_F(DrawRoutineMappingTest, VerifiesPhase4Step2Mappings) {
+TEST_F(DrawRoutineMappingTest, MapsDownwardAndHorizontalVariantFamilies) {
   ObjectDrawer drawer(rom_.get(), 0);
 
-  // Step 2 Simple Variant Routines
   // 0x81-0x84: routine 65 (DownwardsDecor3x4spaced2_1to16)
   EXPECT_EQ(drawer.GetDrawRoutineId(0x81), 65);
   EXPECT_EQ(drawer.GetDrawRoutineId(0x84), 65);
@@ -611,10 +723,9 @@ TEST_F(DrawRoutineMappingTest, VerifiesPhase4Step2Mappings) {
             DrawRoutineIds::kDownwardsEdge1x1_1to16plus7);
 }
 
-TEST_F(DrawRoutineMappingTest, VerifiesPhase4Step3DiagonalCeilingMappings) {
+TEST_F(DrawRoutineMappingTest, MapsDiagonalCeilingFamilies) {
   ObjectDrawer drawer(rom_.get(), 0);
 
-  // Step 3 Diagonal Ceiling Routines
   // DiagonalCeilingTopLeft: 0xA0, 0xA5, 0xA9 -> routine 75
   EXPECT_EQ(drawer.GetDrawRoutineId(0xA0), 75);
   EXPECT_EQ(drawer.GetDrawRoutineId(0xA5), 75);
@@ -671,29 +782,29 @@ TEST_F(DrawRoutineMappingTest,
        RoomObject(0xA1, 10, 10, 0, 0),
        10,
        13,
-       7,
-       10,
-       {10, 10},
-       {10, 7},
-       {13, 7}},
-      {77,
-       RoomObject(0xA2, 10, 10, 0, 0),
-       7,
-       10,
        10,
        13,
        {10, 10},
-       {7, 10},
-       {7, 13}},
+       {13, 13},
+       {13, 10}},
+      {77,
+       RoomObject(0xA2, 10, 10, 0, 0),
+       10,
+       13,
+       10,
+       13,
+       {10, 10},
+       {13, 13},
+       {10, 13}},
       {78,
        RoomObject(0xA3, 10, 10, 0, 0),
-       7,
        10,
+       13,
        7,
        10,
        {10, 10},
-       {10, 7},
-       {7, 7}},
+       {13, 7},
+       {10, 7}},
   };
 
   for (const auto& tc : cases) {
@@ -742,10 +853,9 @@ TEST_F(DrawRoutineMappingTest,
   }
 }
 
-TEST_F(DrawRoutineMappingTest, VerifiesPhase4Step5SpecialMappings) {
+TEST_F(DrawRoutineMappingTest, MapsMovingWallAndChestPlatformFamilies) {
   ObjectDrawer drawer(rom_.get(), 0);
 
-  // Step 5 Special Routines
   // ClosedChestPlatform: 0xC1 -> routine 79
   EXPECT_EQ(drawer.GetDrawRoutineId(0xC1), 79);
 

--- a/test/unit/zelda3/dungeon/object_dimensions_test.cc
+++ b/test/unit/zelda3/dungeon/object_dimensions_test.cc
@@ -1145,19 +1145,19 @@ TEST_F(ObjectDimensionsTest, CalculatesDimensionsForDiagonalWalls) {
 
   // Test object 0x10 (Diagonal Wall /)
   // Routine 5: DrawDiagonalAcute_1to16
-  // Logic: width = (size + 7) * 8
+  // Logic: width = (size + 6) * 8
 
   RoomObject obj10(0x10, 10, 10, 0, 0);  // Size 0
-  // width = (0 + 7) * 8 = 56
+  // width = (0 + 6) * 8 = 48
   auto dims = drawer.CalculateObjectDimensions(obj10);
-  EXPECT_EQ(dims.first, 56);
-  EXPECT_EQ(dims.second, 88);
+  EXPECT_EQ(dims.first, 48);
+  EXPECT_EQ(dims.second, 80);
 
   RoomObject obj10_size10(0x10, 10, 10, 10, 0);  // Size 10
-  // width = (10 + 7) * 8 = 136
+  // width = (10 + 6) * 8 = 128
   dims = drawer.CalculateObjectDimensions(obj10_size10);
-  EXPECT_EQ(dims.first, 136);
-  EXPECT_EQ(dims.second, 168);
+  EXPECT_EQ(dims.first, 128);
+  EXPECT_EQ(dims.second, 160);
 }
 
 TEST_F(ObjectDimensionsTest, CalculatesDimensionsForType2Corners) {
@@ -1418,31 +1418,31 @@ TEST_F(ObjectDimensionTableTest, DiagonalCeilingSelectionOffsetsCorrect) {
     EXPECT_EQ(bounds.height, 4);
   }
 
-  // BottomLeft (extends up-right): offset_y = -(width-1)
+  // BottomLeft grows down-right from the encoded origin.
   for (int id : {0xA1, 0xA6, 0xAA}) {
     SCOPED_TRACE(absl::StrFormat("BottomLeft 0x%02X", id));
     auto bounds = table.GetSelectionBounds(id, 0);
     EXPECT_EQ(bounds.offset_x, 0);
-    EXPECT_EQ(bounds.offset_y, -(bounds.width - 1));
-    EXPECT_EQ(bounds.width, 4);
-    EXPECT_EQ(bounds.height, 4);
-  }
-
-  // TopRight (extends down-left): offset_x = -(width-1)
-  for (int id : {0xA2, 0xA7, 0xAB}) {
-    SCOPED_TRACE(absl::StrFormat("TopRight 0x%02X", id));
-    auto bounds = table.GetSelectionBounds(id, 0);
-    EXPECT_EQ(bounds.offset_x, -(bounds.width - 1));
     EXPECT_EQ(bounds.offset_y, 0);
     EXPECT_EQ(bounds.width, 4);
     EXPECT_EQ(bounds.height, 4);
   }
 
-  // BottomRight (extends up-left): both offsets = -(width-1)
+  // TopRight also grows down-right; its rows contract from the left.
+  for (int id : {0xA2, 0xA7, 0xAB}) {
+    SCOPED_TRACE(absl::StrFormat("TopRight 0x%02X", id));
+    auto bounds = table.GetSelectionBounds(id, 0);
+    EXPECT_EQ(bounds.offset_x, 0);
+    EXPECT_EQ(bounds.offset_y, 0);
+    EXPECT_EQ(bounds.width, 4);
+    EXPECT_EQ(bounds.height, 4);
+  }
+
+  // BottomRight grows upward, but still begins at the encoded X coordinate.
   for (int id : {0xA3, 0xA8, 0xAC}) {
     SCOPED_TRACE(absl::StrFormat("BottomRight 0x%02X", id));
     auto bounds = table.GetSelectionBounds(id, 0);
-    EXPECT_EQ(bounds.offset_x, -(bounds.width - 1));
+    EXPECT_EQ(bounds.offset_x, 0);
     EXPECT_EQ(bounds.offset_y, -(bounds.width - 1));
     EXPECT_EQ(bounds.width, 4);
     EXPECT_EQ(bounds.height, 4);

--- a/test/unit/zelda3/dungeon/object_drawer_registry_replay_test.cc
+++ b/test/unit/zelda3/dungeon/object_drawer_registry_replay_test.cc
@@ -18,6 +18,7 @@
 
 #include "gtest/gtest.h"
 
+#include <algorithm>
 #include <array>
 #include <chrono>
 #include <cstdint>
@@ -638,6 +639,61 @@ void ExpectBitmapFilledWith(const gfx::BackgroundBuffer& bg, uint8_t value) {
 void WriteWord(std::vector<uint8_t>& rom_data, int addr, uint16_t value) {
   rom_data[addr] = static_cast<uint8_t>(value & 0xFF);
   rom_data[addr + 1] = static_cast<uint8_t>(value >> 8);
+}
+
+TEST(ObjectDrawerRegistryReplayTest,
+     FloorCopyObjectsUseRoomHeaderPatternsInsteadOfObjectPayloads) {
+  ScopedCustomObjectsFlag disable_custom(false);
+
+  constexpr uint8_t kFloor1 = 6;
+  constexpr uint8_t kFloor2 = 11;
+  constexpr uint16_t kFloor1Tile = 0x120;
+  constexpr uint16_t kFloor2Tile = 0x1A0;
+  std::vector<uint8_t> dummy_rom(1024 * 1024, 0);
+  const auto write_floor_pattern = [&](uint8_t pattern,
+                                       uint16_t first_tile_id) {
+    const int offset = static_cast<int>(pattern) << 4;
+    for (int index = 0; index < 4; ++index) {
+      WriteWord(dummy_rom, kRoomObjectTileAddress + offset + index * 2,
+                gfx::TileInfoToWord(
+                    gfx::TileInfo(static_cast<uint16_t>(first_tile_id + index),
+                                  2, false, false, false)));
+      WriteWord(dummy_rom, kRoomObjectTileAddressFloor + offset + index * 2,
+                gfx::TileInfoToWord(gfx::TileInfo(
+                    static_cast<uint16_t>(first_tile_id + index + 4), 2, false,
+                    false, false)));
+    }
+  };
+  write_floor_pattern(kFloor1, kFloor1Tile);
+  write_floor_pattern(kFloor2, kFloor2Tile);
+
+  Rom rom;
+  rom.LoadFromData(dummy_rom);
+  ObjectDrawer drawer(&rom, /*room_id=*/0);
+  drawer.SetRoomFloorGraphics(kFloor1, kFloor2);
+  gfx::BackgroundBuffer bg1(512, 512);
+  gfx::BackgroundBuffer bg2(512, 512);
+  gfx::PaletteGroup palette_group;
+
+  for (const auto [object_id, first_tile_id] :
+       {std::pair<int16_t, uint16_t>{0x00C4, kFloor1Tile},
+        std::pair<int16_t, uint16_t>{0x00DB, kFloor2Tile}}) {
+    RoomObject object(object_id, /*x=*/8, /*y=*/12, /*size=*/0, /*layer=*/0);
+    object.tiles_loaded_ = true;
+    object.tiles_ = MakeSequentialTiles(8, /*start_tile_id=*/0x300);
+
+    std::vector<ObjectDrawer::TileTrace> trace;
+    drawer.SetTraceCollector(&trace, /*trace_only=*/true);
+    ASSERT_TRUE(drawer.DrawObject(object, bg1, bg2, palette_group).ok());
+    drawer.ClearTraceCollector();
+
+    ASSERT_EQ(trace.size(), 16U);
+    for (size_t index = 0; index < trace.size(); ++index) {
+      EXPECT_EQ(trace[index].tile_id,
+                first_tile_id + static_cast<uint16_t>(index % 8));
+      EXPECT_LT(trace[index].tile_id, 0x300);
+    }
+  }
 }
 
 TEST(ObjectDrawerRegistryReplayTest, SuperSquareRendersToBitmap) {
@@ -2660,24 +2716,44 @@ TEST(ObjectDrawerRegistryReplayTest,
 
   std::vector<SnapshotTileWrite> expected_top;
   std::vector<SnapshotTileWrite> expected_bottom;
-  expected_top.reserve(kCount * 2);
-  expected_bottom.reserve(kCount * 2);
+  expected_top.reserve((kCount * 2) + 8);
+  expected_bottom.reserve((kCount * 2) + 8);
 
   // USDASM:
   // - $01:8FBD (top corners): body uses top=tile3, bottom=tile0.
   // - $01:9001 (bottom corners): mirrored body uses top=tile0, bottom=tile3.
-  // Endpoints consume cap tiles (tile1 at start, tile4 at end).
-  for (int s = 0; s < kCount; ++s) {
-    const uint16_t top_cap = (s == 0) ? 1 : ((s == kCount - 1) ? 4 : 3);
-    const uint16_t bottom_cap = (s == 0) ? 1 : ((s == kCount - 1) ? 4 : 3);
-    const int x = kX + 13 + s;
+  // Both variants draw a two-column opening cap, size+10 body columns, and a
+  // two-column closing cap. The routine-name suffix describes that size+13
+  // extent; it is not an X offset.
+  expected_top.push_back({kX, kY, 1});
+  expected_top.push_back({kX + 1, kY, 2});
+  expected_top.push_back({kX, kY + 1, 0});
+  expected_top.push_back({kX + 1, kY + 1, 0});
 
-    expected_top.push_back({x, kY, top_cap});
+  expected_bottom.push_back({kX, kY + 1, 1});
+  expected_bottom.push_back({kX + 1, kY + 1, 2});
+  expected_bottom.push_back({kX, kY, 0});
+  expected_bottom.push_back({kX + 1, kY, 0});
+
+  for (int s = 0; s < kCount; ++s) {
+    const int x = kX + 2 + s;
+
+    expected_top.push_back({x, kY, 3});
     expected_top.push_back({x, kY + 1, 0});
 
-    expected_bottom.push_back({x, kY + 1, 0});
-    expected_bottom.push_back({x, kY + 2, bottom_cap});
+    expected_bottom.push_back({x, kY + 1, 3});
+    expected_bottom.push_back({x, kY, 0});
   }
+
+  expected_top.push_back({kX + kCount + 2, kY, 4});
+  expected_top.push_back({kX + kCount + 3, kY, 5});
+  expected_top.push_back({kX + kCount + 2, kY + 1, 0});
+  expected_top.push_back({kX + kCount + 3, kY + 1, 0});
+
+  expected_bottom.push_back({kX + kCount + 2, kY + 1, 4});
+  expected_bottom.push_back({kX + kCount + 3, kY + 1, 5});
+  expected_bottom.push_back({kX + kCount + 2, kY, 0});
+  expected_bottom.push_back({kX + kCount + 3, kY, 0});
 
   ExpectTraceMatchesSnapshot(top_bg1, expected_top);
   ExpectTraceMatchesSnapshot(bottom_bg1, expected_bottom);
@@ -2716,36 +2792,37 @@ TEST(ObjectDrawerRegistryReplayTest,
   //   left=tile0/right=tile3 and matching 2x2 caps.
   //
   // On a blank destination the opening cap is emitted, so the body begins two
-  // rows below the anchor.
-  expected_left.push_back({kX + 12, kY, 1});
-  expected_left.push_back({kX + 13, kY, 0});
-  expected_left.push_back({kX + 12, kY + 1, 2});
-  expected_left.push_back({kX + 13, kY + 1, 0});
+  // rows below the anchor. The routine-name suffix describes the size+12
+  // extent; it is not an X offset.
+  expected_left.push_back({kX, kY, 1});
+  expected_left.push_back({kX, kY + 1, 2});
+  expected_left.push_back({kX + 1, kY, 0});
+  expected_left.push_back({kX + 1, kY + 1, 0});
 
-  expected_right.push_back({kX + 12, kY, 0});
-  expected_right.push_back({kX + 13, kY, 1});
-  expected_right.push_back({kX + 12, kY + 1, 0});
-  expected_right.push_back({kX + 13, kY + 1, 2});
+  expected_right.push_back({kX + 1, kY, 1});
+  expected_right.push_back({kX + 1, kY + 1, 2});
+  expected_right.push_back({kX, kY, 0});
+  expected_right.push_back({kX, kY + 1, 0});
 
   for (int s = 0; s < kCount; ++s) {
     const int y = kY + 2 + s;
 
-    expected_left.push_back({kX + 12, y, 3});
-    expected_left.push_back({kX + 13, y, 0});
+    expected_left.push_back({kX, y, 3});
+    expected_left.push_back({kX + 1, y, 0});
 
-    expected_right.push_back({kX + 12, y, 0});
-    expected_right.push_back({kX + 13, y, 3});
+    expected_right.push_back({kX + 1, y, 3});
+    expected_right.push_back({kX, y, 0});
   }
 
-  expected_left.push_back({kX + 12, kY + 2 + kCount, 4});
-  expected_left.push_back({kX + 13, kY + 2 + kCount, 0});
-  expected_left.push_back({kX + 12, kY + 3 + kCount, 5});
-  expected_left.push_back({kX + 13, kY + 3 + kCount, 0});
+  expected_left.push_back({kX, kY + 2 + kCount, 4});
+  expected_left.push_back({kX, kY + 3 + kCount, 5});
+  expected_left.push_back({kX + 1, kY + 2 + kCount, 0});
+  expected_left.push_back({kX + 1, kY + 3 + kCount, 0});
 
-  expected_right.push_back({kX + 12, kY + 2 + kCount, 0});
-  expected_right.push_back({kX + 13, kY + 2 + kCount, 4});
-  expected_right.push_back({kX + 12, kY + 3 + kCount, 0});
-  expected_right.push_back({kX + 13, kY + 3 + kCount, 5});
+  expected_right.push_back({kX + 1, kY + 2 + kCount, 4});
+  expected_right.push_back({kX + 1, kY + 3 + kCount, 5});
+  expected_right.push_back({kX, kY + 2 + kCount, 0});
+  expected_right.push_back({kX, kY + 3 + kCount, 0});
 
   ExpectTraceMatchesSnapshot(left_bg1, expected_left);
   ExpectTraceMatchesSnapshot(right_bg1, expected_right);
@@ -3341,6 +3418,192 @@ TEST(ObjectDrawerPillarStrideTest, RightwardsPillar2x4Spaced4Uses6TileStride) {
   EXPECT_NE(xs.count(17), 0u);
   EXPECT_EQ(xs.count(14), 0u);
   EXPECT_EQ(xs.count(15), 0u);
+}
+
+TEST(ObjectDrawerRegistryReplayTest,
+     BuiltInWallRoutingAndDiagonalCountMatchUsdasm) {
+  ScopedCustomObjectsFlag disable_custom(false);
+
+  struct Case {
+    int16_t object_id;
+    size_t expected_bg1_writes;
+    size_t expected_bg2_writes;
+    bool diagonal;
+  };
+  const std::array<Case, 6> cases = {{{0x03, 8, 8, false},
+                                      {0x05, 0, 8, false},
+                                      {0x0C, 0, 30, true},
+                                      {0x14, 0, 30, true},
+                                      {0x15, 30, 30, true},
+                                      {0x20, 30, 30, true}}};
+
+  constexpr int kX = 20;
+  constexpr int kY = 20;
+  for (const auto& test_case : cases) {
+    SCOPED_TRACE(::testing::Message()
+                 << "object=0x" << std::hex << test_case.object_id);
+    const auto trace = ReplayObjectTrace(test_case.object_id, kX, kY,
+                                         /*size=*/0, RoomObject::LayerType::BG2,
+                                         MakeSequentialTiles(/*count=*/8));
+    const auto bg1 = FilterTraceByLayer(trace, RoomObject::LayerType::BG1);
+    const auto bg2 = FilterTraceByLayer(trace, RoomObject::LayerType::BG2);
+    EXPECT_EQ(bg1.size(), test_case.expected_bg1_writes);
+    EXPECT_EQ(bg2.size(), test_case.expected_bg2_writes);
+
+    if (test_case.diagonal) {
+      for (const auto* layer_trace : {&bg1, &bg2}) {
+        if (layer_trace->empty()) {
+          continue;
+        }
+        const auto [min_it, max_it] =
+            std::minmax_element(layer_trace->begin(), layer_trace->end(),
+                                [](const auto& lhs, const auto& rhs) {
+                                  return lhs.x_tile < rhs.x_tile;
+                                });
+        EXPECT_EQ(min_it->x_tile, kX);
+        EXPECT_EQ(max_it->x_tile, kX + 5);
+      }
+    }
+  }
+}
+
+TEST(ObjectDrawerRegistryReplayTest,
+     ConditionalEdgeCapsReadTheMatchingLayoutOwner) {
+  ScopedCustomObjectsFlag disable_custom(false);
+
+  Rom rom;
+  ASSERT_TRUE(rom.LoadFromData(std::vector<uint8_t>(1024 * 1024, 0)).ok());
+  std::array<uint8_t, 0x10000> gfx{};
+  gfx.fill(1);
+
+  struct Case {
+    int16_t object_id;
+    uint16_t matching_tile_id;
+    int edge_dx;
+    int edge_dy;
+    std::array<uint16_t, 2> opening_tile_ids;
+    int opening_tile_count;
+  };
+  const std::array<Case, 9> cases = {{{0x22, 0x00E2, 0, 0, {0x300, 0}, 1},
+                                      {0x23, 0x01DB, 0, 0, {0x300, 0}, 1},
+                                      {0x2F, 0x00E2, 0, 0, {0x301, 0x302}, 2},
+                                      {0x30, 0x00E2, 0, 1, {0x301, 0x302}, 2},
+                                      {0x5F, 0x00E2, 0, 0, {0x300, 0}, 1},
+                                      {0x69, 0x00E3, 0, 0, {0x300, 0}, 1},
+                                      {0x6C, 0x00E3, 0, 0, {0x301, 0x302}, 2},
+                                      {0x6D, 0x00E3, 1, 0, {0x301, 0x302}, 2},
+                                      {0x8A, 0x00E3, 0, 0, {0x300, 0}, 1}}};
+
+  constexpr int kX = 20;
+  constexpr int kY = 20;
+  for (const auto layer :
+       {RoomObject::LayerType::BG1, RoomObject::LayerType::BG2}) {
+    for (const auto& test_case : cases) {
+      SCOPED_TRACE(::testing::Message()
+                   << "object=0x" << std::hex << test_case.object_id
+                   << " layer=" << std::dec << static_cast<int>(layer));
+
+      gfx::BackgroundBuffer object_bg1(512, 512);
+      gfx::BackgroundBuffer object_bg2(512, 512);
+      gfx::BackgroundBuffer layout_bg1(512, 512);
+      gfx::BackgroundBuffer layout_bg2(512, 512);
+      for (auto* buffer :
+           {&object_bg1, &object_bg2, &layout_bg1, &layout_bg2}) {
+        buffer->EnsureBitmapInitialized();
+        buffer->bitmap().Fill(255);
+        buffer->ClearBuffer();
+      }
+
+      auto& matching_layout =
+          layer == RoomObject::LayerType::BG2 ? layout_bg2 : layout_bg1;
+      matching_layout.SetTileAt(kX + test_case.edge_dx, kY + test_case.edge_dy,
+                                test_case.matching_tile_id);
+
+      ObjectDrawer drawer(&rom, /*room_id=*/0, gfx.data());
+      std::vector<ObjectDrawer::TileTrace> trace;
+      drawer.SetTraceCollector(&trace, /*trace_only=*/false);
+
+      RoomObject object(test_case.object_id, kX, kY, /*size=*/0,
+                        static_cast<uint8_t>(layer));
+      object.tiles_loaded_ = true;
+      object.tiles_ = MakeSequentialTiles(/*count=*/6,
+                                          /*start_tile_id=*/0x300);
+      gfx::PaletteGroup palette_group;
+      ASSERT_TRUE(drawer
+                      .DrawObject(object, object_bg1, object_bg2, palette_group,
+                                  /*state=*/nullptr, &layout_bg1, &layout_bg2)
+                      .ok());
+
+      const auto layer_trace = FilterTraceByLayer(trace, layer);
+      ASSERT_FALSE(layer_trace.empty());
+      for (int index = 0; index < test_case.opening_tile_count; ++index) {
+        const uint16_t opening_tile_id = test_case.opening_tile_ids[index];
+        EXPECT_TRUE(std::none_of(layer_trace.begin(), layer_trace.end(),
+                                 [&](const auto& write) {
+                                   return write.tile_id == opening_tile_id;
+                                 }));
+      }
+    }
+  }
+}
+
+TEST(ObjectDrawerRegistryReplayTest,
+     ConditionalEdgeCapsPreferPriorObjectWritesOverLayout) {
+  ScopedCustomObjectsFlag disable_custom(false);
+
+  Rom rom;
+  ASSERT_TRUE(rom.LoadFromData(std::vector<uint8_t>(1024 * 1024, 0)).ok());
+  std::array<uint8_t, 0x10000> gfx{};
+  gfx.fill(1);
+
+  constexpr int kX = 20;
+  constexpr int kY = 20;
+  for (const bool prior_object_matches : {false, true}) {
+    SCOPED_TRACE(::testing::Message()
+                 << "prior_object_matches=" << prior_object_matches);
+
+    gfx::BackgroundBuffer object_bg1(512, 512);
+    gfx::BackgroundBuffer object_bg2(512, 512);
+    gfx::BackgroundBuffer layout_bg1(512, 512);
+    gfx::BackgroundBuffer layout_bg2(512, 512);
+    for (auto* buffer : {&object_bg1, &object_bg2, &layout_bg1, &layout_bg2}) {
+      buffer->EnsureBitmapInitialized();
+      buffer->bitmap().Fill(255);
+      buffer->ClearBuffer();
+    }
+    layout_bg1.SetTileAt(kX, kY, 0x00E2);
+
+    ObjectDrawer drawer(&rom, /*room_id=*/0, gfx.data());
+    gfx::PaletteGroup palette_group;
+
+    RoomObject prior(/*id=*/0x11F, kX, kY, /*size=*/0,
+                     RoomObject::LayerType::BG1);
+    prior.tiles_loaded_ = true;
+    prior.tiles_ = MakeSequentialTiles(/*count=*/4,
+                                       /*start_tile_id=*/0x320);
+    prior.tiles_[0].id_ = prior_object_matches ? 0x00E2 : 0x0320;
+    ASSERT_TRUE(drawer
+                    .DrawObject(prior, object_bg1, object_bg2, palette_group,
+                                /*state=*/nullptr, &layout_bg1, &layout_bg2)
+                    .ok());
+
+    std::vector<ObjectDrawer::TileTrace> trace;
+    drawer.SetTraceCollector(&trace, /*trace_only=*/false);
+    RoomObject edge(/*id=*/0x22, kX, kY, /*size=*/0,
+                    RoomObject::LayerType::BG1);
+    edge.tiles_loaded_ = true;
+    edge.tiles_ = MakeSequentialTiles(/*count=*/3,
+                                      /*start_tile_id=*/0x300);
+    ASSERT_TRUE(drawer
+                    .DrawObject(edge, object_bg1, object_bg2, palette_group,
+                                /*state=*/nullptr, &layout_bg1, &layout_bg2)
+                    .ok());
+
+    const bool opening_cap_was_drawn =
+        std::any_of(trace.begin(), trace.end(),
+                    [](const auto& write) { return write.tile_id == 0x0300; });
+    EXPECT_EQ(opening_cap_was_drawn, !prior_object_matches);
+  }
 }
 
 TEST(ObjectDrawerRegistryReplayTest,
@@ -4611,27 +4874,53 @@ TEST(ObjectDrawerMaskPropagationTest,
 
   const int pixel_x = (lower.x_ + 3) * 8;
   const int pixel_y = lower.y_ * 8;
-  const int index = pixel_y * obj_bg1.bitmap().width() + pixel_x;
+  const int bitmap_width = obj_bg1.bitmap().width();
+  const int opaque_index = pixel_y * bitmap_width + pixel_x;
+  const int transparent_index = opaque_index + 1;
+  const int outside_index = opaque_index + 8;
   ASSERT_TRUE(drawer
                   .DrawObject(lower, obj_bg1, obj_bg2, palette_group,
                               /*state=*/nullptr, /*layout_bg1=*/&layout_bg1)
                   .ok());
-  ASSERT_NE(obj_bg1.bg1_reveal_mask_data()[index] & kBG2ObjectRevealMask, 0);
+  ASSERT_NE(obj_bg1.bg1_reveal_mask_data()[opaque_index] & kBG2ObjectRevealMask,
+            0);
 
+  obj_bg1.SetBG1RevealMaskRect(gfx::BG1RevealMaskSource::kBG2Objects, pixel_x,
+                               pixel_y, 8, 8);
+  obj_bg1.SetBG1RevealMaskRect(gfx::BG1RevealMaskSource::kBG2Objects,
+                               pixel_x + 8, pixel_y, 1, 1);
   obj_bg1.SetBG1RevealMaskRect(gfx::BG1RevealMaskSource::kBG2Layout, pixel_x,
-                               pixel_y, 1, 1);
+                               pixel_y, 8, 8);
+  ASSERT_NE(
+      obj_bg1.bg1_reveal_mask_data()[transparent_index] & kBG2ObjectRevealMask,
+      0);
+  ASSERT_NE(
+      obj_bg1.bg1_reveal_mask_data()[outside_index] & kBG2ObjectRevealMask, 0);
+
   RoomObject later_upper = lower;
   later_upper.layer_ = RoomObject::LayerType::BG1;
   ASSERT_TRUE(
       drawer.DrawObject(later_upper, obj_bg1, obj_bg2, palette_group).ok());
 
-  const uint8_t remaining = obj_bg1.bg1_reveal_mask_data()[index];
-  EXPECT_EQ(remaining & kBG2ObjectRevealMask, 0);
+  const uint8_t layout_reveal_mask =
+      static_cast<uint8_t>(gfx::BG1RevealMaskSource::kBG2Layout);
+  for (int dy = 0; dy < 8; ++dy) {
+    for (int dx = 0; dx < 8; ++dx) {
+      const int inside_index = (pixel_y + dy) * bitmap_width + pixel_x + dx;
+      const uint8_t remaining = obj_bg1.bg1_reveal_mask_data()[inside_index];
+      EXPECT_EQ(remaining & kBG2ObjectRevealMask, 0)
+          << "pixel=(" << dx << "," << dy << ")";
+      EXPECT_NE(remaining & layout_reveal_mask, 0)
+          << "pixel=(" << dx << "," << dy << ")";
+    }
+  }
   EXPECT_NE(
-      remaining & static_cast<uint8_t>(gfx::BG1RevealMaskSource::kBG2Layout),
+      obj_bg1.bg1_reveal_mask_data()[outside_index] & kBG2ObjectRevealMask, 0);
+  EXPECT_NE(obj_bg1.bitmap().data()[opaque_index], 255);
+  EXPECT_EQ(obj_bg1.bitmap().data()[transparent_index], 255);
+  EXPECT_NE(
+      layout_bg1.bg1_reveal_mask_data()[opaque_index] & kBG2ObjectRevealMask,
       0);
-  EXPECT_NE(obj_bg1.bitmap().data()[index], 255);
-  EXPECT_NE(layout_bg1.bg1_reveal_mask_data()[index] & kBG2ObjectRevealMask, 0);
 }
 
 TEST(ObjectDrawerMaskPropagationTest, StoredBg2SpiralStairsUsePerPixelMasking) {
@@ -4904,6 +5193,71 @@ TEST(ObjectDrawerRegistryReplayTest,
 
   ExpectTraceMatchesSnapshot(bg2, expected_bg2);
   ExpectTraceMatchesSnapshot(bg1, expected_bg1);
+}
+
+TEST(ObjectDrawerRegistryReplayTest,
+     StraightInterroomLowerPromotesFixedBg1ColumnWithoutPaintingIt) {
+  ScopedCustomObjectsFlag disable_custom(false);
+
+  Rom rom;
+  ASSERT_TRUE(rom.LoadFromData(std::vector<uint8_t>(1024 * 1024, 0)).ok());
+  std::array<uint8_t, 0x10000> room_gfx{};
+  room_gfx.fill(1);
+  gfx::PaletteGroup palette_group;
+
+  struct Case {
+    int16_t object_id;
+    int priority_start_y;
+    int bg1_raster_y;
+  };
+  constexpr int kX = 8;
+  constexpr int kY = 8;
+  const std::array<Case, 2> cases = {
+      {{0x0FA6, kY - 4, kY}, {0x0FA8, kY + 4, kY + 3}}};
+
+  for (const auto& test_case : cases) {
+    SCOPED_TRACE(::testing::Message()
+                 << "object=0x" << std::hex << test_case.object_id);
+    gfx::BackgroundBuffer object_bg1(512, 512);
+    gfx::BackgroundBuffer object_bg2(512, 512);
+    gfx::BackgroundBuffer layout_bg1(512, 512);
+    gfx::BackgroundBuffer layout_bg2(512, 512);
+    for (auto* buffer : {&object_bg1, &object_bg2, &layout_bg1, &layout_bg2}) {
+      InitializeEmptyDoorBuffer(*buffer);
+    }
+
+    ObjectDrawer drawer(&rom, /*room_id=*/0x51, room_gfx.data());
+    RoomObject object(test_case.object_id, kX, kY, /*size=*/0,
+                      RoomObject::LayerType::BG2);
+    object.tiles_loaded_ = true;
+    object.tiles_ = MakeSequentialTiles(/*count=*/16);
+    ASSERT_TRUE(drawer
+                    .DrawObject(object, object_bg1, object_bg2, palette_group,
+                                /*state=*/nullptr, &layout_bg1, &layout_bg2)
+                    .ok());
+
+    ExpectOnlyCoverageRect(object_bg1, kX, test_case.bg1_raster_y,
+                           /*width_tiles=*/4, /*height_tiles=*/1);
+    ExpectOnlyCoverageRect(object_bg2, kX, kY, /*width_tiles=*/4,
+                           /*height_tiles=*/4);
+    ExpectOnlyCoverageRect(layout_bg1, 0, 0, 0, 0);
+    ExpectOnlyCoverageRect(layout_bg2, 0, 0, 0, 0);
+
+    ExpectPriorityRectSet(object_bg1, kX, test_case.priority_start_y,
+                          /*width_tiles=*/1, /*height_tiles=*/4);
+    ExpectPriorityRectSet(layout_bg1, kX, test_case.priority_start_y,
+                          /*width_tiles=*/1, /*height_tiles=*/4);
+    EXPECT_EQ(object_bg2.GetPriorityAt(kX * 8, test_case.priority_start_y * 8),
+              0xFF);
+    EXPECT_EQ(layout_bg2.GetPriorityAt(kX * 8, test_case.priority_start_y * 8),
+              0xFF);
+
+    const int priority_pixel = test_case.priority_start_y * 8 * 512 + kX * 8;
+    ASSERT_LT(priority_pixel,
+              static_cast<int>(object_bg1.bitmap().vector().size()));
+    EXPECT_EQ(object_bg1.bitmap().vector()[priority_pixel], 255);
+    EXPECT_EQ(layout_bg1.bitmap().vector()[priority_pixel], 255);
+  }
 }
 
 TEST(ObjectDrawerRegistryReplayTest,

--- a/test/unit/zelda3/dungeon/object_drawer_registry_replay_test.cc
+++ b/test/unit/zelda3/dungeon/object_drawer_registry_replay_test.cc
@@ -69,6 +69,7 @@ class FakeDungeonState : public DungeonState {
   bool dam_floodgate_open = false;
   bool big_chest_open = false;
   bool wall_moved = false;
+  bool door_switch_active = false;
 
   bool IsChestOpen(int room_id, int chest_index) const override {
     chest_queries.emplace_back(room_id, chest_index);
@@ -82,7 +83,9 @@ class FakeDungeonState : public DungeonState {
     }
     return room_id == open_lock_room_id;
   }
-  bool IsDoorSwitchActive(int /*room_id*/) const override { return false; }
+  bool IsDoorSwitchActive(int /*room_id*/) const override {
+    return door_switch_active;
+  }
   bool IsBigKeyLockOpen(int room_id, int room_event_index) const override {
     big_key_lock_queries.emplace_back(room_id, room_event_index);
     return open_big_key_lock_slots.contains({room_id, room_event_index});
@@ -761,13 +764,13 @@ TEST(ObjectDrawerRegistryReplayTest,
   constexpr int kDoorwayReplacementDoorGfxBase = 0x1A02;
   constexpr int kDoorGfxNorthTableBase = 0x4D9E;
   constexpr int kCurtainDoorType = 0x32;
-  constexpr int kOpenCurtainReplacementType = 0x54;
+  constexpr int kOpenCurtainReplacementType = 0x56;
   constexpr int kOpenCurtainObjectOffset = 0x0800;
 
   Rom rom;
   std::vector<uint8_t> dummy_rom(1024 * 1024, 0);
-  dummy_rom[kDoorwayReplacementDoorGfxBase + kCurtainDoorType] =
-      kOpenCurtainReplacementType;
+  WriteWord(dummy_rom, kDoorwayReplacementDoorGfxBase + kCurtainDoorType,
+            kOpenCurtainReplacementType);
   WriteWord(dummy_rom, kDoorGfxNorthTableBase + kCurtainDoorType, 0xFFFF);
   WriteWord(dummy_rom, kDoorGfxNorthTableBase + kOpenCurtainReplacementType,
             kOpenCurtainObjectOffset);
@@ -806,6 +809,164 @@ TEST(ObjectDrawerRegistryReplayTest,
   EXPECT_FALSE(TileHasCoverage(bg1, 18, 4));
   EXPECT_FALSE(TileHasCoverage(bg1, 14, 8));
   EXPECT_FALSE(TileHasCoverage(bg2, 14, 0));
+}
+
+TEST(ObjectDrawerRegistryReplayTest,
+     OpenGenericDoorUsesRomReplacementWithoutChangingWriterFamily) {
+  ScopedCustomObjectsFlag disable_custom(false);
+
+  constexpr int kDoorwayReplacementDoorGfxBase = 0x1A02;
+  constexpr int kDoorGfxWestTableBase = 0x4E66;
+  constexpr int kClosedObjectOffset = 0x0C00;
+  constexpr int kOpenObjectOffset = 0x0C20;
+  constexpr uint16_t kClosedFirstWord = 0x0800;
+  constexpr uint16_t kOpenFirstWord = 0x0900;
+  constexpr DoorType kOpenReplacementType = DoorType::UnusableBombedDoor;
+
+  Rom rom;
+  std::vector<uint8_t> dummy_rom(1024 * 1024, 0);
+  WriteWord(
+      dummy_rom,
+      kDoorwayReplacementDoorGfxBase + static_cast<int>(DoorType::BombableDoor),
+      static_cast<int>(kOpenReplacementType));
+  WriteWord(dummy_rom,
+            kDoorGfxWestTableBase + static_cast<int>(DoorType::BombableDoor),
+            kClosedObjectOffset);
+  WriteWord(dummy_rom,
+            kDoorGfxWestTableBase + static_cast<int>(kOpenReplacementType),
+            kOpenObjectOffset);
+  WriteDoorObjectDataWords(dummy_rom, kClosedObjectOffset, kClosedFirstWord,
+                           /*word_count=*/12);
+  WriteDoorObjectDataWords(dummy_rom, kOpenObjectOffset, kOpenFirstWord,
+                           /*word_count=*/12);
+  rom.LoadFromData(dummy_rom);
+
+  auto gfx = MakeOpaqueDoorGfx();
+  ObjectDrawer drawer(&rom, /*room_id=*/0x42, gfx.data());
+  gfx::BackgroundBuffer bg1(512, 512);
+  gfx::BackgroundBuffer bg2(512, 512);
+  InitializeEmptyDoorBuffer(bg1);
+  InitializeEmptyDoorBuffer(bg2);
+  FakeDungeonState open_state;
+  open_state.open_lock_room_id = 0x42;
+
+  ObjectDrawer::DoorDef door{
+      .type = DoorType::BombableDoor,
+      .direction = DoorDirection::West,
+      .position = 0,
+  };
+  drawer.DrawDoor(door, /*door_index=*/0, bg1, bg2, &open_state);
+
+  const auto [tile_x, tile_y] = door.GetTileCoords();
+  ExpectOnlyCoverageRect(bg1, tile_x, tile_y, /*width=*/3, /*height=*/4);
+  ExpectOnlyCoverageRect(bg2, 0, 0, 0, 0);
+  EXPECT_EQ(bg1.GetTileAt(tile_x, tile_y), kOpenFirstWord);
+  EXPECT_NE(bg1.GetTileAt(tile_x, tile_y), kClosedFirstWord);
+}
+
+TEST(ObjectDrawerRegistryReplayTest,
+     GenericCurtainAndWaterfallFinalTypesSuppressRaster) {
+  ScopedCustomObjectsFlag disable_custom(false);
+
+  constexpr int kDoorGfxSouthTableBase = 0x4E06;
+  constexpr int kDoorGfxWestTableBase = 0x4E66;
+  constexpr int kWaterfallObjectOffset = 0x0D00;
+  constexpr int kCurtainObjectOffset = 0x0D20;
+
+  Rom rom;
+  std::vector<uint8_t> dummy_rom(1024 * 1024, 0);
+  WriteWord(dummy_rom,
+            kDoorGfxSouthTableBase + static_cast<int>(DoorType::WaterfallDoor),
+            kWaterfallObjectOffset);
+  WriteWord(dummy_rom,
+            kDoorGfxWestTableBase + static_cast<int>(DoorType::CurtainDoor),
+            kCurtainObjectOffset);
+  WriteDoorObjectDataWords(dummy_rom, kWaterfallObjectOffset,
+                           /*start_word=*/0x0A00, /*word_count=*/12);
+  WriteDoorObjectDataWords(dummy_rom, kCurtainObjectOffset,
+                           /*start_word=*/0x0B00, /*word_count=*/12);
+  rom.LoadFromData(dummy_rom);
+
+  auto gfx = MakeOpaqueDoorGfx();
+  ObjectDrawer drawer(&rom, /*room_id=*/0x42, gfx.data());
+
+  for (const auto& [type, direction] :
+       std::array<std::pair<DoorType, DoorDirection>, 2>{
+           {{DoorType::WaterfallDoor, DoorDirection::South},
+            {DoorType::CurtainDoor, DoorDirection::West}}}) {
+    SCOPED_TRACE(::testing::Message()
+                 << "type=" << static_cast<int>(type)
+                 << " direction=" << static_cast<int>(direction));
+    gfx::BackgroundBuffer bg1(512, 512);
+    gfx::BackgroundBuffer bg2(512, 512);
+    InitializeEmptyDoorBuffer(bg1);
+    InitializeEmptyDoorBuffer(bg2);
+
+    ObjectDrawer::DoorDef door{
+        .type = type,
+        .direction = direction,
+        .position = 0,
+    };
+    drawer.DrawDoor(door, /*door_index=*/0, bg1, bg2, nullptr);
+
+    ExpectOnlyCoverageRect(bg1, 0, 0, 0, 0);
+    ExpectOnlyCoverageRect(bg2, 0, 0, 0, 0);
+  }
+}
+
+TEST(ObjectDrawerRegistryReplayTest,
+     ActiveShutterControllerKeepsOpenFlaggedShutterClosed) {
+  ScopedCustomObjectsFlag disable_custom(false);
+
+  constexpr int kDoorwayReplacementDoorGfxBase = 0x1A02;
+  constexpr int kDoorGfxSouthTableBase = 0x4E06;
+  constexpr int kClosedObjectOffset = 0x0D40;
+  constexpr int kOpenObjectOffset = 0x0D60;
+  constexpr uint16_t kClosedFirstWord = 0x0C00;
+  constexpr uint16_t kOpenFirstWord = 0x0D00;
+
+  Rom rom;
+  std::vector<uint8_t> dummy_rom(1024 * 1024, 0);
+  WriteWord(dummy_rom,
+            kDoorwayReplacementDoorGfxBase +
+                static_cast<int>(DoorType::DoubleSidedShutter),
+            static_cast<int>(DoorType::UnusableNormalDoor50));
+  WriteWord(
+      dummy_rom,
+      kDoorGfxSouthTableBase + static_cast<int>(DoorType::DoubleSidedShutter),
+      kClosedObjectOffset);
+  WriteWord(
+      dummy_rom,
+      kDoorGfxSouthTableBase + static_cast<int>(DoorType::UnusableNormalDoor50),
+      kOpenObjectOffset);
+  WriteDoorObjectDataWords(dummy_rom, kClosedObjectOffset, kClosedFirstWord,
+                           /*word_count=*/12);
+  WriteDoorObjectDataWords(dummy_rom, kOpenObjectOffset, kOpenFirstWord,
+                           /*word_count=*/12);
+  rom.LoadFromData(dummy_rom);
+
+  auto gfx = MakeOpaqueDoorGfx();
+  ObjectDrawer drawer(&rom, /*room_id=*/0x42, gfx.data());
+  gfx::BackgroundBuffer bg1(512, 512);
+  gfx::BackgroundBuffer bg2(512, 512);
+  InitializeEmptyDoorBuffer(bg1);
+  InitializeEmptyDoorBuffer(bg2);
+  FakeDungeonState state;
+  state.open_lock_room_id = 0x42;
+  state.door_switch_active = true;
+
+  ObjectDrawer::DoorDef door{
+      .type = DoorType::DoubleSidedShutter,
+      .direction = DoorDirection::South,
+      .position = 0,
+  };
+  drawer.DrawDoor(door, /*door_index=*/0, bg1, bg2, &state);
+
+  const auto [tile_x, tile_y] = door.GetTileCoords();
+  ExpectOnlyCoverageRect(bg1, tile_x, tile_y, /*width=*/4, /*height=*/3);
+  ExpectOnlyCoverageRect(bg2, 0, 0, 0, 0);
+  EXPECT_EQ(bg1.GetTileAt(tile_x, tile_y), kClosedFirstWord);
+  EXPECT_NE(bg1.GetTileAt(tile_x, tile_y), kOpenFirstWord);
 }
 
 TEST(ObjectDrawerRegistryReplayTest,
@@ -1551,6 +1712,56 @@ TEST(ObjectDrawerRegistryReplayTest,
     drawer.DrawDoor(door, /*door_index=*/0, open_bg1, open_bg2, &open_state);
     ExpectOnlyCoverageRect(open_bg1, 0, 0, 0, 0);
     ExpectOnlyCoverageRect(open_bg2, 0, 0, 0, 0);
+  }
+}
+
+TEST(ObjectDrawerRegistryReplayTest,
+     OpenNorthUpperKeyStairsSuppressValidReplacementArt) {
+  ScopedCustomObjectsFlag disable_custom(false);
+
+  constexpr int kDoorwayReplacementDoorGfxBase = 0x1A02;
+  constexpr int kDoorGfxNorthTableBase = 0x4D9E;
+  constexpr int kReplacementObjectOffset = 0x0B30;
+  constexpr uint16_t kReplacementType =
+      static_cast<uint16_t>(DoorType::NormalDoor);
+
+  Rom rom;
+  std::vector<uint8_t> dummy_rom(1024 * 1024, 0);
+  for (DoorType type :
+       {DoorType::SmallKeyStairsUp, DoorType::SmallKeyStairsDown}) {
+    WriteWord(dummy_rom,
+              kDoorwayReplacementDoorGfxBase + static_cast<int>(type),
+              kReplacementType);
+  }
+  WriteWord(dummy_rom, kDoorGfxNorthTableBase + kReplacementType,
+            kReplacementObjectOffset);
+  WriteDoorObjectDataWords(dummy_rom,
+                           /*object_offset=*/kReplacementObjectOffset,
+                           /*start_word=*/0x08E0, /*word_count=*/12);
+  rom.LoadFromData(dummy_rom);
+
+  auto gfx = MakeOpaqueDoorGfx();
+  ObjectDrawer drawer(&rom, /*room_id=*/0x42, gfx.data());
+  FakeDungeonState open_state;
+  open_state.open_lock_room_id = 0x42;
+
+  for (DoorType type :
+       {DoorType::SmallKeyStairsUp, DoorType::SmallKeyStairsDown}) {
+    SCOPED_TRACE(static_cast<int>(type));
+    gfx::BackgroundBuffer bg1(512, 512);
+    gfx::BackgroundBuffer bg2(512, 512);
+    InitializeEmptyDoorBuffer(bg1);
+    InitializeEmptyDoorBuffer(bg2);
+
+    ObjectDrawer::DoorDef door{
+        .type = type,
+        .direction = DoorDirection::North,
+        .position = 0,
+    };
+    drawer.DrawDoor(door, /*door_index=*/0, bg1, bg2, &open_state);
+
+    ExpectOnlyCoverageRect(bg1, 0, 0, 0, 0);
+    ExpectOnlyCoverageRect(bg2, 0, 0, 0, 0);
   }
 }
 
@@ -4398,14 +4609,13 @@ TEST(ObjectDrawerMaskPropagationTest,
   lower.tiles_ = {gfx::TileInfo(/*id=*/0, /*pal=*/2, false, false, false)};
   gfx::PaletteGroup palette_group;
 
+  const int pixel_x = (lower.x_ + 3) * 8;
+  const int pixel_y = lower.y_ * 8;
+  const int index = pixel_y * obj_bg1.bitmap().width() + pixel_x;
   ASSERT_TRUE(drawer
                   .DrawObject(lower, obj_bg1, obj_bg2, palette_group,
                               /*state=*/nullptr, /*layout_bg1=*/&layout_bg1)
                   .ok());
-
-  const int pixel_x = (lower.x_ + 3) * 8;
-  const int pixel_y = lower.y_ * 8;
-  const int index = pixel_y * obj_bg1.bitmap().width() + pixel_x;
   ASSERT_NE(obj_bg1.bg1_reveal_mask_data()[index] & kBG2ObjectRevealMask, 0);
 
   obj_bg1.SetBG1RevealMaskRect(gfx::BG1RevealMaskSource::kBG2Layout, pixel_x,
@@ -4424,7 +4634,7 @@ TEST(ObjectDrawerMaskPropagationTest,
   EXPECT_NE(layout_bg1.bg1_reveal_mask_data()[index] & kBG2ObjectRevealMask, 0);
 }
 
-TEST(ObjectDrawerMaskPropagationTest, Layer2SpiralStairsUsePerPixelMasking) {
+TEST(ObjectDrawerMaskPropagationTest, StoredBg2SpiralStairsUsePerPixelMasking) {
   ScopedCustomObjectsFlag disable_custom(false);
 
   Rom rom;
@@ -4466,7 +4676,6 @@ TEST(ObjectDrawerMaskPropagationTest, Layer2SpiralStairsUsePerPixelMasking) {
   const int opaque_idx = base_y * obj_bg1.bitmap().width() + base_x;
   const int transparent_idx = opaque_idx + 1;
   ASSERT_LT(transparent_idx, static_cast<int>(obj_bg1.bitmap().size()));
-
   ASSERT_TRUE(drawer
                   .DrawObject(obj, obj_bg1, obj_bg2, palette_group,
                               /*state=*/nullptr, /*layout_bg1=*/&layout_bg1)
@@ -4523,39 +4732,112 @@ TEST(ObjectDrawerRegistryReplayTest,
 }
 
 TEST(ObjectDrawerRegistryReplayTest,
-     SpiralStairsUpperAlwaysRenderOnBg1InColumnMajorOrder) {
+     SpiralStairsRastersFollowStoredLayerInColumnMajorOrder) {
   ScopedCustomObjectsFlag disable_custom(false);
 
   constexpr int kX = 3;
   constexpr int kY = 5;
-  auto trace = ReplayObjectTrace(
-      /*object_id=*/0x0139, kX, kY, /*size=*/0, RoomObject::LayerType::BG2,
-      MakeSequentialTiles(/*count=*/12));
-
-  const auto bg1 = FilterTraceByLayer(trace, RoomObject::LayerType::BG1);
-  const auto bg2 = FilterTraceByLayer(trace, RoomObject::LayerType::BG2);
   const auto expected = MakeColumnMajorSnapshot(kX, kY, 4, 3, 0);
 
-  ExpectTraceMatchesSnapshot(bg1, expected);
-  EXPECT_TRUE(bg2.empty());
+  for (const int object_id : {0x0138, 0x0139, 0x013A, 0x013B}) {
+    for (const auto stored_layer :
+         {RoomObject::LayerType::BG1, RoomObject::LayerType::BG2}) {
+      SCOPED_TRACE(::testing::Message()
+                   << "object=0x" << std::hex << object_id
+                   << " layer=" << static_cast<int>(stored_layer));
+      const auto trace =
+          ReplayObjectTrace(object_id, kX, kY, /*size=*/0, stored_layer,
+                            MakeSequentialTiles(/*count=*/12));
+      const auto bg1 = FilterTraceByLayer(trace, RoomObject::LayerType::BG1);
+      const auto bg2 = FilterTraceByLayer(trace, RoomObject::LayerType::BG2);
+
+      if (stored_layer == RoomObject::LayerType::BG1) {
+        ExpectTraceMatchesSnapshot(bg1, expected);
+        EXPECT_TRUE(bg2.empty());
+      } else {
+        EXPECT_TRUE(bg1.empty());
+        ExpectTraceMatchesSnapshot(bg2, expected);
+      }
+    }
+  }
 }
 
 TEST(ObjectDrawerRegistryReplayTest,
-     SpiralStairsLowerAlwaysRenderOnBg2InColumnMajorOrder) {
+     SpiralStairsPromoteFixedMapFlanksWithoutRasterOrCoverage) {
   ScopedCustomObjectsFlag disable_custom(false);
+
+  Rom rom;
+  std::vector<uint8_t> dummy_rom(1024 * 1024, 0);
+  rom.LoadFromData(dummy_rom);
+
+  std::array<uint8_t, 0x10000> room_gfx{};
+  room_gfx.fill(1);
+  ObjectDrawer drawer(&rom, /*room_id=*/0x77, room_gfx.data());
+  gfx::PaletteGroup palette_group;
+
+  struct SpiralCase {
+    int object_id;
+    RoomObject::LayerType stored_layer;
+    bool priority_on_upper;
+  };
+  const std::array<SpiralCase, 4> cases = {{
+      {0x0138, RoomObject::LayerType::BG2, true},
+      {0x0139, RoomObject::LayerType::BG2, true},
+      {0x013A, RoomObject::LayerType::BG1, false},
+      {0x013B, RoomObject::LayerType::BG1, false},
+  }};
 
   constexpr int kX = 3;
   constexpr int kY = 5;
-  auto trace = ReplayObjectTrace(
-      /*object_id=*/0x013B, kX, kY, /*size=*/0, RoomObject::LayerType::BG1,
-      MakeSequentialTiles(/*count=*/12));
+  for (const auto& test_case : cases) {
+    SCOPED_TRACE(::testing::Message()
+                 << "object=0x" << std::hex << test_case.object_id);
+    gfx::BackgroundBuffer object_upper(512, 512);
+    gfx::BackgroundBuffer object_lower(512, 512);
+    gfx::BackgroundBuffer layout_upper(512, 512);
+    gfx::BackgroundBuffer layout_lower(512, 512);
+    for (auto* buffer :
+         {&object_upper, &object_lower, &layout_upper, &layout_lower}) {
+      InitializeEmptyDoorBuffer(*buffer);
+    }
 
-  const auto bg1 = FilterTraceByLayer(trace, RoomObject::LayerType::BG1);
-  const auto bg2 = FilterTraceByLayer(trace, RoomObject::LayerType::BG2);
-  const auto expected = MakeColumnMajorSnapshot(kX, kY, 4, 3, 0);
+    RoomObject object(test_case.object_id, kX, kY, /*size=*/0,
+                      static_cast<int>(test_case.stored_layer));
+    object.tiles_loaded_ = true;
+    object.tiles_ = MakeSequentialTiles(/*count=*/12);
 
-  EXPECT_TRUE(bg1.empty());
-  ExpectTraceMatchesSnapshot(bg2, expected);
+    ASSERT_TRUE(drawer
+                    .DrawObject(object, object_upper, object_lower,
+                                palette_group, /*state=*/nullptr, &layout_upper,
+                                &layout_lower)
+                    .ok());
+
+    const auto& raster = test_case.stored_layer == RoomObject::LayerType::BG1
+                             ? object_upper
+                             : object_lower;
+    const auto& other_object =
+        test_case.stored_layer == RoomObject::LayerType::BG1 ? object_lower
+                                                             : object_upper;
+    ExpectOnlyCoverageRect(raster, kX, kY, /*width_tiles=*/4,
+                           /*height_tiles=*/3);
+    ExpectOnlyCoverageRect(other_object, 0, 0, 0, 0);
+
+    const auto& fixed_object =
+        test_case.priority_on_upper ? object_upper : object_lower;
+    const auto& fixed_layout =
+        test_case.priority_on_upper ? layout_upper : layout_lower;
+    const auto& opposite_layout =
+        test_case.priority_on_upper ? layout_lower : layout_upper;
+    for (const int flank_x : {kX - 1, kX + 4}) {
+      ExpectPriorityRectSet(fixed_object, flank_x, kY, 1, 1);
+      ExpectPriorityRectSet(fixed_layout, flank_x, kY, 1, 1);
+    }
+    ExpectOnlyCoverageRect(fixed_layout, 0, 0, 0, 0);
+    ExpectOnlyCoverageRect(opposite_layout, 0, 0, 0, 0);
+    ExpectOnlyPriorityRect(opposite_layout, 0, 0, 0, 0);
+    ExpectBitmapFilledWith(fixed_layout, 255);
+    ExpectBitmapFilledWith(opposite_layout, 255);
+  }
 }
 
 TEST(ObjectDrawerRegistryReplayTest,

--- a/test/unit/zelda3/dungeon/object_drawer_registry_replay_test.cc
+++ b/test/unit/zelda3/dungeon/object_drawer_registry_replay_test.cc
@@ -23,6 +23,7 @@
 #include <cstdint>
 #include <filesystem>
 #include <fstream>
+#include <initializer_list>
 #include <set>
 #include <string>
 #include <unordered_map>
@@ -483,6 +484,13 @@ std::array<uint8_t, 0x10000> MakeOpaqueDoorGfx() {
   return gfx;
 }
 
+void InitializeEmptyDoorBuffer(gfx::BackgroundBuffer& bg) {
+  bg.EnsureBitmapInitialized();
+  bg.bitmap().Fill(255);
+  bg.ClearPriorityBuffer();
+  bg.ClearCoverageBuffer();
+}
+
 void WriteDoorObjectDataWords(std::vector<uint8_t>& rom_data, int object_offset,
                               uint16_t start_word, int word_count) {
   constexpr int kRoomDrawObjectDataBase = 0x1B52;
@@ -505,6 +513,123 @@ bool TileHasCoverage(const gfx::BackgroundBuffer& bg, int tile_x, int tile_y) {
   const int index = pixel_y * width + pixel_x;
   return index >= 0 && index < static_cast<int>(coverage.size()) &&
          coverage[index] != 0;
+}
+
+struct TileRect {
+  int x;
+  int y;
+  int width;
+  int height;
+};
+
+bool PixelIsInAnyTileRect(int pixel_x, int pixel_y,
+                          std::initializer_list<TileRect> rects) {
+  for (const auto& rect : rects) {
+    if (pixel_x >= rect.x * 8 && pixel_x < (rect.x + rect.width) * 8 &&
+        pixel_y >= rect.y * 8 && pixel_y < (rect.y + rect.height) * 8) {
+      return true;
+    }
+  }
+  return false;
+}
+
+void ExpectOnlyCoverageRects(const gfx::BackgroundBuffer& bg,
+                             std::initializer_list<TileRect> rects) {
+  const auto& coverage = bg.coverage_data();
+  ASSERT_EQ(coverage.size(),
+            static_cast<size_t>(bg.bitmap().width() * bg.bitmap().height()));
+  for (int y = 0; y < bg.bitmap().height(); ++y) {
+    for (int x = 0; x < bg.bitmap().width(); ++x) {
+      const bool expected = PixelIsInAnyTileRect(x, y, rects);
+      const bool actual = coverage[y * bg.bitmap().width() + x] != 0;
+      if (actual != expected) {
+        ADD_FAILURE() << "coverage mismatch at pixel (" << x << "," << y
+                      << ") expected=" << expected << " actual=" << actual;
+        return;
+      }
+    }
+  }
+}
+
+void ExpectOnlyCoverageRect(const gfx::BackgroundBuffer& bg, int start_tile_x,
+                            int start_tile_y, int width_tiles,
+                            int height_tiles) {
+  const auto& coverage = bg.coverage_data();
+  ASSERT_EQ(coverage.size(),
+            static_cast<size_t>(bg.bitmap().width() * bg.bitmap().height()));
+  const int start_x = start_tile_x * 8;
+  const int start_y = start_tile_y * 8;
+  const int end_x = (start_tile_x + width_tiles) * 8;
+  const int end_y = (start_tile_y + height_tiles) * 8;
+  for (int y = 0; y < bg.bitmap().height(); ++y) {
+    for (int x = 0; x < bg.bitmap().width(); ++x) {
+      const bool expected =
+          x >= start_x && x < end_x && y >= start_y && y < end_y;
+      const bool actual = coverage[y * bg.bitmap().width() + x] != 0;
+      if (actual != expected) {
+        ADD_FAILURE() << "coverage mismatch at pixel (" << x << "," << y
+                      << ") expected=" << expected << " actual=" << actual;
+        return;
+      }
+    }
+  }
+}
+
+void ExpectOnlyPriorityValueRect(const gfx::BackgroundBuffer& bg,
+                                 int start_tile_x, int start_tile_y,
+                                 int width_tiles, int height_tiles,
+                                 uint8_t priority_value) {
+  const auto& priority = bg.priority_data();
+  ASSERT_EQ(priority.size(),
+            static_cast<size_t>(bg.bitmap().width() * bg.bitmap().height()));
+  const int start_x = start_tile_x * 8;
+  const int start_y = start_tile_y * 8;
+  const int end_x = (start_tile_x + width_tiles) * 8;
+  const int end_y = (start_tile_y + height_tiles) * 8;
+  for (int y = 0; y < bg.bitmap().height(); ++y) {
+    for (int x = 0; x < bg.bitmap().width(); ++x) {
+      const bool promoted =
+          x >= start_x && x < end_x && y >= start_y && y < end_y;
+      const uint8_t expected = promoted ? priority_value : 0xFF;
+      const uint8_t actual = priority[y * bg.bitmap().width() + x];
+      if (actual != expected) {
+        ADD_FAILURE() << "priority mismatch at pixel (" << x << "," << y
+                      << ") expected=" << static_cast<int>(expected)
+                      << " actual=" << static_cast<int>(actual);
+        return;
+      }
+    }
+  }
+}
+
+void ExpectOnlyPriorityRect(const gfx::BackgroundBuffer& bg, int start_tile_x,
+                            int start_tile_y, int width_tiles,
+                            int height_tiles) {
+  ExpectOnlyPriorityValueRect(bg, start_tile_x, start_tile_y, width_tiles,
+                              height_tiles, /*priority_value=*/1);
+}
+
+void ExpectPriorityRectSet(const gfx::BackgroundBuffer& bg, int start_tile_x,
+                           int start_tile_y, int width_tiles,
+                           int height_tiles) {
+  for (int y = start_tile_y * 8; y < (start_tile_y + height_tiles) * 8; ++y) {
+    for (int x = start_tile_x * 8; x < (start_tile_x + width_tiles) * 8; ++x) {
+      ASSERT_EQ(bg.GetPriorityAt(x, y), 1)
+          << "priority not promoted at pixel (" << x << "," << y << ")";
+    }
+  }
+}
+
+void ExpectBitmapFilledWith(const gfx::BackgroundBuffer& bg, uint8_t value) {
+  const auto& pixels = bg.bitmap().vector();
+  for (size_t i = 0; i < pixels.size(); ++i) {
+    if (pixels[i] != value) {
+      ADD_FAILURE() << "bitmap mismatch at pixel index " << i
+                    << " expected=" << static_cast<int>(value)
+                    << " actual=" << static_cast<int>(pixels[i]);
+      return;
+    }
+  }
 }
 
 void WriteWord(std::vector<uint8_t>& rom_data, int addr, uint16_t value) {
@@ -779,10 +904,11 @@ TEST(ObjectDrawerRegistryReplayTest, NorthMiddleDoorsRenderBothSidesOfTheSeam) {
 
   drawer.DrawDoor(door, /*door_index=*/0, bg1, bg2, nullptr);
 
-  EXPECT_TRUE(TileHasCoverage(bg1, 14, 36));
-  EXPECT_TRUE(TileHasCoverage(bg1, 17, 38));
-  EXPECT_TRUE(TileHasCoverage(bg1, 14, 39));
-  EXPECT_TRUE(TileHasCoverage(bg1, 17, 39));
+  ExpectOnlyCoverageRects(bg1, {{14, 27, 4, 3},    // South-facing counterpart.
+                                {14, 36, 4, 3}});  // North-facing current half.
+  ExpectOnlyCoverageRect(bg2, 0, 0, 0, 0);
+  EXPECT_EQ(bg1.GetTileAt(14, 27), 0x0900);
+  EXPECT_EQ(bg1.GetTileAt(14, 36), 0x0800);
 }
 
 TEST(ObjectDrawerRegistryReplayTest,
@@ -825,6 +951,911 @@ TEST(ObjectDrawerRegistryReplayTest,
   EXPECT_FALSE(TileHasCoverage(bg1, 14, 62));
 }
 
+TEST(ObjectDrawerRegistryReplayTest,
+     EastDoorsRenderOneTileRightOfUsdasmTableAnchor) {
+  ScopedCustomObjectsFlag disable_custom(false);
+
+  constexpr int kDoorGfxEastTableBase = 0x4EC6;
+  constexpr int kEastObjectOffset = 0x0A30;
+
+  Rom rom;
+  std::vector<uint8_t> dummy_rom(1024 * 1024, 0);
+  WriteWord(dummy_rom, kDoorGfxEastTableBase, kEastObjectOffset);
+  WriteDoorObjectDataWords(dummy_rom, /*object_offset=*/kEastObjectOffset,
+                           /*start_word=*/0x0980, /*word_count=*/12);
+  rom.LoadFromData(dummy_rom);
+
+  auto gfx = MakeOpaqueDoorGfx();
+  ObjectDrawer drawer(&rom, /*room_id=*/0x42, gfx.data());
+
+  gfx::BackgroundBuffer bg1(512, 512);
+  gfx::BackgroundBuffer bg2(512, 512);
+  bg1.EnsureBitmapInitialized();
+  bg2.EnsureBitmapInitialized();
+  bg1.bitmap().Fill(255);
+  bg2.bitmap().Fill(255);
+  bg1.ClearCoverageBuffer();
+  bg2.ClearCoverageBuffer();
+
+  ObjectDrawer::DoorDef door{
+      .type = DoorType::NormalDoor,
+      .direction = DoorDirection::East,
+      .position = 9,
+  };
+
+  drawer.DrawDoor(door, /*door_index=*/0, bg1, bg2, nullptr);
+
+  EXPECT_FALSE(TileHasCoverage(bg1, 55, 15));
+  EXPECT_TRUE(TileHasCoverage(bg1, 56, 15));
+  EXPECT_TRUE(TileHasCoverage(bg1, 58, 18));
+  EXPECT_FALSE(TileHasCoverage(bg1, 59, 15));
+}
+
+TEST(ObjectDrawerRegistryReplayTest,
+     DoorControlMarkersDoNotOverwritePhysicalDoorArt) {
+  ScopedCustomObjectsFlag disable_custom(false);
+
+  constexpr int kDoorGfxNorthTableBase = 0x4D9E;
+  constexpr int kNormalLowerObjectOffset = 0x0A80;
+  constexpr uint16_t kFirstNormalLowerWord = 0x0840;
+
+  Rom rom;
+  std::vector<uint8_t> dummy_rom(1024 * 1024, 0);
+  WriteWord(
+      dummy_rom,
+      kDoorGfxNorthTableBase + static_cast<int>(DoorType::NormalDoorLower),
+      kNormalLowerObjectOffset);
+  WriteDoorObjectDataWords(dummy_rom,
+                           /*object_offset=*/kNormalLowerObjectOffset,
+                           /*start_word=*/kFirstNormalLowerWord,
+                           /*word_count=*/12);
+  rom.LoadFromData(dummy_rom);
+
+  auto gfx = MakeOpaqueDoorGfx();
+  ObjectDrawer drawer(&rom, /*room_id=*/0x76, gfx.data());
+
+  gfx::BackgroundBuffer bg1(512, 512);
+  gfx::BackgroundBuffer bg2(512, 512);
+  bg1.EnsureBitmapInitialized();
+  bg2.EnsureBitmapInitialized();
+  bg1.bitmap().Fill(255);
+  bg2.bitmap().Fill(255);
+  bg1.ClearCoverageBuffer();
+  bg2.ClearCoverageBuffer();
+
+  ObjectDrawer::DoorDef physical_door{
+      .type = DoorType::NormalDoorLower,
+      .direction = DoorDirection::North,
+      .position = 3,
+  };
+  drawer.DrawDoor(physical_door, /*door_index=*/0, bg1, bg2, nullptr);
+  ASSERT_EQ(bg1.GetTileAt(14, 7), kFirstNormalLowerWord);
+
+  ObjectDrawer::DoorDef marker{
+      .type = DoorType::LayerSwapMarker,
+      .direction = DoorDirection::North,
+      .position = 3,
+  };
+  drawer.DrawDoor(marker, /*door_index=*/1, bg1, bg2, nullptr);
+
+  EXPECT_EQ(bg1.GetTileAt(14, 7), kFirstNormalLowerWord);
+}
+
+TEST(ObjectDrawerRegistryReplayTest,
+     DoorControlMarkersHaveDirectionAwareZeroRasterSemantics) {
+  ScopedCustomObjectsFlag disable_custom(false);
+
+  Rom rom;
+  std::vector<uint8_t> dummy_rom(1024 * 1024, 0);
+  rom.LoadFromData(dummy_rom);
+
+  auto gfx = MakeOpaqueDoorGfx();
+  ObjectDrawer drawer(&rom, /*room_id=*/0x42, gfx.data());
+
+  auto marker_writes_pixels = [&](DoorType type, DoorDirection direction) {
+    gfx::BackgroundBuffer bg1(512, 512);
+    gfx::BackgroundBuffer bg2(512, 512);
+    bg1.EnsureBitmapInitialized();
+    bg2.EnsureBitmapInitialized();
+    bg1.bitmap().Fill(255);
+    bg2.bitmap().Fill(255);
+    bg1.ClearCoverageBuffer();
+    bg2.ClearCoverageBuffer();
+
+    ObjectDrawer::DoorDef marker{
+        .type = type,
+        .direction = direction,
+        .position = 0,
+    };
+    drawer.DrawDoor(marker, /*door_index=*/0, bg1, bg2, nullptr);
+    const auto [x, y] = marker.GetTileCoords();
+    return TileHasCoverage(bg1, x, y) || TileHasCoverage(bg2, x, y);
+  };
+
+  for (DoorDirection direction : {DoorDirection::North, DoorDirection::South,
+                                  DoorDirection::West, DoorDirection::East}) {
+    EXPECT_FALSE(marker_writes_pixels(DoorType::DungeonSwapMarker, direction));
+    EXPECT_FALSE(marker_writes_pixels(DoorType::LayerSwapMarker, direction));
+  }
+  EXPECT_FALSE(
+      marker_writes_pixels(DoorType::ExitMarker, DoorDirection::North));
+  EXPECT_FALSE(
+      marker_writes_pixels(DoorType::ExitMarker, DoorDirection::South));
+  EXPECT_TRUE(marker_writes_pixels(DoorType::ExitMarker, DoorDirection::West));
+  EXPECT_TRUE(marker_writes_pixels(DoorType::ExitMarker, DoorDirection::East));
+}
+
+TEST(ObjectDrawerRegistryReplayTest,
+     HighRangeDoorsSplitTilesBetweenUpperAndLowerBackgrounds) {
+  ScopedCustomObjectsFlag disable_custom(false);
+
+  constexpr int kDoorGfxNorthTableBase = 0x4D9E;
+  constexpr int kDoorGfxSouthTableBase = 0x4E06;
+  constexpr int kDoorGfxWestTableBase = 0x4E66;
+  constexpr int kDoorGfxEastTableBase = 0x4EC6;
+  constexpr int kHighRangeType = 0x40;
+  constexpr int kObjectOffset = 0x0AC0;
+  constexpr uint16_t kFirstWord = 0x0880;
+
+  Rom rom;
+  std::vector<uint8_t> dummy_rom(1024 * 1024, 0);
+  for (int table_base : {kDoorGfxNorthTableBase, kDoorGfxSouthTableBase,
+                         kDoorGfxWestTableBase, kDoorGfxEastTableBase}) {
+    WriteWord(dummy_rom, table_base + kHighRangeType, kObjectOffset);
+  }
+  WriteDoorObjectDataWords(dummy_rom, /*object_offset=*/kObjectOffset,
+                           /*start_word=*/kFirstWord, /*word_count=*/12);
+  rom.LoadFromData(dummy_rom);
+
+  auto gfx = MakeOpaqueDoorGfx();
+  ObjectDrawer drawer(&rom, /*room_id=*/0x42, gfx.data());
+
+  auto verify_direction = [&](DoorDirection direction, int start_x,
+                              int start_y) {
+    SCOPED_TRACE(static_cast<int>(direction));
+    gfx::BackgroundBuffer bg1(512, 512);
+    gfx::BackgroundBuffer bg2(512, 512);
+    bg1.EnsureBitmapInitialized();
+    bg2.EnsureBitmapInitialized();
+    bg1.bitmap().Fill(255);
+    bg2.bitmap().Fill(255);
+    bg1.ClearCoverageBuffer();
+    bg2.ClearCoverageBuffer();
+
+    ObjectDrawer::DoorDef door{
+        .type = DoorType::NormalDoorOneSidedShutter,
+        .direction = direction,
+        .position = 0,
+    };
+    drawer.DrawDoor(door, /*door_index=*/0, bg1, bg2, nullptr);
+
+    const auto dims = door.GetDimensions();
+    int tile_idx = 0;
+    for (int dx = 0; dx < dims.width_tiles; ++dx) {
+      for (int dy = 0; dy < dims.height_tiles; ++dy) {
+        bool upper = false;
+        switch (direction) {
+          case DoorDirection::North:
+            upper = dy == 0;
+            break;
+          case DoorDirection::South:
+            upper = dy == dims.height_tiles - 1;
+            break;
+          case DoorDirection::West:
+            upper = dx == 0;
+            break;
+          case DoorDirection::East:
+            upper = dx == dims.width_tiles - 1;
+            break;
+        }
+        const int x = start_x + dx;
+        const int y = start_y + dy;
+        EXPECT_EQ(TileHasCoverage(bg1, x, y), upper);
+        EXPECT_EQ(TileHasCoverage(bg2, x, y), !upper);
+        const auto& owner = upper ? bg1 : bg2;
+        EXPECT_EQ(owner.GetTileAt(x, y),
+                  static_cast<uint16_t>(kFirstWord + tile_idx));
+        ++tile_idx;
+      }
+    }
+  };
+
+  verify_direction(DoorDirection::North, /*start_x=*/14, /*start_y=*/4);
+  verify_direction(DoorDirection::South, /*start_x=*/14, /*start_y=*/27);
+  verify_direction(DoorDirection::West, /*start_x=*/2, /*start_y=*/15);
+  verify_direction(DoorDirection::East, /*start_x=*/27, /*start_y=*/15);
+}
+
+TEST(ObjectDrawerRegistryReplayTest,
+     NormalLowerDoorsPromoteFixedUsdasmRegionsAndStillRaster) {
+  ScopedCustomObjectsFlag disable_custom(false);
+
+  constexpr int kDoorGfxNorthTableBase = 0x4D9E;
+  constexpr int kDoorGfxSouthTableBase = 0x4E06;
+  constexpr int kDoorGfxWestTableBase = 0x4E66;
+  constexpr int kDoorGfxEastTableBase = 0x4EC6;
+  constexpr int kObjectOffset = 0x0AE0;
+
+  Rom rom;
+  std::vector<uint8_t> dummy_rom(1024 * 1024, 0);
+  for (int table_base : {kDoorGfxNorthTableBase, kDoorGfxSouthTableBase,
+                         kDoorGfxWestTableBase, kDoorGfxEastTableBase}) {
+    WriteWord(dummy_rom,
+              table_base + static_cast<int>(DoorType::NormalDoorLower),
+              kObjectOffset);
+  }
+  WriteDoorObjectDataWords(dummy_rom, /*object_offset=*/kObjectOffset,
+                           /*start_word=*/0x0840, /*word_count=*/12);
+  rom.LoadFromData(dummy_rom);
+
+  auto gfx = MakeOpaqueDoorGfx();
+  ObjectDrawer drawer(&rom, /*room_id=*/0x42, gfx.data());
+
+  struct PriorityCase {
+    DoorDirection direction;
+    uint8_t position;
+    int render_x;
+    int render_y;
+    int priority_x;
+    int priority_y;
+    int priority_width;
+    int priority_height;
+  };
+  const std::array<PriorityCase, 4> cases = {{
+      {DoorDirection::North, 3, 14, 7, 14, 0, 4, 7},
+      {DoorDirection::South, 3, 14, 24, 14, 27, 4, 7},
+      {DoorDirection::West, 3, 5, 15, 0, 15, 5, 4},
+      {DoorDirection::East, 3, 24, 15, 27, 15, 5, 4},
+  }};
+
+  for (const auto& test_case : cases) {
+    SCOPED_TRACE(static_cast<int>(test_case.direction));
+    gfx::BackgroundBuffer bg1(512, 512);
+    gfx::BackgroundBuffer bg2(512, 512);
+    gfx::BackgroundBuffer layout_bg1(512, 512);
+    gfx::BackgroundBuffer layout_bg2(512, 512);
+    for (auto* buffer : {&bg1, &bg2, &layout_bg1, &layout_bg2}) {
+      InitializeEmptyDoorBuffer(*buffer);
+    }
+
+    ObjectDrawer::DoorDef door{
+        .type = DoorType::NormalDoorLower,
+        .direction = test_case.direction,
+        .position = test_case.position,
+    };
+    drawer.DrawDoor(door, /*door_index=*/0, bg1, bg2, nullptr, &layout_bg1,
+                    &layout_bg2);
+
+    const auto dims = door.GetDimensions();
+    ExpectOnlyCoverageRect(bg1, test_case.render_x, test_case.render_y,
+                           dims.width_tiles, dims.height_tiles);
+    ExpectOnlyCoverageRect(bg2, 0, 0, 0, 0);
+    ExpectOnlyPriorityRect(layout_bg1, test_case.priority_x,
+                           test_case.priority_y, test_case.priority_width,
+                           test_case.priority_height);
+    ExpectOnlyPriorityRect(layout_bg2, 0, 0, 0, 0);
+    ExpectPriorityRectSet(bg1, test_case.priority_x, test_case.priority_y,
+                          test_case.priority_width, test_case.priority_height);
+    ExpectOnlyCoverageRect(layout_bg1, 0, 0, 0, 0);
+    ExpectBitmapFilledWith(layout_bg1, 255);
+  }
+}
+
+TEST(ObjectDrawerRegistryReplayTest,
+     NormalLowerMiddleDoorsUseSeparatedCounterpartsAndPromoteBothWalls) {
+  ScopedCustomObjectsFlag disable_custom(false);
+
+  constexpr std::array<int, 4> kDoorTableBases = {
+      0x4D9E,  // North
+      0x4E06,  // South
+      0x4E66,  // West
+      0x4EC6,  // East
+  };
+  constexpr int kObjectOffset = 0x0B80;
+
+  Rom rom;
+  std::vector<uint8_t> dummy_rom(1024 * 1024, 0);
+  for (int table_base : kDoorTableBases) {
+    WriteWord(dummy_rom,
+              table_base + static_cast<int>(DoorType::NormalDoorLower),
+              kObjectOffset);
+  }
+  WriteDoorObjectDataWords(dummy_rom, /*object_offset=*/kObjectOffset,
+                           /*start_word=*/0x0940, /*word_count=*/12);
+  rom.LoadFromData(dummy_rom);
+
+  auto gfx = MakeOpaqueDoorGfx();
+  ObjectDrawer drawer(&rom, /*room_id=*/0x42, gfx.data());
+
+  auto verify = [&](DoorDirection direction) {
+    SCOPED_TRACE(static_cast<int>(direction));
+    gfx::BackgroundBuffer bg1(512, 512);
+    gfx::BackgroundBuffer bg2(512, 512);
+    gfx::BackgroundBuffer layout_bg1(512, 512);
+    gfx::BackgroundBuffer layout_bg2(512, 512);
+    for (auto* buffer : {&bg1, &bg2, &layout_bg1, &layout_bg2}) {
+      InitializeEmptyDoorBuffer(*buffer);
+    }
+
+    ObjectDrawer::DoorDef door{
+        .type = DoorType::NormalDoorLower,
+        .direction = direction,
+        .position = 6,
+    };
+    drawer.DrawDoor(door, /*door_index=*/0, bg1, bg2, nullptr, &layout_bg1,
+                    &layout_bg2);
+
+    if (direction == DoorDirection::North) {
+      ExpectOnlyCoverageRects(bg1, {{14, 27, 4, 3}, {14, 36, 4, 3}});
+      ExpectOnlyPriorityRect(layout_bg1, 14, 30, 4, 9);
+    } else {
+      ExpectOnlyCoverageRects(bg1, {{27, 15, 3, 4}, {34, 15, 3, 4}});
+      ExpectOnlyPriorityRect(layout_bg1, 30, 15, 7, 4);
+    }
+    ExpectOnlyCoverageRect(bg2, 0, 0, 0, 0);
+    ExpectOnlyPriorityRect(layout_bg2, 0, 0, 0, 0);
+  };
+
+  verify(DoorDirection::North);
+  verify(DoorDirection::West);
+}
+
+TEST(ObjectDrawerRegistryReplayTest,
+     Type06PromotesBothUpperOwnersWithoutRasterizing) {
+  ScopedCustomObjectsFlag disable_custom(false);
+
+  Rom rom;
+  std::vector<uint8_t> dummy_rom(1024 * 1024, 0);
+  rom.LoadFromData(dummy_rom);
+
+  auto gfx = MakeOpaqueDoorGfx();
+  ObjectDrawer drawer(&rom, /*room_id=*/0x42, gfx.data());
+
+  struct PriorityCase {
+    DoorDirection direction;
+    uint8_t position;
+    int priority_x;
+    int priority_y;
+    int priority_width;
+    int priority_height;
+  };
+  const std::array<PriorityCase, 4> cases = {{
+      {DoorDirection::North, 3, 14, 0, 4, 8},
+      {DoorDirection::South, 3, 14, 25, 4, 7},
+      {DoorDirection::West, 3, 0, 15, 6, 4},
+      {DoorDirection::East, 3, 25, 15, 7, 4},
+  }};
+
+  for (const auto& test_case : cases) {
+    SCOPED_TRACE(static_cast<int>(test_case.direction));
+    gfx::BackgroundBuffer bg1(512, 512);
+    gfx::BackgroundBuffer bg2(512, 512);
+    gfx::BackgroundBuffer layout_bg1(512, 512);
+    gfx::BackgroundBuffer layout_bg2(512, 512);
+    for (auto* buffer : {&bg1, &bg2, &layout_bg1, &layout_bg2}) {
+      InitializeEmptyDoorBuffer(*buffer);
+    }
+
+    ObjectDrawer::DoorDef door{
+        .type = DoorType::UnusedCaveExit,
+        .direction = test_case.direction,
+        .position = test_case.position,
+    };
+    drawer.DrawDoor(door, /*door_index=*/0, bg1, bg2, nullptr, &layout_bg1,
+                    &layout_bg2);
+
+    ExpectOnlyCoverageRect(bg1, 0, 0, 0, 0);
+    ExpectOnlyCoverageRect(bg2, 0, 0, 0, 0);
+    ExpectOnlyPriorityRect(bg1, test_case.priority_x, test_case.priority_y,
+                           test_case.priority_width, test_case.priority_height);
+    ExpectOnlyPriorityRect(layout_bg1, test_case.priority_x,
+                           test_case.priority_y, test_case.priority_width,
+                           test_case.priority_height);
+    ExpectOnlyPriorityRect(bg2, 0, 0, 0, 0);
+    ExpectOnlyPriorityRect(layout_bg2, 0, 0, 0, 0);
+    for (const auto* buffer : {&bg1, &bg2, &layout_bg1, &layout_bg2}) {
+      ExpectBitmapFilledWith(*buffer, 255);
+    }
+  }
+}
+
+TEST(ObjectDrawerRegistryReplayTest,
+     HighRangeDoorsPromoteDirectionalUsdasmRegions) {
+  ScopedCustomObjectsFlag disable_custom(false);
+
+  constexpr int kDoorGfxNorthTableBase = 0x4D9E;
+  constexpr int kDoorGfxSouthTableBase = 0x4E06;
+  constexpr int kDoorGfxWestTableBase = 0x4E66;
+  constexpr int kDoorGfxEastTableBase = 0x4EC6;
+  constexpr int kObjectOffset = 0x0B00;
+
+  Rom rom;
+  std::vector<uint8_t> dummy_rom(1024 * 1024, 0);
+  for (int table_base : {kDoorGfxNorthTableBase, kDoorGfxSouthTableBase,
+                         kDoorGfxWestTableBase, kDoorGfxEastTableBase}) {
+    for (int type : {0x40, 0x46, 0x66}) {
+      WriteWord(dummy_rom, table_base + type, kObjectOffset);
+    }
+  }
+  WriteDoorObjectDataWords(dummy_rom, /*object_offset=*/kObjectOffset,
+                           /*start_word=*/0x0880, /*word_count=*/12);
+  rom.LoadFromData(dummy_rom);
+
+  auto gfx = MakeOpaqueDoorGfx();
+  ObjectDrawer drawer(&rom, /*room_id=*/0x42, gfx.data());
+
+  struct PriorityCase {
+    DoorType type;
+    DoorDirection direction;
+    int priority_x;
+    int priority_y;
+    int priority_width;
+    int priority_height;
+  };
+  const std::array<PriorityCase, 6> cases = {{
+      {DoorType::NormalDoorOneSidedShutter, DoorDirection::North, 14, 0, 4, 4},
+      {DoorType::NormalDoorOneSidedShutter, DoorDirection::South, 14, 30, 4, 2},
+      {DoorType::NormalDoorOneSidedShutter, DoorDirection::West, 0, 15, 2, 4},
+      {DoorType::NormalDoorOneSidedShutter, DoorDirection::East, 30, 15, 2, 4},
+      // North explicit-room doors raster across BG1/BG2 but skip priority.
+      {DoorType::ExplicitRoomDoor, DoorDirection::North, 0, 0, 0, 0},
+      // Verify the upper inclusive endpoint of the supported high range.
+      {static_cast<DoorType>(0x66), DoorDirection::North, 14, 0, 4, 4},
+  }};
+
+  for (const auto& test_case : cases) {
+    SCOPED_TRACE(::testing::Message()
+                 << "type=" << static_cast<int>(test_case.type)
+                 << " direction=" << static_cast<int>(test_case.direction));
+    gfx::BackgroundBuffer bg1(512, 512);
+    gfx::BackgroundBuffer bg2(512, 512);
+    gfx::BackgroundBuffer layout_bg1(512, 512);
+    gfx::BackgroundBuffer layout_bg2(512, 512);
+    for (auto* buffer : {&bg1, &bg2, &layout_bg1, &layout_bg2}) {
+      InitializeEmptyDoorBuffer(*buffer);
+    }
+
+    ObjectDrawer::DoorDef door{
+        .type = test_case.type,
+        .direction = test_case.direction,
+        .position = 0,
+    };
+    drawer.DrawDoor(door, /*door_index=*/0, bg1, bg2, nullptr, &layout_bg1,
+                    &layout_bg2);
+
+    ExpectOnlyPriorityRect(layout_bg1, test_case.priority_x,
+                           test_case.priority_y, test_case.priority_width,
+                           test_case.priority_height);
+    ExpectOnlyPriorityRect(layout_bg2, 0, 0, 0, 0);
+    EXPECT_TRUE(TileHasCoverage(bg1, door.GetTileCoords().first,
+                                door.GetTileCoords().second) ||
+                TileHasCoverage(bg2, door.GetTileCoords().first,
+                                door.GetTileCoords().second));
+  }
+}
+
+TEST(ObjectDrawerRegistryReplayTest,
+     HighRangeMiddleDoorsSeparateCounterpartRasterAndPriority) {
+  ScopedCustomObjectsFlag disable_custom(false);
+
+  constexpr std::array<int, 4> kDoorTableBases = {
+      0x4D9E,  // North
+      0x4E06,  // South
+      0x4E66,  // West
+      0x4EC6,  // East
+  };
+  constexpr int kObjectOffset = 0x0BA0;
+
+  Rom rom;
+  std::vector<uint8_t> dummy_rom(1024 * 1024, 0);
+  for (int table_base : kDoorTableBases) {
+    WriteWord(
+        dummy_rom,
+        table_base + static_cast<int>(DoorType::NormalDoorOneSidedShutter),
+        kObjectOffset);
+  }
+  WriteDoorObjectDataWords(dummy_rom, /*object_offset=*/kObjectOffset,
+                           /*start_word=*/0x0980, /*word_count=*/12);
+  rom.LoadFromData(dummy_rom);
+
+  auto gfx = MakeOpaqueDoorGfx();
+  ObjectDrawer drawer(&rom, /*room_id=*/0x42, gfx.data());
+
+  auto verify = [&](DoorDirection direction) {
+    SCOPED_TRACE(static_cast<int>(direction));
+    gfx::BackgroundBuffer bg1(512, 512);
+    gfx::BackgroundBuffer bg2(512, 512);
+    gfx::BackgroundBuffer layout_bg1(512, 512);
+    gfx::BackgroundBuffer layout_bg2(512, 512);
+    for (auto* buffer : {&bg1, &bg2, &layout_bg1, &layout_bg2}) {
+      InitializeEmptyDoorBuffer(*buffer);
+    }
+
+    ObjectDrawer::DoorDef door{
+        .type = DoorType::NormalDoorOneSidedShutter,
+        .direction = direction,
+        .position = 6,
+    };
+    drawer.DrawDoor(door, /*door_index=*/0, bg1, bg2, nullptr, &layout_bg1,
+                    &layout_bg2);
+
+    if (direction == DoorDirection::North) {
+      ExpectOnlyCoverageRects(bg1, {{14, 29, 4, 1}, {14, 36, 4, 1}});
+      ExpectOnlyCoverageRects(bg2, {{14, 27, 4, 2}, {14, 37, 4, 2}});
+      ExpectOnlyPriorityRect(layout_bg1, 14, 30, 4, 6);
+    } else {
+      ExpectOnlyCoverageRects(bg1, {{29, 15, 1, 4}, {34, 15, 1, 4}});
+      ExpectOnlyCoverageRects(bg2, {{27, 15, 2, 4}, {35, 15, 2, 4}});
+      ExpectOnlyPriorityRect(layout_bg1, 30, 15, 4, 4);
+    }
+    ExpectOnlyPriorityRect(layout_bg2, 0, 0, 0, 0);
+  };
+
+  verify(DoorDirection::North);
+  verify(DoorDirection::West);
+}
+
+TEST(ObjectDrawerRegistryReplayTest,
+     NorthLowerKeyStairsRasterOnlyToLowerBackground) {
+  ScopedCustomObjectsFlag disable_custom(false);
+
+  constexpr int kDoorGfxNorthTableBase = 0x4D9E;
+  constexpr int kObjectOffset = 0x0B20;
+  constexpr uint16_t kFirstWord = 0x08C0;
+
+  Rom rom;
+  std::vector<uint8_t> dummy_rom(1024 * 1024, 0);
+  for (DoorType type :
+       {DoorType::SmallKeyStairsUpLower, DoorType::SmallKeyStairsDownLower}) {
+    WriteWord(dummy_rom, kDoorGfxNorthTableBase + static_cast<int>(type),
+              kObjectOffset);
+  }
+  WriteDoorObjectDataWords(dummy_rom, /*object_offset=*/kObjectOffset,
+                           /*start_word=*/kFirstWord, /*word_count=*/12);
+  rom.LoadFromData(dummy_rom);
+
+  auto gfx = MakeOpaqueDoorGfx();
+  ObjectDrawer drawer(&rom, /*room_id=*/0x42, gfx.data());
+
+  for (DoorType type :
+       {DoorType::SmallKeyStairsUpLower, DoorType::SmallKeyStairsDownLower}) {
+    SCOPED_TRACE(static_cast<int>(type));
+    gfx::BackgroundBuffer bg1(512, 512);
+    gfx::BackgroundBuffer bg2(512, 512);
+    gfx::BackgroundBuffer layout_bg1(512, 512);
+    gfx::BackgroundBuffer layout_bg2(512, 512);
+    for (auto* buffer : {&bg1, &bg2, &layout_bg1, &layout_bg2}) {
+      InitializeEmptyDoorBuffer(*buffer);
+    }
+
+    ObjectDrawer::DoorDef door{
+        .type = type,
+        .direction = DoorDirection::North,
+        .position = 6,
+    };
+    drawer.DrawDoor(door, /*door_index=*/0, bg1, bg2, nullptr, &layout_bg1,
+                    &layout_bg2);
+
+    ExpectOnlyCoverageRect(bg1, 0, 0, 0, 0);
+    ExpectOnlyCoverageRect(bg2, 14, 36, 4, 3);
+    EXPECT_EQ(bg2.GetTileAt(14, 36), kFirstWord);
+    ExpectOnlyPriorityRect(layout_bg1, 0, 0, 0, 0);
+    ExpectOnlyPriorityRect(layout_bg2, 0, 0, 0, 0);
+
+    gfx::BackgroundBuffer open_bg1(512, 512);
+    gfx::BackgroundBuffer open_bg2(512, 512);
+    InitializeEmptyDoorBuffer(open_bg1);
+    InitializeEmptyDoorBuffer(open_bg2);
+    FakeDungeonState open_state;
+    open_state.open_lock_room_id = 0x42;
+    drawer.DrawDoor(door, /*door_index=*/0, open_bg1, open_bg2, &open_state);
+    ExpectOnlyCoverageRect(open_bg1, 0, 0, 0, 0);
+    ExpectOnlyCoverageRect(open_bg2, 0, 0, 0, 0);
+  }
+}
+
+TEST(ObjectDrawerRegistryReplayTest,
+     SouthBigKeyDoorUsesNormalDoorTableEntryWhenClosed) {
+  ScopedCustomObjectsFlag disable_custom(false);
+
+  constexpr int kDoorGfxSouthTableBase = 0x4E06;
+  constexpr int kNormalObjectOffset = 0x0B40;
+  constexpr int kBigKeyObjectOffset = 0x0B60;
+  constexpr uint16_t kNormalFirstWord = 0x0900;
+  constexpr uint16_t kBigKeyFirstWord = 0x0A00;
+
+  Rom rom;
+  std::vector<uint8_t> dummy_rom(1024 * 1024, 0);
+  WriteWord(dummy_rom,
+            kDoorGfxSouthTableBase + static_cast<int>(DoorType::NormalDoor),
+            kNormalObjectOffset);
+  WriteWord(dummy_rom,
+            kDoorGfxSouthTableBase + static_cast<int>(DoorType::BigKeyDoor),
+            kBigKeyObjectOffset);
+  WriteDoorObjectDataWords(dummy_rom, /*object_offset=*/kNormalObjectOffset,
+                           /*start_word=*/kNormalFirstWord,
+                           /*word_count=*/12);
+  WriteDoorObjectDataWords(dummy_rom, /*object_offset=*/kBigKeyObjectOffset,
+                           /*start_word=*/kBigKeyFirstWord,
+                           /*word_count=*/12);
+  rom.LoadFromData(dummy_rom);
+
+  auto gfx = MakeOpaqueDoorGfx();
+  ObjectDrawer drawer(&rom, /*room_id=*/0x42, gfx.data());
+  gfx::BackgroundBuffer bg1(512, 512);
+  gfx::BackgroundBuffer bg2(512, 512);
+  InitializeEmptyDoorBuffer(bg1);
+  InitializeEmptyDoorBuffer(bg2);
+
+  ObjectDrawer::DoorDef door{
+      .type = DoorType::BigKeyDoor,
+      .direction = DoorDirection::South,
+      .position = 0,
+  };
+  drawer.DrawDoor(door, /*door_index=*/0, bg1, bg2, nullptr);
+
+  ExpectOnlyCoverageRect(bg1, 14, 27, 4, 3);
+  ExpectOnlyCoverageRect(bg2, 0, 0, 0, 0);
+  EXPECT_EQ(bg1.GetTileAt(14, 27), kNormalFirstWord);
+  EXPECT_NE(bg1.GetTileAt(14, 27), kBigKeyFirstWord);
+}
+
+TEST(ObjectDrawerRegistryReplayTest,
+     SouthFancyExitUsesUsdasmTenByEightRowMajorStamp) {
+  ScopedCustomObjectsFlag disable_custom(false);
+
+  constexpr int kFancyDungeonExitObjectOffset = 0x2656;
+  constexpr uint16_t kFirstWord = 0x0800;
+
+  Rom rom;
+  std::vector<uint8_t> dummy_rom(1024 * 1024, 0);
+  WriteDoorObjectDataWords(dummy_rom, kFancyDungeonExitObjectOffset, kFirstWord,
+                           /*word_count=*/80);
+  rom.LoadFromData(dummy_rom);
+
+  auto gfx = MakeOpaqueDoorGfx();
+  ObjectDrawer drawer(&rom, /*room_id=*/0x05, gfx.data());
+  gfx::BackgroundBuffer bg1(512, 512);
+  gfx::BackgroundBuffer bg2(512, 512);
+  InitializeEmptyDoorBuffer(bg1);
+  InitializeEmptyDoorBuffer(bg2);
+
+  ObjectDrawer::DoorDef fancy_exit{
+      .type = DoorType::FancyDungeonExit,
+      .direction = DoorDirection::South,
+      .position = 8,
+  };
+  drawer.DrawDoor(fancy_exit, /*door_index=*/0, bg1, bg2, nullptr);
+
+  // Room $005 uses raw South anchor (46,58). RoomDraw_SomeBigDecors subtracts
+  // three columns/four rows and consumes ten words per destination row.
+  ExpectOnlyCoverageRect(bg1, 43, 54, 10, 8);
+  ExpectOnlyCoverageRect(bg2, 0, 0, 0, 0);
+  ExpectOnlyPriorityValueRect(bg1, 43, 54, 10, 8,
+                              /*priority_value=*/0);
+  for (int dy = 0; dy < 8; ++dy) {
+    for (int dx = 0; dx < 10; ++dx) {
+      EXPECT_EQ(bg1.GetTileAt(43 + dx, 54 + dy),
+                static_cast<uint16_t>(kFirstWord + dy * 10 + dx));
+    }
+  }
+
+  ObjectDrawer::DoorDef exit_marker{
+      .type = DoorType::ExitMarker,
+      .direction = DoorDirection::South,
+      .position = 8,
+  };
+  drawer.DrawDoor(exit_marker, /*door_index=*/1, bg1, bg2, nullptr);
+
+  // The paired marker must preserve both the outer frame and center bottom
+  // row of the physical exit.
+  ExpectOnlyCoverageRect(bg1, 43, 54, 10, 8);
+  EXPECT_EQ(bg1.GetTileAt(43, 54), kFirstWord);
+  for (int dx = 3; dx < 7; ++dx) {
+    EXPECT_EQ(bg1.GetTileAt(43 + dx, 61), kFirstWord + 70 + dx);
+  }
+}
+
+TEST(ObjectDrawerRegistryReplayTest,
+     SouthLowerFancyExitCopiesOnlyPriorityBottomRowToUpperBackground) {
+  ScopedCustomObjectsFlag disable_custom(false);
+
+  constexpr int kFancyDungeonExitObjectOffset = 0x2656;
+  constexpr uint16_t kFirstWord = 0x0900;
+
+  Rom rom;
+  std::vector<uint8_t> dummy_rom(1024 * 1024, 0);
+  WriteDoorObjectDataWords(dummy_rom, kFancyDungeonExitObjectOffset, kFirstWord,
+                           /*word_count=*/80);
+  rom.LoadFromData(dummy_rom);
+
+  auto gfx = MakeOpaqueDoorGfx();
+  ObjectDrawer drawer(&rom, /*room_id=*/0x42, gfx.data());
+  gfx::BackgroundBuffer bg1(512, 512);
+  gfx::BackgroundBuffer bg2(512, 512);
+  InitializeEmptyDoorBuffer(bg1);
+  InitializeEmptyDoorBuffer(bg2);
+
+  ObjectDrawer::DoorDef door{
+      .type = DoorType::FancyDungeonExitLower,
+      .direction = DoorDirection::South,
+      .position = 8,
+  };
+  drawer.DrawDoor(door, /*door_index=*/0, bg1, bg2, nullptr);
+
+  ExpectOnlyCoverageRect(bg2, 43, 54, 10, 8);
+  ExpectOnlyCoverageRect(bg1, 43, 61, 10, 1);
+  ExpectOnlyPriorityValueRect(bg2, 43, 54, 10, 8,
+                              /*priority_value=*/0);
+  ExpectOnlyPriorityRect(bg1, 43, 61, 10, 1);
+  for (int dy = 0; dy < 8; ++dy) {
+    for (int dx = 0; dx < 10; ++dx) {
+      EXPECT_EQ(bg2.GetTileAt(43 + dx, 54 + dy),
+                static_cast<uint16_t>(kFirstWord + dy * 10 + dx));
+    }
+  }
+  for (int dx = 0; dx < 10; ++dx) {
+    EXPECT_EQ(bg1.GetTileAt(43 + dx, 61),
+              static_cast<uint16_t>((kFirstWord + 70 + dx) | 0x2000));
+  }
+}
+
+TEST(ObjectDrawerRegistryReplayTest,
+     SouthExitLowerUsesRawAnchorLowerLayerAndPriorityUpperRowCopy) {
+  ScopedCustomObjectsFlag disable_custom(false);
+
+  constexpr int kCaveExitLightObjectOffset = 0x26F6;
+  constexpr uint16_t kFirstWord = 0x0800;
+
+  Rom rom;
+  std::vector<uint8_t> dummy_rom(1024 * 1024, 0);
+  WriteDoorObjectDataWords(dummy_rom, kCaveExitLightObjectOffset, kFirstWord,
+                           /*word_count=*/16);
+  rom.LoadFromData(dummy_rom);
+
+  auto gfx = MakeOpaqueDoorGfx();
+  ObjectDrawer drawer(&rom, /*room_id=*/0x42, gfx.data());
+  gfx::BackgroundBuffer bg1(512, 512);
+  gfx::BackgroundBuffer bg2(512, 512);
+  gfx::BackgroundBuffer layout_bg1(512, 512);
+  gfx::BackgroundBuffer layout_bg2(512, 512);
+  for (auto* buffer : {&bg1, &bg2, &layout_bg1, &layout_bg2}) {
+    InitializeEmptyDoorBuffer(*buffer);
+  }
+
+  ObjectDrawer::DoorDef door{
+      .type = DoorType::ExitLower,
+      .direction = DoorDirection::South,
+      .position = 0,
+  };
+  drawer.DrawDoor(door, /*door_index=*/0, bg1, bg2, nullptr, &layout_bg1,
+                  &layout_bg2);
+
+  ExpectOnlyCoverageRect(bg2, 14, 26, 4, 4);
+  ExpectOnlyCoverageRect(bg1, 14, 29, 4, 1);
+  for (int dx = 0; dx < 4; ++dx) {
+    for (int dy = 0; dy < 4; ++dy) {
+      EXPECT_EQ(bg2.GetTileAt(14 + dx, 26 + dy),
+                static_cast<uint16_t>(kFirstWord + dx * 4 + dy));
+    }
+    EXPECT_EQ(bg1.GetTileAt(14 + dx, 29),
+              static_cast<uint16_t>((kFirstWord + dx * 4 + 3) | 0x2000));
+  }
+  ExpectOnlyPriorityRect(bg1, 14, 29, 4, 1);
+  ExpectOnlyPriorityRect(layout_bg1, 0, 0, 0, 0);
+  ExpectOnlyPriorityRect(layout_bg2, 14, 30, 4, 7);
+  ExpectPriorityRectSet(bg2, 14, 30, 4, 7);
+}
+
+TEST(ObjectDrawerRegistryReplayTest,
+     SouthCaveExitAndLitLowerExitUseRawFourByFourAnchor) {
+  ScopedCustomObjectsFlag disable_custom(false);
+
+  constexpr int kCaveExitLightObjectOffset = 0x26F6;
+  constexpr uint16_t kFirstWord = 0x0880;
+
+  Rom rom;
+  std::vector<uint8_t> dummy_rom(1024 * 1024, 0);
+  WriteDoorObjectDataWords(dummy_rom, kCaveExitLightObjectOffset, kFirstWord,
+                           /*word_count=*/16);
+  rom.LoadFromData(dummy_rom);
+
+  auto gfx = MakeOpaqueDoorGfx();
+  ObjectDrawer drawer(&rom, /*room_id=*/0x42, gfx.data());
+
+  for (DoorType type : {DoorType::CaveExit, DoorType::LitCaveExitLower}) {
+    SCOPED_TRACE(static_cast<int>(type));
+    gfx::BackgroundBuffer bg1(512, 512);
+    gfx::BackgroundBuffer bg2(512, 512);
+    gfx::BackgroundBuffer layout_bg1(512, 512);
+    gfx::BackgroundBuffer layout_bg2(512, 512);
+    for (auto* buffer : {&bg1, &bg2, &layout_bg1, &layout_bg2}) {
+      InitializeEmptyDoorBuffer(*buffer);
+    }
+
+    ObjectDrawer::DoorDef door{
+        .type = type,
+        .direction = DoorDirection::South,
+        .position = 0,
+    };
+    drawer.DrawDoor(door, /*door_index=*/0, bg1, bg2, nullptr, &layout_bg1,
+                    &layout_bg2);
+
+    ExpectOnlyCoverageRect(bg1, 14, 26, 4, 4);
+    ExpectOnlyCoverageRect(bg2, 0, 0, 0, 0);
+    for (int dx = 0; dx < 4; ++dx) {
+      for (int dy = 0; dy < 4; ++dy) {
+        EXPECT_EQ(bg1.GetTileAt(14 + dx, 26 + dy),
+                  static_cast<uint16_t>(kFirstWord + dx * 4 + dy));
+      }
+    }
+    if (type == DoorType::LitCaveExitLower) {
+      ExpectOnlyPriorityRect(layout_bg1, 14, 30, 4, 7);
+      ExpectPriorityRectSet(bg1, 14, 30, 4, 7);
+    } else {
+      ExpectOnlyPriorityRect(layout_bg1, 0, 0, 0, 0);
+    }
+    ExpectOnlyPriorityRect(layout_bg2, 0, 0, 0, 0);
+  }
+}
+
+TEST(ObjectDrawerRegistryReplayTest,
+     SouthSpecialExitStampsAreInvariantWhenDoorStateIsOpen) {
+  ScopedCustomObjectsFlag disable_custom(false);
+
+  constexpr int kFancyDungeonExitObjectOffset = 0x2656;
+  constexpr int kCaveExitLightObjectOffset = 0x26F6;
+  constexpr uint16_t kFirstWord = 0x0800;
+
+  Rom rom;
+  std::vector<uint8_t> dummy_rom(1024 * 1024, 0);
+  WriteDoorObjectDataWords(dummy_rom, kFancyDungeonExitObjectOffset, kFirstWord,
+                           /*word_count=*/80);
+  WriteDoorObjectDataWords(dummy_rom, kCaveExitLightObjectOffset, kFirstWord,
+                           /*word_count=*/16);
+  rom.LoadFromData(dummy_rom);
+
+  auto gfx = MakeOpaqueDoorGfx();
+  ObjectDrawer drawer(&rom, /*room_id=*/0x42, gfx.data());
+  FakeDungeonState open_state;
+  open_state.open_lock_room_id = 0x42;
+
+  for (DoorType type : {
+           DoorType::FancyDungeonExit,
+           DoorType::FancyDungeonExitLower,
+           DoorType::ExitLower,
+           DoorType::CaveExit,
+           DoorType::LitCaveExitLower,
+       }) {
+    SCOPED_TRACE(static_cast<int>(type));
+    gfx::BackgroundBuffer bg1(512, 512);
+    gfx::BackgroundBuffer bg2(512, 512);
+    InitializeEmptyDoorBuffer(bg1);
+    InitializeEmptyDoorBuffer(bg2);
+
+    ObjectDrawer::DoorDef door{
+        .type = type,
+        .direction = DoorDirection::South,
+        .position = 8,
+    };
+    drawer.DrawDoor(door, /*door_index=*/0, bg1, bg2, &open_state);
+
+    if (type == DoorType::FancyDungeonExit) {
+      ExpectOnlyCoverageRect(bg1, 43, 54, 10, 8);
+      ExpectOnlyCoverageRect(bg2, 0, 0, 0, 0);
+    } else if (type == DoorType::FancyDungeonExitLower) {
+      ExpectOnlyCoverageRect(bg1, 43, 61, 10, 1);
+      ExpectOnlyCoverageRect(bg2, 43, 54, 10, 8);
+    } else if (type == DoorType::ExitLower) {
+      ExpectOnlyCoverageRect(bg1, 46, 61, 4, 1);
+      ExpectOnlyCoverageRect(bg2, 46, 58, 4, 4);
+    } else {
+      ExpectOnlyCoverageRect(bg1, 46, 58, 4, 4);
+      ExpectOnlyCoverageRect(bg2, 0, 0, 0, 0);
+    }
+  }
+}
+
 TEST(ObjectDrawerRegistryReplayTest, WestMiddleDoorsRenderBothSidesOfTheSeam) {
   ScopedCustomObjectsFlag disable_custom(false);
 
@@ -863,10 +1894,11 @@ TEST(ObjectDrawerRegistryReplayTest, WestMiddleDoorsRenderBothSidesOfTheSeam) {
 
   drawer.DrawDoor(door, /*door_index=*/0, bg1, bg2, nullptr);
 
-  EXPECT_TRUE(TileHasCoverage(bg1, 34, 15));
-  EXPECT_TRUE(TileHasCoverage(bg1, 36, 18));
-  EXPECT_TRUE(TileHasCoverage(bg1, 37, 15));
-  EXPECT_TRUE(TileHasCoverage(bg1, 37, 18));
+  ExpectOnlyCoverageRects(bg1, {{27, 15, 3, 4},    // East-facing counterpart.
+                                {34, 15, 3, 4}});  // West-facing current half.
+  ExpectOnlyCoverageRect(bg2, 0, 0, 0, 0);
+  EXPECT_EQ(bg1.GetTileAt(27, 15), 0x0B00);
+  EXPECT_EQ(bg1.GetTileAt(34, 15), 0x0A00);
 }
 
 TEST(ObjectDrawerRegistryReplayTest,

--- a/test/unit/zelda3/dungeon/object_drawing_comprehensive_test.cc
+++ b/test/unit/zelda3/dungeon/object_drawing_comprehensive_test.cc
@@ -744,37 +744,25 @@ TEST_F(ObjectDrawingComprehensiveTest, ObjectEncoding_Roundtrip) {
 }
 
 // ============================================================================
-// BothBG Flag Tests
+// Built-in Layer Routing Tests
 // ============================================================================
 
-TEST_F(ObjectDrawingComprehensiveTest, AllBgsFlag_SetDuringDecoding) {
-  // Objects with specific IDs should have all_bgs_ flag set during decoding
-  // Based on DecodeObjectFromBytes logic
-
-  // Routine 3 objects (0x03-0x04)
-  for (int id : {0x03, 0x04}) {
-    RoomObject obj(id, 0, 0, 0, 0);
-    // Create via decoding to trigger all_bgs logic
-    auto decoded = RoomObject::DecodeObjectFromBytes(0x00, 0x00, id, 0);
-    EXPECT_TRUE(decoded.all_bgs_)
-        << "ID 0x" << std::hex << id << " should have all_bgs set";
-  }
-
-  // Routine 9 objects (0x63-0x64)
-  for (int id : {0x63, 0x64}) {
-    auto decoded = RoomObject::DecodeObjectFromBytes(0x00, 0x00, id, 0);
-    EXPECT_TRUE(decoded.all_bgs_)
-        << "ID 0x" << std::hex << id << " should have all_bgs set";
-  }
-
-  // Diagonal BothBG objects
-  std::vector<int> bothbg_diagonals = {
-      0x0C, 0x0D, 0x10, 0x11, 0x14, 0x15, 0x18, 0x19, 0x1C, 0x1D, 0x20,
-      0x0E, 0x0F, 0x12, 0x13, 0x16, 0x17, 0x1A, 0x1B, 0x1E, 0x1F};
-  for (int id : bothbg_diagonals) {
-    auto decoded = RoomObject::DecodeObjectFromBytes(0x00, 0x00, id, 0);
-    EXPECT_TRUE(decoded.all_bgs_)
-        << "Diagonal ID 0x" << std::hex << id << " should have all_bgs set";
+TEST_F(ObjectDrawingComprehensiveTest,
+       BuiltInBothBgRoutingLivesInRoutineRegistry) {
+  auto& registry = DrawRoutineRegistry::Get();
+  for (const auto& [object_id, expected_both_bg] :
+       std::vector<std::pair<int, bool>>{{0x03, true},
+                                         {0x05, false},
+                                         {0x0C, false},
+                                         {0x14, false},
+                                         {0x15, true},
+                                         {0x20, true}}) {
+    auto decoded = RoomObject::DecodeObjectFromBytes(0x00, 0x00, object_id, 0);
+    EXPECT_FALSE(decoded.all_bgs_)
+        << "built-in routing must not mutate the manual override field";
+    const int routine_id = registry.GetRoutineIdForObject(object_id);
+    EXPECT_EQ(registry.RoutineDrawsToBothBGs(routine_id), expected_both_bg)
+        << "object 0x" << std::hex << object_id;
   }
 }
 
@@ -801,17 +789,17 @@ TEST_F(ObjectDrawingComprehensiveTest,
 TEST_F(ObjectDrawingComprehensiveTest, DimensionCalculation_DiagonalPatterns) {
   ObjectDrawer drawer(rom_.get(), 0);
 
-  // Diagonal walls use (size + 6) or (size + 7) count
+  // All diagonal walls render size + 6 columns. Routines 5/6 enter the
+  // assembly loop after its initial decrement; routines 17/18 enter before it.
   RoomObject diagonal_size0(0x10, 0, 0, 0, 0);
   auto dims = drawer.CalculateObjectDimensions(diagonal_size0);
-  // Diagonal: count = size + 7, width = count * 8, height = (count + 4) * 8
-  EXPECT_EQ(dims.first, 56);   // 7 * 8 = 56
-  EXPECT_EQ(dims.second, 88);  // (7 + 4) * 8 = 88
+  EXPECT_EQ(dims.first, 48);   // 6 * 8 = 48
+  EXPECT_EQ(dims.second, 80);  // (6 + 4) * 8 = 80
 
   RoomObject diagonal_size10(0x10, 0, 0, 10, 0);
   dims = drawer.CalculateObjectDimensions(diagonal_size10);
-  EXPECT_EQ(dims.first, 136);   // 17 * 8 = 136
-  EXPECT_EQ(dims.second, 168);  // (17 + 4) * 8 = 168
+  EXPECT_EQ(dims.first, 128);   // 16 * 8 = 128
+  EXPECT_EQ(dims.second, 160);  // (16 + 4) * 8 = 160
 }
 
 // ============================================================================
@@ -1098,9 +1086,8 @@ TEST_F(ObjectDrawingComprehensiveTest, ParityBothBGRoutinesCorrect) {
   // Routine IDs that should have draws_to_both_bgs flag.
   // Note: routine 2 (kRightwards2x4_1to16) has the flag because the ASM
   // explicitly writes to both $7E2000 and $7E4000 tilemaps.
-  // Routine 3 (kRightwards2x4_1to16_BothBG) does NOT have the flag because
-  // the BothBG dispatch is handled by the engine via object.all_bgs_, not
-  // by the routine itself.
+  // Routine 3 (kRightwards2x4_1to16_BothBG) is single-layer despite its legacy
+  // name; USDASM writes it through the active stream pointer only.
   std::vector<int> bothbg_routines = {
       2,   // kRightwards2x4_1to16 (explicitly writes both tilemaps)
       9,   // kDownwards4x2_1to16_BothBG

--- a/test/unit/zelda3/dungeon/object_geometry_test.cc
+++ b/test/unit/zelda3/dungeon/object_geometry_test.cc
@@ -50,10 +50,10 @@ TEST(ObjectGeometryTest, DiagonalAcuteExtendsUpward) {
   RoomObject obj(/*id=*/0x09, /*x=*/0, /*y=*/0, /*size=*/0);
   auto bounds = ObjectGeometry::Get().MeasureByRoutineId(/*routine_id=*/5, obj);
   ASSERT_TRUE(bounds.ok());
-  EXPECT_EQ(bounds->width_tiles, 7);    // count = size + 7
-  EXPECT_EQ(bounds->height_tiles, 11);  // count + 4 rows
+  EXPECT_EQ(bounds->width_tiles, 6);    // count = size + 6
+  EXPECT_EQ(bounds->height_tiles, 10);  // count + 4 rows
   EXPECT_EQ(bounds->min_x_tiles, 0);
-  EXPECT_EQ(bounds->min_y_tiles, -6);  // routine walks upward from origin
+  EXPECT_EQ(bounds->min_y_tiles, -5);  // routine walks upward from origin
 }
 
 TEST(ObjectGeometryTest, DiagonalCeilingBoundsMatchRenderForAllAnchors) {
@@ -64,12 +64,13 @@ TEST(ObjectGeometryTest, DiagonalCeilingBoundsMatchRenderForAllAnchors) {
   struct Case {
     int routine_id;
     const char* name;
+    bool extends_up;
   };
   const Case anchors[] = {
-      {75, "TopLeft"},
-      {76, "BottomLeft"},
-      {77, "TopRight"},
-      {78, "BottomRight"},
+      {75, "TopLeft", false},
+      {76, "BottomLeft", false},
+      {77, "TopRight", false},
+      {78, "BottomRight", true},
   };
 
   const uint8_t sizes[] = {0x00, 0x01, 0x03, 0x07, 0x0F};
@@ -83,6 +84,14 @@ TEST(ObjectGeometryTest, DiagonalCeilingBoundsMatchRenderForAllAnchors) {
       ASSERT_TRUE(bounds.ok()) << bounds.status();
       EXPECT_EQ(bounds->width_tiles, expected_side);
       EXPECT_EQ(bounds->height_tiles, expected_side);
+      EXPECT_EQ(bounds->min_x_tiles, 0);
+      EXPECT_EQ(bounds->min_y_tiles,
+                anchor.extends_up ? -(expected_side - 1) : 0);
+      const auto selection = bounds->GetSelectionBounds();
+      EXPECT_EQ(selection.x_tiles, bounds->min_x_tiles);
+      EXPECT_EQ(selection.y_tiles, bounds->min_y_tiles);
+      EXPECT_EQ(selection.width_tiles, expected_side);
+      EXPECT_EQ(selection.height_tiles, expected_side);
     }
   }
 }

--- a/test/unit/zelda3/dungeon/object_layer_semantics_test.cc
+++ b/test/unit/zelda3/dungeon/object_layer_semantics_test.cc
@@ -71,9 +71,9 @@ constexpr std::array<AuditedRoutingCase, 22> kAuditedRoutingCases = {{
     {0xF9D, DrawRoutineIds::kAutoStairs, ObjectRenderRouting::kStoredPlacement},
     {0xFB3, DrawRoutineIds::kAutoStairs, ObjectRenderRouting::kStoredPlacement},
     {0x138, DrawRoutineIds::kSpiralStairsGoingUpUpper,
-     ObjectRenderRouting::kFixedBg1},
+     ObjectRenderRouting::kStoredPlacement},
     {0x139, DrawRoutineIds::kSpiralStairsGoingDownUpper,
-     ObjectRenderRouting::kFixedBg1},
+     ObjectRenderRouting::kStoredPlacement},
     {0xF9E, DrawRoutineIds::kStraightInterRoomStairs,
      ObjectRenderRouting::kFixedBg1},
     {0xF9F, DrawRoutineIds::kStraightInterRoomStairs,
@@ -83,9 +83,9 @@ constexpr std::array<AuditedRoutingCase, 22> kAuditedRoutingCases = {{
     {0xFA1, DrawRoutineIds::kStraightInterRoomStairs,
      ObjectRenderRouting::kFixedBg1},
     {0x13A, DrawRoutineIds::kSpiralStairsGoingUpLower,
-     ObjectRenderRouting::kFixedBg2},
+     ObjectRenderRouting::kStoredPlacement},
     {0x13B, DrawRoutineIds::kSpiralStairsGoingDownLower,
-     ObjectRenderRouting::kFixedBg2},
+     ObjectRenderRouting::kStoredPlacement},
     {0xFA6, DrawRoutineIds::kStraightInterRoomStairs,
      ObjectRenderRouting::kMixedBg1Bg2},
     {0xFA7, DrawRoutineIds::kStraightInterRoomStairs,
@@ -162,9 +162,9 @@ TEST(ObjectLayerSemanticsTest,
      ActiveCustomOverridePreemptsBuiltInFixedLayerRouting) {
   ScopedCustomObjectRoutingState custom_state;
   custom_state.WriteOneTileObject("override.bin");
-  CustomObjectManager::Get().SetObjectFileMap({{0x138, {"override.bin"}}});
+  CustomObjectManager::Get().SetObjectFileMap({{0xFAD, {"override.bin"}}});
 
-  RoomObject object(/*id=*/0x138, /*x=*/0, /*y=*/0, /*size=*/0,
+  RoomObject object(/*id=*/0xFAD, /*x=*/0, /*y=*/0, /*size=*/0,
                     /*layer=*/1);
   const auto built_in = GetObjectLayerSemantics(object);
   ASSERT_EQ(built_in.render_routing, ObjectRenderRouting::kFixedBg1);

--- a/test/unit/zelda3/dungeon/object_layer_semantics_test.cc
+++ b/test/unit/zelda3/dungeon/object_layer_semantics_test.cc
@@ -1,9 +1,13 @@
 #include "gtest/gtest.h"
 
 #include <array>
+#include <chrono>
+#include <filesystem>
+#include <fstream>
 #include <iomanip>
 #include <vector>
 
+#include "core/features.h"
 #include "rom/rom.h"
 #include "zelda3/dungeon/dungeon_object_editor.h"
 #include "zelda3/dungeon/object_layer_semantics.h"
@@ -13,6 +17,43 @@ namespace yaze {
 namespace zelda3 {
 
 namespace {
+
+class ScopedCustomObjectRoutingState {
+ public:
+  ScopedCustomObjectRoutingState()
+      : previous_state_(CustomObjectManager::Get().SnapshotState()),
+        previous_enabled_(core::FeatureFlags::get().kEnableCustomObjects) {
+    const auto nonce =
+        std::chrono::steady_clock::now().time_since_epoch().count();
+    directory_ = std::filesystem::temp_directory_path() /
+                 ("yaze_object_layer_semantics_" + std::to_string(nonce));
+    std::filesystem::create_directories(directory_);
+    CustomObjectManager::Get().Initialize(directory_.string());
+    core::FeatureFlags::get().kEnableCustomObjects = true;
+  }
+
+  ~ScopedCustomObjectRoutingState() {
+    core::FeatureFlags::get().kEnableCustomObjects = previous_enabled_;
+    CustomObjectManager::Get().RestoreState(previous_state_);
+    std::error_code error;
+    std::filesystem::remove_all(directory_, error);
+  }
+
+  void WriteOneTileObject(const std::string& filename) const {
+    const std::array<uint8_t, 6> bytes = {
+        0x01, 0x00,  // one tile, no row jump
+        0x40, 0x08,  // tile word 0x0840
+        0x00, 0x00,  // terminator
+    };
+    std::ofstream output(directory_ / filename, std::ios::binary);
+    output.write(reinterpret_cast<const char*>(bytes.data()), bytes.size());
+  }
+
+ private:
+  CustomObjectManager::State previous_state_;
+  bool previous_enabled_;
+  std::filesystem::path directory_;
+};
 
 struct AuditedRoutingCase {
   int object_id;
@@ -115,6 +156,61 @@ TEST(ObjectLayerSemanticsTest, NonBothBgUsesStoredLayer) {
   EXPECT_FALSE(sem.draws_to_both_bgs);
   EXPECT_EQ(sem.effective_bg_layer, EffectiveBgLayer::kBg2);
   EXPECT_EQ(sem.render_routing, ObjectRenderRouting::kStoredPlacement);
+}
+
+TEST(ObjectLayerSemanticsTest,
+     ActiveCustomOverridePreemptsBuiltInFixedLayerRouting) {
+  ScopedCustomObjectRoutingState custom_state;
+  custom_state.WriteOneTileObject("override.bin");
+  CustomObjectManager::Get().SetObjectFileMap({{0x138, {"override.bin"}}});
+
+  RoomObject object(/*id=*/0x138, /*x=*/0, /*y=*/0, /*size=*/0,
+                    /*layer=*/1);
+  const auto built_in = GetObjectLayerSemantics(object);
+  ASSERT_EQ(built_in.render_routing, ObjectRenderRouting::kFixedBg1);
+  ASSERT_EQ(built_in.effective_bg_layer, EffectiveBgLayer::kBg1);
+
+  const auto effective = GetEffectiveObjectLayerSemantics(
+      object, /*allow_track_corner_aliases=*/true);
+  EXPECT_TRUE(effective.custom_override_active);
+  EXPECT_EQ(effective.render_routing, ObjectRenderRouting::kStoredPlacement);
+  EXPECT_EQ(effective.effective_bg_layer, EffectiveBgLayer::kBg2);
+
+  object.all_bgs_ = true;
+  const auto both = GetEffectiveObjectLayerSemantics(
+      object, /*allow_track_corner_aliases=*/true);
+  EXPECT_TRUE(both.custom_override_active);
+  EXPECT_EQ(both.render_routing, ObjectRenderRouting::kFullBothBg1Bg2);
+  EXPECT_EQ(both.effective_bg_layer, EffectiveBgLayer::kBothBg1Bg2);
+}
+
+TEST(ObjectLayerSemanticsTest,
+     TrackCornerCustomOverrideHonorsRoomAliasPermission) {
+  ScopedCustomObjectRoutingState custom_state;
+  custom_state.WriteOneTileObject("track_corner_tl.bin");
+  CustomObjectManager::Get().SetObjectFileMap(
+      {{0x31,
+        {"unused_lr.bin", "unused_ud.bin", "track_corner_tl.bin",
+         "unused_tr.bin", "unused_bl.bin", "unused_br.bin"}}});
+
+  RoomObject corner(/*id=*/0x100, /*x=*/0, /*y=*/0, /*size=*/0,
+                    /*layer=*/1);
+  EXPECT_FALSE(HasActiveCustomObjectOverride(
+      corner, /*allow_track_corner_aliases=*/false));
+  EXPECT_TRUE(HasActiveCustomObjectOverride(
+      corner, /*allow_track_corner_aliases=*/true));
+
+  const auto built_in =
+      GetEffectiveObjectLayerSemantics(corner,
+                                       /*allow_track_corner_aliases=*/false);
+  EXPECT_FALSE(built_in.custom_override_active);
+  EXPECT_EQ(built_in.effective_bg_layer, EffectiveBgLayer::kBg2);
+  const auto custom =
+      GetEffectiveObjectLayerSemantics(corner,
+                                       /*allow_track_corner_aliases=*/true);
+  EXPECT_TRUE(custom.custom_override_active);
+  EXPECT_EQ(custom.effective_bg_layer, EffectiveBgLayer::kBg2);
+  EXPECT_EQ(custom.render_routing, ObjectRenderRouting::kStoredPlacement);
 }
 
 TEST(ObjectLayerSemanticsTest,

--- a/test/unit/zelda3/dungeon/object_layer_semantics_test.cc
+++ b/test/unit/zelda3/dungeon/object_layer_semantics_test.cc
@@ -140,7 +140,8 @@ TEST(ObjectLayerSemanticsTest, RoutineMetadataCanForceBothBgForType2Objects) {
 }
 
 TEST(ObjectLayerSemanticsTest, AllBgsOverrideForcesBothBg) {
-  RoomObject obj(/*id=*/0x0C, /*x=*/0, /*y=*/0, /*size=*/0, /*layer=*/1);
+  RoomObject obj(/*id=*/0x21, /*x=*/0, /*y=*/0, /*size=*/0, /*layer=*/1);
+  obj.all_bgs_ = true;
 
   EXPECT_TRUE(obj.all_bgs_);
   const auto sem = GetObjectLayerSemantics(obj);

--- a/test/unit/zelda3/dungeon/room_layer_manager_test.cc
+++ b/test/unit/zelda3/dungeon/room_layer_manager_test.cc
@@ -159,6 +159,52 @@ TEST_F(RoomLayerManagerTest, ApplyLayerMergingOff) {
             LayerBlendMode::Normal);
 }
 
+TEST_F(RoomLayerManagerTest, SetBg2SynchronizesDecodedRenderingState) {
+  Room room(/*room_id=*/0, /*rom=*/nullptr);
+
+  room.SetBg2(static_cast<background2>(6));
+  EXPECT_EQ(room.bg2(), static_cast<background2>(6));
+  EXPECT_EQ(room.layer2_mode(), 6);
+  EXPECT_EQ(room.layer_merging(), LayerMerge06);
+  EXPECT_FALSE(room.IsLight());
+
+  room.SetBg2(static_cast<background2>(4));
+  EXPECT_EQ(room.bg2(), static_cast<background2>(4));
+  EXPECT_EQ(room.layer2_mode(), 4);
+  EXPECT_EQ(room.layer_merging(), LayerMerge04);
+
+  // The dark-room flag occupies a separate header bit. Entering that editor
+  // state must retain the three-bit BG2 mode that will be serialized with it.
+  room.SetBg2(background2::DarkRoom);
+  EXPECT_EQ(room.bg2(), background2::DarkRoom);
+  EXPECT_EQ(room.layer2_mode(), 4);
+  EXPECT_EQ(room.layer_merging(), LayerMerge08);
+  EXPECT_TRUE(room.IsLight());
+
+  // Leaving DarkRoom clears the flag and restores the selected BG2 mode as the
+  // active compositor state without requiring a ROM reload.
+  room.SetBg2(static_cast<background2>(6));
+  EXPECT_EQ(room.bg2(), static_cast<background2>(6));
+  EXPECT_EQ(room.layer2_mode(), 6);
+  EXPECT_EQ(room.layer_merging(), LayerMerge06);
+  EXPECT_FALSE(room.IsLight());
+}
+
+TEST_F(RoomLayerManagerTest, SetLayer2ModeSynchronizesNonDarkBg2State) {
+  Room room(/*room_id=*/0, /*rom=*/nullptr);
+
+  room.SetLayer2Mode(6);
+  EXPECT_EQ(room.bg2(), static_cast<background2>(6));
+  EXPECT_EQ(room.layer2_mode(), 6);
+  EXPECT_EQ(room.layer_merging(), LayerMerge06);
+
+  room.SetBg2(background2::DarkRoom);
+  room.SetLayer2Mode(4);
+  EXPECT_EQ(room.bg2(), background2::DarkRoom);
+  EXPECT_EQ(room.layer2_mode(), 4);
+  EXPECT_EQ(room.layer_merging(), LayerMerge08);
+}
+
 TEST_F(RoomLayerManagerTest,
        ApplyRoomEffectMovingWaterPromotesBG2Translucency) {
   manager_.SetLayerBlendMode(LayerType::BG2_Layout, LayerBlendMode::Normal);
@@ -290,6 +336,104 @@ TEST_F(RoomLayerManagerTest, PriorityCompositing_BG1Priority0OverBG2Priority0) {
   manager_.CompositeToOutput(room, output);
   ASSERT_TRUE(output.is_active());
   EXPECT_EQ(output.data()[0], 11);
+}
+
+TEST_F(RoomLayerManagerTest,
+       ModeSixUpperMainScreenWinsRegardlessOfTilePriority) {
+  manager_.ApplyLayerMerging(LayerMerge06);
+
+  Room room(/*room_id=*/0, /*rom=*/nullptr);
+  room.SetLayer2Mode(0x06);
+  for (auto* buffer : {&room.bg1_buffer(), &room.bg2_buffer(),
+                       &room.object_bg1_buffer(), &room.object_bg2_buffer()}) {
+    buffer->EnsureBitmapInitialized();
+    buffer->bitmap().Fill(255);
+    buffer->ClearPriorityBuffer();
+    buffer->ClearCoverageBuffer();
+  }
+
+  room.bg1_buffer().bitmap().mutable_data()[0] = 11;
+  room.bg1_buffer().mutable_priority_data()[0] = 0;
+  room.bg2_buffer().bitmap().mutable_data()[0] = 22;
+  room.bg2_buffer().mutable_priority_data()[0] = 1;
+
+  gfx::Bitmap output;
+  manager_.CompositeToOutput(room, output);
+
+  ASSERT_TRUE(output.is_active());
+  EXPECT_EQ(output.data()[0], 11)
+      << "Mode 6 places the upper tilemap on the main screen; lower-tilemap "
+         "priority cannot cover it";
+}
+
+TEST_F(RoomLayerManagerTest,
+       ModeSixRevealsLowerOnlyThroughTransparentUpperTilemap) {
+  manager_.ApplyLayerMerging(LayerMerge06);
+
+  Room room(/*room_id=*/0, /*rom=*/nullptr);
+  room.SetLayer2Mode(0x06);
+  for (auto* buffer : {&room.bg1_buffer(), &room.bg2_buffer(),
+                       &room.object_bg1_buffer(), &room.object_bg2_buffer()}) {
+    buffer->EnsureBitmapInitialized();
+    buffer->bitmap().Fill(255);
+    buffer->ClearPriorityBuffer();
+    buffer->ClearCoverageBuffer();
+    buffer->ClearBG1RevealMask();
+  }
+
+  // A historic reveal bit must not erase an opaque upper tile in mode 6.
+  room.bg1_buffer().bitmap().mutable_data()[0] = 11;
+  room.bg2_buffer().bitmap().mutable_data()[0] = 21;
+  room.bg1_buffer().SetBG1RevealMaskRect(gfx::BG1RevealMaskSource::kBG2Objects,
+                                         0, 0, 1, 1);
+
+  // A transparent object write still replaces its own tilemap layout entry,
+  // making the lower tilemap visible at this pixel.
+  room.bg1_buffer().bitmap().mutable_data()[1] = 12;
+  room.object_bg1_buffer().bitmap().mutable_data()[1] = 255;
+  room.object_bg1_buffer().mutable_coverage_data()[1] = 1;
+  room.bg2_buffer().bitmap().mutable_data()[1] = 22;
+
+  // Opaque objects replace layout within a tilemap before main/sub resolution.
+  room.bg1_buffer().bitmap().mutable_data()[2] = 13;
+  room.object_bg1_buffer().bitmap().mutable_data()[2] = 14;
+  room.object_bg1_buffer().mutable_coverage_data()[2] = 1;
+  room.bg2_buffer().bitmap().mutable_data()[2] = 23;
+
+  gfx::Bitmap output;
+  manager_.CompositeToOutput(room, output);
+
+  ASSERT_TRUE(output.is_active());
+  EXPECT_EQ(output.data()[0], 11);
+  EXPECT_EQ(output.data()[1], 22);
+  EXPECT_EQ(output.data()[2], 14);
+}
+
+TEST_F(RoomLayerManagerTest,
+       ModeSixUsesSerializedModeWhenDarkMergeOverridesMergeId) {
+  manager_.ApplyLayerMerging(LayerMerge08);
+
+  Room room(/*room_id=*/0, /*rom=*/nullptr);
+  room.SetLayer2Mode(0x06);
+  for (auto* buffer : {&room.bg1_buffer(), &room.bg2_buffer(),
+                       &room.object_bg1_buffer(), &room.object_bg2_buffer()}) {
+    buffer->EnsureBitmapInitialized();
+    buffer->bitmap().Fill(255);
+    buffer->ClearPriorityBuffer();
+    buffer->ClearCoverageBuffer();
+  }
+
+  room.bg1_buffer().bitmap().mutable_data()[0] = 11;
+  room.bg1_buffer().mutable_priority_data()[0] = 0;
+  room.bg2_buffer().bitmap().mutable_data()[0] = 22;
+  room.bg2_buffer().mutable_priority_data()[0] = 1;
+
+  gfx::Bitmap output;
+  manager_.CompositeToOutput(room, output);
+
+  ASSERT_TRUE(output.is_active());
+  EXPECT_EQ(output.data()[0], 11);
+  EXPECT_EQ(manager_.GetMergeTypeId(), LayerMerge08.ID);
 }
 
 TEST_F(RoomLayerManagerTest, Coverage_ObjectTransparentWriteClearsLayout) {

--- a/test/unit/zelda3/dungeon/room_object_rom_parity_test.cc
+++ b/test/unit/zelda3/dungeon/room_object_rom_parity_test.cc
@@ -23,6 +23,8 @@
 
 #include <gtest/gtest.h>
 
+#include <algorithm>
+#include <array>
 #include <cstdint>
 #include <memory>
 #include <vector>
@@ -30,6 +32,7 @@
 #include "absl/strings/str_format.h"
 #include "app/gfx/render/background_buffer.h"
 #include "app/gfx/types/snes_tile.h"
+#include "core/features.h"
 #include "rom/rom.h"
 #include "test_utils.h"
 #include "zelda3/dungeon/dungeon_rom_addresses.h"
@@ -66,6 +69,19 @@ constexpr int kFirstWeirdCornerBottom = 0x110;
 constexpr int kLastWeirdCornerBottom = 0x113;
 constexpr int kFirstWeirdCornerTop = 0x114;
 constexpr int kLastWeirdCornerTop = 0x117;
+
+struct ScopedCustomObjectsFlag {
+  bool previous = false;
+
+  explicit ScopedCustomObjectsFlag(bool enabled)
+      : previous(core::FeatureFlags::get().kEnableCustomObjects) {
+    core::FeatureFlags::get().kEnableCustomObjects = enabled;
+  }
+
+  ~ScopedCustomObjectsFlag() {
+    core::FeatureFlags::get().kEnableCustomObjects = previous;
+  }
+};
 
 // Read 2 bytes at rom[addr] as a little-endian 16-bit word.
 uint16_t ReadWordLE(const ::yaze::Rom& rom, int addr) {
@@ -118,6 +134,15 @@ std::vector<ObjectDrawer::TileTrace> FilterByLayer(
       filtered.push_back(t);
   }
   return filtered;
+}
+
+void ExpectTraceTileMatches(const ObjectDrawer::TileTrace& actual,
+                            const gfx::TileInfo& expected) {
+  EXPECT_EQ(actual.tile_id, expected.id_);
+  EXPECT_EQ((actual.flags & 0x01) != 0, expected.horizontal_mirror_);
+  EXPECT_EQ((actual.flags & 0x02) != 0, expected.vertical_mirror_);
+  EXPECT_EQ((actual.flags & 0x04) != 0, expected.over_);
+  EXPECT_EQ((actual.flags >> 3) & 0x07, expected.palette_);
 }
 
 // Drive ObjectDrawer for a ROM-loaded object, capturing writes in trace-only
@@ -308,6 +333,148 @@ TEST_P(RoomObjectRomParityTest, Subtype1SmokeSample_ParserMatchesRawRomWords) {
     ASSERT_EQ(static_cast<int>(parsed.size()), s.tile_count);
     for (size_t i = 0; i < expected.size(); ++i) {
       EXPECT_TRUE(parsed[i] == expected[i]) << "tile idx=" << i;
+    }
+  }
+}
+
+// -----------------------------------------------------------------------------
+// Floor-copy objects select room-header patterns, not subtype tile pointers
+// -----------------------------------------------------------------------------
+
+TEST_P(RoomObjectRomParityTest,
+       FloorCopyObjectsUseCanonicalVanillaRoomHeaderPatterns) {
+  if (GetParam() != ::yaze::test::RomRole::kVanilla) {
+    GTEST_SKIP() << "Fixed floor-copy witnesses belong to the canonical US ROM";
+  }
+  ScopedCustomObjectsFlag disable_custom_objects(false);
+
+  struct FloorCopyWitness {
+    int room_id;
+    int16_t object_id;
+    uint8_t x;
+    uint8_t y;
+    uint8_t size;
+    uint8_t list_index;
+    uint8_t expected_floor1;
+    uint8_t expected_floor2;
+  };
+
+  // Verified against roms/zelda3.sfc (SHA-1
+  // 6d4f10a8b10e10dbe624cb23cf03b88bb8252973). These witnesses exercise both
+  // USDASM selectors: 0xC4 copies $046A (Floor 1), while 0xDB copies $0490
+  // (Floor 2).
+  constexpr std::array<FloorCopyWitness, 2> kWitnesses = {{
+      {0x000, 0x00C4, 49, 5, 11, 0, 6, 14},
+      {0x014, 0x00DB, 4, 6, 13, 1, 1, 11},
+  }};
+
+  for (const auto& witness : kWitnesses) {
+    SCOPED_TRACE(absl::StrFormat("room=0x%03X object=0x%03X", witness.room_id,
+                                 witness.object_id));
+    Room room = LoadRoomFromRom(rom_.get(), witness.room_id);
+    ASSERT_EQ(room.floor1(), witness.expected_floor1);
+    ASSERT_EQ(room.floor2(), witness.expected_floor2);
+
+    const auto& room_objects = room.GetTileObjects();
+    const auto object_it = std::find_if(
+        room_objects.begin(), room_objects.end(),
+        [&](const RoomObject& object) {
+          return object.id_ == witness.object_id && object.x() == witness.x &&
+                 object.y() == witness.y && object.size() == witness.size;
+        });
+    ASSERT_NE(object_it, room_objects.end())
+        << "canonical room-object witness moved or disappeared";
+    ASSERT_EQ(object_it->GetLayerValue(), witness.list_index);
+
+    const uint8_t selected_floor =
+        witness.object_id == 0x00C4 ? room.floor1() : room.floor2();
+    const auto expected_pattern = gfx::DecodeDungeonFloorTilePattern(
+        rom_->vector(), kRoomObjectTileAddress, kRoomObjectTileAddressFloor,
+        selected_floor);
+    ASSERT_TRUE(expected_pattern.has_value());
+
+    // Both object IDs have a zero subtype pointer in vanilla. Their normal
+    // descriptor payload therefore decodes pattern 0 and must not be used when
+    // a real room header is available.
+    ASSERT_EQ(ReadWordLE(*rom_, kSubtype1Base + witness.object_id * 2), 0);
+    const auto& descriptor_tiles = object_it->tiles();
+    ASSERT_GE(descriptor_tiles.size(), expected_pattern->size());
+    bool selected_pattern_differs_from_descriptor = false;
+    for (size_t index = 0; index < expected_pattern->size(); ++index) {
+      selected_pattern_differs_from_descriptor |=
+          gfx::TileInfoToWord(descriptor_tiles[index]) !=
+          gfx::TileInfoToWord((*expected_pattern)[index]);
+    }
+    ASSERT_TRUE(selected_pattern_differs_from_descriptor)
+        << "witness cannot distinguish room-floor selection from descriptor "
+           "fallback";
+
+    RoomObject render_object = *object_it;
+    render_object.layer_ =
+        MapRoomObjectListIndexToDrawLayer(witness.list_index);
+    ObjectDrawer drawer(rom_.get(), witness.room_id);
+    drawer.SetRoomFloorGraphics(room.floor1(), room.floor2());
+    gfx::BackgroundBuffer bg1(512, 512);
+    gfx::BackgroundBuffer bg2(512, 512);
+    gfx::PaletteGroup palette_group;
+    std::vector<ObjectDrawer::TileTrace> trace;
+    drawer.SetTraceCollector(&trace, /*trace_only=*/true);
+    ASSERT_TRUE(drawer.DrawObject(render_object, bg1, bg2, palette_group).ok());
+
+    const auto expected_layer =
+        MapRoomObjectListIndexToDrawLayer(witness.list_index);
+    const auto layer_trace = FilterByLayer(trace, expected_layer);
+    const int super_square_columns = ((witness.size >> 2) & 0x03) + 1;
+    const int super_square_rows = (witness.size & 0x03) + 1;
+    ASSERT_EQ(layer_trace.size(), static_cast<size_t>(super_square_columns *
+                                                      super_square_rows * 16));
+    ASSERT_EQ(layer_trace.size(), trace.size());
+
+    for (size_t index = 0; index < layer_trace.size(); ++index) {
+      SCOPED_TRACE(absl::StrFormat("trace index=%zu", index));
+      ExpectTraceTileMatches(layer_trace[index],
+                             (*expected_pattern)[index % 8]);
+      EXPECT_NE(layer_trace[index].tile_id,
+                descriptor_tiles[index % descriptor_tiles.size()].id_)
+          << "floor-copy draw fell back to the ordinary object payload";
+    }
+  }
+}
+
+TEST(ObjectDrawerFloorCopyFallbackTest,
+     ContextFreeObjectsKeepTheirSyntheticDescriptorPayload) {
+  ScopedCustomObjectsFlag disable_custom_objects(false);
+  std::vector<uint8_t> dummy_rom(1024 * 1024, 0);
+  ::yaze::Rom rom;
+  ASSERT_TRUE(rom.LoadFromData(dummy_rom).ok());
+
+  gfx::BackgroundBuffer bg1(512, 512);
+  gfx::BackgroundBuffer bg2(512, 512);
+  gfx::PaletteGroup palette_group;
+  ObjectDrawer drawer(&rom, /*room_id=*/0);
+
+  for (const int16_t object_id : {int16_t{0x00C4}, int16_t{0x00DB}}) {
+    SCOPED_TRACE(absl::StrFormat("object=0x%03X", object_id));
+    RoomObject object(object_id, /*x=*/8, /*y=*/12, /*size=*/0,
+                      /*layer=*/0);
+    object.tiles_loaded_ = true;
+    for (int index = 0; index < 8; ++index) {
+      object.tiles_.emplace_back(static_cast<uint16_t>(0x300 + index),
+                                 index & 0x07,
+                                 /*vertical_mirror=*/(index & 0x01) != 0,
+                                 /*horizontal_mirror=*/(index & 0x02) != 0,
+                                 /*over=*/(index & 0x04) != 0);
+    }
+
+    std::vector<ObjectDrawer::TileTrace> trace;
+    drawer.SetTraceCollector(&trace, /*trace_only=*/true);
+    ASSERT_TRUE(drawer.DrawObject(object, bg1, bg2, palette_group).ok());
+    drawer.ClearTraceCollector();
+
+    ASSERT_EQ(trace.size(), 16U);
+    for (size_t index = 0; index < trace.size(); ++index) {
+      SCOPED_TRACE(absl::StrFormat("trace index=%zu", index));
+      ExpectTraceTileMatches(trace[index], object.tiles_[index % 8]);
     }
   }
 }

--- a/test/unit/zelda3/dungeon/room_object_set_id_test.cc
+++ b/test/unit/zelda3/dungeon/room_object_set_id_test.cc
@@ -29,7 +29,7 @@ std::vector<uint8_t> MakeObjectTileRomData(uint16_t first_word) {
 
 }  // namespace
 
-TEST(RoomObjectSetIdTest, RecomputesAllBgsAndInvalidatesTileCache) {
+TEST(RoomObjectSetIdTest, ClearsManualLayerOverrideAndInvalidatesTileCache) {
   RoomObject obj(/*id=*/0x21, /*x=*/0, /*y=*/0, /*size=*/0, /*layer=*/0);
 
   // Seed state so we can validate that changing the ID invalidates caches.
@@ -37,12 +37,12 @@ TEST(RoomObjectSetIdTest, RecomputesAllBgsAndInvalidatesTileCache) {
   obj.tile_count_ = 123;
   obj.tile_data_ptr_ = 456;
   obj.tiles_.push_back(gfx::TileInfo{});
-  obj.all_bgs_ = false;
+  obj.all_bgs_ = true;
 
   obj.set_id(/*id=*/0x0C);
 
   EXPECT_EQ(obj.id_, 0x0C);
-  EXPECT_TRUE(obj.all_bgs_);
+  EXPECT_FALSE(obj.all_bgs_);
   EXPECT_FALSE(obj.tiles_loaded_);
   EXPECT_TRUE(obj.tiles_.empty());
   EXPECT_EQ(obj.tile_count_, 0);


### PR DESCRIPTION
## Outcome

This follow-up to #210 consolidates the dungeon renderer around the ROM's actual draw semantics and fixes the editor problems found during hands-on Oracle room testing. The installed test build is available at `/Applications/yaze.app`.

## Rendering corrections

- Keep explicit door bodies above Room `0x001` wall-guidance objects while preserving ROM object-stream order, layout ownership, reveal masks, and SNES priority bits.
- Treat `Plus3` / `Plus23` as draw extents rather than coordinate offsets for thin horizontal and vertical strips, including carpet/wall edges and their direction-specific caps.
- Match USDASM geometry for wall corners, diagonal walls, and all four diagonal-ceiling orientations.
- Use Room Header `Floor1` / `Floor2` patterns for `0xC4` / `0xDB` floor-copy objects instead of the subtype payload.
- Restore lower-level straight-stair routing and its priority-only BG1 flank strip without painting over stored BG2 raster tiles.
- Correct moving-wall, water-hop stair, long-rail, conditional edge/cap, and room-layout reveal behavior.
- Remove the stale hard-coded `all_bgs` object-ID heuristic; registry routing is now the built-in layer authority.
- Route object dimensions through `DimensionService`, deleting the duplicate ~800-line legacy switch from `ObjectDrawer`.

## Editor and diagnostics

- Stabilize the right-click menu with fixed `Selection`, `Insert`, `Room`, and `Capture Issue` submenus.
- Replace the conditional `Sample Object` row with an always-positioned `Use Object as Brush` action, disabled when nothing is under the original right-click anchor.
- Make issue capture explicitly local and opt-in: opening, copying, and closing no longer auto-write a report; only **Save Report** persists it.
- Replay the selected object's real room-stream prefix, layout tilewords, layer, and floor-header context in the captured trace.
- Retire selector-preview and report bitmaps safely after presentation so invalidation cannot leave queued raw pointers or leak surfaces/textures.
- Keep the simplified room-first Dungeon Workbench and specialist panels introduced by the preceding commits.

## Verification

Canonical ROM: `roms/zelda3.sfc`, SHA-1 `6d4f10a8b10e10dbe624cb23cf03b88bb8252973`.

- `cmake --build --preset mac-ai --target yaze_test_unit yaze_test_integration yaze_test_rom_dependent yaze z3ed --parallel 4` — pass.
- `env -u YAZE_TEST_ROM_VANILLA ctest --preset mac-ai-unit --output-on-failure` — **3272/3272 passed**.
- `env -u YAZE_TEST_ROM_VANILLA ctest --preset mac-ai-integration --output-on-failure` — **335/335 passed**.
- Focused preview-retirement, selector, issue-report, and mask group — **39/39 passed**.
- Layer-move integration regression — **1/1 passed**.
- Refreshed room fingerprint checks — **2/2 passed**; an independent audit attributed every changed room and confirmed unchanged control Room `0x004`.
- `YAZE_TEST_ROM_VANILLA="$PWD/roms/zelda3.sfc" scripts/agents/audit-dungeon-visual-parity.sh --with-validate-report /tmp/yaze-dungeon-object-validation-final.json`:
  - Tier 1 synthetic geometry/routing: **32/32 passed**.
  - Tier 2 canonical-ROM parser/drawer parity: **10/10 passed**; 10 expanded-ROM variants skipped because no expanded fixture was supplied.
  - Tier 3/4 room fingerprints and existing independent Mesen ROIs: **17/17 active tests passed**; three opt-in capture/discovery helpers skipped.
  - ROM tile-count check: **1/1 passed**.
  - Tier 5: **0 mismatches across 1190 cases; 0 empty traces**.
- The audit now fails if `z3ed` is missing, the JSON is invalid/empty, mismatches are nonzero, or unexpected empty traces are present; it can no longer print a false-success completion.
- Repository pre-commit gate and normal pre-push gate passed. Push used `YAZE_PREPUSH_BUILD_DIR=build/presets/mac-ai`; no hook bypass.
- `/Applications/yaze.app` was ad-hoc signed, strictly verified, and relaunched. Source/deployed executable SHA-256: `ec9796a585e3ebdd41565d75b8029ae922eb5c7b9ccdd0994cd30d409f100471`.

## Fingerprint refresh rationale

- `0x000`: `0xC4` now uses the room's Floor 1 pattern.
- `0x001` / `0x050`: `0x34` / `0x71` thin strips now start at the stored origin.
- `0x00E`: single-layer `0x0D-0x10` diagonals no longer create an editor-only BG2 duplicate; this room has no BG2 overlay stream, so its object-BG2 buffer is intentionally empty.
- `0x016`: diagonal orientation/count, conditional caps, and object ownership changed while the composite pixel count and layout checksum stayed fixed.
- `0x004`: unchanged control; every prior checksum and pixel count stayed fixed.

These are Tier-3 self-fingerprints, not independent emulator truth. The existing Mesen ROIs remain unchanged and green.

## Manual test checklist

- Room `0x001`: north, west, and east door bodies stay above the guidance walls; thin strips begin at their real origins.
- Room `0x000`: floor-copy tiles match Floor 1.
- Rooms `0x00E` and `0x016`: inspect all diagonal-wall and diagonal-ceiling orientations for seams or unwanted BG2 copies.
- Room `0x050`: inspect the repeated horizontal/vertical thin strips.
- Room `0x077`: lower straight/spiral stair raster remains visible on its stored layer and the front edge has the correct priority.
- Exercise moving floors/walls, water-hop stairs, carpet edges, and ordinary water-control rooms.
- Right-click at different objects and empty space: the menu must stay in place; `Use Object as Brush` should enable/disable without shifting rows.
- Use **Capture Issue** on any remaining bad object and confirm nothing is written until **Save Report** is pressed.

Vanilla Room `0x001` contains spiral stair `0x013B @ (30,10)`. Oracle `oos168.sfc` / `oos168x.sfc` omit that object, so its absence there is ROM data rather than a renderer regression; this PR does not mutate either Oracle ROM.

## Honest limits

- Full emulator 1:1 parity is not claimed. Independent Mesen coverage is still partial for additional key/shutter/bombable/exploding doors and the corrected diagonal families.
- Vanilla `0xD8` / `0xDA` are HDMA controls rather than stamped tiles; their editor indicators remain structurally tested instead of pixel-compared to Mesen.
- The expanded-ROM Tier-2 variants were not run in this audit.
- Running the entire integration preset with the canonical 1 MiB ROM exported globally exposes 37 non-dungeon legacy Tile16/Overworld/Sprite tests that read offset `1311049` beyond size `1048576`. The generic 335-test preset and the targeted ROM-backed dungeon ladder are green; the legacy fixture assumption is tracked as a separate harness gap.
- Keep this PR in draft until the deployed app has been visually exercised across the checklist above.

## Hygiene

The commit intentionally excludes unrelated local changes in `ext/imgui`, `ext/nativefiledialog-extended`, `dungeon_object_validation_report.csv`, and `dungeon_object_validation_report.json`.
