### PR TITLE
fix(dungeon): consolidate Workbench tools in the inspector

### DIFF
--- a/docs/internal/agents/dungeon-object-rendering-spec.md
+++ b/docs/internal/agents/dungeon-object-rendering-spec.md
@@ -146,6 +146,27 @@ independent pixel proof.
 - RGB averaging and indexed-palette fallback paths approximate SNES color math; only committed Mesen ROIs are pixel-parity claims.
 - More key, shutter, bombable, and exploding door ROIs are required before claiming full door-family parity.
 
+### Oracle project witnesses
+
+Custom object `0x31` is subtype-overloaded. Only subtypes `0–12` and `14` are
+minecart track pieces and may enable the `0x100–0x103` track-corner aliases.
+Subtype `13` (`wall_sword_house`) and subtype `15` (`small_statue`) are
+decorations and must leave those ordinary 4×4 wall corners on their built-in
+routine. Mushroom Grotto uses subtype `15` in rooms `0x1A`, `0x1B`, `0x2A`,
+`0x3B`, `0x4A`, `0x4B`, and `0x6A`.
+
+The next Oracle-specific pixel fixtures are intentionally small:
+
+| Family | Primary witness | What must be isolated |
+| --- | --- | --- |
+| Static water `0xC8`, edges `0x3F–0x46` | Mushroom Grotto `0x4A`, then water-dense `0x33` | Interior motif versus edge/cap overlap order |
+| Icy floor `0xD1` | `0x08C` at `(10,11)` for BG1; `0x0CE` at `(29,23)` for BG2 | Shared routine-58 pixels and stored-layer routing |
+| Bars `0x4C`, `0x8F`, `0xFD6–0xFD9` | `0x042` | A complete vertical-bar, corner, and horizontal-bar join |
+
+These are investigation targets, not parity claims. Do not alter shared draw
+routines from a visual report alone; first capture the affected layer and a
+matching emulator or known-good editor ROI.
+
 ### Render issue capture UX
 
 The room canvas context menu exposes `Capture Issue` for room rendering, room palette, or the current selection. Opening or closing the dialog does not create a log entry. `Copy Report` and `Copy Diagnostics` only copy; `Save to Issue Log` is the explicit persistence action. Raw diagnostics and local file paths are collapsed by default.

--- a/docs/internal/agents/dungeon-ux-validation-pass.md
+++ b/docs/internal/agents/dungeon-ux-validation-pass.md
@@ -285,39 +285,38 @@ Field: `filter_range_error_` (bool), error condition: `parsed_min > parsed_max`.
 
 ---
 
-## 5. Workbench Tool Drawer and Window Filtering
+## 5. Workbench Tools Inspector and Window Filtering
 
 **Source:**
-- `DungeonWorkbenchContent::DrawInspectorToolDrawer()`
+- `DungeonWorkbenchContent::DrawInspectorToolPanel()`
 - `DungeonWorkbenchContent::Open*Tool()`
 - `WindowSidebar::IsDungeonWindowModeTarget()` (room-prefixed nav windows)
 - `WindowBrowser::Draw()`
 
-### 5a — Local tool requests open the right inspector drawer
+### 5a — Local tool requests open the Tools inspector
 
 **Click-path:**
 1. Launch YAZE with a ROM and open Dungeon Workbench:
    `--editor=Dungeon --room=16 --open_panels=dungeon.workbench`.
 2. In the Workbench right inspector, click **Tools**.
-3. From the 2x5 icon strip at the top of the drawer, click each of the ten
-   tool icons in order: **Object Selector**, **Doors**, **Sprites**, **Items**,
-   **Palette**, **Room Graphics**, **Room Tags**, **Custom Collision**,
-   **Water Fill**, and **Minecart**.
+3. Open the grouped tool chooser and select each of the ten tools: **Object
+   Selector**, **Door Tools**, **Sprite Tools**, **Item Tools**, **Room
+   Graphics**, **Palette**, **Room Tags**, **Custom Collision**, **Water Fill**,
+   and **Minecart Tracks**.
 
 **Expected:**
 - The selected tool renders inside the right inspector, not in a separate modal
   or top-level Dungeon window.
-- The icon for the active tool is highlighted (accent color) in the strip; only
-  one icon is highlighted at a time.
-- Hovering each icon shows a tooltip with the tool's full name.
-- The active tool's body fills the inspector height beneath the strip and the
-  active tool's title (no developer-doc subtitle, no in-drawer back button).
+- The chooser displays the active tool name and groups choices under **Edit**,
+  **Room**, and **Review**.
+- The active tool's body fills the inspector height beneath the chooser.
+- **Pop out** moves the active tool to its standalone window and restores the
+  inspector mode that was active before Tools.
 - Returning to room metadata is one click on the inspector primary segmented
-  selector ("Room") at the top of the inspector, not a separate button inside
-  the drawer.
+  selector ("Room") at the top of the inspector.
 - The active tool remains selected after navigating to another room.
 - Selecting an object/entity on the canvas may focus Selection, but it should
-  not steal focus away from the Tools drawer while the drawer is active.
+  not steal focus away from the Tools inspector while Tools is active.
 
 ### 5b — Dungeon Map and Connected Graph keep their special homes
 
@@ -327,7 +326,8 @@ Field: `filter_range_error_` (bool), error condition: `parsed_min > parsed_max`.
 
 **Expected:**
 - Dungeon Map opens as a bounded popup.
-- Connected Graph switches the canvas mode; it is not embedded as a drawer tool.
+- Connected Graph switches the canvas mode; it is not embedded as an inspector
+  tool.
 
 ### 5c — Window Browser/sidebar list Workbench-local tools in either mode
 
@@ -348,11 +348,12 @@ Field: `filter_range_error_` (bool), error condition: `parsed_min > parsed_max`.
   Browser regardless of workflow mode.
 - Toggling **Workbench / Windows** in the Dungeon sidebar workflow strip never
   auto-closes a standalone tool window. Only the room-mode navigation windows
-  (`dungeon.room_selector`, `dungeon.room_matrix`, and per-room `dungeon.room_*`
-  windows) are collapsed when entering Workbench mode, and pinned room windows
-  are preserved.
-- Opening a tool from the sidebar while the Workbench drawer also has the same
-  tool active yields two edit surfaces for the same room state — by design.
+  (`dungeon.room_selector`, `dungeon.entrance_list`, `dungeon.room_matrix`, and
+  per-room `dungeon.room_*` windows) are collapsed when entering Workbench
+  mode, and pinned room windows are preserved.
+- If the requested tool already has a standalone window open, the Workbench
+  focuses that window and restores the previous Room/Selection inspector. One
+  `WindowContent` instance is never drawn twice in the same frame.
 - Switching to Window workflow restores the room-mode windows.
 
 **Focused automated coverage:**
@@ -362,8 +363,9 @@ Field: `filter_range_error_` (bool), error condition: `parsed_min > parsed_max`.
   --gtest_filter='DungeonWorkbenchToolbar*.*:DungeonWorkbenchContentLayoutTest.*:SidebarSortTest.*'
 ```
 
-Expected result: all tests pass, including drawer-state persistence and the
-mode-parity contract pinned by `SidebarSortTest.DungeonWindowModeTargets…`.
+Expected result: all tests pass, including Tools-inspector state persistence,
+pop-out ownership, and the mode-parity contract pinned by
+`SidebarSortTest.DungeonWindowModeTargets…`.
 
 ---
 
@@ -373,7 +375,7 @@ mode-parity contract pinned by `SidebarSortTest.DungeonWindowModeTargets…`.
 # 1. Build
 cmake --build --preset mac-ai --target yaze_test_quick_unit_editor z3ed --parallel 8
 
-# 2. Targeted unit tests (original UX suites plus Workbench drawer/window filtering)
+# 2. Targeted unit tests (original UX suites plus Tools inspector/window filtering)
 ./build/presets/mac-ai/bin/Debug/yaze_test_quick_unit_editor \
   --gtest_filter="TileSelectorWidgetTest.*:DoorInteractionHandlerTest.*:SpriteInteractionHandlerTest.*:TileObjectHandlerTest.*:DungeonWorkbenchToolbar*.*:DungeonWorkbenchContentLayoutTest.*:SidebarSortTest.*"
 

--- a/docs/internal/agents/initiative-dungeon-workbench-2026-02.md
+++ b/docs/internal/agents/initiative-dungeon-workbench-2026-02.md
@@ -3,8 +3,8 @@
 Status: ACTIVE
 Owner: imgui-frontend-engineer
 Created: 2026-02-07
-Last Reviewed: 2026-04-26
-Next Review: 2026-05-03
+Last Reviewed: 2026-09-11
+Next Review: 2026-09-18
 
 ## Summary
 - Lead agent/persona: imgui-frontend-engineer
@@ -14,23 +14,24 @@ Next Review: 2026-05-03
   - A single default “Dungeon Workbench” layout is usable without manual docking.
   - Room navigation never moves/respawns windows unintentionally.
   - Inspector-driven UI reduces vertical chrome vs. always-on properties.
-  - Workbench-local edit tools live in the Workbench inspector drawer, not as
+  - Workbench-local edit tools live in the Workbench Tools inspector, not as
     competing top-level Dungeon windows.
   - PanelManager supports explicit panel scopes so defaults and persistence are predictable.
   - A command palette makes navigation/panel actions discoverable and fast.
 
-## Status Update — 2026-04-26
+## Status Update — 2026-09-11
 
-The Workbench now has a right-inspector `Tools` mode/drawer. Object Selector,
+The Workbench now has a right-inspector `Tools` mode. Object Selector,
 Door, Sprite, Item, Palette, Room Graphics, Room Tags, Custom Collision, Water
 Fill, and Minecart tools route there when Workbench mode is active. Dungeon Map
 remains a popup and Connected Graph remains a canvas mode.
 
-Workbench-local tool windows are closed when entering Workbench mode and hidden
-from the Window Browser/sidebar while Workbench mode is active, so users are not
-invited back into the scattered multi-window workflow by default.
-Navigation/review surfaces remain discoverable there: Workbench, Room List,
-Room Matrix, Entrances, and Object Tile Editor.
+The prior bottom drawer and permanent 2x5 tool strip were removed because they
+reduced canvas height and added a dense row of ambiguous icons. Tools now use one
+grouped chooser above the full-height inspector body. Object Selector controls
+and cards were compacted for this narrower home. **Pop out** preserves the
+traditional floating-window workflow, while presentation ownership prevents the
+same `WindowContent` instance from drawing in both locations.
 
 Canonical handoff for this slice:
 `docs/internal/agents/dungeon-workbench-usability-handoff-2026-04-26.md`.
@@ -40,7 +41,7 @@ Canonical handoff for this slice:
   - (1) Room header polish (pin placement + compact controls) and immediate layout fixes.
   - (2) “Room Workbench”: one stable window that hosts the room canvas + supporting panes.
   - (3) Context-sensitive Inspector replacing tall always-on controls.
-  - (4) Workbench-local tool drawer replacing local utility popups/windows.
+  - (4) Workbench-local Tools inspector replacing local utility popups/windows.
   - (5) Panel scopes + better default rules for visibility/pinning/persistence.
   - (6) Room tabs: MRU ordering, split view, and predictable focus.
   - (7) Command palette for room navigation + panel actions.
@@ -90,7 +91,7 @@ Canonical handoff for this slice:
 - Milestone 1 (Step 1): Fix clipping/cutoff + preserve panel/viewer state when navigating.
 - Milestone 2 (Step 2): Ship “Dungeon Workbench” behind a feature flag with a default layout preset.
 - Milestone 3 (Step 3): Add Context Inspector (selection-driven UI) and migrate tall always-on controls into it. **In progress; Room/Selection/Tools modes exist.**
-- Milestone 3b (Step 4): Fold local edit tools into the Workbench right drawer. **Implemented 2026-04-26; needs manual visual polish pass.**
+- Milestone 3b (Step 4): Fold local edit tools into the Workbench right inspector. **Implemented; sidebar consolidation and compact selector pass completed 2026-09-11, pending hands-on acceptance.**
 - Milestone 4 (Step 5): Introduce Panel Scopes (opt-in) and migrate Dungeon to scoped behavior.
 - Milestone 5 (Step 6): MRU room tabs + split view inside Workbench.
 - Milestone 6 (Step 7): Command palette for room navigation + panel actions.
@@ -128,10 +129,10 @@ Canonical handoff for this slice:
   - Sprite/item selected: show entity properties.
 - Keep high-frequency actions reachable from the canvas (context menu + command palette), but move low-frequency settings out of the header.
 
-### Step 4: Workbench-Local Tool Drawer
+### Step 4: Workbench-Local Tools Inspector
 - Route local editing tools into a right-inspector `Tools` mode instead of
   opening another high-level panel.
-- Keep the drawer as the default path, but allow standalone copies to remain
+- Keep the inspector as the default path, but allow standalone copies to remain
   open and discoverable for users who intentionally prefer a multi-window
   layout.
 - Keep Object Tile Editor standalone unless Object Selector invokes it directly

--- a/docs/internal/architecture/editor-ui-module-pattern.md
+++ b/docs/internal/architecture/editor-ui-module-pattern.md
@@ -98,7 +98,7 @@ inside that Workbench before adding or preserving another high-level panel.
 Preferred hierarchy:
 
 1. **Canvas/toolbar** for high-frequency spatial actions.
-2. **Inspector modes/drawers** for local tools that edit the current room,
+2. **Inspector modes** for local tools that edit the current room,
    selection, palette, tags, collision, or other nearby state.
 3. **Popups** for bounded review surfaces that should not persist as primary
    windows (for example, a dungeon map).
@@ -109,22 +109,24 @@ Dungeon Workbench examples:
 
 | Surface | Expected home in Workbench mode |
 |---|---|
-| Object Selector, Door, Sprite, Item tools | Inspector `Tools` drawer |
-| Palette, Room Graphics, Room Tags | Inspector `Tools` drawer |
-| Custom Collision, Water Fill, Minecart | Inspector `Tools` drawer |
+| Object Selector, Door, Sprite, Item tools | Inspector `Tools` mode |
+| Palette, Room Graphics, Room Tags | Inspector `Tools` mode |
+| Custom Collision, Water Fill, Minecart | Inspector `Tools` mode |
 | Dungeon Map | Popup |
 | Connected Graph | Canvas mode |
 | Object Tile Editor | Standalone asset-authoring window |
 
-If a tool is embedded in a Workbench drawer, keep the drawer as the primary
-default path, but do not force-close an already visible standalone copy when
-entering Workbench mode. Keep standalone panel entries discoverable for users
-who intentionally prefer a multi-window layout; Workbench entry should only
-collapse navigation windows and per-room windows by default.
+If a tool is embedded in the Workbench inspector, keep the inspector as the
+primary default path, but do not force-close an already visible standalone copy
+when entering Workbench mode. Keep standalone panel entries discoverable for
+users who intentionally prefer a multi-window layout. If the same content is
+already floating, focus that window instead of drawing one `WindowContent`
+instance twice. Workbench entry should only collapse navigation windows and
+per-room windows by default.
 
-Avoid dual implementations. Do not keep both a modal popup path and a drawer path
-for the same local tool unless the temporary duplicate is tracked by a handoff
-with deletion criteria.
+Avoid dual implementations. Do not keep both a modal popup path and an inspector
+path for the same local tool unless the temporary duplicate is tracked by a
+handoff with deletion criteria.
 
 ### Refactor triggers
 

--- a/docs/internal/hand-off/HANDOFF_CUSTOM_OBJECTS.md
+++ b/docs/internal/hand-off/HANDOFF_CUSTOM_OBJECTS.md
@@ -108,11 +108,18 @@ Repeat Header + Tiles until Header == 0x0000
 | 0x31 | 3 | track_corner_TR.bin |
 | 0x31 | 4 | track_corner_BL.bin |
 | 0x31 | 5 | track_corner_BR.bin |
-| 0x31 | 6-14 | track_floor_*.bin, track_any.bin |
+| 0x31 | 6-12 | track_floor_*.bin |
+| 0x31 | 13 | wall_sword_house.bin |
+| 0x31 | 14 | track_any.bin |
 | 0x31 | 15 | small_statue.bin |
 | 0x32 | 0 | furnace.bin |
 | 0x32 | 1 | firewood.bin |
 | 0x32 | 2 | ice_chair.bin |
+
+Only the real track subtypes `0–12` and `14` enable the optional
+`0x100–0x103` track-corner aliases. Decorative subtypes `13` and `15` do not;
+otherwise rooms containing a sword wall or Mushroom Grotto statue replace
+ordinary 4×4 wall corners with 2×2 track-corner graphics.
 
 ---
 
@@ -248,4 +255,3 @@ The MinecartTrackEditorPanel loads and saves `minecart_tracks.asm` which defines
 ## Contact
 
 For questions about this system, refer to the Oracle of Secrets project structure or check the custom object handler in the ASM source.
-

--- a/docs/public/usage/dungeon-editor.md
+++ b/docs/public/usage/dungeon-editor.md
@@ -13,7 +13,7 @@ require chasing separate floating panels.
 
 - **512x512 canvas** per room with pan, zoom, grid, and collision overlays
 - **Layer visualization** with BG1/BG2 toggles and colored object outlines
-- **Dungeon Workbench** with room browser, canvas, inspector, and local tool drawer
+- **Dungeon Workbench** with room browser, canvas, and a three-mode inspector
 - **Window workflow fallback** for users who still want standalone panels
 - **Undo/Redo** shared across all panels
 - **Overworld integration** - double-click entrances to open linked rooms
@@ -65,24 +65,23 @@ The right inspector has three primary modes:
 |------|---------|
 | **Room** | Current room summary, room actions, header fields, apply scope, layer/compositing controls |
 | **Selection** | Focused object/entity properties, copy/delete/clear actions, and entity-specific tools |
-| **Tools** | Workbench-local edit tools embedded in the inspector drawer |
+| **Tools** | Workbench-local edit tools embedded as primary inspector content |
 
-The **Tools** drawer includes Object Selector, Door tools, Sprite tools, Item
+The **Tools** mode includes Object Selector, Door tools, Sprite tools, Item
 tools, Palette, Room Graphics, Room Tags, Custom Collision, Water Fill, and
-Minecart tools. A compact 2x5 icon strip at the top of the drawer lets you hop
-between tools in one click; the active tool is highlighted with the accent
-color and hovering each icon shows a tooltip with the full tool name. Returning
-to the room metadata view is one click on the inspector's primary segmented
-selector. The drawer body fills the remaining inspector height so embedded
-tools render as primary content rather than cramped popups. Standalone copies
-of these tools remain available in the Window Browser/sidebar while Workbench
-mode is active; entering Workbench mode only collapses navigation windows and
-per-room windows by default.
+Minecart tools. Choose the active tool from one grouped menu; the tool fills the
+remaining inspector height. Use **Room** or **Selection** to return to metadata,
+or **Pop out** to move the active tool into its traditional floating window.
+Standalone tool entries remain available in the Window Browser/sidebar while
+Workbench mode is active. If a tool is already floating, opening it from the
+Workbench focuses that window instead of drawing the same tool twice.
 
 The Object Selector renders room-context thumbnails by default when room
-graphics are available. Entries that cannot render a tile layout fall back to a
-typed symbol, and the hover tooltip shows whether the visible preview is a
-rendered layout or a fallback.
+graphics are available. The compact cards preserve each object's aspect ratio,
+show its hexadecimal ID in a stable footer, and put the full name and diagnostic
+detail in the hover tooltip. Search and the two primary filters stay visible;
+thumbnail, card-size, reset, and custom-object actions live under **More**.
+Entries that cannot render a tile layout fall back to a typed symbol.
 
 ### Available Panels
 
@@ -94,9 +93,9 @@ rendered layout or a fallback.
 | **Object Tile Editor** | Standalone 8x8 tile composition editor for object asset authoring |
 | **Window Browser** | Manage standalone windows when using Window workflow |
 
-Workbench-local edit tools are available both inside the Workbench drawer and as
-standalone windows. Switch to **Window** workflow from the sidebar when you want
-the older navigation-first panel layout.
+Workbench-local edit tools can run inside the Tools inspector or in standalone
+windows. Switch to **Window** workflow from the sidebar when you want the older
+navigation-first panel layout.
 
 ### Canvas Controls
 

--- a/src/app/editor/dungeon/dungeon_canvas_overlays.cc
+++ b/src/app/editor/dungeon/dungeon_canvas_overlays.cc
@@ -27,93 +27,13 @@ namespace {
 
 constexpr int kSpritePreviewSize = 64;
 constexpr int kSpritePreviewAnchor = 16;
-constexpr int kSpritePaletteRowsStart = 8;
-constexpr int kPaletteRowSize = 16;
-
-struct DungeonSpriteColorTable {
-  std::array<ImU32, 256> colors{};
-  bool has_sprite_colors = false;
-};
-
-ImU32 ToImU32(const gfx::SnesColor& color) {
-  const auto rgb = color.rom_color();
-  return IM_COL32(static_cast<int>(rgb.red), static_cast<int>(rgb.green),
-                  static_cast<int>(rgb.blue), 255);
-}
-
-void CopyPaletteRange(std::array<ImU32, 256>& colors, bool& has_colors, int row,
-                      int start_column, const gfx::SnesPalette& palette,
-                      size_t max_colors) {
-  const size_t count = std::min(max_colors, palette.size());
-  for (size_t i = 0; i < count; ++i) {
-    const int column = start_column + static_cast<int>(i);
-    const int index = row * kPaletteRowSize + column;
-    if (index < 0 || index >= static_cast<int>(colors.size())) {
-      continue;
-    }
-    colors[static_cast<size_t>(index)] = ToImU32(palette[i]);
-    has_colors = true;
-  }
-}
-
-DungeonSpriteColorTable BuildDungeonSpriteColorTable(
-    const zelda3::GameData* game_data) {
-  DungeonSpriteColorTable table;
-  if (!game_data) {
-    return table;
-  }
-
-  const auto& groups = game_data->palette_groups;
-
-  if (groups.sprites_aux1.size() > 1) {
-    CopyPaletteRange(table.colors, table.has_sprite_colors,
-                     kSpritePaletteRowsStart, 1,
-                     groups.sprites_aux1.palette_ref(1), 7);
-  }
-  if (!groups.sprites_aux3.empty()) {
-    CopyPaletteRange(table.colors, table.has_sprite_colors,
-                     kSpritePaletteRowsStart, 9,
-                     groups.sprites_aux3.palette_ref(0), 7);
-  }
-
-  if (!groups.global_sprites.empty()) {
-    const auto& global = groups.global_sprites.palette_ref(0);
-    size_t source_index = 0;
-    for (int row = 9; row <= 12; ++row) {
-      for (int column = 1; column < kPaletteRowSize; ++column) {
-        if (source_index >= global.size()) {
-          break;
-        }
-        table.colors[static_cast<size_t>(row * kPaletteRowSize + column)] =
-            ToImU32(global[source_index++]);
-        table.has_sprite_colors = true;
-      }
-    }
-  }
-
-  if (!groups.sprites_aux1.empty()) {
-    CopyPaletteRange(table.colors, table.has_sprite_colors, 13, 1,
-                     groups.sprites_aux1.palette_ref(0), 7);
-  }
-  if (!groups.sprites_aux2.empty()) {
-    CopyPaletteRange(table.colors, table.has_sprite_colors, 14, 1,
-                     groups.sprites_aux2.palette_ref(0), 7);
-  }
-  if (!groups.armors.empty()) {
-    CopyPaletteRange(table.colors, table.has_sprite_colors, 15, 1,
-                     groups.armors.palette_ref(0), 15);
-  }
-
-  return table;
-}
 
 bool DrawSpritePreviewPixels(const gui::CanvasRuntime& rt,
                              const std::vector<uint8_t>& preview, int room_x,
                              int room_y,
-                             const DungeonSpriteColorTable& color_table) {
+                             const std::array<SDL_Color, 256>& color_table) {
   if (!rt.draw_list ||
-      preview.size() < kSpritePreviewSize * kSpritePreviewSize ||
-      !color_table.has_sprite_colors) {
+      preview.size() < kSpritePreviewSize * kSpritePreviewSize) {
     return false;
   }
 
@@ -130,11 +50,16 @@ bool DrawSpritePreviewPixels(const gui::CanvasRuntime& rt,
     while (x < kSpritePreviewSize) {
       const uint8_t palette_index =
           preview[static_cast<size_t>(y * kSpritePreviewSize + x)];
-      const ImU32 color = color_table.colors[palette_index];
-      if (palette_index == 0xFF || color == 0) {
+      const SDL_Color& palette_color = color_table[palette_index];
+      // RenderPreviewGraphics reserves index 0 for transparency. Unlike the
+      // former 0xFF sentinel, index 0 cannot collide with a visible dungeon
+      // sprite pixel: the preview encoder emits CGRAM indices 0x71..0xFF.
+      if (palette_index == 0 || palette_color.a == 0) {
         ++x;
         continue;
       }
+      const ImU32 color = IM_COL32(palette_color.r, palette_color.g,
+                                   palette_color.b, palette_color.a);
 
       const int start_x = x;
       while (x < kSpritePreviewSize &&
@@ -187,8 +112,8 @@ void DungeonCanvasViewer::RenderSprites(const gui::CanvasRuntime& rt,
   const auto& theme = AgentUI::GetTheme();
   const bool is_touch = gui::LayoutHelpers::IsTouchDevice();
   const int entity_size = is_touch ? 24 : 16;
-  const DungeonSpriteColorTable sprite_colors =
-      BuildDungeonSpriteColorTable(game_data_);
+  const auto sprite_colors =
+      zelda3::BuildDungeonSpriteRenderPalette(room, game_data_);
   const auto& room_gfx = room.get_gfx_buffer();
   const std::span<const uint8_t> room_gfx_span(room_gfx.data(),
                                                room_gfx.size());

--- a/src/app/editor/dungeon/dungeon_canvas_room_chrome.cc
+++ b/src/app/editor/dungeon/dungeon_canvas_room_chrome.cc
@@ -74,9 +74,9 @@ absl::Status DungeonCanvasViewer::LoadAndRenderRoomGraphics(int room_id) {
     current_palette_group_id_ =
         static_cast<uint64_t>(room.ResolveDungeonPaletteId());
 
-    auto full_palette = dungeon_main[current_palette_group_id_];
-    ASSIGN_OR_RETURN(current_palette_group_,
-                     gfx::CreatePaletteGroupFromLargePalette(full_palette, 16));
+    const auto& full_palette = dungeon_main[current_palette_group_id_];
+    current_palette_group_ = zelda3::BuildDungeonRenderPaletteGroupFromGameData(
+        full_palette, game_data_);
     LOG_DEBUG("[LoadAndRender]", "Palette loaded: group_id=%zu",
               current_palette_group_id_);
   }

--- a/src/app/editor/dungeon/dungeon_editor_v2.cc
+++ b/src/app/editor/dungeon/dungeon_editor_v2.cc
@@ -153,28 +153,18 @@ bool IsTransientDungeonRoomWindowId(const std::string& card_id) {
                      [](unsigned char ch) { return std::isdigit(ch) != 0; });
 }
 
-bool IsWorkbenchDuplicateWindowId(const std::string& card_id) {
-  constexpr std::array<const char*, 13> kWorkbenchDuplicatePanelIds = {
+bool IsWorkbenchNavigationWindowId(const std::string& card_id) {
+  constexpr std::array<const char*, 3> kWorkbenchNavigationPanelIds = {
       DungeonEditorV2::kRoomSelectorId,
       DungeonEditorV2::kEntranceListId,
       DungeonEditorV2::kRoomMatrixId,
-      DungeonEditorV2::kRoomGraphicsId,
-      DungeonEditorV2::kObjectSelectorId,
-      DungeonEditorV2::kDoorEditorId,
-      DungeonEditorV2::kPaletteEditorId,
-      "dungeon.sprite_editor",
-      "dungeon.item_editor",
-      "dungeon.room_tags",
-      "dungeon.custom_collision",
-      "dungeon.water_fill",
-      "dungeon.minecart_tracks",
   };
 
   return IsTransientDungeonRoomWindowId(card_id) ||
-         std::any_of(kWorkbenchDuplicatePanelIds.begin(),
-                     kWorkbenchDuplicatePanelIds.end(),
-                     [&card_id](const char* duplicate_id) {
-                       return card_id == duplicate_id;
+         std::any_of(kWorkbenchNavigationPanelIds.begin(),
+                     kWorkbenchNavigationPanelIds.end(),
+                     [&card_id](const char* navigation_id) {
+                       return card_id == navigation_id;
                      });
 }
 
@@ -302,6 +292,7 @@ absl::Status DungeonEditorV2::RefreshRomBackedState() {
   pending_water_fill_undo_ = {};
   pending_swap_ = {};
   pending_workflow_mode_ = {};
+  pending_standalone_tool_window_ = {};
   undo_restore_triggered_ping_ = false;
 
   room_selector_.SetRom(rom_);
@@ -715,18 +706,14 @@ void DungeonEditorV2::Initialize() {
           const size_t session_id = window_manager->GetActiveSessionId();
           return window_manager->IsWindowOpen(session_id, window_id);
         },
-        [window_manager](const std::string& window_id) {
-          const size_t session_id = window_manager->GetActiveSessionId();
-          if (!window_manager->OpenWindow(session_id, window_id)) {
+        [this, window_manager](const std::string& window_id) {
+          if (window_id.empty()) {
             return false;
           }
-          if (ImGui::GetCurrentContext() != nullptr) {
-            const std::string window_name =
-                window_manager->GetWorkspaceWindowName(session_id, window_id);
-            if (!window_name.empty()) {
-              ImGui::SetWindowFocus(window_name.c_str());
-            }
-          }
+          pending_standalone_tool_window_.session_id =
+              window_manager->GetActiveSessionId();
+          pending_standalone_tool_window_.window_id = window_id;
+          pending_standalone_tool_window_.pending = true;
           return true;
         });
     workbench_panel_->SetOpenKeyboardShortcutsCallback(
@@ -884,10 +871,10 @@ absl::Status DungeonEditorV2::Load() {
             dependencies_.project->custom_objects_folder));
   }
 
-  // Room-scoped utility tools are embedded in the Workbench drawer by default,
-  // but the same WindowContent instances remain available in the explicit
-  // Window workflow. Workbench mode closes and hides these entries so they do
-  // not compete with the integrated drawer.
+  // Room-scoped utility tools use the Workbench inspector by default, while the
+  // same WindowContent instances remain available to users who prefer floating
+  // windows. OpenTool keeps one presentation owner at a time so one content
+  // instance is never drawn in both places during the same frame.
   auto custom_collision_panel =
       std::make_unique<CustomCollisionPanel>(nullptr, nullptr);
   custom_collision_panel_ = custom_collision_panel.get();
@@ -1211,6 +1198,7 @@ void DungeonEditorV2::InvalidateDungeonPaletteUsers(
 
 absl::Status DungeonEditorV2::Update() {
   ProcessPendingWorkflowMode();
+  ProcessPendingStandaloneToolWindow();
   ExpireStaleRoomCanvasDeleteShortcut();
 
   // Mirror the workbench inspector to the LEFT when user_settings says so.
@@ -1471,20 +1459,21 @@ void DungeonEditorV2::SetWorkbenchWorkflowMode(bool enabled, bool show_toast) {
     window_manager->OpenWindow(session_id, "dungeon.workbench");
 
     if (!was_enabled) {
-      workbench_suspended_window_ids_.clear();
+      workbench_suspended_navigation_window_ids_.clear();
 
-      // Temporarily hide only unpinned windows whose content is duplicated by
-      // the Workbench. Auxiliary HM/ZS-style windows stay open, and the exact
-      // duplicate set is restored when the user returns to panel workflow.
+      // The Workbench replaces room navigation, but not standalone editing
+      // tools. Keep those tool windows open so user-owned HM/ZS-style layouts
+      // survive workflow switches; the embedded inspector yields ownership to
+      // any standalone tool that is already visible.
       for (const auto& descriptor :
            window_manager->GetWindowsInCategory(session_id, "Dungeon")) {
         const std::string& card_id = descriptor.card_id;
-        if (!IsWorkbenchDuplicateWindowId(card_id) ||
+        if (!IsWorkbenchNavigationWindowId(card_id) ||
             !window_manager->IsWindowOpen(session_id, card_id) ||
             window_manager->IsWindowPinned(session_id, card_id)) {
           continue;
         }
-        workbench_suspended_window_ids_.push_back(card_id);
+        workbench_suspended_navigation_window_ids_.push_back(card_id);
         window_manager->CloseWindow(session_id, card_id);
       }
     }
@@ -1495,10 +1484,11 @@ void DungeonEditorV2::SetWorkbenchWorkflowMode(bool enabled, bool show_toast) {
     if (current_room_id_ >= 0) {
       ShowRoomPanel(current_room_id_);
     }
-    for (const std::string& card_id : workbench_suspended_window_ids_) {
+    for (const std::string& card_id :
+         workbench_suspended_navigation_window_ids_) {
       window_manager->OpenWindow(session_id, card_id);
     }
-    workbench_suspended_window_ids_.clear();
+    workbench_suspended_navigation_window_ids_.clear();
   }
 
   if (show_toast && dependencies_.toast_manager && was_enabled != enabled) {
@@ -2316,6 +2306,33 @@ void DungeonEditorV2::ProcessPendingWorkflowMode() {
   const bool show_toast = pending_workflow_mode_.show_toast;
   pending_workflow_mode_.pending = false;
   SetWorkbenchWorkflowMode(enabled, show_toast);
+}
+
+void DungeonEditorV2::ProcessPendingStandaloneToolWindow() {
+  if (!pending_standalone_tool_window_.pending) {
+    return;
+  }
+
+  PendingStandaloneToolWindow request =
+      std::move(pending_standalone_tool_window_);
+  pending_standalone_tool_window_ = {};
+
+  auto* window_manager = dependencies_.window_manager;
+  if (!window_manager) {
+    return;
+  }
+
+  if (!window_manager->OpenWindow(request.session_id, request.window_id)) {
+    return;
+  }
+
+  if (ImGui::GetCurrentContext() != nullptr) {
+    const std::string window_name = window_manager->GetWorkspaceWindowName(
+        request.session_id, request.window_id);
+    if (!window_name.empty()) {
+      ImGui::SetWindowFocus(window_name.c_str());
+    }
+  }
 }
 
 void DungeonEditorV2::TouchViewerLru(int room_id) {

--- a/src/app/editor/dungeon/dungeon_editor_v2.cc
+++ b/src/app/editor/dungeon/dungeon_editor_v2.cc
@@ -153,6 +153,31 @@ bool IsTransientDungeonRoomWindowId(const std::string& card_id) {
                      [](unsigned char ch) { return std::isdigit(ch) != 0; });
 }
 
+bool IsWorkbenchDuplicateWindowId(const std::string& card_id) {
+  constexpr std::array<const char*, 13> kWorkbenchDuplicatePanelIds = {
+      DungeonEditorV2::kRoomSelectorId,
+      DungeonEditorV2::kEntranceListId,
+      DungeonEditorV2::kRoomMatrixId,
+      DungeonEditorV2::kRoomGraphicsId,
+      DungeonEditorV2::kObjectSelectorId,
+      DungeonEditorV2::kDoorEditorId,
+      DungeonEditorV2::kPaletteEditorId,
+      "dungeon.sprite_editor",
+      "dungeon.item_editor",
+      "dungeon.room_tags",
+      "dungeon.custom_collision",
+      "dungeon.water_fill",
+      "dungeon.minecart_tracks",
+  };
+
+  return IsTransientDungeonRoomWindowId(card_id) ||
+         std::any_of(kWorkbenchDuplicatePanelIds.begin(),
+                     kWorkbenchDuplicatePanelIds.end(),
+                     [&card_id](const char* duplicate_id) {
+                       return card_id == duplicate_id;
+                     });
+}
+
 }  // namespace
 
 DungeonEditorV2::DungeonEditorV2(Rom* rom)
@@ -685,6 +710,27 @@ void DungeonEditorV2::Initialize() {
         [this]() { return undo_manager_.GetUndoDescription(); },
         [this]() { return undo_manager_.GetRedoDescription(); },
         [this]() { return static_cast<int>(undo_manager_.UndoStackSize()); });
+    workbench_panel_->SetStandaloneToolCallbacks(
+        [window_manager](const std::string& window_id) {
+          const size_t session_id = window_manager->GetActiveSessionId();
+          return window_manager->IsWindowOpen(session_id, window_id);
+        },
+        [window_manager](const std::string& window_id) {
+          const size_t session_id = window_manager->GetActiveSessionId();
+          if (!window_manager->OpenWindow(session_id, window_id)) {
+            return false;
+          }
+          if (ImGui::GetCurrentContext() != nullptr) {
+            const std::string window_name =
+                window_manager->GetWorkspaceWindowName(session_id, window_id);
+            if (!window_name.empty()) {
+              ImGui::SetWindowFocus(window_name.c_str());
+            }
+          }
+          return true;
+        });
+    workbench_panel_->SetOpenKeyboardShortcutsCallback(
+        [window_manager]() { window_manager->TriggerShowShortcuts(); });
     workbench_panel_->SetOnInspectorSideChanged([this](bool on_left) {
       if (dependencies_.user_settings) {
         dependencies_.user_settings->SetDungeonInspectorSide(on_left ? "left"
@@ -1424,24 +1470,21 @@ void DungeonEditorV2::SetWorkbenchWorkflowMode(bool enabled, bool show_toast) {
   if (enabled) {
     window_manager->OpenWindow(session_id, "dungeon.workbench");
 
-    // Workbench-local tool windows (Object/Door/Sprite/Item Selector, Palette,
-    // Room Graphics/Tags, Custom Collision, Water Fill, Minecart) are NOT
-    // auto-closed on Workbench entry. The Workbench drawer embeds the same
-    // tools, but users may also keep a standalone window open if they prefer
-    // a multi-window layout. Only navigation windows (room selector/matrix
-    // and per-room windows) are collapsed when entering Workbench mode.
-    for (const auto& descriptor :
-         window_manager->GetWindowsInCategory(session_id, "Dungeon")) {
-      const std::string& card_id = descriptor.card_id;
-      if (card_id == "dungeon.workbench") {
-        continue;
-      }
-      if (window_manager->IsWindowPinned(session_id, card_id)) {
-        continue;
-      }
-      const bool is_room_window = IsTransientDungeonRoomWindowId(card_id);
-      if (card_id == kRoomSelectorId || card_id == kRoomMatrixId ||
-          is_room_window) {
+    if (!was_enabled) {
+      workbench_suspended_window_ids_.clear();
+
+      // Temporarily hide only unpinned windows whose content is duplicated by
+      // the Workbench. Auxiliary HM/ZS-style windows stay open, and the exact
+      // duplicate set is restored when the user returns to panel workflow.
+      for (const auto& descriptor :
+           window_manager->GetWindowsInCategory(session_id, "Dungeon")) {
+        const std::string& card_id = descriptor.card_id;
+        if (!IsWorkbenchDuplicateWindowId(card_id) ||
+            !window_manager->IsWindowOpen(session_id, card_id) ||
+            window_manager->IsWindowPinned(session_id, card_id)) {
+          continue;
+        }
+        workbench_suspended_window_ids_.push_back(card_id);
         window_manager->CloseWindow(session_id, card_id);
       }
     }
@@ -1452,6 +1495,10 @@ void DungeonEditorV2::SetWorkbenchWorkflowMode(bool enabled, bool show_toast) {
     if (current_room_id_ >= 0) {
       ShowRoomPanel(current_room_id_);
     }
+    for (const std::string& card_id : workbench_suspended_window_ids_) {
+      window_manager->OpenWindow(session_id, card_id);
+    }
+    workbench_suspended_window_ids_.clear();
   }
 
   if (show_toast && dependencies_.toast_manager && was_enabled != enabled) {

--- a/src/app/editor/dungeon/dungeon_editor_v2.cc
+++ b/src/app/editor/dungeon/dungeon_editor_v2.cc
@@ -339,8 +339,8 @@ absl::Status DungeonEditorV2::RefreshRomBackedState() {
     current_palette_group_id_ = current_palette_id_;
     current_palette_ =
         game_data_->palette_groups.dungeon_main[current_palette_id_];
-    ASSIGN_OR_RETURN(current_palette_group_,
-                     gfx::CreatePaletteGroupFromLargePalette(current_palette_));
+    current_palette_group_ = zelda3::BuildDungeonRenderPaletteGroupFromGameData(
+        current_palette_, game_data_);
   }
 
   if (is_loaded_) {
@@ -759,8 +759,8 @@ absl::Status DungeonEditorV2::Load() {
   }
   auto dungeon_main_pal_group = game_data()->palette_groups.dungeon_main;
   current_palette_ = dungeon_main_pal_group[current_palette_group_id_];
-  ASSIGN_OR_RETURN(current_palette_group_,
-                   gfx::CreatePaletteGroupFromLargePalette(current_palette_));
+  current_palette_group_ = zelda3::BuildDungeonRenderPaletteGroupFromGameData(
+      current_palette_, game_data());
 
   room_selector_.set_rooms(&rooms_);
   room_selector_.set_entrances(&entrances_);
@@ -1123,54 +1123,48 @@ void DungeonEditorV2::HandleDungeonPaletteChanged(
         static_cast<uint64_t>(dungeon_main_pal_group.size())) {
       current_palette_group_id_ = current_palette_id_;
       current_palette_ = dungeon_main_pal_group[current_palette_id_];
-      if (auto pal_group =
-              gfx::CreatePaletteGroupFromLargePalette(current_palette_);
-          pal_group.ok()) {
-        current_palette_group_ = pal_group.value();
-        apply_palette(workbench_viewer_.get(), current_palette_id_,
-                      current_palette_group_, force_shared_palette_refresh);
-        apply_palette(workbench_compare_viewer_.get(), current_palette_id_,
-                      current_palette_group_, force_shared_palette_refresh);
-        room_viewers_.ForEach(
-            [this, change, &apply_palette, &dungeon_main_pal_group,
-             &render_once, force_shared_palette_refresh](
-                int room_id, std::unique_ptr<DungeonCanvasViewer>& viewer) {
-              if (room_id < 0 || room_id >= static_cast<int>(rooms_.size())) {
-                return;
-              }
-              const int palette_id = rooms_[room_id].ResolveDungeonPaletteId();
-              if (palette_id < 0 ||
-                  palette_id >=
-                      static_cast<int>(dungeon_main_pal_group.size())) {
-                return;
-              }
-              if (change.source ==
-                      gui::DungeonRenderPaletteSource::kDungeonMain &&
-                  change.palette_id >= 0 && palette_id != change.palette_id) {
-                return;
-              }
-              auto room_palette_group = gfx::CreatePaletteGroupFromLargePalette(
-                  dungeon_main_pal_group.palette_ref(palette_id));
-              if (room_palette_group.ok()) {
-                if (viewer && viewer->object_interaction().IsObjectLoaded()) {
-                  render_once(room_id);
-                }
-                apply_palette(viewer.get(), palette_id,
-                              room_palette_group.value(),
-                              force_shared_palette_refresh);
-              }
-            });
-        if (object_selector_panel_) {
-          object_selector_panel_->SetCurrentPaletteGroup(
-              current_palette_group_);
+      current_palette_group_ =
+          zelda3::BuildDungeonRenderPaletteGroupFromGameData(current_palette_,
+                                                             game_data());
+      apply_palette(workbench_viewer_.get(), current_palette_id_,
+                    current_palette_group_, force_shared_palette_refresh);
+      apply_palette(workbench_compare_viewer_.get(), current_palette_id_,
+                    current_palette_group_, force_shared_palette_refresh);
+      room_viewers_.ForEach([this, change, &apply_palette,
+                             &dungeon_main_pal_group, &render_once,
+                             force_shared_palette_refresh](
+                                int room_id,
+                                std::unique_ptr<DungeonCanvasViewer>& viewer) {
+        if (room_id < 0 || room_id >= static_cast<int>(rooms_.size())) {
+          return;
         }
-        if (room_graphics_panel_) {
-          room_graphics_panel_->SetCurrentPaletteGroup(current_palette_group_);
+        const int palette_id = rooms_[room_id].ResolveDungeonPaletteId();
+        if (palette_id < 0 ||
+            palette_id >= static_cast<int>(dungeon_main_pal_group.size())) {
+          return;
         }
-        if (object_tile_editor_panel_) {
-          object_tile_editor_panel_->SetCurrentPaletteGroupForRoom(
-              current_room_id_, current_palette_group_);
+        if (change.source == gui::DungeonRenderPaletteSource::kDungeonMain &&
+            change.palette_id >= 0 && palette_id != change.palette_id) {
+          return;
         }
+        const auto room_palette_group =
+            zelda3::BuildDungeonRenderPaletteGroupFromGameData(
+                dungeon_main_pal_group.palette_ref(palette_id), game_data());
+        if (viewer && viewer->object_interaction().IsObjectLoaded()) {
+          render_once(room_id);
+        }
+        apply_palette(viewer.get(), palette_id, room_palette_group,
+                      force_shared_palette_refresh);
+      });
+      if (object_selector_panel_) {
+        object_selector_panel_->SetCurrentPaletteGroup(current_palette_group_);
+      }
+      if (room_graphics_panel_) {
+        room_graphics_panel_->SetCurrentPaletteGroup(current_palette_group_);
+      }
+      if (object_tile_editor_panel_) {
+        object_tile_editor_panel_->SetCurrentPaletteGroupForRoom(
+            current_room_id_, current_palette_group_);
       }
     }
   }
@@ -1846,24 +1840,22 @@ void DungeonEditorV2::OnRoomSelected(int room_id, bool request_focus) {
               game_data()->palette_groups.dungeon_main;
           if (current_palette_id_ < (int)dungeon_main_pal_group.size()) {
             current_palette_ = dungeon_main_pal_group[current_palette_id_];
-            auto result =
-                gfx::CreatePaletteGroupFromLargePalette(current_palette_);
-            if (result.ok()) {
-              current_palette_group_ = result.value();
-              viewer->SetCurrentPaletteGroup(current_palette_group_);
-              if (object_selector_panel_) {
-                object_selector_panel_->SetCurrentPaletteGroup(
-                    current_palette_group_);
-              }
-              // Sync palette to graphics panel for proper sheet coloring
-              if (room_graphics_panel_) {
-                room_graphics_panel_->SetCurrentPaletteGroup(
-                    current_palette_group_);
-              }
-              if (object_tile_editor_panel_) {
-                object_tile_editor_panel_->SetCurrentPaletteGroupForRoom(
-                    room_id, current_palette_group_);
-              }
+            current_palette_group_ =
+                zelda3::BuildDungeonRenderPaletteGroupFromGameData(
+                    current_palette_, game_data());
+            viewer->SetCurrentPaletteGroup(current_palette_group_);
+            if (object_selector_panel_) {
+              object_selector_panel_->SetCurrentPaletteGroup(
+                  current_palette_group_);
+            }
+            // Sync palette to graphics panel for proper sheet coloring
+            if (room_graphics_panel_) {
+              room_graphics_panel_->SetCurrentPaletteGroup(
+                  current_palette_group_);
+            }
+            if (object_tile_editor_panel_) {
+              object_tile_editor_panel_->SetCurrentPaletteGroupForRoom(
+                  room_id, current_palette_group_);
             }
           }
         }
@@ -2172,8 +2164,8 @@ absl::Status DungeonEditorV2::OpenObjectTileEditorForObject(
         "Room resolves to an unavailable dungeon palette");
   }
   auto room_palette = dungeon_palettes[palette_id];
-  ASSIGN_OR_RETURN(auto palette_group,
-                   gfx::CreatePaletteGroupFromLargePalette(room_palette));
+  const auto palette_group = zelda3::BuildDungeonRenderPaletteGroupFromGameData(
+      room_palette, game_data_);
 
   const absl::Status open_status = object_tile_editor_panel_->OpenForObject(
       object.id_, room_id, &rooms_, palette_group);

--- a/src/app/editor/dungeon/dungeon_editor_v2.h
+++ b/src/app/editor/dungeon/dungeon_editor_v2.h
@@ -485,6 +485,11 @@ class DungeonEditorV2 : public Editor {
   };
   PendingWorkflowMode pending_workflow_mode_;
 
+  // Unpinned standalone panels hidden by the most recent transition into the
+  // integrated Workbench. Restore this exact set when returning to the
+  // traditional panel workflow.
+  std::vector<std::string> workbench_suspended_window_ids_;
+
   // Two-phase undo capture: BeginUndoSnapshot saves state before mutation,
   // FinalizeUndoAction captures state after mutation and pushes the action.
   void BeginUndoSnapshot(int room_id);

--- a/src/app/editor/dungeon/dungeon_editor_v2.h
+++ b/src/app/editor/dungeon/dungeon_editor_v2.h
@@ -401,8 +401,9 @@ class DungeonEditorV2 : public Editor {
   gui::PaletteEditorWidget palette_editor_;
   // Panel pointers. WorkspaceWindowManager owns these when available; fallback
   // unique_ptrs keep non-workspace tests and direct embedding paths alive.
-  // Workbench mode embeds room-local utilities in the inspector drawer and
-  // closes/hides their standalone window entries.
+  // Workbench mode embeds room-local utilities in the Tools inspector. Their
+  // standalone entries remain discoverable, but one content instance has only
+  // one active presentation owner at a time.
   ObjectSelectorContent* object_selector_panel_ = nullptr;
   ObjectEditorContent* object_editor_content_ = nullptr;
   DoorEditorContent* door_editor_panel_ = nullptr;
@@ -485,10 +486,21 @@ class DungeonEditorV2 : public Editor {
   };
   PendingWorkflowMode pending_workflow_mode_;
 
-  // Unpinned standalone panels hidden by the most recent transition into the
-  // integrated Workbench. Restore this exact set when returning to the
-  // traditional panel workflow.
-  std::vector<std::string> workbench_suspended_window_ids_;
+  // Opening or focusing a standalone tool mutates WorkspaceWindowManager and
+  // Dear ImGui focus state. Workbench buttons are drawn inside child windows,
+  // so defer that mutation to the next Update() safe point. Capture the
+  // originating session so a session switch cannot redirect the request.
+  struct PendingStandaloneToolWindow {
+    size_t session_id = 0;
+    std::string window_id;
+    bool pending = false;
+  };
+  PendingStandaloneToolWindow pending_standalone_tool_window_;
+
+  // Unpinned room-navigation panels hidden by the most recent transition into
+  // the integrated Workbench. Standalone editing tools remain user-owned and
+  // are never added to this restoration set.
+  std::vector<std::string> workbench_suspended_navigation_window_ids_;
 
   // Two-phase undo capture: BeginUndoSnapshot saves state before mutation,
   // FinalizeUndoAction captures state after mutation and pushes the action.
@@ -509,6 +521,7 @@ class DungeonEditorV2 : public Editor {
   void SwapRoomInPanel(int old_room_id, int new_room_id);
   void ProcessPendingSwap();  // Process deferred swap after draw
   void ProcessPendingWorkflowMode();
+  void ProcessPendingStandaloneToolWindow();
 
   // Room panel slot IDs provide stable ImGui window IDs across "swap room in
   // panel" navigation. This keeps the window position/dock state when the room

--- a/src/app/editor/dungeon/dungeon_object_selector.cc
+++ b/src/app/editor/dungeon/dungeon_object_selector.cc
@@ -21,7 +21,6 @@
 #include "app/gui/core/agent_theme.h"
 #include "app/gui/core/drag_drop.h"
 #include "app/gui/core/icons.h"
-#include "app/gui/core/layout_helpers.h"
 #include "app/gui/core/style_guard.h"
 #include "app/gui/core/ui_helpers.h"
 #include "app/gui/widgets/themed_widgets.h"
@@ -43,12 +42,12 @@ constexpr int kPersistedCustomSubtypeSlots = 16;
 float GetObjectGridItemSize(int density) {
   switch (density) {
     case 0:
-      return 56.0f;
+      return 48.0f;
     case 2:
-      return 88.0f;
+      return 76.0f;
     case 1:
     default:
-      return 72.0f;
+      return 60.0f;
   }
 }
 
@@ -61,38 +60,23 @@ ImVec4 WithAlpha(ImVec4 color, float alpha) {
   return color;
 }
 
-ImVec4 Dimmed(ImVec4 color, float factor) {
-  color.x *= factor;
-  color.y *= factor;
-  color.z *= factor;
-  return color;
-}
-
-ImU32 GetObjectRangeHeaderColor(int start_id) {
-  const auto& theme = AgentUI::GetTheme();
-  if (start_id >= 0xF80) {
-    return ThemeColor(theme.music_zone_color);
-  }
-  if (start_id >= 0x100) {
-    return ThemeColor(theme.selection_secondary);
-  }
-  return ThemeColor(theme.dungeon_object_wall);
-}
-
 void DrawFallbackPreviewTile(ImDrawList* draw_list, ImVec2 top_left,
-                             float item_size, const ImVec4& accent_color,
+                             ImVec2 size, const ImVec4& accent_color,
                              const char* label) {
   const auto& theme = AgentUI::GetTheme();
-  const ImU32 accent = ThemeColor(accent_color);
-  const ImU32 dimmed = ThemeColor(Dimmed(accent_color, 0.55f));
-
-  draw_list->AddRectFilledMultiColor(
-      top_left, ImVec2(top_left.x + item_size, top_left.y + item_size), dimmed,
-      dimmed, accent, accent);
+  draw_list->AddRectFilled(
+      top_left, ImVec2(top_left.x + size.x, top_left.y + size.y),
+      ThemeColor(WithAlpha(theme.panel_bg_darker, 0.72f)), 2.0f);
+  draw_list->AddRectFilled(top_left,
+                           ImVec2(top_left.x + 2.0f, top_left.y + size.y),
+                           ThemeColor(WithAlpha(accent_color, 0.72f)), 2.0f);
 
   ImVec2 label_size = ImGui::CalcTextSize(label);
-  ImVec2 label_pos(top_left.x + (item_size - label_size.x) / 2,
-                   top_left.y + (item_size - label_size.y) / 2 - 10);
+  if (label_size.x > size.x - 4.0f || label_size.y > size.y - 4.0f) {
+    return;
+  }
+  ImVec2 label_pos(top_left.x + (size.x - label_size.x) / 2,
+                   top_left.y + (size.y - label_size.y) / 2);
   draw_list->AddText(label_pos,
                      ThemeColor(WithAlpha(theme.text_primary, 0.82f)), label);
 }
@@ -117,40 +101,28 @@ DungeonObjectSelectorGridLayout ResolveDungeonObjectSelectorGridLayout(
   return layout;
 }
 
-DungeonObjectSelectorTypeTabLayout ResolveDungeonObjectSelectorTypeTabLayout(
-    float available_width, float requested_tab_width, float item_spacing,
-    int tab_count) {
-  if (tab_count <= 0) {
-    return {};
+DungeonObjectPreviewFit ResolveDungeonObjectPreviewFit(float source_width,
+                                                       float source_height,
+                                                       float box_width,
+                                                       float box_height) {
+  DungeonObjectPreviewFit fit;
+  if (source_width <= 0.0f || source_height <= 0.0f || box_width <= 0.0f ||
+      box_height <= 0.0f) {
+    return fit;
   }
 
-  const float safe_width = std::max(available_width, 1.0f);
-  const float safe_tab_width = std::max(requested_tab_width, 1.0f);
-  const float safe_spacing = std::max(item_spacing, 0.0f);
-  const auto columns_fit = [&](int columns) {
-    return safe_width >= safe_tab_width * static_cast<float>(columns) +
-                             safe_spacing * static_cast<float>(columns - 1);
-  };
-
-  DungeonObjectSelectorTypeTabLayout layout;
-  if (columns_fit(tab_count)) {
-    layout.columns = tab_count;
-  } else if (tab_count > 2 && columns_fit(2)) {
-    layout.columns = 2;
-  } else {
-    layout.columns = 1;
-  }
-
-  const float width_per_column =
-      std::max((safe_width - safe_spacing * (layout.columns - 1)) /
-                   static_cast<float>(layout.columns),
-               1.0f);
-  layout.item_width = std::min(safe_tab_width, width_per_column);
-  return layout;
+  const float scale =
+      std::min(box_width / source_width, box_height / source_height);
+  fit.valid = true;
+  fit.width = source_width * scale;
+  fit.height = source_height * scale;
+  fit.x = (box_width - fit.width) * 0.5f;
+  fit.y = (box_height - fit.height) * 0.5f;
+  return fit;
 }
 
-bool MatchesDungeonObjectTypeTab(int object_id, int selected_tab) {
-  switch (selected_tab) {
+bool MatchesDungeonObjectStreamFilter(int object_id, int selected_filter) {
+  switch (selected_filter) {
     case 1:
       return object_id >= 0x000 && object_id <= 0x0F7;
     case 2:
@@ -318,111 +290,84 @@ void DungeonObjectSelector::DrawObjectAssetBrowser() {
 
   const ImGuiStyle& style = ImGui::GetStyle();
   const float control_spacing = std::max(2.0f, style.ItemSpacing.x * 0.5f);
-  const float action_size = std::max(ImGui::GetFrameHeight(),
-                                     gui::LayoutHelpers::GetMinTouchTarget());
   {
     gui::StyleVarGuard toolbar_spacing_guard(
         ImGuiStyleVar_ItemSpacing,
         ImVec2(control_spacing, std::max(2.0f, style.ItemSpacing.y * 0.5f)));
 
-    // Search stays dominant, but shares a row with filters when the drawer is
-    // wide enough. Narrow presentations wrap the control groups as a unit.
     const float toolbar_width =
         std::max(ImGui::GetContentRegionAvail().x, 1.0f);
-    const float compact_actions_width =
-        action_size * 3.0f + control_spacing * 3.0f;
-    const bool inline_toolbar = toolbar_width >= 600.0f;
-    const float search_width = inline_toolbar
-                                   ? std::max(220.0f, toolbar_width - 390.0f)
-                                   : toolbar_width;
-    ImGui::SetNextItemWidth(search_width);
-    ImGui::InputTextWithHint(
-        "##ObjectSearch", ICON_MD_SEARCH " Filter objects by name or hex...",
-        object_search_buffer_, sizeof(object_search_buffer_));
-    if (inline_toolbar) {
-      ImGui::SameLine(0.0f, control_spacing);
-    }
+    ImGui::SetNextItemWidth(toolbar_width);
+    ImGui::InputTextWithHint("##ObjectSearch", "Search by name or hex ID...",
+                             object_search_buffer_,
+                             sizeof(object_search_buffer_));
 
-    // Category plus three compact utility actions. Only this control cluster
-    // wraps on genuinely narrow hosts; individual icon buttons never stretch.
-    static const char* kFilterLabels[] = {"All",   "Walls", "Floors", "Chests",
-                                          "Doors", "Decor", "Stairs"};
-    const float controls_width =
-        std::max(ImGui::GetContentRegionAvail().x, 1.0f);
-    const bool actions_fit = controls_width >= compact_actions_width + 96.0f;
-    const float filter_width =
-        actions_fit
-            ? std::min(160.0f,
-                       std::max(96.0f, controls_width - compact_actions_width))
-            : controls_width;
-    ImGui::SetNextItemWidth(filter_width);
+    static const char* kFilterLabels[] = {"All categories", "Walls", "Floors",
+                                          "Chests",         "Doors", "Decor",
+                                          "Stairs"};
+    static const char* kStreamLabels[] = {"All streams", "Type 1", "Type 2",
+                                          "Type 3"};
+    constexpr const char* kMoreLabel = "More##ObjectSelectorMore";
+    const float more_width = ImGui::CalcTextSize(kMoreLabel, nullptr, true).x +
+                             style.FramePadding.x * 2.0f;
+    const bool stack_filters = toolbar_width < 230.0f;
+    const float filter_row_width =
+        std::max(1.0f, toolbar_width - more_width - control_spacing);
+    const float category_width =
+        stack_filters ? toolbar_width : filter_row_width * 0.56f;
+    const float stream_width =
+        stack_filters ? filter_row_width
+                      : std::max(1.0f, filter_row_width - category_width -
+                                           control_spacing);
+
+    ImGui::SetNextItemWidth(category_width);
     ImGui::Combo("##ObjectFilterType", &object_type_filter_, kFilterLabels,
                  IM_ARRAYSIZE(kFilterLabels));
-    if (actions_fit) {
+    if (!stack_filters) {
       ImGui::SameLine(0.0f, control_spacing);
     }
-    if (gui::TransparentIconButton(ICON_MD_CLEAR,
-                                   ImVec2(action_size, action_size),
-                                   "Clear search and category filter")) {
-      object_search_buffer_[0] = '\0';
-      object_type_filter_ = 0;
-    }
+    ImGui::SetNextItemWidth(stream_width);
+    ImGui::Combo("##ObjectStreamFilter", &object_stream_filter_, kStreamLabels,
+                 IM_ARRAYSIZE(kStreamLabels));
     ImGui::SameLine(0.0f, control_spacing);
-    if (gui::TransparentIconButton(ICON_MD_TUNE,
-                                   ImVec2(action_size, action_size),
-                                   "Display options")) {
-      ImGui::OpenPopup("##ObjectSelectorDisplayPopup");
+    if (ImGui::Button(kMoreLabel, ImVec2(more_width, 0.0f))) {
+      ImGui::OpenPopup("##ObjectSelectorOptionsPopup");
     }
-    ImGui::SameLine(0.0f, control_spacing);
-    DrawCustomObjectWorkshopButton(custom_count,
-                                   ImVec2(action_size, action_size));
-    if (ImGui::BeginPopup("##ObjectSelectorDisplayPopup")) {
-      ImGui::TextDisabled(tr("Display"));
-      ImGui::Checkbox(ICON_MD_IMAGE " Thumbnails", &enable_object_previews_);
+    if (ImGui::BeginPopup("##ObjectSelectorOptionsPopup")) {
+      const bool has_filters = object_search_buffer_[0] != '\0' ||
+                               object_type_filter_ != 0 ||
+                               object_stream_filter_ != 0;
+      if (ImGui::MenuItem(tr("Clear filters"), nullptr, false, has_filters)) {
+        object_search_buffer_[0] = '\0';
+        object_type_filter_ = 0;
+        object_stream_filter_ = 0;
+      }
+
+      ImGui::SeparatorText(tr("Display"));
+      ImGui::Checkbox(tr("Show thumbnails"), &enable_object_previews_);
       if (ImGui::IsItemHovered()) {
         ImGui::SetTooltip(
             tr("Show rendered object thumbnails in the selector.\n"
                "Requires a room to be loaded and may cost some performance."));
       }
-      ImGui::Spacing();
-      ImGui::TextDisabled(tr("Grid density"));
-      static constexpr const char* kDensityLabels[] = {"Small", "Medium",
+      ImGui::SeparatorText(tr("Card size"));
+      static constexpr const char* kDensityLabels[] = {"Compact", "Medium",
                                                        "Large"};
       for (int density = 0; density < 3; ++density) {
-        if (density > 0) {
-          ImGui::SameLine(0.0f, control_spacing);
-        }
-        if (gui::ToggleButton(kDensityLabels[density],
-                              object_grid_density_ == density)) {
+        if (ImGui::MenuItem(kDensityLabels[density], nullptr,
+                            object_grid_density_ == density)) {
           object_grid_density_ = density;
         }
       }
+
+      ImGui::Separator();
+      const std::string workshop_label =
+          absl::StrFormat("Custom Object Workshop... (%d)", custom_count);
+      if (ImGui::MenuItem(workshop_label.c_str())) {
+        open_custom_workshop_popup_ = true;
+      }
       ImGui::EndPopup();
     }
-
-    // Compact object-stream tabs replace three full-width disclosure bars.
-    static constexpr const char* kTypeLabels[] = {"All", "Type 1", "Type 2",
-                                                  "Type 3"};
-    float type_tab_width = 1.0f;
-    for (const char* label : kTypeLabels) {
-      type_tab_width =
-          std::max(type_tab_width,
-                   ImGui::CalcTextSize(label).x + style.FramePadding.x * 2.0f);
-    }
-    const auto type_tab_layout = ResolveDungeonObjectSelectorTypeTabLayout(
-        ImGui::GetContentRegionAvail().x, type_tab_width, control_spacing,
-        IM_ARRAYSIZE(kTypeLabels));
-    ImGui::PushID("ObjectTypeTabs");
-    for (int tab = 0; tab < IM_ARRAYSIZE(kTypeLabels); ++tab) {
-      if (tab > 0 && tab % type_tab_layout.columns != 0) {
-        ImGui::SameLine(0.0f, control_spacing);
-      }
-      if (gui::ToggleButton(kTypeLabels[tab], object_subtype_tab_ == tab,
-                            ImVec2(type_tab_layout.item_width, 0.0f))) {
-        object_subtype_tab_ = tab;
-      }
-    }
-    ImGui::PopID();
   }
 
   // The grid is the selector's sole scroll owner. Calculate its geometry only
@@ -442,15 +387,14 @@ void DungeonObjectSelector::DrawObjectAssetBrowser() {
 
     // Iterate through all object ranges
     for (const auto& range : ranges) {
-      if (!MatchesDungeonObjectTypeTab(range.start, object_subtype_tab_)) {
+      if (!MatchesDungeonObjectStreamFilter(range.start,
+                                            object_stream_filter_)) {
         continue;
       }
 
-      if (object_subtype_tab_ == 0) {
-        ImGui::TextColored(ImGui::ColorConvertU32ToFloat4(
-                               GetObjectRangeHeaderColor(range.start)),
-                           "%s  0x%03X-0x%03X", range.label, range.start,
-                           range.end);
+      if (object_stream_filter_ == 0) {
+        ImGui::TextDisabled("%s  0x%03X-0x%03X", range.label, range.start,
+                            range.end);
       }
 
       int current_column = 0;
@@ -459,7 +403,7 @@ void DungeonObjectSelector::DrawObjectAssetBrowser() {
         if (!MatchesObjectFilter(obj_id, object_type_filter_)) {
           continue;
         }
-        if (!MatchesDungeonObjectTypeTab(obj_id, object_subtype_tab_)) {
+        if (!MatchesDungeonObjectStreamFilter(obj_id, object_stream_filter_)) {
           continue;
         }
 
@@ -505,73 +449,62 @@ void DungeonObjectSelector::DrawObjectAssetBrowser() {
         gui::BeginRoomObjectDragSource(
             static_cast<uint16_t>(obj_id), current_room_id_, 0, 0,
             zelda3::DefaultRoomObjectSizeForPlacement(obj_id));
-        // Draw object preview on the button; fall back to styled placeholder
         ImDrawList* draw_list = ImGui::GetWindowDrawList();
+        const bool show_id = item_size >= 32.0f;
+        const float footer_height =
+            show_id ? std::min(item_size * 0.32f, ImGui::GetFontSize() + 3.0f)
+                    : 0.0f;
+        const float card_padding = std::min(3.0f, item_size * 0.08f);
+        const ImVec2 preview_pos(button_pos.x + card_padding,
+                                 button_pos.y + card_padding);
+        const ImVec2 preview_box(
+            std::max(1.0f, item_size - card_padding * 2.0f),
+            std::max(1.0f, item_size - footer_height - card_padding * 2.0f));
 
         // Only attempt graphical preview if enabled (performance optimization)
         bool rendered = false;
         if (item_visible && enable_object_previews_) {
-          rendered = DrawObjectPreview(MakePreviewObject(obj_id), button_pos,
-                                       item_size);
+          rendered = DrawObjectPreview(MakePreviewObject(obj_id), preview_pos,
+                                       preview_box);
         }
 
         if (item_visible && !rendered) {
-          // Draw a styled fallback with gradient background
           std::string symbol = GetObjectTypeSymbol(obj_id);
           DrawFallbackPreviewTile(
-              draw_list, button_pos, item_size,
+              draw_list, preview_pos, preview_box,
               ImGui::ColorConvertU32ToFloat4(GetObjectTypeColor(obj_id)),
               symbol.c_str());
         }
 
-        // Draw selection border
-        ImU32 border_color;
-        float border_thickness;
-
-        if (is_selected) {
-          border_color = ImGui::GetColorU32(theme.dungeon_selection_primary);
-          border_thickness = 3.0f;
-        } else {
-          border_color = ImGui::GetColorU32(theme.panel_bg_darker);
-          border_thickness = 1.0f;
-        }
-
-        if (item_visible) {
+        const bool item_hovered = ImGui::IsItemHovered();
+        if (item_visible && (is_selected || item_hovered)) {
+          const ImU32 border_color =
+              ImGui::GetColorU32(is_selected ? theme.dungeon_selection_primary
+                                             : theme.panel_border_color);
           draw_list->AddRect(
               button_pos,
               ImVec2(button_pos.x + item_size, button_pos.y + item_size),
-              border_color, 0.0f, 0, border_thickness);
+              border_color, 2.0f, 0, is_selected ? 2.0f : 1.0f);
         }
 
-        // Get object name for display
-        // Truncate name for display
-        std::string display_name = full_name;
-        const size_t max_display_chars =
-            std::max<size_t>(7, static_cast<size_t>(item_size / 6.0f));
-        if (display_name.length() > max_display_chars) {
-          display_name = display_name.substr(0, max_display_chars - 2) + "..";
-        }
-
-        if (item_visible) {
-          // Draw object name (smaller, above ID)
-          ImVec2 name_size = ImGui::CalcTextSize(display_name.c_str());
-          ImVec2 name_pos = ImVec2(button_pos.x + (item_size - name_size.x) / 2,
-                                   button_pos.y + item_size - 26);
-          draw_list->AddText(name_pos,
-                             ImGui::GetColorU32(theme.text_secondary_gray),
-                             display_name.c_str());
-
-          // Draw object ID at bottom (hex format)
+        if (item_visible && show_id) {
+          const ImVec2 card_bottom(button_pos.x + item_size,
+                                   button_pos.y + item_size);
+          const float footer_y = card_bottom.y - footer_height;
+          draw_list->AddRectFilled(
+              ImVec2(button_pos.x, footer_y), card_bottom,
+              ImGui::GetColorU32(WithAlpha(theme.panel_bg_darker, 0.88f)),
+              2.0f);
           std::string id_text = absl::StrFormat("%03X", obj_id);
           ImVec2 id_size = ImGui::CalcTextSize(id_text.c_str());
           ImVec2 id_pos = ImVec2(button_pos.x + (item_size - id_size.x) / 2,
-                                 button_pos.y + item_size - id_size.y - 2);
+                                 footer_y + (footer_height - id_size.y) * 0.5f);
           draw_list->AddText(id_pos, ImGui::GetColorU32(theme.text_primary),
                              id_text.c_str());
         }
 
         // Enhanced tooltip
-        if (ImGui::IsItemHovered()) {
+        if (item_hovered) {
           gui::StyleColorGuard tooltip_guard(
               {{ImGuiCol_PopupBg, theme.panel_bg_color},
                {ImGuiCol_Border, theme.panel_border_color}});
@@ -657,6 +590,10 @@ void DungeonObjectSelector::DrawObjectAssetBrowser() {
   }
 
   ImGui::EndChild();
+  if (open_custom_workshop_popup_) {
+    ImGui::OpenPopup("Custom Object Workshop");
+    open_custom_workshop_popup_ = false;
+  }
   DrawCustomObjectWorkshopPopup();
 }
 
@@ -816,7 +753,6 @@ uint32_t DungeonObjectSelector::MakeLayoutCacheKey(int object_id,
 }
 
 bool DungeonObjectSelector::GetOrCreatePreview(const zelda3::RoomObject& object,
-                                               float size,
                                                gfx::BackgroundBuffer** out) {
   if (out == nullptr) {
     return false;
@@ -922,9 +858,10 @@ bool DungeonObjectSelector::GetOrCreatePreview(const zelda3::RoomObject& object,
 }
 
 bool DungeonObjectSelector::DrawObjectPreview(const zelda3::RoomObject& object,
-                                              ImVec2 top_left, float size) {
+                                              ImVec2 top_left,
+                                              ImVec2 box_size) {
   gfx::BackgroundBuffer* preview = nullptr;
-  if (!GetOrCreatePreview(object, size, &preview)) {
+  if (!GetOrCreatePreview(object, &preview)) {
     return false;
   }
 
@@ -934,10 +871,18 @@ bool DungeonObjectSelector::DrawObjectPreview(const zelda3::RoomObject& object,
     return false;
   }
 
-  ImDrawList* draw_list = ImGui::GetWindowDrawList();
-  ImVec2 bottom_right(top_left.x + size, top_left.y + size);
-  draw_list->AddImage((ImTextureID)(intptr_t)bitmap.texture(), top_left,
-                      bottom_right);
+  const DungeonObjectPreviewFit fit = ResolveDungeonObjectPreviewFit(
+      static_cast<float>(bitmap.width()), static_cast<float>(bitmap.height()),
+      box_size.x, box_size.y);
+  if (!fit.valid) {
+    return false;
+  }
+
+  const ImVec2 image_top_left(top_left.x + fit.x, top_left.y + fit.y);
+  const ImVec2 image_bottom_right(image_top_left.x + fit.width,
+                                  image_top_left.y + fit.height);
+  ImGui::GetWindowDrawList()->AddImage((ImTextureID)(intptr_t)bitmap.texture(),
+                                       image_top_left, image_bottom_right);
   return true;
 }
 
@@ -1063,24 +1008,6 @@ void DungeonObjectSelector::DrawNewCustomObjectDialog() {
   }
 }
 
-void DungeonObjectSelector::DrawCustomObjectWorkshopButton(int custom_count,
-                                                           const ImVec2& size) {
-  if (open_custom_workshop_popup_) {
-    ImGui::OpenPopup("Custom Object Workshop");
-    open_custom_workshop_popup_ = false;
-  }
-
-  if (gui::TransparentIconButton(
-          ICON_MD_PRECISION_MANUFACTURING "##CustomObjectWorkshop", size)) {
-    ImGui::OpenPopup("Custom Object Workshop");
-  }
-  if (ImGui::IsItemHovered()) {
-    ImGui::SetTooltip(
-        tr("Custom Object Workshop\n%d custom object%s available"),
-        custom_count, custom_count == 1 ? "" : "s");
-  }
-}
-
 void DungeonObjectSelector::DrawCustomObjectWorkshopPopup() {
   const auto& theme = AgentUI::GetTheme();
   auto& obj_manager = zelda3::CustomObjectManager::Get();
@@ -1202,40 +1129,59 @@ void DungeonObjectSelector::DrawCustomObjectWorkshopPopup() {
             zelda3::CanonicalRoomObjectSize(obj_id,
                                             static_cast<uint8_t>(subtype)));
         ImDrawList* draw_list = ImGui::GetWindowDrawList();
+        const bool show_id = item_size >= 44.0f;
+        const float footer_height =
+            show_id ? std::min(item_size * 0.32f, ImGui::GetFontSize() + 3.0f)
+                    : 0.0f;
+        const float card_padding = std::min(3.0f, item_size * 0.08f);
+        const ImVec2 preview_pos(button_pos.x + card_padding,
+                                 button_pos.y + card_padding);
+        const ImVec2 preview_box(
+            std::max(1.0f, item_size - card_padding * 2.0f),
+            std::max(1.0f, item_size - footer_height - card_padding * 2.0f));
 
         bool rendered = false;
         if (item_visible && enable_object_previews_) {
           auto temp_obj = MakePreviewObject(obj_id);
           temp_obj.size_ = zelda3::CanonicalRoomObjectSize(
               obj_id, static_cast<uint8_t>(subtype));
-          rendered = DrawObjectPreview(temp_obj, button_pos, item_size);
+          rendered = DrawObjectPreview(temp_obj, preview_pos, preview_box);
         }
 
         if (item_visible && !rendered) {
           std::string sub_text = absl::StrFormat("%02X", subtype);
-          DrawFallbackPreviewTile(draw_list, button_pos, item_size,
+          DrawFallbackPreviewTile(draw_list, preview_pos, preview_box,
                                   theme.status_success, sub_text.c_str());
         }
 
-        ImU32 border_color =
-            is_selected ? ImGui::GetColorU32(theme.dungeon_selection_primary)
-                        : ImGui::GetColorU32(theme.panel_bg_darker);
-        float border_thickness = is_selected ? 3.0f : 1.0f;
-        if (item_visible) {
+        const bool item_hovered = ImGui::IsItemHovered();
+        if (item_visible && (is_selected || item_hovered)) {
+          const ImU32 border_color =
+              ImGui::GetColorU32(is_selected ? theme.dungeon_selection_primary
+                                             : theme.panel_border_color);
           draw_list->AddRect(
               button_pos,
               ImVec2(button_pos.x + item_size, button_pos.y + item_size),
-              border_color, 0.0f, 0, border_thickness);
+              border_color, 2.0f, 0, is_selected ? 2.0f : 1.0f);
+        }
 
+        if (item_visible && show_id) {
+          const ImVec2 card_bottom(button_pos.x + item_size,
+                                   button_pos.y + item_size);
+          const float footer_y = card_bottom.y - footer_height;
+          draw_list->AddRectFilled(
+              ImVec2(button_pos.x, footer_y), card_bottom,
+              ImGui::GetColorU32(WithAlpha(theme.panel_bg_darker, 0.88f)),
+              2.0f);
           std::string id_text = absl::StrFormat("%02X:%02X", obj_id, subtype);
           ImVec2 id_size = ImGui::CalcTextSize(id_text.c_str());
           ImVec2 id_pos = ImVec2(button_pos.x + (item_size - id_size.x) / 2,
-                                 button_pos.y + item_size - id_size.y - 2);
+                                 footer_y + (footer_height - id_size.y) * 0.5f);
           draw_list->AddText(id_pos, ImGui::GetColorU32(theme.text_primary),
                              id_text.c_str());
         }
 
-        if (ImGui::IsItemHovered()) {
+        if (item_hovered) {
           gui::StyleColorGuard tooltip_guard(
               {{ImGuiCol_PopupBg, theme.panel_bg_color},
                {ImGuiCol_Border, theme.panel_border_color}});

--- a/src/app/editor/dungeon/dungeon_object_selector.cc
+++ b/src/app/editor/dungeon/dungeon_object_selector.cc
@@ -84,20 +84,24 @@ void DrawFallbackPreviewTile(ImDrawList* draw_list, ImVec2 top_left,
 }  // namespace
 
 DungeonObjectSelectorGridLayout ResolveDungeonObjectSelectorGridLayout(
-    float available_width, float requested_item_size, float item_spacing,
-    float reserved_scrollbar_width, float min_item_size) {
+    float available_width, float preferred_item_size, float item_spacing,
+    float min_item_size) {
   const float safe_spacing = std::max(item_spacing, 0.0f);
-  const float usable_width = std::max(
-      available_width - std::max(reserved_scrollbar_width, 0.0f), 1.0f);
+  const float usable_width = std::max(available_width, 1.0f);
   const float safe_min_item_size =
       std::min(std::max(min_item_size, 1.0f), usable_width);
+  const float clamped_preferred_item_size =
+      std::clamp(preferred_item_size, safe_min_item_size, usable_width);
 
   DungeonObjectSelectorGridLayout layout;
-  layout.item_size =
-      std::clamp(requested_item_size, safe_min_item_size, usable_width);
-  layout.columns =
-      std::max(1, static_cast<int>((usable_width + safe_spacing) /
-                                   (layout.item_size + safe_spacing)));
+  layout.columns = std::max(
+      1, static_cast<int>((usable_width + safe_spacing) /
+                          (clamped_preferred_item_size + safe_spacing)));
+  layout.item_size = clamped_preferred_item_size;
+  const float total_spacing = safe_spacing * (layout.columns - 1);
+  const float occupied_width =
+      layout.item_size * layout.columns + total_spacing;
+  layout.leading_inset = std::max((usable_width - occupied_width) * 0.5f, 0.0f);
   return layout;
 }
 
@@ -370,10 +374,12 @@ void DungeonObjectSelector::DrawObjectAssetBrowser() {
   const float child_height = std::max(ImGui::GetContentRegionAvail().y, 1.0f);
   if (ImGui::BeginChild("##ObjectGrid", ImVec2(0, child_height), false)) {
     const float item_spacing = control_spacing;
+    // GetContentRegionAvail() already excludes the child window's scrollbar
+    // and padding. Centering the fixed-density grid balances any remainder so
+    // a resize cannot leave a second, artificial gutter on the right.
     const auto grid_layout = ResolveDungeonObjectSelectorGridLayout(
         ImGui::GetContentRegionAvail().x,
-        GetObjectGridItemSize(object_grid_density_), item_spacing,
-        style.ScrollbarSize + control_spacing);
+        GetObjectGridItemSize(object_grid_density_), item_spacing);
     const float item_size = grid_layout.item_size;
     const int columns = grid_layout.columns;
     gui::StyleVarGuard grid_spacing_guard(
@@ -409,6 +415,9 @@ void DungeonObjectSelector::DrawObjectAssetBrowser() {
 
         if (current_column > 0) {
           ImGui::SameLine(0.0f, item_spacing);
+        } else {
+          ImGui::SetCursorPosX(ImGui::GetCursorPosX() +
+                               grid_layout.leading_inset);
         }
 
         ImGui::PushID(obj_id);
@@ -1074,8 +1083,7 @@ void DungeonObjectSelector::DrawCustomObjectWorkshopPopup() {
     const float item_spacing = std::max(2.0f, style.ItemSpacing.x * 0.5f);
     const auto grid_layout = ResolveDungeonObjectSelectorGridLayout(
         ImGui::GetContentRegionAvail().x,
-        GetObjectGridItemSize(object_grid_density_), item_spacing,
-        style.ScrollbarSize + item_spacing);
+        GetObjectGridItemSize(object_grid_density_), item_spacing);
     const int columns = grid_layout.columns;
     const float item_size = grid_layout.item_size;
     gui::StyleVarGuard grid_spacing_guard(
@@ -1098,6 +1106,9 @@ void DungeonObjectSelector::DrawCustomObjectWorkshopPopup() {
 
         if (custom_col > 0) {
           ImGui::SameLine(0.0f, item_spacing);
+        } else {
+          ImGui::SetCursorPosX(ImGui::GetCursorPosX() +
+                               grid_layout.leading_inset);
         }
 
         ImGui::PushID(obj_id * 1000 + subtype);

--- a/src/app/editor/dungeon/dungeon_object_selector.cc
+++ b/src/app/editor/dungeon/dungeon_object_selector.cc
@@ -21,6 +21,7 @@
 #include "app/gui/core/agent_theme.h"
 #include "app/gui/core/drag_drop.h"
 #include "app/gui/core/icons.h"
+#include "app/gui/core/layout_helpers.h"
 #include "app/gui/core/style_guard.h"
 #include "app/gui/core/ui_helpers.h"
 #include "app/gui/widgets/themed_widgets.h"
@@ -78,17 +79,6 @@ ImU32 GetObjectRangeHeaderColor(int start_id) {
   return ThemeColor(theme.dungeon_object_wall);
 }
 
-ImU32 GetObjectRangeHeaderHoverColor(int start_id) {
-  const auto& theme = AgentUI::GetTheme();
-  if (start_id >= 0xF80) {
-    return ThemeColor(WithAlpha(theme.music_zone_color, 1.0f));
-  }
-  if (start_id >= 0x100) {
-    return ThemeColor(WithAlpha(theme.selection_secondary, 1.0f));
-  }
-  return ThemeColor(WithAlpha(theme.dungeon_object_wall, 1.0f));
-}
-
 void DrawFallbackPreviewTile(ImDrawList* draw_list, ImVec2 top_left,
                              float item_size, const ImVec4& accent_color,
                              const char* label) {
@@ -108,6 +98,70 @@ void DrawFallbackPreviewTile(ImDrawList* draw_list, ImVec2 top_left,
 }
 
 }  // namespace
+
+DungeonObjectSelectorGridLayout ResolveDungeonObjectSelectorGridLayout(
+    float available_width, float requested_item_size, float item_spacing,
+    float reserved_scrollbar_width, float min_item_size) {
+  const float safe_spacing = std::max(item_spacing, 0.0f);
+  const float usable_width = std::max(
+      available_width - std::max(reserved_scrollbar_width, 0.0f), 1.0f);
+  const float safe_min_item_size =
+      std::min(std::max(min_item_size, 1.0f), usable_width);
+
+  DungeonObjectSelectorGridLayout layout;
+  layout.item_size =
+      std::clamp(requested_item_size, safe_min_item_size, usable_width);
+  layout.columns =
+      std::max(1, static_cast<int>((usable_width + safe_spacing) /
+                                   (layout.item_size + safe_spacing)));
+  return layout;
+}
+
+DungeonObjectSelectorTypeTabLayout ResolveDungeonObjectSelectorTypeTabLayout(
+    float available_width, float requested_tab_width, float item_spacing,
+    int tab_count) {
+  if (tab_count <= 0) {
+    return {};
+  }
+
+  const float safe_width = std::max(available_width, 1.0f);
+  const float safe_tab_width = std::max(requested_tab_width, 1.0f);
+  const float safe_spacing = std::max(item_spacing, 0.0f);
+  const auto columns_fit = [&](int columns) {
+    return safe_width >= safe_tab_width * static_cast<float>(columns) +
+                             safe_spacing * static_cast<float>(columns - 1);
+  };
+
+  DungeonObjectSelectorTypeTabLayout layout;
+  if (columns_fit(tab_count)) {
+    layout.columns = tab_count;
+  } else if (tab_count > 2 && columns_fit(2)) {
+    layout.columns = 2;
+  } else {
+    layout.columns = 1;
+  }
+
+  const float width_per_column =
+      std::max((safe_width - safe_spacing * (layout.columns - 1)) /
+                   static_cast<float>(layout.columns),
+               1.0f);
+  layout.item_width = std::min(safe_tab_width, width_per_column);
+  return layout;
+}
+
+bool MatchesDungeonObjectTypeTab(int object_id, int selected_tab) {
+  switch (selected_tab) {
+    case 1:
+      return object_id >= 0x000 && object_id <= 0x0F7;
+    case 2:
+      return object_id >= 0x100 && object_id <= 0x13F;
+    case 3:
+      return object_id >= 0xF80 && object_id <= 0xFFF;
+    case 0:
+    default:
+      return true;
+  }
+}
 
 DungeonObjectSelector::~DungeonObjectSelector() {
   RetirePreviewCache();
@@ -158,11 +212,6 @@ ImU32 DungeonObjectSelector::GetObjectTypeColor(int object_id) {
     return ImGui::GetColorU32(theme.dungeon_object_wall);  // Gray for walls
   } else if (object_id >= 0x20 && object_id <= 0x2F) {
     return ImGui::GetColorU32(theme.dungeon_object_floor);  // Brown for floors
-  } else if (object_id >= 0x17 && object_id <= 0x1E) {
-    return ImGui::GetColorU32(theme.dungeon_object_floor);  // Brown for doors
-  } else if (object_id == 0x2F || object_id == 0x2B) {
-    return ImGui::GetColorU32(
-        theme.dungeon_object_pot);  // Saddle brown for pots
   } else if (object_id >= 0x30 && object_id <= 0x3F) {
     return ImGui::GetColorU32(
         theme.dungeon_object_decoration);  // Dim gray for decorations
@@ -207,10 +256,6 @@ std::string DungeonObjectSelector::GetObjectTypeSymbol(int object_id) {
     return "|";  // Wall
   } else if (object_id >= 0x20 && object_id <= 0x2F) {
     return "_";  // Floor
-  } else if (object_id >= 0x17 && object_id <= 0x1E) {
-    return "+";  // Door
-  } else if (object_id == 0x2F || object_id == 0x2B) {
-    return "o";  // Pot
   } else if (object_id >= 0x30 && object_id <= 0x3F) {
     return "~";  // Decoration
   } else if (object_id >= 0x00 && object_id <= 0x0F) {
@@ -264,10 +309,6 @@ void DungeonObjectSelector::DrawObjectAssetBrowser() {
       {0xF80, 0xFFF, "Type 3"},
   };
 
-  // Total object count
-  int total_objects =
-      (0xF7 - 0x00 + 1) + (0x13F - 0x100 + 1) + (0xFFF - 0xF80 + 1);
-
   EnsureCustomObjectsInitialized();
   auto& obj_manager = zelda3::CustomObjectManager::Get();
   const int custom_count =
@@ -275,127 +316,150 @@ void DungeonObjectSelector::DrawObjectAssetBrowser() {
                kPersistedCustomSubtypeSlots) +
       std::min(obj_manager.GetSubtypeCount(0x32), kPersistedCustomSubtypeSlots);
 
-  // Row 1: search input, full-width since this is the most-used control.
-  ImGui::SetNextItemWidth(-1.0f);
-  ImGui::InputTextWithHint(
-      "##ObjectSearch", ICON_MD_SEARCH " Filter objects by name or hex...",
-      object_search_buffer_, sizeof(object_search_buffer_));
+  const ImGuiStyle& style = ImGui::GetStyle();
+  const float control_spacing = std::max(2.0f, style.ItemSpacing.x * 0.5f);
+  const float action_size = std::max(ImGui::GetFrameHeight(),
+                                     gui::LayoutHelpers::GetMinTouchTarget());
+  {
+    gui::StyleVarGuard toolbar_spacing_guard(
+        ImGuiStyleVar_ItemSpacing,
+        ImVec2(control_spacing, std::max(2.0f, style.ItemSpacing.y * 0.5f)));
 
-  // Row 2: category filter + clear + display popover. Display options
-  // (thumbnails toggle, grid density) are rare-use preferences hidden behind
-  // an ICON_MD_TUNE popover so the chrome stays one row instead of three.
-  static const char* kFilterLabels[] = {"All",   "Walls", "Floors", "Chests",
-                                        "Doors", "Decor", "Stairs"};
-  const float controls_width = ImGui::GetContentRegionAvail().x;
-  const float filter_width = std::min(170.0f, controls_width);
-  ImGui::SetNextItemWidth(filter_width);
-  ImGui::Combo("##ObjectFilterType", &object_type_filter_, kFilterLabels,
-               IM_ARRAYSIZE(kFilterLabels));
-  ImGui::SameLine();
-  if (gui::ThemedIconButton(ICON_MD_CLEAR, "Clear search and category filter",
-                            gui::IconSize::Small())) {
-    object_search_buffer_[0] = '\0';
-    object_type_filter_ = 0;
-  }
-  ImGui::SameLine();
-  if (gui::ThemedIconButton(ICON_MD_TUNE, "Display options",
-                            gui::IconSize::Small())) {
-    ImGui::OpenPopup("##ObjectSelectorDisplayPopup");
-  }
-  if (ImGui::BeginPopup("##ObjectSelectorDisplayPopup")) {
-    ImGui::TextDisabled(tr("Display"));
-    ImGui::Checkbox(ICON_MD_IMAGE " Thumbnails", &enable_object_previews_);
-    if (ImGui::IsItemHovered()) {
-      ImGui::SetTooltip(
-          tr("Show rendered object thumbnails in the selector.\n"
-             "Requires a room to be loaded and may cost some performance."));
+    // Search stays dominant, but shares a row with filters when the drawer is
+    // wide enough. Narrow presentations wrap the control groups as a unit.
+    const float toolbar_width =
+        std::max(ImGui::GetContentRegionAvail().x, 1.0f);
+    const float compact_actions_width =
+        action_size * 3.0f + control_spacing * 3.0f;
+    const bool inline_toolbar = toolbar_width >= 600.0f;
+    const float search_width = inline_toolbar
+                                   ? std::max(220.0f, toolbar_width - 390.0f)
+                                   : toolbar_width;
+    ImGui::SetNextItemWidth(search_width);
+    ImGui::InputTextWithHint(
+        "##ObjectSearch", ICON_MD_SEARCH " Filter objects by name or hex...",
+        object_search_buffer_, sizeof(object_search_buffer_));
+    if (inline_toolbar) {
+      ImGui::SameLine(0.0f, control_spacing);
     }
-    ImGui::Spacing();
-    ImGui::TextDisabled(tr("Grid density"));
-    static constexpr const char* kDensityLabels[] = {"Small", "Medium",
-                                                     "Large"};
-    constexpr float kDensitySegmentWidth = 84.0f;
-    const float density_spacing = ImGui::GetStyle().ItemSpacing.x;
-    for (int density = 0; density < 3; ++density) {
-      if (density > 0) {
-        ImGui::SameLine(0.0f, density_spacing);
+
+    // Category plus three compact utility actions. Only this control cluster
+    // wraps on genuinely narrow hosts; individual icon buttons never stretch.
+    static const char* kFilterLabels[] = {"All",   "Walls", "Floors", "Chests",
+                                          "Doors", "Decor", "Stairs"};
+    const float controls_width =
+        std::max(ImGui::GetContentRegionAvail().x, 1.0f);
+    const bool actions_fit = controls_width >= compact_actions_width + 96.0f;
+    const float filter_width =
+        actions_fit
+            ? std::min(160.0f,
+                       std::max(96.0f, controls_width - compact_actions_width))
+            : controls_width;
+    ImGui::SetNextItemWidth(filter_width);
+    ImGui::Combo("##ObjectFilterType", &object_type_filter_, kFilterLabels,
+                 IM_ARRAYSIZE(kFilterLabels));
+    if (actions_fit) {
+      ImGui::SameLine(0.0f, control_spacing);
+    }
+    if (gui::TransparentIconButton(ICON_MD_CLEAR,
+                                   ImVec2(action_size, action_size),
+                                   "Clear search and category filter")) {
+      object_search_buffer_[0] = '\0';
+      object_type_filter_ = 0;
+    }
+    ImGui::SameLine(0.0f, control_spacing);
+    if (gui::TransparentIconButton(ICON_MD_TUNE,
+                                   ImVec2(action_size, action_size),
+                                   "Display options")) {
+      ImGui::OpenPopup("##ObjectSelectorDisplayPopup");
+    }
+    ImGui::SameLine(0.0f, control_spacing);
+    DrawCustomObjectWorkshopButton(custom_count,
+                                   ImVec2(action_size, action_size));
+    if (ImGui::BeginPopup("##ObjectSelectorDisplayPopup")) {
+      ImGui::TextDisabled(tr("Display"));
+      ImGui::Checkbox(ICON_MD_IMAGE " Thumbnails", &enable_object_previews_);
+      if (ImGui::IsItemHovered()) {
+        ImGui::SetTooltip(
+            tr("Show rendered object thumbnails in the selector.\n"
+               "Requires a room to be loaded and may cost some performance."));
       }
-      if (gui::ToggleButton(kDensityLabels[density],
-                            object_grid_density_ == density,
-                            ImVec2(kDensitySegmentWidth, 0.0f))) {
-        object_grid_density_ = density;
+      ImGui::Spacing();
+      ImGui::TextDisabled(tr("Grid density"));
+      static constexpr const char* kDensityLabels[] = {"Small", "Medium",
+                                                       "Large"};
+      for (int density = 0; density < 3; ++density) {
+        if (density > 0) {
+          ImGui::SameLine(0.0f, control_spacing);
+        }
+        if (gui::ToggleButton(kDensityLabels[density],
+                              object_grid_density_ == density)) {
+          object_grid_density_ = density;
+        }
+      }
+      ImGui::EndPopup();
+    }
+
+    // Compact object-stream tabs replace three full-width disclosure bars.
+    static constexpr const char* kTypeLabels[] = {"All", "Type 1", "Type 2",
+                                                  "Type 3"};
+    float type_tab_width = 1.0f;
+    for (const char* label : kTypeLabels) {
+      type_tab_width =
+          std::max(type_tab_width,
+                   ImGui::CalcTextSize(label).x + style.FramePadding.x * 2.0f);
+    }
+    const auto type_tab_layout = ResolveDungeonObjectSelectorTypeTabLayout(
+        ImGui::GetContentRegionAvail().x, type_tab_width, control_spacing,
+        IM_ARRAYSIZE(kTypeLabels));
+    ImGui::PushID("ObjectTypeTabs");
+    for (int tab = 0; tab < IM_ARRAYSIZE(kTypeLabels); ++tab) {
+      if (tab > 0 && tab % type_tab_layout.columns != 0) {
+        ImGui::SameLine(0.0f, control_spacing);
+      }
+      if (gui::ToggleButton(kTypeLabels[tab], object_subtype_tab_ == tab,
+                            ImVec2(type_tab_layout.item_width, 0.0f))) {
+        object_subtype_tab_ = tab;
       }
     }
-    ImGui::EndPopup();
+    ImGui::PopID();
   }
 
-  // Row 3: status row, count + selection chip + Custom Workshop entry.
-  // Inlines on wider drawers, wraps on narrow.
-  ImGui::Spacing();
-  ImGui::TextColored(theme.text_secondary_gray, tr("%d vanilla objects"),
-                     total_objects);
-  if (selected_object_id_ >= 0) {
-    if (ImGui::GetContentRegionAvail().x > 220.0f) {
-      ImGui::SameLine();
-    }
-    ImGui::TextColored(theme.text_info, ICON_MD_LABEL " Queued 0x%03X %s",
-                       selected_object_id_,
-                       zelda3::GetObjectName(selected_object_id_).c_str());
-  }
-  if (ImGui::GetContentRegionAvail().x > 180.0f) {
-    ImGui::SameLine();
-  }
-  DrawCustomObjectWorkshopButton(custom_count);
-
-  // Create asset browser-style grid
-  const float item_spacing = 6.0f;
-  // Defensive clamp: when the inspector drawer narrows below the user's chosen
-  // density, scale the cell down so at least one item is fully visible per row
-  // before the horizontal scrollbar engages. The 16px margin accounts for the
-  // child window's vertical scrollbar plus a small buffer for the cell border.
-  constexpr float kRightMargin = 16.0f;
-  constexpr float kMinItemSize = 32.0f;
-  const float available_width = ImGui::GetContentRegionAvail().x;
-  const float requested_item_size = GetObjectGridItemSize(object_grid_density_);
-  const float item_size =
-      std::min(requested_item_size,
-               std::max(kMinItemSize, available_width - kRightMargin));
-  const int columns =
-      std::max(1, static_cast<int>((available_width - item_spacing) /
-                                   (item_size + item_spacing)));
-
-  // Scrollable child region for grid - use all available space.
-  // Horizontal scrollbar guards against silent right-edge clipping when a row
-  // overruns due to per-frame column recalculation; the Item/Sprite selectors
-  // use the same flag combination.
-  float child_height = ImGui::GetContentRegionAvail().y;
-  if (ImGui::BeginChild("##ObjectGrid", ImVec2(0, child_height), false,
-                        ImGuiWindowFlags_AlwaysVerticalScrollbar |
-                            ImGuiWindowFlags_HorizontalScrollbar)) {
+  // The grid is the selector's sole scroll owner. Calculate its geometry only
+  // after entering the child so themed padding and the scrollbar are included.
+  const float child_height = std::max(ImGui::GetContentRegionAvail().y, 1.0f);
+  if (ImGui::BeginChild("##ObjectGrid", ImVec2(0, child_height), false)) {
+    const float item_spacing = control_spacing;
+    const auto grid_layout = ResolveDungeonObjectSelectorGridLayout(
+        ImGui::GetContentRegionAvail().x,
+        GetObjectGridItemSize(object_grid_density_), item_spacing,
+        style.ScrollbarSize + control_spacing);
+    const float item_size = grid_layout.item_size;
+    const int columns = grid_layout.columns;
+    gui::StyleVarGuard grid_spacing_guard(
+        ImGuiStyleVar_ItemSpacing,
+        ImVec2(item_spacing, std::max(item_spacing, style.ItemSpacing.y)));
 
     // Iterate through all object ranges
     for (const auto& range : ranges) {
-      // Section header for each type
-      const ImU32 header_color = GetObjectRangeHeaderColor(range.start);
-      const ImU32 header_hover_color =
-          GetObjectRangeHeaderHoverColor(range.start);
-      gui::StyleColorGuard section_guard(
-          {{ImGuiCol_Header, ImGui::ColorConvertU32ToFloat4(header_color)},
-           {ImGuiCol_HeaderHovered,
-            ImGui::ColorConvertU32ToFloat4(header_hover_color)}});
-      bool section_open = ImGui::CollapsingHeader(
-          absl::StrFormat("%s (0x%03X-0x%03X)", range.label, range.start,
-                          range.end)
-              .c_str(),
-          ImGuiTreeNodeFlags_DefaultOpen);
-
-      if (!section_open)
+      if (!MatchesDungeonObjectTypeTab(range.start, object_subtype_tab_)) {
         continue;
+      }
+
+      if (object_subtype_tab_ == 0) {
+        ImGui::TextColored(ImGui::ColorConvertU32ToFloat4(
+                               GetObjectRangeHeaderColor(range.start)),
+                           "%s  0x%03X-0x%03X", range.label, range.start,
+                           range.end);
+      }
 
       int current_column = 0;
 
       for (int obj_id = range.start; obj_id <= range.end; ++obj_id) {
         if (!MatchesObjectFilter(obj_id, object_type_filter_)) {
+          continue;
+        }
+        if (!MatchesDungeonObjectTypeTab(obj_id, object_subtype_tab_)) {
           continue;
         }
 
@@ -405,7 +469,7 @@ void DungeonObjectSelector::DrawObjectAssetBrowser() {
         }
 
         if (current_column > 0) {
-          ImGui::SameLine();
+          ImGui::SameLine(0.0f, item_spacing);
         }
 
         ImGui::PushID(obj_id);
@@ -593,7 +657,7 @@ void DungeonObjectSelector::DrawObjectAssetBrowser() {
   }
 
   ImGui::EndChild();
-  DrawCustomObjectWorkshopPopup(item_size);
+  DrawCustomObjectWorkshopPopup();
 }
 
 bool DungeonObjectSelector::MatchesObjectFilter(int obj_id, int filter_type) {
@@ -999,26 +1063,25 @@ void DungeonObjectSelector::DrawNewCustomObjectDialog() {
   }
 }
 
-void DungeonObjectSelector::DrawCustomObjectWorkshopButton(int custom_count) {
+void DungeonObjectSelector::DrawCustomObjectWorkshopButton(int custom_count,
+                                                           const ImVec2& size) {
   if (open_custom_workshop_popup_) {
     ImGui::OpenPopup("Custom Object Workshop");
     open_custom_workshop_popup_ = false;
   }
 
-  if (ImGui::SmallButton(absl::StrFormat(ICON_MD_PRECISION_MANUFACTURING
-                                         " Workshop (%d)",
-                                         custom_count)
-                             .c_str())) {
+  if (gui::TransparentIconButton(
+          ICON_MD_PRECISION_MANUFACTURING "##CustomObjectWorkshop", size)) {
     ImGui::OpenPopup("Custom Object Workshop");
   }
   if (ImGui::IsItemHovered()) {
-    ImGui::SetTooltip(tr(
-        "Browse and create custom dungeon objects without cluttering the main "
-        "selector."));
+    ImGui::SetTooltip(
+        tr("Custom Object Workshop\n%d custom object%s available"),
+        custom_count, custom_count == 1 ? "" : "s");
   }
 }
 
-void DungeonObjectSelector::DrawCustomObjectWorkshopPopup(float item_size) {
+void DungeonObjectSelector::DrawCustomObjectWorkshopPopup() {
   const auto& theme = AgentUI::GetTheme();
   auto& obj_manager = zelda3::CustomObjectManager::Get();
   const std::string custom_base_path = obj_manager.GetBasePath();
@@ -1091,13 +1154,18 @@ void DungeonObjectSelector::DrawCustomObjectWorkshopPopup(float item_size) {
 
   if (ImGui::BeginChild("##CustomObjectGrid",
                         ImVec2(0, -ImGui::GetFrameHeightWithSpacing() - 4.0f),
-                        false,
-                        ImGuiWindowFlags_AlwaysVerticalScrollbar |
-                            ImGuiWindowFlags_HorizontalScrollbar)) {
-    const float item_spacing = 6.0f;
-    const int columns = std::max(
-        1, static_cast<int>((ImGui::GetContentRegionAvail().x - item_spacing) /
-                            (item_size + item_spacing)));
+                        false)) {
+    const ImGuiStyle& style = ImGui::GetStyle();
+    const float item_spacing = std::max(2.0f, style.ItemSpacing.x * 0.5f);
+    const auto grid_layout = ResolveDungeonObjectSelectorGridLayout(
+        ImGui::GetContentRegionAvail().x,
+        GetObjectGridItemSize(object_grid_density_), item_spacing,
+        style.ScrollbarSize + item_spacing);
+    const int columns = grid_layout.columns;
+    const float item_size = grid_layout.item_size;
+    gui::StyleVarGuard grid_spacing_guard(
+        ImGuiStyleVar_ItemSpacing,
+        ImVec2(item_spacing, std::max(item_spacing, style.ItemSpacing.y)));
     int custom_col = 0;
     for (int obj_id : {0x31, 0x32}) {
       if (!MatchesObjectFilter(obj_id, object_type_filter_)) {
@@ -1114,7 +1182,7 @@ void DungeonObjectSelector::DrawCustomObjectWorkshopPopup(float item_size) {
         }
 
         if (custom_col > 0) {
-          ImGui::SameLine();
+          ImGui::SameLine(0.0f, item_spacing);
         }
 
         ImGui::PushID(obj_id * 1000 + subtype);

--- a/src/app/editor/dungeon/dungeon_object_selector.cc
+++ b/src/app/editor/dungeon/dungeon_object_selector.cc
@@ -42,7 +42,7 @@ constexpr int kPersistedCustomSubtypeSlots = 16;
 float GetObjectGridItemSize(int density) {
   switch (density) {
     case 0:
-      return 48.0f;
+      return 54.0f;
     case 2:
       return 76.0f;
     case 1:
@@ -253,11 +253,6 @@ void DungeonObjectSelector::SelectObject(int obj_id, int subtype) {
   }
   preview_object_ = zelda3::RoomObject(obj_id, 0, 0, size, 0);
   preview_object_.SetRom(rom_);
-  if (game_data_) {
-    auto palette =
-        game_data_->palette_groups.dungeon_main[current_palette_group_id_];
-    preview_palette_ = palette;
-  }
   object_loaded_ = true;
 
   // Notify callback
@@ -430,13 +425,6 @@ void DungeonObjectSelector::DrawObjectAssetBrowser() {
               obj_id, 0, 0, zelda3::DefaultRoomObjectSizeForPlacement(obj_id),
               0);
           preview_object_.SetRom(rom_);
-          if (game_data_ &&
-              current_palette_group_id_ <
-                  game_data_->palette_groups.dungeon_main.size()) {
-            auto palette = game_data_->palette_groups
-                               .dungeon_main[current_palette_group_id_];
-            preview_palette_ = palette;
-          }
           object_loaded_ = true;
 
           // Notify callbacks

--- a/src/app/editor/dungeon/dungeon_object_selector.h
+++ b/src/app/editor/dungeon/dungeon_object_selector.h
@@ -33,6 +33,7 @@ struct DungeonObjectSelectorTestAccess;
 struct DungeonObjectSelectorGridLayout {
   int columns = 1;
   float item_size = 1.0f;
+  float leading_inset = 0.0f;
 };
 
 struct DungeonObjectPreviewFit {
@@ -45,8 +46,8 @@ struct DungeonObjectPreviewFit {
 
 // Pure responsive-layout helpers shared by the selector and its unit tests.
 DungeonObjectSelectorGridLayout ResolveDungeonObjectSelectorGridLayout(
-    float available_width, float requested_item_size, float item_spacing,
-    float reserved_scrollbar_width, float min_item_size = 32.0f);
+    float available_width, float preferred_item_size, float item_spacing,
+    float min_item_size = 32.0f);
 DungeonObjectPreviewFit ResolveDungeonObjectPreviewFit(float source_width,
                                                        float source_height,
                                                        float box_width,

--- a/src/app/editor/dungeon/dungeon_object_selector.h
+++ b/src/app/editor/dungeon/dungeon_object_selector.h
@@ -80,9 +80,6 @@ class DungeonObjectSelector {
   void set_current_room_id(int room_id) { current_room_id_ = room_id; }
 
   // Palette access
-  void set_current_palette_group_id(uint64_t id) {
-    current_palette_group_id_ = id;
-  }
   // Replace the active palette group used by preview rendering. The preview
   // cache is keyed on object identity plus room blockset, palette, and floor
   // graphics, none of which capture the *contents* of the palette group: switching
@@ -93,9 +90,6 @@ class DungeonObjectSelector {
   void SetCurrentPaletteGroup(const gfx::PaletteGroup& palette_group) {
     current_palette_group_ = palette_group;
     InvalidatePreviewCache();
-  }
-  void SetCurrentPaletteId(uint64_t palette_id) {
-    current_palette_id_ = palette_id;
   }
   void SetCustomObjectsFolder(const std::string& folder);
 
@@ -189,15 +183,12 @@ class DungeonObjectSelector {
   int current_room_id_ = 0;
 
   // Palette data
-  uint64_t current_palette_group_id_ = 0;
-  uint64_t current_palette_id_ = 0;
   gfx::PaletteGroup current_palette_group_;
 
   zelda3::DungeonObjectRegistry object_registry_;
 
   // Object preview system
   zelda3::RoomObject preview_object_{0, 0, 0, 0, 0};
-  gfx::SnesPalette preview_palette_;
   bool object_loaded_ = false;
 
   // Callback for object selection

--- a/src/app/editor/dungeon/dungeon_object_selector.h
+++ b/src/app/editor/dungeon/dungeon_object_selector.h
@@ -30,6 +30,25 @@ namespace editor {
 class ObjectTileEditorPanel;
 struct DungeonObjectSelectorTestAccess;
 
+struct DungeonObjectSelectorGridLayout {
+  int columns = 1;
+  float item_size = 1.0f;
+};
+
+struct DungeonObjectSelectorTypeTabLayout {
+  int columns = 0;
+  float item_width = 1.0f;
+};
+
+// Pure responsive-layout helpers shared by the selector and its unit tests.
+DungeonObjectSelectorGridLayout ResolveDungeonObjectSelectorGridLayout(
+    float available_width, float requested_item_size, float item_spacing,
+    float reserved_scrollbar_width, float min_item_size = 32.0f);
+DungeonObjectSelectorTypeTabLayout ResolveDungeonObjectSelectorTypeTabLayout(
+    float available_width, float requested_tab_width, float item_spacing,
+    int tab_count = 4);
+bool MatchesDungeonObjectTypeTab(int object_id, int selected_tab);
+
 /**
  * @brief Handles object selection, preview, and editing UI
  */
@@ -136,8 +155,8 @@ class DungeonObjectSelector {
   ImU32 GetObjectTypeColor(int object_id);
   std::string GetObjectTypeSymbol(int object_id);
   void EnsureCustomObjectsInitialized();
-  void DrawCustomObjectWorkshopButton(int custom_count);
-  void DrawCustomObjectWorkshopPopup(float item_size);
+  void DrawCustomObjectWorkshopButton(int custom_count, const ImVec2& size);
+  void DrawCustomObjectWorkshopPopup();
   void DrawNewCustomObjectDialog();
   absl::Status OpenNewCustomObjectEditor(int width, int height,
                                          const std::string& filename,
@@ -186,7 +205,7 @@ class DungeonObjectSelector {
 
   // UI state for object browser filter
   int object_type_filter_ = 0;
-  int object_subtype_tab_ = 0;   // 0=Type1, 1=Type2, 2=Type3
+  int object_subtype_tab_ = 0;   // 0=All, 1=Type1, 2=Type2, 3=Type3
   int object_grid_density_ = 1;  // 0=Small, 1=Medium, 2=Large
   char object_search_buffer_[64] = {0};
 

--- a/src/app/editor/dungeon/dungeon_object_selector.h
+++ b/src/app/editor/dungeon/dungeon_object_selector.h
@@ -35,19 +35,23 @@ struct DungeonObjectSelectorGridLayout {
   float item_size = 1.0f;
 };
 
-struct DungeonObjectSelectorTypeTabLayout {
-  int columns = 0;
-  float item_width = 1.0f;
+struct DungeonObjectPreviewFit {
+  bool valid = false;
+  float x = 0.0f;
+  float y = 0.0f;
+  float width = 0.0f;
+  float height = 0.0f;
 };
 
 // Pure responsive-layout helpers shared by the selector and its unit tests.
 DungeonObjectSelectorGridLayout ResolveDungeonObjectSelectorGridLayout(
     float available_width, float requested_item_size, float item_spacing,
     float reserved_scrollbar_width, float min_item_size = 32.0f);
-DungeonObjectSelectorTypeTabLayout ResolveDungeonObjectSelectorTypeTabLayout(
-    float available_width, float requested_tab_width, float item_spacing,
-    int tab_count = 4);
-bool MatchesDungeonObjectTypeTab(int object_id, int selected_tab);
+DungeonObjectPreviewFit ResolveDungeonObjectPreviewFit(float source_width,
+                                                       float source_height,
+                                                       float box_width,
+                                                       float box_height);
+bool MatchesDungeonObjectStreamFilter(int object_id, int selected_filter);
 
 /**
  * @brief Handles object selection, preview, and editing UI
@@ -149,13 +153,12 @@ class DungeonObjectSelector {
   void CalculateObjectDimensions(const zelda3::RoomObject& object, int& width,
                                  int& height);
   bool DrawObjectPreview(const zelda3::RoomObject& object, ImVec2 top_left,
-                         float size);
+                         ImVec2 box_size);
   zelda3::RoomObject MakePreviewObject(int obj_id) const;
   void EnsureRegistryInitialized();
   ImU32 GetObjectTypeColor(int object_id);
   std::string GetObjectTypeSymbol(int object_id);
   void EnsureCustomObjectsInitialized();
-  void DrawCustomObjectWorkshopButton(int custom_count, const ImVec2& size);
   void DrawCustomObjectWorkshopPopup();
   void DrawNewCustomObjectDialog();
   absl::Status OpenNewCustomObjectEditor(int width, int height,
@@ -205,8 +208,8 @@ class DungeonObjectSelector {
 
   // UI state for object browser filter
   int object_type_filter_ = 0;
-  int object_subtype_tab_ = 0;   // 0=All, 1=Type1, 2=Type2, 3=Type3
-  int object_grid_density_ = 1;  // 0=Small, 1=Medium, 2=Large
+  int object_stream_filter_ = 0;  // 0=All, 1=Type1, 2=Type2, 3=Type3
+  int object_grid_density_ = 0;   // 0=Compact, 1=Medium, 2=Large
   char object_search_buffer_[64] = {0};
 
   // Registry initialization flag
@@ -236,7 +239,7 @@ class DungeonObjectSelector {
   void SynchronizePreviewCacheRoomContext(const zelda3::Room& room);
   static uint32_t MakeLayoutCacheKey(int object_id, uint8_t preview_size,
                                      const zelda3::Room* room);
-  bool GetOrCreatePreview(const zelda3::RoomObject& object, float size,
+  bool GetOrCreatePreview(const zelda3::RoomObject& object,
                           gfx::BackgroundBuffer** out);
 };
 

--- a/src/app/editor/dungeon/dungeon_workbench_state.h
+++ b/src/app/editor/dungeon/dungeon_workbench_state.h
@@ -8,6 +8,7 @@ namespace yaze::editor {
 struct DungeonWorkbenchLayoutState {
   bool show_left_sidebar = true;
   bool show_right_inspector = true;
+  bool show_tool_drawer = false;
 
   // Remembered widths for the collapsible panes when expanded. The right
   // inspector defaults narrower than the left room browser because the
@@ -15,6 +16,11 @@ struct DungeonWorkbenchLayoutState {
   // ~280 px, whereas the room matrix on the left wants a little more room.
   float left_width = 280.0f;
   float right_width = 280.0f;
+
+  // The Workbench presents editor tools below the central canvas. Keep the
+  // last comfortable drawer height for this Workbench session so switching
+  // tools does not make the canvas jump between sizes.
+  float tool_drawer_height = 300.0f;
 
   // Split/compare quality-of-life.
   bool sync_split_view = false;

--- a/src/app/editor/dungeon/dungeon_workbench_state.h
+++ b/src/app/editor/dungeon/dungeon_workbench_state.h
@@ -8,7 +8,6 @@ namespace yaze::editor {
 struct DungeonWorkbenchLayoutState {
   bool show_left_sidebar = true;
   bool show_right_inspector = true;
-  bool show_tool_drawer = false;
 
   // Remembered widths for the collapsible panes when expanded. The right
   // inspector defaults narrower than the left room browser because the
@@ -16,11 +15,6 @@ struct DungeonWorkbenchLayoutState {
   // ~280 px, whereas the room matrix on the left wants a little more room.
   float left_width = 280.0f;
   float right_width = 280.0f;
-
-  // The Workbench presents editor tools below the central canvas. Remember a
-  // proportion instead of a pixel height so the drawer follows window size
-  // changes without jumping when the active tool changes.
-  float tool_drawer_ratio = 0.4f;
 
   // Split/compare quality-of-life.
   bool sync_split_view = false;

--- a/src/app/editor/dungeon/dungeon_workbench_state.h
+++ b/src/app/editor/dungeon/dungeon_workbench_state.h
@@ -17,10 +17,10 @@ struct DungeonWorkbenchLayoutState {
   float left_width = 280.0f;
   float right_width = 280.0f;
 
-  // The Workbench presents editor tools below the central canvas. Keep the
-  // last comfortable drawer height for this Workbench session so switching
-  // tools does not make the canvas jump between sizes.
-  float tool_drawer_height = 300.0f;
+  // The Workbench presents editor tools below the central canvas. Remember a
+  // proportion instead of a pixel height so the drawer follows window size
+  // changes without jumping when the active tool changes.
+  float tool_drawer_ratio = 0.4f;
 
   // Split/compare quality-of-life.
   bool sync_split_view = false;

--- a/src/app/editor/dungeon/selectors/object_selector_content.cc
+++ b/src/app/editor/dungeon/selectors/object_selector_content.cc
@@ -278,9 +278,12 @@ void ObjectSelectorContent::DrawInteractionSummary() {
     drew_primary_status = true;
   }
 
-  // Selection and room-capacity context is useful in a tall presentation, but
-  // the object grid takes priority in a short bottom drawer.
-  const bool show_secondary_status = ImGui::GetContentRegionAvail().y >= 260.0f;
+  // Capacity and validation detail belongs in the wider standalone picker.
+  // A full-height inspector is still narrow, so preserve that space for the
+  // object grid while keeping placement and error feedback visible above.
+  const ImVec2 available = ImGui::GetContentRegionAvail();
+  const bool show_secondary_status =
+      available.x >= 420.0f && available.y >= 260.0f;
   if (!is_placing && show_secondary_status &&
       snapshot.kind == DungeonSelectionKind::ObjectSingle) {
     ImGui::TextColored(theme.status_success,

--- a/src/app/editor/dungeon/selectors/object_selector_content.cc
+++ b/src/app/editor/dungeon/selectors/object_selector_content.cc
@@ -193,14 +193,8 @@ void ObjectSelectorContent::Draw(bool* p_open) {
     }
   }
 
-  float available_height = ImGui::GetContentRegionAvail().y;
-  float browser_height = std::max(240.0f, available_height);
-
   DrawInteractionSummary();
-  ImGui::Spacing();
-  ImGui::BeginChild("ObjectBrowserRegion", ImVec2(0, browser_height), false);
   DrawObjectSelector();
-  ImGui::EndChild();
 }
 
 void ObjectSelectorContent::SelectObject(int obj_id) {
@@ -242,21 +236,17 @@ void ObjectSelectorContent::DrawInteractionSummary() {
                                   viewer->current_room_id())
                             : DungeonSelectionSnapshot{};
 
-  ImGui::AlignTextToFramePadding();
-  ImGui::TextColored(theme.text_info, ICON_MD_CATEGORY " Object Selector");
-
+  bool drew_primary_status = false;
   if (!last_placement_error_.empty()) {
     double elapsed = ImGui::GetTime() - placement_error_time_;
     if (!toast_manager_ && elapsed < kPlacementErrorDuration) {
-      ImGui::SameLine();
       ImGui::TextColored(theme.status_error, ICON_MD_WARNING " %s",
                          last_placement_error_.c_str());
+      drew_primary_status = true;
     } else if (elapsed >= kPlacementErrorDuration) {
       last_placement_error_.clear();
     }
   }
-
-  ImGui::Separator();
 
   bool is_placing = has_preview_object_ && canvas_viewer_ &&
                     canvas_viewer_->object_interaction().IsObjectLoaded();
@@ -265,6 +255,9 @@ void ObjectSelectorContent::DrawInteractionSummary() {
   }
 
   if (is_placing) {
+    if (drew_primary_status) {
+      ImGui::Spacing();
+    }
     ImGui::TextColored(theme.status_warning,
                        ICON_MD_ADD_CIRCLE " Queued 0x%03X %s",
                        preview_object_.id_,
@@ -282,31 +275,41 @@ void ObjectSelectorContent::DrawInteractionSummary() {
     if (ImGui::SmallButton(cancel_label)) {
       CancelPlacement();
     }
-  } else if (snapshot.kind == DungeonSelectionKind::ObjectSingle) {
+    drew_primary_status = true;
+  }
+
+  // Selection and room-capacity context is useful in a tall presentation, but
+  // the object grid takes priority in a short bottom drawer.
+  const bool show_secondary_status = ImGui::GetContentRegionAvail().y >= 260.0f;
+  if (!is_placing && show_secondary_status &&
+      snapshot.kind == DungeonSelectionKind::ObjectSingle) {
     ImGui::TextColored(theme.status_success,
                        ICON_MD_CHECK_CIRCLE " 1 object selected");
     DrawInlineInspectButton(open_object_editor_callback_);
-  } else if (snapshot.kind == DungeonSelectionKind::ObjectMulti) {
+  } else if (!is_placing && show_secondary_status &&
+             snapshot.kind == DungeonSelectionKind::ObjectMulti) {
     ImGui::TextColored(theme.status_success,
                        ICON_MD_SELECT_ALL " %zu objects selected",
                        snapshot.count);
     DrawInlineInspectButton(open_object_editor_callback_);
-  } else if (snapshot.kind == DungeonSelectionKind::Door ||
-             snapshot.kind == DungeonSelectionKind::Sprite ||
-             snapshot.kind == DungeonSelectionKind::Item) {
+  } else if (!is_placing && show_secondary_status &&
+             (snapshot.kind == DungeonSelectionKind::Door ||
+              snapshot.kind == DungeonSelectionKind::Sprite ||
+              snapshot.kind == DungeonSelectionKind::Item)) {
     ImGui::TextColored(theme.status_success,
                        ICON_MD_MANAGE_SEARCH " 1 %s selected",
                        GetDungeonSelectionKindLabel(snapshot.kind));
     DrawInlineInspectButton(open_object_editor_callback_);
-  } else if (snapshot.kind == DungeonSelectionKind::EntityMulti ||
-             snapshot.kind == DungeonSelectionKind::Mixed) {
+  } else if (!is_placing && show_secondary_status &&
+             (snapshot.kind == DungeonSelectionKind::EntityMulti ||
+              snapshot.kind == DungeonSelectionKind::Mixed)) {
     ImGui::TextColored(theme.status_success, ICON_MD_SELECT_ALL " %s",
                        GetDungeonSelectionSummaryText(snapshot).c_str());
     DrawInlineInspectButton(open_object_editor_callback_);
-  } else {
-    ImGui::TextColored(
-        theme.text_secondary_gray, ICON_MD_MOUSE
-        " Browse, filter, and click an object below to queue placement.");
+  }
+
+  if (!show_secondary_status) {
+    return;
   }
 
   auto* rooms = object_selector_.get_rooms();
@@ -381,10 +384,6 @@ void ObjectSelectorContent::DrawInteractionSummary() {
         ImGui::EndTooltip();
       }
     }
-  } else {
-    ImGui::Spacing();
-    ImGui::TextColored(theme.text_secondary_gray,
-                       ICON_MD_INFO " Room data unavailable");
   }
 }
 

--- a/src/app/editor/dungeon/widgets/dungeon_status_bar.cc
+++ b/src/app/editor/dungeon/widgets/dungeon_status_bar.cc
@@ -131,6 +131,15 @@ void DungeonStatusBar::Draw(const DungeonStatusBarState& state) {
   } else {
     ImGui::TextDisabled("%s", state.selection_summary.c_str());
   }
+  if (state.selection_count > 0 && state.on_selection) {
+    if (ImGui::IsItemHovered()) {
+      ImGui::SetMouseCursor(ImGuiMouseCursor_Hand);
+      ImGui::SetTooltip(tr("Open Selection inspector"));
+    }
+    if (ImGui::IsItemClicked(ImGuiMouseButton_Left)) {
+      state.on_selection();
+    }
+  }
   ImGui::SameLine(0, spacing * 2);
 
   // Separator
@@ -141,21 +150,6 @@ void DungeonStatusBar::Draw(const DungeonStatusBarState& state) {
   ImGui::TextDisabled(ICON_MD_ZOOM_IN);
   ImGui::SameLine(0, 4);
   ImGui::Text("%d%%", state.zoom_percent);
-  ImGui::SameLine(0, spacing * 2);
-
-  // Separator
-  ImGui::TextDisabled("|");
-  ImGui::SameLine(0, spacing * 2);
-
-  // Cursor tile coordinates
-  if (state.cursor_tile_x >= 0 && state.cursor_tile_y >= 0) {
-    ImGui::TextDisabled(ICON_MD_MY_LOCATION);
-    ImGui::SameLine(0, 4);
-    ImGui::Text("(%d, %d)", state.cursor_tile_x, state.cursor_tile_y);
-  } else {
-    ImGui::TextDisabled(ICON_MD_MY_LOCATION " --");
-  }
-
   // Right-aligned section: dirty indicator + room ID
   {
     char right_text[64];
@@ -211,14 +205,6 @@ DungeonStatusBarState DungeonStatusBar::BuildState(
   state.selection_count = static_cast<int>(snapshot.count);
   state.selection_layer = snapshot.selection_layer;
   state.selection_summary = GetDungeonSelectionSummaryText(snapshot);
-
-  // Cursor coordinates from ImGui hover state on canvas
-  // Note: the actual tile coordinates are derived from the canvas hover
-  // position. Since we don't have direct access to the canvas mouse pos
-  // from outside the draw call, we leave these at -1 (the canvas viewer
-  // itself could populate this if we add a public accessor later).
-  state.cursor_tile_x = -1;
-  state.cursor_tile_y = -1;
 
   return state;
 }

--- a/src/app/editor/dungeon/widgets/dungeon_status_bar.h
+++ b/src/app/editor/dungeon/widgets/dungeon_status_bar.h
@@ -28,10 +28,6 @@ struct DungeonStatusBarState {
   // Whether the current room has unsaved changes
   bool room_dirty = false;
 
-  // Cursor position in tile coordinates (-1 = not hovering)
-  int cursor_tile_x = -1;
-  int cursor_tile_y = -1;
-
   // Current room ID for display
   int room_id = -1;
 
@@ -42,14 +38,17 @@ struct DungeonStatusBarState {
   const char* redo_desc = nullptr;  // Description of redo action
   int undo_depth = 0;               // Number of undo actions available
 
-  // Callbacks for undo/redo buttons (set by the host panel)
+  // Callbacks for stable status-bar actions (set by the host panel).
+  // Selection opens the detailed inspector without adding transient canvas
+  // chrome above the drawing surface.
   std::function<void()> on_undo;
   std::function<void()> on_redo;
+  std::function<void()> on_selection;
 };
 
 // Thin persistent bar drawn at the bottom of the dungeon editor canvas area.
-// Displays tool mode, selection summary, zoom level, dirty indicator, and
-// cursor coordinates at a glance.
+// Displays tool mode, selection summary, zoom level, and dirty state at a
+// glance.
 class DungeonStatusBar {
  public:
   // Draws the status bar using the provided state. Should be called once per

--- a/src/app/editor/dungeon/widgets/dungeon_workbench_toolbar.cc
+++ b/src/app/editor/dungeon/widgets/dungeon_workbench_toolbar.cc
@@ -44,20 +44,24 @@ constexpr float kToolbarClusterGap = 12.0f;
 constexpr char kToolbarPopupIdViewOptions[] = "##WorkbenchViewOptions";
 constexpr char kToolbarPopupIdCompareSearchList[] = "##CompareSearchList";
 constexpr char kToolbarPopupIdCompareMenu[] = "##WorkbenchCompareMenu";
+constexpr char kToolbarPopupIdRecentRooms[] = "##WorkbenchRecentRooms";
+constexpr char kToolbarPopupIdOverflow[] = "##WorkbenchToolbarOverflow";
 constexpr char kToolbarStartCompareLabel[] = ICON_MD_COMPARE_ARROWS;
+constexpr char kToolbarRecentRoomsLabel[] = ICON_MD_HISTORY;
 constexpr char kToolbarViewOptionsLabel[] = ICON_MD_VISIBILITY;
 constexpr char kToolbarModeConnectedLabel[] = ICON_MD_VIEW_QUILT;
-constexpr char kToolbarRoomReviewLabel[] = ICON_MD_GRID_VIEW;
+constexpr char kToolbarOverflowLabel[] = ICON_MD_MORE_HORIZ;
 constexpr char kToolbarRoomSearchHint[] = "Type to filter rooms...";
 constexpr char kToolbarComparePickerTooltip[] = "Pick a room to compare";
 constexpr char kToolbarCompareRoomIdTooltip[] = "Compare room ID";
 constexpr char kToolbarPanelWorkflowTooltip[] =
     "Switch to standalone panel workflow (Ctrl+Shift+W)";
-constexpr char kToolbarRoomMatrixTooltip[] = "Open room review tools";
 constexpr char kToolbarNoCompareHistoryMessage[] =
     "Visit another room to seed compare history.";
 constexpr char kToolbarNoCompareHistoryTooltip[] =
     "Visit another room first to seed compare history.";
+constexpr char kToolbarNoRecentRoomsTooltip[] =
+    "Visit another room to build room history.";
 struct ToolbarLayout {
   float width = 0.0f;
   float spacing = 0.0f;
@@ -67,6 +71,18 @@ struct ToolbarLayout {
 struct CompareDefaultResult {
   bool found = false;
   int room_id = -1;
+};
+
+struct ToolbarVisibility {
+  bool pane_toggles = true;
+  bool recent_rooms = true;
+  bool stitched_rooms = true;
+  bool compare = false;
+  bool apply_room = false;
+  bool dungeon_map = false;
+  bool view_options = false;
+  bool panel_mode = false;
+  bool overflow = false;
 };
 
 ToolbarLayout ResolveToolbarLayout(float toolbar_width) {
@@ -131,6 +147,70 @@ bool IconToggleButton(const char* id, const char* icon_on, const char* icon_off,
   return pressed;
 }
 
+void DrawViewOptionsContents(DungeonCanvasViewer* viewer) {
+  if (!viewer) {
+    return;
+  }
+
+  // Canvas overlays — generic, common, expected on by default.
+  ImGui::TextDisabled(tr("Canvas"));
+  bool v = viewer->show_grid();
+  if (ImGui::Checkbox(tr("Grid (8x8)"), &v)) {
+    viewer->set_show_grid(v);
+  }
+  v = viewer->show_object_bounds();
+  if (ImGui::Checkbox(tr("Object Bounds"), &v)) {
+    viewer->set_show_object_bounds(v);
+  }
+  v = viewer->show_coordinate_overlay();
+  if (ImGui::Checkbox(tr("Hover Coordinates"), &v)) {
+    viewer->set_show_coordinate_overlay(v);
+  }
+  v = viewer->show_camera_quadrant_overlay();
+  if (ImGui::Checkbox(tr("Camera Quadrants"), &v)) {
+    viewer->set_show_camera_quadrant_overlay(v);
+  }
+
+  // Authoring overlays — specialized, infrequent. Grouped together so the
+  // common four don't get visually drowned by Oracle/track-specific ones.
+  ImGui::Spacing();
+  ImGui::Separator();
+  ImGui::TextDisabled(tr("Authoring"));
+  v = viewer->show_track_collision_overlay();
+  if (ImGui::Checkbox(tr("Track Collision"), &v)) {
+    viewer->set_show_track_collision_overlay(v);
+  }
+  v = viewer->show_custom_collision_overlay();
+  if (ImGui::Checkbox(tr("Custom Collision"), &v)) {
+    viewer->set_show_custom_collision_overlay(v);
+  }
+  v = viewer->show_water_fill_overlay();
+  if (ImGui::Checkbox(tr("Water Fill (Oracle)"), &v)) {
+    viewer->set_show_water_fill_overlay(v);
+  }
+  v = viewer->show_minecart_sprite_overlay();
+  if (ImGui::Checkbox(tr("Minecart Pathing"), &v)) {
+    viewer->set_show_minecart_sprite_overlay(v);
+  }
+  v = viewer->show_track_gap_overlay();
+  if (ImGui::Checkbox(tr("Track Gaps"), &v)) {
+    viewer->set_show_track_gap_overlay(v);
+  }
+  v = viewer->show_track_route_overlay();
+  if (ImGui::Checkbox(tr("Track Routes"), &v)) {
+    viewer->set_show_track_route_overlay(v);
+  }
+  v = viewer->show_custom_objects_overlay();
+  if (ImGui::Checkbox(tr("Custom Objects (Oracle)"), &v)) {
+    viewer->set_show_custom_objects_overlay(v);
+  }
+  if (ImGui::IsItemHovered()) {
+    ImGui::SetTooltip(
+        tr("Highlight custom-draw objects (IDs 0x31/0x32)\n"
+           "with a cyan overlay showing position and subtype."));
+  }
+}
+
 void DrawViewOptionsButton(DungeonCanvasViewer* viewer,
                            const ToolbarLayout& layout) {
   if (!viewer) {
@@ -146,63 +226,7 @@ void DrawViewOptionsButton(DungeonCanvasViewer* viewer,
   }
 
   if (ImGui::BeginPopup(kToolbarPopupIdViewOptions)) {
-    // Canvas overlays — generic, common, expected on by default.
-    ImGui::TextDisabled(tr("Canvas"));
-    bool v = viewer->show_grid();
-    if (ImGui::Checkbox(tr("Grid (8x8)"), &v)) {
-      viewer->set_show_grid(v);
-    }
-    v = viewer->show_object_bounds();
-    if (ImGui::Checkbox(tr("Object Bounds"), &v)) {
-      viewer->set_show_object_bounds(v);
-    }
-    v = viewer->show_coordinate_overlay();
-    if (ImGui::Checkbox(tr("Hover Coordinates"), &v)) {
-      viewer->set_show_coordinate_overlay(v);
-    }
-    v = viewer->show_camera_quadrant_overlay();
-    if (ImGui::Checkbox(tr("Camera Quadrants"), &v)) {
-      viewer->set_show_camera_quadrant_overlay(v);
-    }
-
-    // Authoring overlays — specialized, infrequent. Grouped together so the
-    // common four don't get visually drowned by Oracle/track-specific ones.
-    ImGui::Spacing();
-    ImGui::Separator();
-    ImGui::TextDisabled(tr("Authoring"));
-    v = viewer->show_track_collision_overlay();
-    if (ImGui::Checkbox(tr("Track Collision"), &v)) {
-      viewer->set_show_track_collision_overlay(v);
-    }
-    v = viewer->show_custom_collision_overlay();
-    if (ImGui::Checkbox(tr("Custom Collision"), &v)) {
-      viewer->set_show_custom_collision_overlay(v);
-    }
-    v = viewer->show_water_fill_overlay();
-    if (ImGui::Checkbox(tr("Water Fill (Oracle)"), &v)) {
-      viewer->set_show_water_fill_overlay(v);
-    }
-    v = viewer->show_minecart_sprite_overlay();
-    if (ImGui::Checkbox(tr("Minecart Pathing"), &v)) {
-      viewer->set_show_minecart_sprite_overlay(v);
-    }
-    v = viewer->show_track_gap_overlay();
-    if (ImGui::Checkbox(tr("Track Gaps"), &v)) {
-      viewer->set_show_track_gap_overlay(v);
-    }
-    v = viewer->show_track_route_overlay();
-    if (ImGui::Checkbox(tr("Track Routes"), &v)) {
-      viewer->set_show_track_route_overlay(v);
-    }
-    v = viewer->show_custom_objects_overlay();
-    if (ImGui::Checkbox(tr("Custom Objects (Oracle)"), &v)) {
-      viewer->set_show_custom_objects_overlay(v);
-    }
-    if (ImGui::IsItemHovered()) {
-      ImGui::SetTooltip(
-          tr("Highlight custom-draw objects (IDs 0x31/0x32)\n"
-             "with a cyan overlay showing position and subtype."));
-    }
+    DrawViewOptionsContents(viewer);
     ImGui::EndPopup();
   }
 }
@@ -355,6 +379,28 @@ void DrawComparePicker(
   }
 }
 
+void DrawActiveCompareRoomControls(const DungeonWorkbenchToolbarParams& p,
+                                   bool show_direct_room_id) {
+  ImGui::TextDisabled(tr("Compare Room"));
+  DrawComparePicker(*p.current_room_id, p.compare_room_id, p.get_recent_rooms,
+                    p.compare_search_buf, p.compare_search_buf_size,
+                    p.primary_viewer ? p.primary_viewer->project() : nullptr);
+  if (!show_direct_room_id) {
+    return;
+  }
+
+  uint16_t cmp = static_cast<uint16_t>(
+      std::clamp(*p.compare_room_id, 0, kDungeonRoomCount - 1));
+  if (auto res = gui::InputHexWordEx("##CompareRoomId", &cmp,
+                                     kDenseToolbarButtonWidth + 6.0f, true);
+      res.ShouldApply()) {
+    *p.compare_room_id = std::clamp<int>(cmp, 0, kDungeonRoomCount - 1);
+  }
+  if (ImGui::IsItemHovered()) {
+    ImGui::SetTooltip("%s", kToolbarCompareRoomIdTooltip);
+  }
+}
+
 void DrawCompareMenu(const DungeonWorkbenchToolbarParams& p,
                      const ToolbarLayout& layout) {
   if (!p.layout || !p.current_room_id || !p.compare_room_id ||
@@ -396,22 +442,8 @@ void DrawCompareMenu(const DungeonWorkbenchToolbarParams& p,
       ImGui::EndDisabled();
     }
   } else {
-    ImGui::TextDisabled(tr("Compare Room"));
-    DrawComparePicker(*p.current_room_id, p.compare_room_id, p.get_recent_rooms,
-                      p.compare_search_buf, p.compare_search_buf_size,
-                      p.primary_viewer ? p.primary_viewer->project() : nullptr);
-    if (layout.width >= kInlineCompareRoomIdToolbarWidth) {
-      uint16_t cmp = static_cast<uint16_t>(
-          std::clamp(*p.compare_room_id, 0, kDungeonRoomCount - 1));
-      if (auto res = gui::InputHexWordEx("##CompareRoomId", &cmp,
-                                         kDenseToolbarButtonWidth + 6.0f, true);
-          res.ShouldApply()) {
-        *p.compare_room_id = std::clamp<int>(cmp, 0, kDungeonRoomCount - 1);
-      }
-      if (ImGui::IsItemHovered()) {
-        ImGui::SetTooltip("%s", kToolbarCompareRoomIdTooltip);
-      }
-    }
+    DrawActiveCompareRoomControls(
+        p, layout.width >= kInlineCompareRoomIdToolbarWidth);
 
     ImGui::Separator();
     if (ImGui::MenuItem(tr("Swap Rooms"))) {
@@ -433,6 +465,355 @@ void DrawCompareMenu(const DungeonWorkbenchToolbarParams& p,
   }
 
   ImGui::EndPopup();
+}
+
+void DrawRecentRoomsContents(const DungeonWorkbenchToolbarParams& p,
+                             bool show_heading) {
+  if (show_heading) {
+    ImGui::TextDisabled(tr("Recent Rooms"));
+    ImGui::Separator();
+  }
+  DungeonRoomStore* rooms =
+      p.primary_viewer ? p.primary_viewer->rooms() : nullptr;
+  const project::YazeProject* project =
+      p.primary_viewer ? p.primary_viewer->project() : nullptr;
+  std::vector<int> recent_ids;
+  if (p.get_recent_rooms) {
+    const auto& recent = p.get_recent_rooms();
+    recent_ids.assign(recent.begin(), recent.end());
+  }
+  std::vector<int> to_forget;
+
+  for (int room_id : recent_ids) {
+    ImGui::PushID(room_id);
+    const bool is_current = p.current_room_id && room_id == *p.current_room_id;
+    const bool room_dirty =
+        rooms != nullptr && rooms->GetIfMaterialized(room_id) != nullptr &&
+        rooms->GetIfMaterialized(room_id)->HasUnsavedChanges();
+    const auto room_name =
+        dungeon_project_labels::GetRoomLabel(project, room_id);
+    char item_label[160];
+    snprintf(item_label, sizeof(item_label), "[%03X]%s %s##RecentRoom", room_id,
+             room_dirty ? "*" : "", room_name.c_str());
+
+    if (ImGui::Selectable(item_label, is_current) && !is_current) {
+      if (p.on_room_selected) {
+        p.on_room_selected(room_id);
+      } else if (p.current_room_id) {
+        *p.current_room_id = room_id;
+      }
+    }
+    if (ImGui::IsItemHovered()) {
+      ImGui::SetTooltip("Click to open; right-click for actions%s",
+                        room_dirty ? "\nPending room changes" : "");
+    }
+
+    if (ImGui::BeginPopupContextItem("##RecentRoomActions")) {
+      if (ImGui::MenuItem(ICON_MD_COMPARE_ARROWS " Compare")) {
+        if (p.layout) {
+          p.layout->show_connected_canvas_view = false;
+        }
+        if (p.split_view_enabled) {
+          *p.split_view_enabled = true;
+        }
+        if (p.compare_room_id) {
+          *p.compare_room_id = room_id;
+        }
+      }
+      if (p.on_open_room_panel &&
+          ImGui::MenuItem(ICON_MD_OPEN_IN_NEW " Open as Panel")) {
+        p.on_open_room_panel(room_id);
+      }
+      if (p.forget_recent_room) {
+        ImGui::Separator();
+        if (ImGui::MenuItem(ICON_MD_CLOSE " Remove from Recent")) {
+          to_forget.push_back(room_id);
+        }
+      }
+      ImGui::EndPopup();
+    }
+    ImGui::PopID();
+  }
+
+  for (int room_id : to_forget) {
+    p.forget_recent_room(room_id);
+  }
+}
+
+void DrawRecentRoomsMenu(const DungeonWorkbenchToolbarParams& p,
+                         const ToolbarLayout& layout) {
+  const bool has_history = p.get_recent_rooms && !p.get_recent_rooms().empty();
+  const float button_width = workbench::CalcIconButtonWidth(
+      kToolbarRecentRoomsLabel, layout.button_size);
+
+  if (!has_history) {
+    ImGui::BeginDisabled();
+  }
+  const bool open_history = DrawToolbarActionButton(
+      "RecentRoomsButton", kToolbarRecentRoomsLabel,
+      ImVec2(button_width, layout.button_size),
+      has_history ? "Recent rooms" : kToolbarNoRecentRoomsTooltip);
+  if (!has_history) {
+    ImGui::EndDisabled();
+  }
+  if (open_history) {
+    ImGui::OpenPopup(kToolbarPopupIdRecentRooms);
+  }
+
+  if (!ImGui::BeginPopup(kToolbarPopupIdRecentRooms)) {
+    return;
+  }
+  DrawRecentRoomsContents(p, /*show_heading=*/true);
+  ImGui::EndPopup();
+}
+
+float ToolbarRightActionsWidth(const DungeonWorkbenchToolbarParams& p,
+                               const ToolbarLayout& layout,
+                               const ToolbarVisibility& visibility) {
+  float width = 0.0f;
+  auto append = [&](float item_width) {
+    if (width > 0.0f) {
+      width += kToolbarActionGap;
+    }
+    width += item_width;
+  };
+
+  if (visibility.view_options && p.primary_viewer) {
+    append(workbench::CalcIconButtonWidth(kToolbarViewOptionsLabel,
+                                          layout.button_size));
+  }
+  if (visibility.panel_mode && p.set_workflow_mode) {
+    append(layout.button_size);
+  }
+  if (visibility.overflow) {
+    append(workbench::CalcIconButtonWidth(kToolbarOverflowLabel,
+                                          layout.button_size));
+  }
+  return width;
+}
+
+float ToolbarEstimatedWidth(const DungeonWorkbenchToolbarParams& p,
+                            const ToolbarLayout& layout,
+                            const ToolbarVisibility& visibility) {
+  float left_width = 0.0f;
+  auto append_left = [&](float item_width, float gap) {
+    if (left_width > 0.0f) {
+      left_width += gap;
+    }
+    left_width += item_width;
+  };
+
+  if (visibility.pane_toggles) {
+    append_left(workbench::CalcIconToggleButtonWidth(ICON_MD_LIST, ICON_MD_LIST,
+                                                     layout.button_size),
+                0.0f);
+    append_left(workbench::CalcIconToggleButtonWidth(ICON_MD_TUNE, ICON_MD_TUNE,
+                                                     layout.button_size),
+                kToolbarActionGap);
+  }
+
+  const float navigation_width =
+      4.0f * ImGui::GetFrameHeight() + 3.0f * ImGui::GetStyle().ItemSpacing.x;
+  append_left(navigation_width, kToolbarClusterGap);
+
+  if (visibility.recent_rooms) {
+    append_left(workbench::CalcIconButtonWidth(kToolbarRecentRoomsLabel,
+                                               layout.button_size),
+                kToolbarActionGap);
+  }
+  if (visibility.apply_room) {
+    append_left(layout.button_size, kToolbarActionGap);
+  }
+  if (visibility.dungeon_map) {
+    append_left(layout.button_size, kToolbarActionGap);
+  }
+  if (visibility.stitched_rooms) {
+    append_left(workbench::CalcIconButtonWidth(kToolbarModeConnectedLabel,
+                                               layout.button_size),
+                kToolbarClusterGap);
+  }
+  if (visibility.compare) {
+    append_left(kCompactCompareButtonWidth, kToolbarClusterGap);
+  }
+
+  const float right_width = ToolbarRightActionsWidth(p, layout, visibility);
+  return left_width +
+         (right_width > 0.0f ? kToolbarActionGap + right_width : 0.0f);
+}
+
+ToolbarVisibility ResolveToolbarVisibility(
+    const DungeonWorkbenchToolbarParams& p, const ToolbarLayout& layout) {
+  ToolbarVisibility visibility;
+  visibility.compare = true;
+  visibility.apply_room =
+      p.on_save_room && p.current_room_id && *p.current_room_id >= 0;
+  visibility.dungeon_map = p.on_request_dungeon_map != nullptr;
+  visibility.view_options = p.primary_viewer != nullptr;
+  visibility.panel_mode = p.set_workflow_mode != nullptr;
+
+  constexpr float kSafetyMargin = 4.0f;
+  auto fits = [&]() {
+    return ToolbarEstimatedWidth(p, layout, visibility) + kSafetyMargin <=
+           layout.width;
+  };
+  if (fits()) {
+    return visibility;
+  }
+
+  auto collapse = [&](bool& item) {
+    if (!item) {
+      return false;
+    }
+    item = false;
+    visibility.overflow = true;
+    return fits();
+  };
+
+  // Collapse infrequent or duplicated actions first. Pane toggles go last;
+  // at ultra-compact widths NESW navigation remains the only inline cluster.
+  if (collapse(visibility.dungeon_map))
+    return visibility;
+  if (collapse(visibility.apply_room))
+    return visibility;
+  if (collapse(visibility.panel_mode))
+    return visibility;
+  if (collapse(visibility.recent_rooms))
+    return visibility;
+  if (collapse(visibility.compare))
+    return visibility;
+  if (collapse(visibility.view_options))
+    return visibility;
+  if (collapse(visibility.stitched_rooms))
+    return visibility;
+  collapse(visibility.pane_toggles);
+  return visibility;
+}
+
+void DrawOverflowCompareActions(const DungeonWorkbenchToolbarParams& p) {
+  const CompareDefaultResult def = PickDefaultCompareRoom(
+      *p.current_room_id, p.previous_room_id ? *p.previous_room_id : -1,
+      p.get_recent_rooms);
+  const bool compare_active = *p.split_view_enabled;
+
+  if (!compare_active) {
+    if (ImGui::MenuItem(ICON_MD_COMPARE_ARROWS " Start Compare", nullptr, false,
+                        def.found)) {
+      p.layout->show_connected_canvas_view = false;
+      *p.split_view_enabled = true;
+      *p.compare_room_id = def.room_id;
+    }
+    if (!def.found &&
+        ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled)) {
+      ImGui::SetTooltip("%s", kToolbarNoCompareHistoryTooltip);
+    }
+    return;
+  }
+
+  DrawActiveCompareRoomControls(p, /*show_direct_room_id=*/true);
+  ImGui::Separator();
+  if (ImGui::MenuItem(tr("Swap Rooms"))) {
+    const int old_current = *p.current_room_id;
+    const int old_compare = *p.compare_room_id;
+    *p.compare_room_id = old_current;
+    if (p.on_room_selected) {
+      p.on_room_selected(old_compare);
+    } else {
+      *p.current_room_id = old_compare;
+    }
+  }
+  if (ImGui::MenuItem(tr("Sync View"), nullptr, p.layout->sync_split_view)) {
+    p.layout->sync_split_view = !p.layout->sync_split_view;
+  }
+  if (ImGui::MenuItem(tr("End Compare"))) {
+    *p.split_view_enabled = false;
+  }
+}
+
+bool DrawToolbarOverflowMenu(const DungeonWorkbenchToolbarParams& p,
+                             const ToolbarLayout& layout,
+                             const ToolbarVisibility& visibility) {
+  const float button_width =
+      workbench::CalcIconButtonWidth(kToolbarOverflowLabel, layout.button_size);
+  if (DrawToolbarActionButton("ToolbarOverflow", kToolbarOverflowLabel,
+                              ImVec2(button_width, layout.button_size),
+                              "More dungeon actions")) {
+    ImGui::OpenPopup(kToolbarPopupIdOverflow);
+  }
+
+  bool request_panel_mode = false;
+  if (!ImGui::BeginPopup(kToolbarPopupIdOverflow)) {
+    return request_panel_mode;
+  }
+
+  if (!visibility.pane_toggles) {
+    if (ImGui::MenuItem(ICON_MD_LIST " Room Browser", nullptr,
+                        p.layout->show_left_sidebar)) {
+      p.layout->show_left_sidebar = !p.layout->show_left_sidebar;
+    }
+    if (ImGui::MenuItem(ICON_MD_TUNE " Inspector", nullptr,
+                        p.layout->show_right_inspector)) {
+      p.layout->show_right_inspector = !p.layout->show_right_inspector;
+    }
+    ImGui::Separator();
+  }
+
+  if (!visibility.recent_rooms) {
+    const bool has_history =
+        p.get_recent_rooms && !p.get_recent_rooms().empty();
+    if (ImGui::BeginMenu(ICON_MD_HISTORY " Recent Rooms", has_history)) {
+      DrawRecentRoomsContents(p, /*show_heading=*/false);
+      ImGui::EndMenu();
+    }
+    if (!has_history &&
+        ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled)) {
+      ImGui::SetTooltip("%s", kToolbarNoRecentRoomsTooltip);
+    }
+  }
+  if (!visibility.stitched_rooms) {
+    if (ImGui::MenuItem(ICON_MD_VIEW_QUILT " Stitched Rooms", nullptr,
+                        p.layout->show_connected_canvas_view)) {
+      p.layout->show_connected_canvas_view =
+          !p.layout->show_connected_canvas_view;
+    }
+  }
+  if (!visibility.compare) {
+    DrawOverflowCompareActions(p);
+  }
+
+  const bool has_hidden_room_action =
+      (!visibility.apply_room && p.on_save_room && p.current_room_id &&
+       *p.current_room_id >= 0) ||
+      (!visibility.dungeon_map && p.on_request_dungeon_map);
+  if (has_hidden_room_action) {
+    ImGui::Separator();
+  }
+  if (!visibility.apply_room && p.on_save_room && p.current_room_id &&
+      *p.current_room_id >= 0 && ImGui::MenuItem(ICON_MD_SAVE " Apply Room")) {
+    p.on_save_room(*p.current_room_id);
+  }
+  if (!visibility.dungeon_map && p.on_request_dungeon_map &&
+      ImGui::MenuItem(ICON_MD_MAP " Dungeon Map")) {
+    p.on_request_dungeon_map();
+  }
+
+  if (!visibility.view_options && p.primary_viewer) {
+    ImGui::Separator();
+    if (ImGui::BeginMenu(ICON_MD_VISIBILITY " Canvas View")) {
+      DrawViewOptionsContents(p.primary_viewer);
+      ImGui::EndMenu();
+    }
+  }
+  if (!visibility.panel_mode && p.set_workflow_mode) {
+    if (ImGui::MenuItem(ICON_MD_VIEW_QUILT " Window Workflow")) {
+      request_panel_mode = true;
+    }
+    if (ImGui::IsItemHovered()) {
+      ImGui::SetTooltip("%s", kToolbarPanelWorkflowTooltip);
+    }
+  }
+
+  ImGui::EndPopup();
+  return request_panel_mode;
 }
 
 }  // namespace
@@ -463,77 +844,9 @@ bool DungeonWorkbenchToolbar::Draw(const DungeonWorkbenchToolbarParams& p) {
       ImGuiStyleVar_ItemSpacing,
       ImVec2(std::max(layout.spacing, 4.0f),
              std::max(3.0f, ImGui::GetStyle().ItemSpacing.y - 1.0f)));
-  // ── Width budget ──────────────────────────────────────────────────
-  // Compute right-cluster total (View Options + optional Panel Mode + Room
-  // Matrix) so we know how much horizontal space the right side will claim,
-  // then decide which optional left-cluster items fit in what's left.
-  const float right_icon_width =
-      workbench::CalcIconButtonWidth(ICON_MD_VISIBILITY, layout.button_size);
-  float right_actions_width = right_icon_width;
-  if (p.set_workflow_mode) {
-    right_actions_width +=
-        kToolbarActionGap +
-        workbench::CalcIconButtonWidth(ICON_MD_VIEW_QUILT, layout.button_size);
-  }
-  bool show_room_matrix = p.open_room_matrix != nullptr;
-  const float room_matrix_chunk =
-      kToolbarActionGap + workbench::CalcIconButtonWidth(
-                              kToolbarRoomReviewLabel, layout.button_size);
-  if (show_room_matrix) {
-    right_actions_width += room_matrix_chunk;
-  }
-
-  // Left-cluster widths. The essentials (sidebar/inspector toggles, NESW nav,
-  // Stitched Rooms toggle) are always shown — NESW is muscle memory and the
-  // toggles are how users restore hidden panes. Apply Room, Dungeon Map, and
-  // Compare are demoted to optional and dropped low-priority-first when the
-  // toolbar narrows.
-  const float toggle_w = layout.button_size;
-  // NESW arrow widget renders 4 ImGui::ArrowButtons (each ~GetFrameHeight wide
-  // ≈ button_size after the StyleVarGuard above) with default item-spacing
-  // gaps between them. Slight overestimate is safer than under here.
-  // Cluster gap leads NESW (toggles → nav boundary).
-  const float nav_w = kToolbarClusterGap + 4.0f * layout.button_size +
-                      3.0f * ImGui::GetStyle().ItemSpacing.x;
-  // Cluster gap leads Connected mode (room actions → canvas modes boundary).
-  const float stitched_w =
-      kToolbarClusterGap + workbench::CalcIconButtonWidth(
-                               kToolbarModeConnectedLabel, layout.button_size);
-  const float essential_left =
-      toggle_w + kToolbarActionGap + toggle_w + nav_w + stitched_w;
-
-  const float apply_room_chunk =
-      kToolbarActionGap +
-      workbench::CalcIconButtonWidth(ICON_MD_SAVE, layout.button_size);
-  const float dungeon_map_chunk =
-      kToolbarActionGap +
-      workbench::CalcIconButtonWidth(ICON_MD_MAP, layout.button_size);
-  // Cluster gap leads Compare (canvas modes → compare boundary).
-  const float compare_chunk = kToolbarClusterGap + kCompactCompareButtonWidth;
-
-  constexpr float kSafetyMargin = 8.0f;
-  float remaining_for_optional =
-      layout.width - essential_left - right_actions_width - kSafetyMargin;
-
-  auto try_show = [&](float chunk_w) -> bool {
-    if (remaining_for_optional >= chunk_w) {
-      remaining_for_optional -= chunk_w;
-      return true;
-    }
-    return false;
-  };
-
-  // Compare > Apply Room > Dungeon Map > Room Matrix in priority because
-  // Compare is the only multi-room workflow entry point on this toolbar.
-  const bool show_compare = try_show(compare_chunk);
-  const bool show_apply_room =
-      p.on_save_room && *p.current_room_id >= 0 && try_show(apply_room_chunk);
-  const bool show_dungeon_map =
-      p.on_request_dungeon_map && try_show(dungeon_map_chunk);
-  if (show_room_matrix && remaining_for_optional < 0.0f) {
-    show_room_matrix = false;
-    right_actions_width -= room_matrix_chunk;
-  }
+  const ToolbarVisibility visibility = ResolveToolbarVisibility(p, layout);
+  const float right_actions_width =
+      ToolbarRightActionsWidth(p, layout, visibility);
 
   // Connected toolbar controls: render as a floating canvas overlay (the
   // viewer's built-in fallback) instead of inline. Inline rendering races
@@ -545,19 +858,25 @@ bool DungeonWorkbenchToolbar::Draw(const DungeonWorkbenchToolbarParams& p) {
   }
 
   // ── Render row ───────────────────────────────────────────────────
-  (void)IconToggleButton("RoomsToggle", ICON_MD_LIST, ICON_MD_LIST,
-                         &p.layout->show_left_sidebar, layout.button_size,
-                         "Hide room browser", "Show room browser");
-  ImGui::SameLine(0.0f, kToolbarActionGap);
-  (void)IconToggleButton("InspectorToggle", ICON_MD_TUNE, ICON_MD_TUNE,
-                         &p.layout->show_right_inspector, layout.button_size,
-                         "Hide inspector", "Show inspector");
-
-  ImGui::SameLine(0.0f, kToolbarClusterGap);
+  if (visibility.pane_toggles) {
+    (void)IconToggleButton("RoomsToggle", ICON_MD_LIST, ICON_MD_LIST,
+                           &p.layout->show_left_sidebar, layout.button_size,
+                           "Hide room browser", "Show room browser");
+    ImGui::SameLine(0.0f, kToolbarActionGap);
+    (void)IconToggleButton("InspectorToggle", ICON_MD_TUNE, ICON_MD_TUNE,
+                           &p.layout->show_right_inspector, layout.button_size,
+                           "Hide inspector", "Show inspector");
+    ImGui::SameLine(0.0f, kToolbarClusterGap);
+  }
   DungeonRoomNavWidget::Draw("WorkbenchNav", *p.current_room_id,
                              p.on_room_selected);
 
-  if (show_apply_room) {
+  if (visibility.recent_rooms) {
+    ImGui::SameLine(0.0f, kToolbarActionGap);
+    DrawRecentRoomsMenu(p, layout);
+  }
+
+  if (visibility.apply_room) {
     ImGui::SameLine(0.0f, kToolbarActionGap);
     if (workbench::DrawHeaderIconAction(
             "ApplyRoomToolbar", ICON_MD_SAVE, layout.button_size,
@@ -566,7 +885,7 @@ bool DungeonWorkbenchToolbar::Draw(const DungeonWorkbenchToolbarParams& p) {
       p.on_save_room(*p.current_room_id);
     }
   }
-  if (show_dungeon_map) {
+  if (visibility.dungeon_map) {
     ImGui::SameLine(0.0f, kToolbarActionGap);
     if (workbench::DrawHeaderIconAction("DungeonMapToolbar", ICON_MD_MAP,
                                         layout.button_size,
@@ -575,38 +894,47 @@ bool DungeonWorkbenchToolbar::Draw(const DungeonWorkbenchToolbarParams& p) {
     }
   }
 
-  ImGui::SameLine(0.0f, kToolbarClusterGap);
-  DrawCanvasModeSelector(p.layout, layout);
+  if (visibility.stitched_rooms) {
+    ImGui::SameLine(0.0f, kToolbarClusterGap);
+    DrawCanvasModeSelector(p.layout, layout);
+  }
 
-  if (show_compare) {
+  if (visibility.compare) {
     ImGui::SameLine(0.0f, kToolbarClusterGap);
     DrawCompareMenu(p, layout);
   }
 
-  const float right_start =
-      std::max(ImGui::GetCursorPosX() + kToolbarActionGap,
-               ImGui::GetWindowContentRegionMax().x - right_actions_width);
-  ImGui::SameLine(right_start, 0.0f);
-  DrawViewOptionsButton(p.primary_viewer, layout);
-  if (p.set_workflow_mode) {
-    ImGui::SameLine(0.0f, kToolbarActionGap);
-    if (workbench::DrawHeaderIconAction("PanelMode", ICON_MD_VIEW_QUILT,
-                                        layout.button_size,
-                                        kToolbarPanelWorkflowTooltip)) {
-      request_panel_mode = true;
-    }
-  }
-  if (show_room_matrix) {
-    ImGui::SameLine(0.0f, kToolbarActionGap);
-    const float review_button_width = workbench::CalcIconButtonWidth(
-        kToolbarRoomReviewLabel, layout.button_size);
-    if (DrawToolbarActionButton("RoomMatrix", kToolbarRoomReviewLabel,
-                                ImVec2(review_button_width, layout.button_size),
-                                kToolbarRoomMatrixTooltip)) {
-      p.open_room_matrix();
-    }
-  }
+  if (right_actions_width > 0.0f) {
+    const float last_left_edge =
+        ImGui::GetItemRectMax().x - ImGui::GetWindowPos().x;
+    const float right_start =
+        std::max(last_left_edge + kToolbarActionGap,
+                 ImGui::GetWindowContentRegionMax().x - right_actions_width);
+    ImGui::SameLine(right_start, 0.0f);
 
+    bool drew_right_action = false;
+    if (visibility.view_options) {
+      DrawViewOptionsButton(p.primary_viewer, layout);
+      drew_right_action = true;
+    }
+    if (visibility.panel_mode) {
+      if (drew_right_action) {
+        ImGui::SameLine(0.0f, kToolbarActionGap);
+      }
+      if (workbench::DrawHeaderIconAction("PanelMode", ICON_MD_VIEW_QUILT,
+                                          layout.button_size,
+                                          kToolbarPanelWorkflowTooltip)) {
+        request_panel_mode = true;
+      }
+      drew_right_action = true;
+    }
+    if (visibility.overflow) {
+      if (drew_right_action) {
+        ImGui::SameLine(0.0f, kToolbarActionGap);
+      }
+      request_panel_mode |= DrawToolbarOverflowMenu(p, layout, visibility);
+    }
+  }
   return request_panel_mode;
 }
 

--- a/src/app/editor/dungeon/widgets/dungeon_workbench_toolbar.h
+++ b/src/app/editor/dungeon/widgets/dungeon_workbench_toolbar.h
@@ -13,7 +13,6 @@ class DungeonCanvasViewer;
 
 struct DungeonWorkbenchToolbarParams {
   DungeonWorkbenchLayoutState* layout = nullptr;
-  bool left_sidebar_visible = false;
 
   int* current_room_id = nullptr;
   int* previous_room_id = nullptr;
@@ -25,8 +24,9 @@ struct DungeonWorkbenchToolbarParams {
 
   std::function<void(int)> on_room_selected;
   std::function<const std::deque<int>&()> get_recent_rooms;
+  std::function<void(int)> on_open_room_panel;
+  std::function<void(int)> forget_recent_room;
   std::function<void(bool)> set_workflow_mode;
-  std::function<void()> open_room_matrix;
   std::function<void(int)> on_save_room;
   std::function<void()> on_request_dungeon_map;
 

--- a/src/app/editor/dungeon/workspace/dungeon_workbench_content.cc
+++ b/src/app/editor/dungeon/workspace/dungeon_workbench_content.cc
@@ -4,7 +4,6 @@
 #include <algorithm>
 #include <array>
 #include <cctype>
-#include <cmath>
 #include <cstdint>
 #include <cstdio>
 #include <cstring>
@@ -127,9 +126,6 @@ constexpr float kCompactLeftSidebarMinWidth = 224.0f;
 constexpr float kCompactRightSidebarMinWidth = 272.0f;
 constexpr float kCompactLeftSidebarScale = 0.72f;
 constexpr float kCompactRightSidebarScale = 0.84f;
-constexpr float kWorkbenchMinCanvasHeight = 240.0f;
-constexpr float kWorkbenchMinToolDrawerHeight = 180.0f;
-
 float GetCompactSidebarWidth(bool right_sidebar, float min_sidebar_width) {
   return std::max(
       right_sidebar ? kCompactRightSidebarMinWidth
@@ -156,26 +152,11 @@ bool ResolveCompactInspectorDetailRequest(bool compact, bool detail_requested) {
   return compact && detail_requested;
 }
 
-int ResolveDungeonWorkbenchToolStripColumns(float available_width,
-                                            float button_size,
-                                            float item_spacing,
-                                            int item_count) {
-  if (item_count <= 0) {
-    return 0;
-  }
-  const float safe_button_size = std::max(button_size, 1.0f);
-  const float safe_spacing = std::max(item_spacing, 0.0f);
-  const int fitting_columns =
-      static_cast<int>((std::max(available_width, 1.0f) + safe_spacing) /
-                       (safe_button_size + safe_spacing));
-  return std::clamp(fitting_columns, 1, item_count);
-}
-
 DungeonWorkbenchToolRequestTarget ResolveDungeonWorkbenchToolRequestTarget(
     bool standalone_window_open) {
   return standalone_window_open
              ? DungeonWorkbenchToolRequestTarget::kStandaloneWindow
-             : DungeonWorkbenchToolRequestTarget::kBottomDrawer;
+             : DungeonWorkbenchToolRequestTarget::kEmbeddedInspector;
 }
 
 DungeonWorkbenchResponsiveLayout ResolveDungeonWorkbenchResponsiveLayout(
@@ -387,12 +368,14 @@ void DungeonWorkbenchContent::SetEmbeddedEditorPanels(
 void DungeonWorkbenchContent::FocusRoomInspector() {
   layout_state_.show_right_inspector = true;
   inspector_mode_ = InspectorMode::Room;
+  inspector_mode_before_tools_ = InspectorMode::Room;
   compact_inspector_detail_requested_ = true;
 }
 
 void DungeonWorkbenchContent::FocusSelectionInspector() {
   layout_state_.show_right_inspector = true;
   inspector_mode_ = InspectorMode::Selection;
+  inspector_mode_before_tools_ = InspectorMode::Selection;
   compact_inspector_detail_requested_ = true;
 }
 
@@ -450,8 +433,8 @@ void DungeonWorkbenchContent::OpenMinecartTool() {
   OpenTool(WorkbenchTool::MinecartTracks);
 }
 
-bool DungeonWorkbenchContent::IsToolDrawerActiveForTesting() const {
-  return layout_state_.show_tool_drawer;
+bool DungeonWorkbenchContent::IsToolInspectorActiveForTesting() const {
+  return inspector_mode_ == InspectorMode::Tools;
 }
 
 const char* DungeonWorkbenchContent::GetInspectorModeIdForTesting() const {
@@ -460,6 +443,8 @@ const char* DungeonWorkbenchContent::GetInspectorModeIdForTesting() const {
       return "room";
     case InspectorMode::Selection:
       return "selection";
+    case InspectorMode::Tools:
+      return "tools";
   }
   return "unknown";
 }
@@ -731,32 +716,8 @@ void DungeonWorkbenchContent::Draw(bool* p_open) {
 void DungeonWorkbenchContent::DrawCanvasPane(
     float width, float height, DungeonCanvasViewer* primary_viewer,
     bool left_sidebar_visible) {
-  if (layout_state_.show_tool_drawer && IsStandaloneToolOpen(active_tool_)) {
-    CloseToolDrawer();
-  }
-  const float splitter_height = gui::UIConfig::kSplitterWidth;
-  const DungeonWorkbenchToolDrawerLayout drawer_layout =
-      ResolveDungeonWorkbenchToolDrawerLayout(
-          height, splitter_height, layout_state_.tool_drawer_ratio,
-          kWorkbenchMinCanvasHeight, kWorkbenchMinToolDrawerHeight,
-          layout_state_.show_tool_drawer);
-
-  // The canvas, splitter, and drawer are one horizontal-layout item. Without
-  // this fixed column child, each nested child resets the parent cursor and
-  // the next SameLine() can attach the inspector beside the drawer's final
-  // row instead of beside the top of the canvas column.
-  const bool column_open = ImGui::BeginChild(
-      "##DungeonWorkbenchCanvasColumn", ImVec2(width, height), false,
-      ImGuiWindowFlags_NoScrollbar | ImGuiWindowFlags_NoScrollWithMouse);
-  if (!column_open) {
-    ImGui::EndChild();
-    return;
-  }
-  const float column_width = std::max(ImGui::GetContentRegionAvail().x, 1.0f);
-
-  const bool canvas_open = ImGui::BeginChild(
-      "##DungeonWorkbenchCanvas",
-      ImVec2(column_width, drawer_layout.canvas_height), false);
+  const bool canvas_open = ImGui::BeginChild("##DungeonWorkbenchCanvas",
+                                             ImVec2(width, height), false);
   if (canvas_open) {
     if (primary_viewer) {
       const bool show_recent_tabs =
@@ -849,45 +810,6 @@ void DungeonWorkbenchContent::DrawCanvasPane(
       DungeonStatusBar::Draw(status);
     } else {
       ImGui::TextDisabled(tr("No active viewer"));
-    }
-  }
-  ImGui::EndChild();
-
-  if (drawer_layout.show_drawer) {
-    // Child items normally add vertical ItemSpacing. Remove it around the
-    // splitter so the canvas + splitter + drawer consume exactly this
-    // column's resolved height, matching the zero-gap vertical pane splitters.
-    const float item_spacing_y = ImGui::GetStyle().ItemSpacing.y;
-    ImGui::SetCursorPosY(ImGui::GetCursorPosY() - item_spacing_y);
-    const float collapse_threshold = drawer_layout.min_drawer_height;
-    float resized_drawer_height = drawer_layout.drawer_height;
-    if (DrawDungeonWorkbenchHorizontalSplitter(
-            "##DungeonWorkbenchToolDrawerSplitter", column_width,
-            &resized_drawer_height, drawer_layout.min_drawer_height,
-            drawer_layout.max_drawer_height, collapse_threshold)) {
-      CloseToolDrawer();
-    } else {
-      // Only a direct splitter drag updates the preference. A temporary clamp
-      // in a short window must not erase the user's preferred proportion.
-      if (!drawer_layout.compact && drawer_layout.available_height > 0.0f &&
-          std::abs(resized_drawer_height - drawer_layout.drawer_height) >
-              0.01f) {
-        layout_state_.tool_drawer_ratio = std::clamp(
-            resized_drawer_height / drawer_layout.available_height, 0.0f, 1.0f);
-      }
-      ImGui::SetCursorPosY(ImGui::GetCursorPosY() - item_spacing_y);
-      if (primary_viewer) {
-        DrawToolDrawerPane(column_width, drawer_layout.drawer_height,
-                           *primary_viewer);
-      } else {
-        const bool drawer_open = ImGui::BeginChild(
-            "##DungeonWorkbenchToolDrawer",
-            ImVec2(column_width, drawer_layout.drawer_height), true);
-        if (drawer_open) {
-          ImGui::TextDisabled(tr("No active viewer"));
-        }
-        ImGui::EndChild();
-      }
     }
   }
   ImGui::EndChild();
@@ -1023,8 +945,12 @@ void DungeonWorkbenchContent::DrawInspectorHeader(float button_size,
   const float spacing = ImGui::GetStyle().ItemSpacing.x;
   const float action_cluster_w = swap_w + spacing + collapse_w;
 
+  const bool tools_mode = inspector_mode_ == InspectorMode::Tools;
   workbench::DrawPaneHeader(
-      "##DungeonWorkbenchInspectorHeader", ICON_MD_TUNE, "Inspect", "Inspect",
+      "##DungeonWorkbenchInspectorHeader",
+      tools_mode ? ICON_MD_BUILD : ICON_MD_TUNE,
+      tools_mode ? "Tools" : "Inspect",
+      tools_mode ? GetWorkbenchToolShortLabel(active_tool_) : "Inspect",
       nullptr, compact, action_cluster_w, [&]() {
         if (workbench::DrawHeaderIconAction(
                 "SwapInspectorSide", ICON_MD_SWAP_HORIZ, button_size,
@@ -1046,7 +972,8 @@ void DungeonWorkbenchContent::DrawInspectorHeader(float button_size,
 
   ImGui::Dummy(ImVec2(0.0f, 2.0f));
   DrawInspectorPrimarySelector(std::max(button_size, 26.0f));
-  if (current_room_id_ && *current_room_id_ >= 0) {
+  if (inspector_mode_ != InspectorMode::Tools && current_room_id_ &&
+      *current_room_id_ >= 0) {
     ImGui::AlignTextToFramePadding();
     ImGui::TextUnformatted(tr("Room"));
     ImGui::SameLine();
@@ -1694,7 +1621,7 @@ void DungeonWorkbenchContent::OpenTool(WorkbenchTool tool) {
       DungeonWorkbenchToolRequestTarget::kStandaloneWindow) {
     // A pinned or explicitly popped-out tool remains the presentation owner.
     // Re-open/focus it, and never draw the same WindowContent twice.
-    CloseToolDrawer();
+    CloseToolInspector();
     if (open_and_focus_standalone_tool_) {
       if (WindowContent* content = GetWorkbenchToolContent(tool)) {
         (void)open_and_focus_standalone_tool_(content->GetId());
@@ -1703,7 +1630,12 @@ void DungeonWorkbenchContent::OpenTool(WorkbenchTool tool) {
     return;
   }
 
-  layout_state_.show_tool_drawer = true;
+  if (inspector_mode_ != InspectorMode::Tools) {
+    inspector_mode_before_tools_ = inspector_mode_;
+  }
+  inspector_mode_ = InspectorMode::Tools;
+  layout_state_.show_right_inspector = true;
+  compact_inspector_detail_requested_ = true;
 }
 
 WindowContent* DungeonWorkbenchContent::GetWorkbenchToolContent(
@@ -1749,8 +1681,10 @@ bool DungeonWorkbenchContent::IsStandaloneToolOpen(WorkbenchTool tool) const {
   return !standalone_id.empty() && is_standalone_tool_open_(standalone_id);
 }
 
-void DungeonWorkbenchContent::CloseToolDrawer() {
-  layout_state_.show_tool_drawer = false;
+void DungeonWorkbenchContent::CloseToolInspector() {
+  if (inspector_mode_ == InspectorMode::Tools) {
+    inspector_mode_ = inspector_mode_before_tools_;
+  }
 }
 
 bool DungeonWorkbenchContent::PopOutActiveTool() {
@@ -1765,7 +1699,7 @@ bool DungeonWorkbenchContent::PopOutActiveTool() {
     return false;
   }
 
-  CloseToolDrawer();
+  CloseToolInspector();
   return true;
 }
 
@@ -1796,35 +1730,6 @@ const char* DungeonWorkbenchContent::GetWorkbenchToolId(
       return "none";
   }
   return "unknown";
-}
-
-const char* DungeonWorkbenchContent::GetWorkbenchToolIcon(
-    WorkbenchTool tool) const {
-  switch (tool) {
-    case WorkbenchTool::RoomTags:
-      return ICON_MD_LABEL;
-    case WorkbenchTool::CustomCollision:
-      return ICON_MD_GRID_ON;
-    case WorkbenchTool::WaterFill:
-      return ICON_MD_WATER_DROP;
-    case WorkbenchTool::MinecartTracks:
-      return ICON_MD_TRAIN;
-    case WorkbenchTool::ObjectSelector:
-      return ICON_MD_CATEGORY;
-    case WorkbenchTool::DoorEditor:
-      return ICON_MD_DOOR_FRONT;
-    case WorkbenchTool::SpriteEditor:
-      return ICON_MD_PERSON;
-    case WorkbenchTool::ItemEditor:
-      return ICON_MD_INVENTORY;
-    case WorkbenchTool::RoomGraphics:
-      return ICON_MD_IMAGE;
-    case WorkbenchTool::Palette:
-      return ICON_MD_PALETTE;
-    case WorkbenchTool::None:
-      return ICON_MD_BUILD;
-  }
-  return ICON_MD_BUILD;
 }
 
 const char* DungeonWorkbenchContent::GetWorkbenchToolShortLabel(
@@ -1963,152 +1868,119 @@ void DungeonWorkbenchContent::DrawWorkbenchTool(DungeonCanvasViewer& viewer,
   ImGui::PopID();
 }
 
-void DungeonWorkbenchContent::DrawInspectorToolStrip() {
-  static constexpr std::array<WorkbenchTool, 10> kStrip = {
+void DungeonWorkbenchContent::DrawInspectorToolPicker() {
+  static constexpr std::array<WorkbenchTool, 10> kTools = {
       WorkbenchTool::ObjectSelector, WorkbenchTool::DoorEditor,
       WorkbenchTool::SpriteEditor,   WorkbenchTool::ItemEditor,
-      WorkbenchTool::Palette,        WorkbenchTool::RoomGraphics,
+      WorkbenchTool::RoomGraphics,   WorkbenchTool::Palette,
       WorkbenchTool::RoomTags,       WorkbenchTool::CustomCollision,
       WorkbenchTool::WaterFill,      WorkbenchTool::MinecartTracks,
   };
 
   const ImGuiStyle& style = ImGui::GetStyle();
-  const float button_size = std::max(ImGui::GetFrameHeight(),
-                                     gui::LayoutHelpers::GetMinTouchTarget());
-  const float spacing = std::max(2.0f, style.ItemSpacing.x * 0.5f);
-  const int columns = ResolveDungeonWorkbenchToolStripColumns(
-      ImGui::GetContentRegionAvail().x, button_size, spacing,
-      static_cast<int>(kStrip.size()));
-  gui::StyleVarGuard spacing_guard(
-      ImGuiStyleVar_ItemSpacing,
-      ImVec2(spacing, std::max(2.0f, style.ItemSpacing.y * 0.5f)));
+  const bool active_tool_is_standalone = IsStandaloneToolOpen(active_tool_);
+  const char* window_action_label = active_tool_is_standalone
+                                        ? "Show window##WorkbenchToolPopOut"
+                                        : "Pop out##WorkbenchToolPopOut";
+  const float pop_out_width =
+      ImGui::CalcTextSize(window_action_label, nullptr, true).x +
+      style.FramePadding.x * 2.0f;
+  const float picker_width =
+      std::max(1.0f, ImGui::GetContentRegionAvail().x - pop_out_width -
+                         style.ItemSpacing.x);
+  const std::string picker_label = absl::StrFormat(
+      "%s  %s##WorkbenchToolPicker", GetWorkbenchToolShortLabel(active_tool_),
+      ICON_MD_ARROW_DROP_DOWN);
+  const bool picker_requested = workbench::DrawActionButton(
+      picker_label.c_str(), ImVec2(picker_width, 0.0f));
+  {
+    gui::AutoWidgetScope automation_scope("Dungeon/Workbench");
+    gui::AutoRegisterLastItem("button", "tool_picker",
+                              "Choose a Dungeon Workbench tool");
+  }
+  if (picker_requested) {
+    ImGui::OpenPopup("##WorkbenchToolPickerPopup");
+  }
+  if (ImGui::BeginPopup("##WorkbenchToolPickerPopup")) {
+    for (size_t index = 0; index < kTools.size(); ++index) {
+      if (index == 0) {
+        ImGui::SeparatorText(tr("Edit"));
+      } else if (index == 4) {
+        ImGui::SeparatorText(tr("Room"));
+      } else if (index == 6) {
+        ImGui::SeparatorText(tr("Review"));
+      }
 
-  ImGui::PushID("WorkbenchToolStrip");
-  for (size_t index = 0; index < kStrip.size(); ++index) {
-    if (index > 0 && static_cast<int>(index) % columns != 0) {
-      ImGui::SameLine(0.0f, spacing);
-    }
-    const WorkbenchTool tool = kStrip[index];
-    const bool enabled = IsWorkbenchToolAvailable(tool);
-    const bool active = active_tool_ == tool;
-    char btn_id[48];
-    std::snprintf(btn_id, sizeof(btn_id), "%s##StripTool_%s",
-                  GetWorkbenchToolIcon(tool), GetWorkbenchToolId(tool));
-    if (!enabled) {
-      ImGui::BeginDisabled();
-    }
-    const bool pressed = gui::TransparentIconButton(
-        btn_id, ImVec2(button_size, button_size), nullptr, active,
-        ImVec4(0, 0, 0, 0), "dungeon_workbench", GetWorkbenchToolId(tool));
-    {
-      gui::AutoWidgetScope automation_scope("Dungeon/Workbench");
-      gui::AutoRegisterLastItem(
-          "button", absl::StrFormat("tool_%s", GetWorkbenchToolId(tool)),
-          "Open a Dungeon Workbench tool");
-    }
-    if (pressed && enabled) {
-      OpenTool(tool);
-    }
-    if (!enabled) {
-      ImGui::EndDisabled();
-    }
-    if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled)) {
-      if (enabled) {
-        ImGui::SetTooltip("%s", GetWorkbenchToolShortLabel(tool));
-      } else {
-        ImGui::SetTooltip("%s\n(%s)", GetWorkbenchToolShortLabel(tool),
-                          GetWorkbenchToolUnavailableMessage(tool));
+      const WorkbenchTool tool = kTools[index];
+      const bool available = IsWorkbenchToolAvailable(tool);
+      if (!available) {
+        ImGui::BeginDisabled();
+      }
+      const bool selected = ImGui::Selectable(GetWorkbenchToolShortLabel(tool),
+                                              active_tool_ == tool);
+      {
+        gui::AutoWidgetScope automation_scope("Dungeon/Workbench");
+        gui::AutoRegisterLastItem(
+            "button", absl::StrFormat("tool_%s", GetWorkbenchToolId(tool)),
+            "Open a Dungeon Workbench tool");
+      }
+      if (!available) {
+        ImGui::EndDisabled();
+      }
+      if (selected && available) {
+        OpenTool(tool);
+      }
+      if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled) &&
+          !available) {
+        ImGui::SetTooltip("%s", GetWorkbenchToolUnavailableMessage(tool));
       }
     }
+    ImGui::EndPopup();
   }
-  ImGui::PopID();
+
+  ImGui::SameLine(0.0f, style.ItemSpacing.x);
+  const bool can_pop_out =
+      IsWorkbenchToolAvailable(active_tool_) && open_and_focus_standalone_tool_;
+  if (!can_pop_out) {
+    ImGui::BeginDisabled();
+  }
+  const bool pop_out_requested = workbench::DrawActionButton(
+      window_action_label, ImVec2(pop_out_width, 0.0f));
+  {
+    gui::AutoWidgetScope automation_scope("Dungeon/Workbench");
+    gui::AutoRegisterLastItem(
+        "button", "pop_out_tool",
+        "Open the active Workbench tool in its standalone window");
+  }
+  if (!can_pop_out) {
+    ImGui::EndDisabled();
+  }
+  if (pop_out_requested && can_pop_out) {
+    (void)PopOutActiveTool();
+  }
 }
 
-void DungeonWorkbenchContent::DrawToolDrawerPane(float width, float height,
-                                                 DungeonCanvasViewer& viewer) {
-  // A panel can also be opened from the global Windows menu. Re-check every
-  // frame so that path cannot make one WindowContent draw in two places.
+void DungeonWorkbenchContent::DrawInspectorToolPanel(
+    DungeonCanvasViewer& viewer) {
+  DrawInspectorToolPicker();
+  if (inspector_mode_ != InspectorMode::Tools) {
+    return;
+  }
+
+  ImGui::Separator();
   if (IsStandaloneToolOpen(active_tool_)) {
-    CloseToolDrawer();
+    ImGui::TextDisabled(tr("%s is open in a standalone window."),
+                        GetWorkbenchToolShortLabel(active_tool_));
+    ImGui::TextDisabled(tr("Choose another tool or select Show window."));
     return;
   }
-
-  const bool drawer_open = ImGui::BeginChild("##DungeonWorkbenchToolDrawer",
-                                             ImVec2(width, height), true);
-  if (drawer_open) {
-    const float button_size = gui::LayoutHelpers::GetTouchSafeWidgetHeight();
-    if (DrawToolDrawerHeader(button_size)) {
-      DrawToolDrawerBody(viewer);
-    }
-  }
-  ImGui::EndChild();
-}
-
-bool DungeonWorkbenchContent::DrawToolDrawerHeader(float button_size) {
-  constexpr const char* kPopOutLabel =
-      ICON_MD_OPEN_IN_NEW " Pop out##WorkbenchToolPopOut";
-  const ImGuiStyle& style = ImGui::GetStyle();
-  const float pop_out_width =
-      ImGui::CalcTextSize(kPopOutLabel, nullptr, true).x +
-      style.FramePadding.x * 2.0f;
-  const float close_width =
-      workbench::CalcIconButtonWidth(ICON_MD_CLOSE, button_size);
-  const float action_width = pop_out_width + style.ItemSpacing.x + close_width;
-  const bool compact = ImGui::GetContentRegionAvail().x < 520.0f;
-
-  workbench::DrawPaneHeader(
-      "##DungeonWorkbenchToolDrawerHeader", GetWorkbenchToolIcon(active_tool_),
-      GetWorkbenchToolShortLabel(active_tool_), "Tool", nullptr, compact,
-      action_width, [&]() {
-        const bool can_pop_out = IsWorkbenchToolAvailable(active_tool_) &&
-                                 open_and_focus_standalone_tool_;
-        if (!can_pop_out) {
-          ImGui::BeginDisabled();
-        }
-        const bool pop_out_requested = workbench::DrawActionButton(
-            kPopOutLabel, ImVec2(0.0f, button_size));
-        {
-          gui::AutoWidgetScope automation_scope("Dungeon/Workbench");
-          gui::AutoRegisterLastItem(
-              "button", "pop_out_tool",
-              "Open the active Workbench tool in its standalone window");
-        }
-        if (!can_pop_out) {
-          ImGui::EndDisabled();
-        }
-        if (pop_out_requested && can_pop_out) {
-          (void)PopOutActiveTool();
-        }
-
-        ImGui::SameLine(0.0f, style.ItemSpacing.x);
-        if (workbench::DrawHeaderIconAction("CloseToolDrawer", ICON_MD_CLOSE,
-                                            button_size, "Close tool drawer")) {
-          CloseToolDrawer();
-        }
-      });
-
-  return layout_state_.show_tool_drawer;
-}
-
-void DungeonWorkbenchContent::DrawToolDrawerBody(DungeonCanvasViewer& viewer) {
-  // Preserve the existing tool switch IDs and embedded WindowContent model so
-  // keyboard/automation users and each editor tool keep the same behavior.
-  DrawInspectorToolStrip();
-  if (!layout_state_.show_tool_drawer || IsStandaloneToolOpen(active_tool_)) {
-    CloseToolDrawer();
-    return;
-  }
-
-  ImGui::Dummy(ImVec2(0.0f, 2.0f));
-  const bool available = IsWorkbenchToolAvailable(active_tool_);
-  if (!available) {
+  if (!IsWorkbenchToolAvailable(active_tool_)) {
     ImGui::TextDisabled("%s", GetWorkbenchToolUnavailableMessage(active_tool_));
     return;
   }
 
-  const float available_h = std::max(1.0f, ImGui::GetContentRegionAvail().y);
-  const bool body_open = ImGui::BeginChild("##WorkbenchToolDrawerBody",
-                                           ImVec2(0.0f, available_h), false);
+  const bool body_open = ImGui::BeginChild("##WorkbenchToolInspectorBody",
+                                           ImVec2(0.0f, 0.0f), false);
   if (body_open) {
     DrawWorkbenchTool(viewer, active_tool_);
   }
@@ -2127,41 +1999,36 @@ void DungeonWorkbenchContent::DrawInspectorPrimarySelector(
   const float available_width = ImGui::GetContentRegionAvail().x;
   const bool stack = available_width < (room_width + selection_width +
                                         tools_width + spacing * 2.0f);
-  auto draw_mode = [&](const char* label, float width, InspectorMode mode) {
+  auto draw_mode = [&](const char* label, const char* automation_key,
+                       float width, InspectorMode mode) {
     const ImVec2 size(stack ? ImGui::GetContentRegionAvail().x : width,
                       segment_height);
     const bool pressed =
         gui::ToggleButton(label, inspector_mode_ == mode, size);
     {
       gui::AutoWidgetScope automation_scope("Dungeon/Workbench");
-      gui::AutoRegisterLastItem(
-          "button",
-          mode == InspectorMode::Room ? "mode_room" : "mode_selection",
-          "Switch Dungeon Workbench inspector mode");
+      gui::AutoRegisterLastItem("button", automation_key,
+                                "Switch Dungeon Workbench inspector mode");
     }
     if (pressed) {
+      if (mode != InspectorMode::Tools) {
+        inspector_mode_before_tools_ = mode;
+      }
       inspector_mode_ = mode;
       compact_inspector_detail_requested_ = true;
     }
-    if (!stack) {
-      ImGui::SameLine(0.0f, spacing);
-    }
   };
 
-  draw_mode("Room", room_width, InspectorMode::Room);
-  draw_mode("Selection", selection_width, InspectorMode::Selection);
-  const ImVec2 tools_size(
-      stack ? ImGui::GetContentRegionAvail().x : tools_width, segment_height);
-  const bool tools_pressed =
-      gui::ToggleButton("Tools", layout_state_.show_tool_drawer, tools_size);
-  {
-    gui::AutoWidgetScope automation_scope("Dungeon/Workbench");
-    gui::AutoRegisterLastItem("button", "mode_tools",
-                              "Open Dungeon Workbench tool drawer");
+  draw_mode("Room", "mode_room", room_width, InspectorMode::Room);
+  if (!stack) {
+    ImGui::SameLine(0.0f, spacing);
   }
-  if (tools_pressed) {
-    OpenTool(active_tool_);
+  draw_mode("Selection", "mode_selection", selection_width,
+            InspectorMode::Selection);
+  if (!stack) {
+    ImGui::SameLine(0.0f, spacing);
   }
+  draw_mode("Tools", "mode_tools", tools_width, InspectorMode::Tools);
 }
 
 void DungeonWorkbenchContent::DrawInspectorCompactSummary(
@@ -2203,8 +2070,8 @@ void DungeonWorkbenchContent::DrawInspectorCompactSummary(
 
   // Apply Room, View overlays, and tool switching all live elsewhere now:
   // Apply Room is on the canvas toolbar, the overlay checkboxes live in the
-  // toolbar's View Options popup, and the Tools segment opens the bottom
-  // drawer. Compact summary stays focused on what's selected.
+  // toolbar's View Options popup, and the Tools segment opens the inspector's
+  // tool surface. Compact summary stays focused on what's selected.
 }
 
 void DungeonWorkbenchContent::DrawInspectorShelf(DungeonCanvasViewer& viewer,
@@ -2212,7 +2079,8 @@ void DungeonWorkbenchContent::DrawInspectorShelf(DungeonCanvasViewer& viewer,
   const auto& interaction = viewer.object_interaction();
   const bool has_selection =
       interaction.GetSelectionCount() > 0 || interaction.HasEntitySelection();
-  if (has_selection && !inspector_selection_was_active_) {
+  if (has_selection && !inspector_selection_was_active_ &&
+      inspector_mode_ != InspectorMode::Tools) {
     inspector_mode_ = InspectorMode::Selection;
   }
   inspector_selection_was_active_ = has_selection;
@@ -2223,7 +2091,8 @@ void DungeonWorkbenchContent::DrawInspectorShelf(DungeonCanvasViewer& viewer,
   // Use the resolved pane layout instead of GetContentRegionAvail().x. The
   // latter changes when a vertical scrollbar appears, which can make the
   // inspector alternate between full and compact content every frame.
-  if (compact && !compact_inspector_detail_requested_) {
+  if (compact && inspector_mode_ != InspectorMode::Tools &&
+      !compact_inspector_detail_requested_) {
     DrawInspectorCompactSummary(viewer);
     return;
   }
@@ -2235,13 +2104,15 @@ void DungeonWorkbenchContent::DrawInspectorShelf(DungeonCanvasViewer& viewer,
     case InspectorMode::Selection:
       DrawInspectorShelfSelection(viewer);
       break;
+    case InspectorMode::Tools:
+      DrawInspectorToolPanel(viewer);
+      return;
   }
 
   // Stitched Rooms, View Options, and the old Tools collapsible intentionally
   // removed: the canvas toolbar exposes the Stitched Rooms toggle directly,
   // the View Options popup off the toolbar's eye icon owns all 11 overlay
-  // checkboxes, and the inspector header's Tools action opens the bottom
-  // drawer without replacing the Room / Selection inspector mode.
+  // checkboxes, and Tools is a peer inspector mode instead of another pane.
 }
 
 void DungeonWorkbenchContent::DrawInspectorShelfRoom(

--- a/src/app/editor/dungeon/workspace/dungeon_workbench_content.cc
+++ b/src/app/editor/dungeon/workspace/dungeon_workbench_content.cc
@@ -597,7 +597,6 @@ void DungeonWorkbenchContent::Draw(bool* p_open) {
   if (current_room_id_) {
     DungeonWorkbenchToolbarParams params;
     params.layout = &layout_state_;
-    params.left_sidebar_visible = show_left;
     params.current_room_id = current_room_id_;
     params.previous_room_id = &previous_room_id_;
     params.split_view_enabled = &split_view_enabled_;
@@ -606,10 +605,14 @@ void DungeonWorkbenchContent::Draw(bool* p_open) {
     params.compare_viewer = compare_viewer;
     params.on_room_selected = on_room_selected_;
     params.get_recent_rooms = get_recent_rooms_;
+    if (on_room_selected_with_intent_) {
+      params.on_open_room_panel = [this](int room_id) {
+        on_room_selected_with_intent_(room_id,
+                                      RoomSelectionIntent::kOpenStandalone);
+      };
+    }
+    params.forget_recent_room = forget_recent_room_;
     params.set_workflow_mode = set_workflow_mode_;
-    params.open_room_matrix = [this]() {
-      ShowConnectedGraph();
-    };
     params.on_save_room = on_save_room_;
     params.on_request_dungeon_map = [this]() {
       RequestDungeonMapPopup();
@@ -655,7 +658,7 @@ void DungeonWorkbenchContent::Draw(bool* p_open) {
       }
       ImGui::SameLine(0.0f, 0.0f);
     }
-    DrawCanvasPane(center_w, total_h, primary_viewer, show_left);
+    DrawCanvasPane(center_w, total_h, primary_viewer);
     if (show_left) {
       ImGui::SameLine(0.0f, 0.0f);
       if (DrawDungeonWorkbenchVerticalSplitter(
@@ -690,7 +693,7 @@ void DungeonWorkbenchContent::Draw(bool* p_open) {
     if (show_left) {
       ImGui::SameLine(0.0f, 0.0f);
     }
-    DrawCanvasPane(center_w, total_h, primary_viewer, show_left);
+    DrawCanvasPane(center_w, total_h, primary_viewer);
 
     if (show_right) {
       ImGui::SameLine(0.0f, 0.0f);
@@ -714,21 +717,11 @@ void DungeonWorkbenchContent::Draw(bool* p_open) {
 }
 
 void DungeonWorkbenchContent::DrawCanvasPane(
-    float width, float height, DungeonCanvasViewer* primary_viewer,
-    bool left_sidebar_visible) {
+    float width, float height, DungeonCanvasViewer* primary_viewer) {
   const bool canvas_open = ImGui::BeginChild("##DungeonWorkbenchCanvas",
                                              ImVec2(width, height), false);
   if (canvas_open) {
     if (primary_viewer) {
-      const bool show_recent_tabs =
-          split_view_enabled_ || !left_sidebar_visible;
-      if (show_recent_tabs) {
-        DrawRecentRoomTabs();
-      }
-      if (!layout_state_.show_connected_canvas_view) {
-        DrawSelectionShelf(*primary_viewer);
-      }
-
       // Reserve a fixed strip at the bottom for the status bar so neither
       // single-room, split, nor connected-mode rendering can run past it and
       // clip against the outer window chrome. Inner scrolling (wheel zoom in
@@ -787,7 +780,7 @@ void DungeonWorkbenchContent::DrawCanvasPane(
           DungeonStatusBar::BuildState(*primary_viewer, tool_mode, room_dirty);
       status.workflow_mode = layout_state_.show_connected_canvas_view
                                  ? workflow_mode_names::kConnected
-                                 : workflow_mode_names::kWorkbench;
+                                 : nullptr;
       status.workflow_primary = true;
       if (can_undo_)
         status.can_undo = can_undo_();
@@ -807,112 +800,17 @@ void DungeonWorkbenchContent::DrawCanvasPane(
         status.undo_depth = undo_depth_();
       status.on_undo = on_undo_;
       status.on_redo = on_redo_;
+      if (!layout_state_.show_connected_canvas_view) {
+        status.on_selection = [this]() {
+          FocusSelectionInspector();
+        };
+      }
       DungeonStatusBar::Draw(status);
     } else {
       ImGui::TextDisabled(tr("No active viewer"));
     }
   }
   ImGui::EndChild();
-}
-
-void DungeonWorkbenchContent::DrawSelectionShelf(DungeonCanvasViewer& viewer) {
-  auto& interaction = viewer.object_interaction();
-  const DungeonSelectionSnapshot snapshot = BuildDungeonSelectionSnapshot(
-      interaction, viewer.rooms(), viewer.current_room_id());
-  const size_t object_count = interaction.GetSelectionCount();
-  const bool has_entity = interaction.HasEntitySelection();
-  if (object_count == 0 && !has_entity) {
-    return;
-  }
-
-  // Gentle compaction only; the start_action lambda's per-button SameLine
-  // already controls inter-button spacing within a row, so don't shrink
-  // ItemSpacing.x below the theme default here.
-  gui::StyleVarGuard frame_padding_guard(
-      ImGuiStyleVar_FramePadding,
-      ImVec2(std::max(4.0f, ImGui::GetStyle().FramePadding.x),
-             std::max(3.0f, ImGui::GetStyle().FramePadding.y - 1.0f)));
-  gui::StyleVarGuard item_spacing_guard(
-      ImGuiStyleVar_ItemSpacing,
-      ImVec2(std::max(ImGui::GetStyle().ItemSpacing.x, 4.0f),
-             std::max(3.0f, ImGui::GetStyle().ItemSpacing.y - 1.0f)));
-
-  const float spacing = ImGui::GetStyle().ItemSpacing.x;
-  bool first_button = true;
-  auto start_action = [&](const char* label) {
-    const float button_width = ImGui::CalcTextSize(label).x +
-                               (ImGui::GetStyle().FramePadding.x * 2.0f) + 8.0f;
-    if (!first_button) {
-      const float next_x = ImGui::GetItemRectMax().x + spacing + button_width;
-      const float max_x =
-          ImGui::GetWindowPos().x + ImGui::GetWindowContentRegionMax().x;
-      if (next_x <= max_x) {
-        ImGui::SameLine(0.0f, spacing);
-      }
-    }
-    first_button = false;
-  };
-
-  auto draw_action = [&](const char* label, bool enabled,
-                         const auto& on_press) {
-    start_action(label);
-    if (!enabled) {
-      ImGui::BeginDisabled();
-    }
-    if (workbench::DrawActionButton(label, ImVec2(0.0f, 0.0f)) && enabled) {
-      on_press();
-    }
-    if (!enabled) {
-      ImGui::EndDisabled();
-    }
-  };
-
-  ImGui::TextColored(AgentUI::GetTheme().text_secondary_gray,
-                     ICON_MD_SELECT_ALL " %s",
-                     GetDungeonSelectionSummaryText(snapshot).c_str());
-
-  const SelectedEntity selection = interaction.GetSelectedEntity();
-  const char* local_tool_label = nullptr;
-  WorkbenchTool local_tool = WorkbenchTool::None;
-  if (object_count == 0 && has_entity) {
-    switch (selection.type) {
-      case EntityType::Door:
-        local_tool = WorkbenchTool::DoorEditor;
-        local_tool_label = ICON_MD_DOOR_FRONT " Door Tools";
-        break;
-      case EntityType::Sprite:
-        local_tool = WorkbenchTool::SpriteEditor;
-        local_tool_label = ICON_MD_PERSON " Sprite Tools";
-        break;
-      case EntityType::Item:
-        local_tool = WorkbenchTool::ItemEditor;
-        local_tool_label = ICON_MD_INVENTORY " Item Tools";
-        break;
-      default:
-        break;
-    }
-  }
-
-  const bool can_copy_selection = snapshot.object_count > 0 ||
-                                  snapshot.sprite_count > 0 ||
-                                  snapshot.item_count > 0;
-  draw_action(ICON_MD_CONTENT_COPY " Copy", can_copy_selection,
-              [&]() { interaction.HandleCopySelected(); });
-  draw_action(ICON_MD_CONTENT_PASTE " Paste", interaction.HasClipboardData(),
-              [&]() { interaction.HandlePasteObjects(); });
-  draw_action(ICON_MD_DELETE " Delete", true,
-              [&]() { interaction.HandleDeleteSelected(); });
-  draw_action(ICON_MD_CLEAR " Clear", true, [&]() {
-    interaction.ClearSelection();
-    interaction.ClearEntitySelection();
-  });
-  draw_action(ICON_MD_TUNE " Inspector", true,
-              [&]() { FocusSelectionInspector(); });
-  if (local_tool_label != nullptr) {
-    draw_action(local_tool_label, true, [&]() { OpenTool(local_tool); });
-  }
-
-  ImGui::Dummy(ImVec2(0.0f, 2.0f));
 }
 
 void DungeonWorkbenchContent::DrawInspectorPane(float width, float height,
@@ -1011,106 +909,6 @@ void DungeonWorkbenchContent::DrawInspectorHeader(float button_size,
     }
   }
   ImGui::Separator();
-}
-
-void DungeonWorkbenchContent::DrawRecentRoomTabs() {
-  if (!get_recent_rooms_ || !current_room_id_ || !on_room_selected_) {
-    return;
-  }
-
-  DungeonRoomStore* rooms = nullptr;
-  if (auto* viewer = get_viewer_ ? get_viewer_() : nullptr) {
-    rooms = viewer->rooms();
-  }
-
-  const auto& recent = get_recent_rooms_();
-  if (recent.empty()) {
-    return;
-  }
-  // Copy IDs up-front so we can safely mutate the underlying MRU list (close
-  // tabs) without invalidating iterators mid-loop.
-  std::vector<int> recent_ids(recent.begin(), recent.end());
-  std::vector<int> to_forget;
-
-  constexpr ImGuiTabBarFlags kFlags = ImGuiTabBarFlags_AutoSelectNewTabs |
-                                      ImGuiTabBarFlags_FittingPolicyScroll |
-                                      ImGuiTabBarFlags_TabListPopupButton;
-
-  // Adaptive frame padding: larger tabs on touch/iPad for easier tapping
-  const ImVec2 frame_pad = ImGui::GetStyle().FramePadding;
-  const bool is_touch = gui::LayoutHelpers::IsTouchDevice();
-  const float extra_y = is_touch ? 6.0f : 1.0f;
-  const float extra_x = is_touch ? 4.0f : 0.0f;
-  gui::StyleVarGuard pad_guard(
-      ImGuiStyleVar_FramePadding,
-      ImVec2(frame_pad.x + extra_x, frame_pad.y + extra_y));
-  const project::YazeProject* label_project =
-      get_viewer_ && get_viewer_() ? get_viewer_()->project() : nullptr;
-
-  if (gui::BeginThemedTabBar("##DungeonRecentRooms", kFlags)) {
-    for (int room_id : recent_ids) {
-      bool open = true;
-      const ImGuiTabItemFlags tab_flags =
-          (room_id == *current_room_id_) ? ImGuiTabItemFlags_SetSelected : 0;
-      const auto room_name =
-          dungeon_project_labels::GetRoomLabel(label_project, room_id);
-      const bool room_dirty =
-          rooms != nullptr && rooms->GetIfMaterialized(room_id) != nullptr &&
-          rooms->GetIfMaterialized(room_id)->HasUnsavedChanges();
-      char tab_label[64];
-      if (room_name.empty() || room_name == "Unknown") {
-        snprintf(tab_label, sizeof(tab_label), "%03X%s##recent_%03X", room_id,
-                 room_dirty ? "*" : "", room_id);
-      } else {
-        snprintf(tab_label, sizeof(tab_label), "%03X%s %.12s##recent_%03X",
-                 room_id, room_dirty ? "*" : "", room_name.c_str(), room_id);
-      }
-      const bool selected = ImGui::BeginTabItem(tab_label, &open, tab_flags);
-
-      if (!open && forget_recent_room_) {
-        to_forget.push_back(room_id);
-      }
-
-      if (ImGui::IsItemHovered()) {
-        const auto label =
-            dungeon_project_labels::GetRoomLabel(label_project, room_id);
-        ImGui::SetTooltip("[%03X] %s%s", room_id, label.c_str(),
-                          room_dirty ? "\nPending room changes" : "");
-      }
-
-      if (ImGui::IsItemActivated() && room_id != *current_room_id_) {
-        on_room_selected_(room_id);
-      }
-
-      if (ImGui::BeginPopupContextItem()) {
-        if (ImGui::MenuItem(ICON_MD_COMPARE_ARROWS " Compare")) {
-          split_view_enabled_ = true;
-          compare_room_id_ = room_id;
-        }
-        if (on_room_selected_with_intent_ &&
-            ImGui::MenuItem(ICON_MD_OPEN_IN_NEW " Open as Panel")) {
-          on_room_selected_with_intent_(room_id,
-                                        RoomSelectionIntent::kOpenStandalone);
-        }
-        if (forget_recent_room_ && ImGui::MenuItem(ICON_MD_CLOSE " Close")) {
-          to_forget.push_back(room_id);
-        }
-        ImGui::EndPopup();
-      }
-
-      if (selected) {
-        ImGui::EndTabItem();
-      }
-    }
-
-    gui::EndThemedTabBar();
-  }
-
-  if (!to_forget.empty() && forget_recent_room_) {
-    for (int rid : to_forget) {
-      forget_recent_room_(rid);
-    }
-  }
 }
 
 void DungeonWorkbenchContent::DrawSplitView(

--- a/src/app/editor/dungeon/workspace/dungeon_workbench_content.cc
+++ b/src/app/editor/dungeon/workspace/dungeon_workbench_content.cc
@@ -722,12 +722,9 @@ void DungeonWorkbenchContent::DrawCanvasPane(
   const float splitter_height = gui::UIConfig::kSplitterWidth;
   const DungeonWorkbenchToolDrawerLayout drawer_layout =
       ResolveDungeonWorkbenchToolDrawerLayout(
-          height, splitter_height, layout_state_.tool_drawer_height,
+          height, splitter_height, layout_state_.tool_drawer_ratio,
           kWorkbenchMinCanvasHeight, kWorkbenchMinToolDrawerHeight,
           layout_state_.show_tool_drawer);
-  if (drawer_layout.show_drawer && !drawer_layout.compact) {
-    layout_state_.tool_drawer_height = drawer_layout.drawer_height;
-  }
 
   // The canvas, splitter, and drawer are one horizontal-layout item. Without
   // this fixed column child, each nested child resets the parent cursor and
@@ -848,12 +845,21 @@ void DungeonWorkbenchContent::DrawCanvasPane(
     const float item_spacing_y = ImGui::GetStyle().ItemSpacing.y;
     ImGui::SetCursorPosY(ImGui::GetCursorPosY() - item_spacing_y);
     const float collapse_threshold = drawer_layout.min_drawer_height;
+    float resized_drawer_height = drawer_layout.drawer_height;
     if (DrawDungeonWorkbenchHorizontalSplitter(
             "##DungeonWorkbenchToolDrawerSplitter", column_width,
-            &layout_state_.tool_drawer_height, drawer_layout.min_drawer_height,
+            &resized_drawer_height, drawer_layout.min_drawer_height,
             drawer_layout.max_drawer_height, collapse_threshold)) {
       CloseToolDrawer();
     } else {
+      // Only a direct splitter drag updates the preference. A temporary clamp
+      // in a short window must not erase the user's preferred proportion.
+      if (!drawer_layout.compact && drawer_layout.available_height > 0.0f &&
+          std::abs(resized_drawer_height - drawer_layout.drawer_height) >
+              0.01f) {
+        layout_state_.tool_drawer_ratio = std::clamp(
+            resized_drawer_height / drawer_layout.available_height, 0.0f, 1.0f);
+      }
       ImGui::SetCursorPosY(ImGui::GetCursorPosY() - item_spacing_y);
       if (primary_viewer) {
         DrawToolDrawerPane(column_width, drawer_layout.drawer_height,

--- a/src/app/editor/dungeon/workspace/dungeon_workbench_content.cc
+++ b/src/app/editor/dungeon/workspace/dungeon_workbench_content.cc
@@ -156,6 +156,21 @@ bool ResolveCompactInspectorDetailRequest(bool compact, bool detail_requested) {
   return compact && detail_requested;
 }
 
+int ResolveDungeonWorkbenchToolStripColumns(float available_width,
+                                            float button_size,
+                                            float item_spacing,
+                                            int item_count) {
+  if (item_count <= 0) {
+    return 0;
+  }
+  const float safe_button_size = std::max(button_size, 1.0f);
+  const float safe_spacing = std::max(item_spacing, 0.0f);
+  const int fitting_columns =
+      static_cast<int>((std::max(available_width, 1.0f) + safe_spacing) /
+                       (safe_button_size + safe_spacing));
+  return std::clamp(fitting_columns, 1, item_count);
+}
+
 DungeonWorkbenchToolRequestTarget ResolveDungeonWorkbenchToolRequestTarget(
     bool standalone_window_open) {
   return standalone_window_open
@@ -1949,60 +1964,64 @@ void DungeonWorkbenchContent::DrawWorkbenchTool(DungeonCanvasViewer& viewer,
 }
 
 void DungeonWorkbenchContent::DrawInspectorToolStrip() {
-  // Two-row icon strip lets users swap tools in one click without scrolling
-  // past the active body. Row 1 holds entity/selection tools; row 2 holds
-  // room-data tools. Active tool is highlighted via gui::ToggleButton accent.
-  static constexpr WorkbenchTool kStrip[2][5] = {
-      {WorkbenchTool::ObjectSelector, WorkbenchTool::DoorEditor,
-       WorkbenchTool::SpriteEditor, WorkbenchTool::ItemEditor,
-       WorkbenchTool::Palette},
-      {WorkbenchTool::RoomGraphics, WorkbenchTool::RoomTags,
-       WorkbenchTool::CustomCollision, WorkbenchTool::WaterFill,
-       WorkbenchTool::MinecartTracks},
+  static constexpr std::array<WorkbenchTool, 10> kStrip = {
+      WorkbenchTool::ObjectSelector, WorkbenchTool::DoorEditor,
+      WorkbenchTool::SpriteEditor,   WorkbenchTool::ItemEditor,
+      WorkbenchTool::Palette,        WorkbenchTool::RoomGraphics,
+      WorkbenchTool::RoomTags,       WorkbenchTool::CustomCollision,
+      WorkbenchTool::WaterFill,      WorkbenchTool::MinecartTracks,
   };
 
-  constexpr ImGuiTableFlags kFlags =
-      ImGuiTableFlags_SizingStretchSame | ImGuiTableFlags_NoPadOuterX;
-  if (!ImGui::BeginTable("##WorkbenchToolStrip", 5, kFlags)) {
-    return;
-  }
-  for (int row = 0; row < 2; ++row) {
-    ImGui::TableNextRow();
-    for (int col = 0; col < 5; ++col) {
-      ImGui::TableNextColumn();
-      const WorkbenchTool tool = kStrip[row][col];
-      const bool enabled = IsWorkbenchToolAvailable(tool);
-      const bool active = active_tool_ == tool;
-      char btn_id[48];
-      std::snprintf(btn_id, sizeof(btn_id), "%s##StripTool_%s",
-                    GetWorkbenchToolIcon(tool), GetWorkbenchToolId(tool));
-      if (!enabled) {
-        ImGui::BeginDisabled();
-      }
-      const bool pressed = gui::ToggleButton(btn_id, active, ImVec2(-1, 0));
-      {
-        gui::AutoWidgetScope automation_scope("Dungeon/Workbench");
-        gui::AutoRegisterLastItem(
-            "button", absl::StrFormat("tool_%s", GetWorkbenchToolId(tool)),
-            "Open a Dungeon Workbench tool");
-      }
-      if (pressed && enabled) {
-        OpenTool(tool);
-      }
-      if (!enabled) {
-        ImGui::EndDisabled();
-      }
-      if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled)) {
-        if (enabled) {
-          ImGui::SetTooltip("%s", GetWorkbenchToolShortLabel(tool));
-        } else {
-          ImGui::SetTooltip("%s\n(%s)", GetWorkbenchToolShortLabel(tool),
-                            GetWorkbenchToolUnavailableMessage(tool));
-        }
+  const ImGuiStyle& style = ImGui::GetStyle();
+  const float button_size = std::max(ImGui::GetFrameHeight(),
+                                     gui::LayoutHelpers::GetMinTouchTarget());
+  const float spacing = std::max(2.0f, style.ItemSpacing.x * 0.5f);
+  const int columns = ResolveDungeonWorkbenchToolStripColumns(
+      ImGui::GetContentRegionAvail().x, button_size, spacing,
+      static_cast<int>(kStrip.size()));
+  gui::StyleVarGuard spacing_guard(
+      ImGuiStyleVar_ItemSpacing,
+      ImVec2(spacing, std::max(2.0f, style.ItemSpacing.y * 0.5f)));
+
+  ImGui::PushID("WorkbenchToolStrip");
+  for (size_t index = 0; index < kStrip.size(); ++index) {
+    if (index > 0 && static_cast<int>(index) % columns != 0) {
+      ImGui::SameLine(0.0f, spacing);
+    }
+    const WorkbenchTool tool = kStrip[index];
+    const bool enabled = IsWorkbenchToolAvailable(tool);
+    const bool active = active_tool_ == tool;
+    char btn_id[48];
+    std::snprintf(btn_id, sizeof(btn_id), "%s##StripTool_%s",
+                  GetWorkbenchToolIcon(tool), GetWorkbenchToolId(tool));
+    if (!enabled) {
+      ImGui::BeginDisabled();
+    }
+    const bool pressed = gui::TransparentIconButton(
+        btn_id, ImVec2(button_size, button_size), nullptr, active,
+        ImVec4(0, 0, 0, 0), "dungeon_workbench", GetWorkbenchToolId(tool));
+    {
+      gui::AutoWidgetScope automation_scope("Dungeon/Workbench");
+      gui::AutoRegisterLastItem(
+          "button", absl::StrFormat("tool_%s", GetWorkbenchToolId(tool)),
+          "Open a Dungeon Workbench tool");
+    }
+    if (pressed && enabled) {
+      OpenTool(tool);
+    }
+    if (!enabled) {
+      ImGui::EndDisabled();
+    }
+    if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled)) {
+      if (enabled) {
+        ImGui::SetTooltip("%s", GetWorkbenchToolShortLabel(tool));
+      } else {
+        ImGui::SetTooltip("%s\n(%s)", GetWorkbenchToolShortLabel(tool),
+                          GetWorkbenchToolUnavailableMessage(tool));
       }
     }
   }
-  ImGui::EndTable();
+  ImGui::PopID();
 }
 
 void DungeonWorkbenchContent::DrawToolDrawerPane(float width, float height,
@@ -2039,8 +2058,8 @@ bool DungeonWorkbenchContent::DrawToolDrawerHeader(float button_size) {
 
   workbench::DrawPaneHeader(
       "##DungeonWorkbenchToolDrawerHeader", GetWorkbenchToolIcon(active_tool_),
-      GetWorkbenchToolShortLabel(active_tool_), "Tool", "Workbench drawer",
-      compact, action_width, [&]() {
+      GetWorkbenchToolShortLabel(active_tool_), "Tool", nullptr, compact,
+      action_width, [&]() {
         const bool can_pop_out = IsWorkbenchToolAvailable(active_tool_) &&
                                  open_and_focus_standalone_tool_;
         if (!can_pop_out) {
@@ -2088,9 +2107,8 @@ void DungeonWorkbenchContent::DrawToolDrawerBody(DungeonCanvasViewer& viewer) {
   }
 
   const float available_h = std::max(1.0f, ImGui::GetContentRegionAvail().y);
-  const bool body_open =
-      ImGui::BeginChild("##WorkbenchToolDrawerBody", ImVec2(0.0f, available_h),
-                        true, ImGuiWindowFlags_HorizontalScrollbar);
+  const bool body_open = ImGui::BeginChild("##WorkbenchToolDrawerBody",
+                                           ImVec2(0.0f, available_h), false);
   if (body_open) {
     DrawWorkbenchTool(viewer, active_tool_);
   }

--- a/src/app/editor/dungeon/workspace/dungeon_workbench_content.cc
+++ b/src/app/editor/dungeon/workspace/dungeon_workbench_content.cc
@@ -21,7 +21,6 @@
 #include "app/editor/dungeon/ui/window/dungeon_map_panel.h"
 #include "app/editor/dungeon/ui/window/minecart_track_editor_panel.h"
 #include "app/editor/dungeon/ui/window/room_tag_editor_panel.h"
-#include "app/editor/dungeon/ui/window/shortcut_legend_panel.h"
 #include "app/editor/dungeon/ui/window/water_fill_panel.h"
 #include "app/editor/dungeon/ui/workbench/dungeon_workbench_chrome.h"
 #include "app/editor/dungeon/widgets/dungeon_status_bar.h"
@@ -128,6 +127,8 @@ constexpr float kCompactLeftSidebarMinWidth = 224.0f;
 constexpr float kCompactRightSidebarMinWidth = 272.0f;
 constexpr float kCompactLeftSidebarScale = 0.72f;
 constexpr float kCompactRightSidebarScale = 0.84f;
+constexpr float kWorkbenchMinCanvasHeight = 240.0f;
+constexpr float kWorkbenchMinToolDrawerHeight = 180.0f;
 
 float GetCompactSidebarWidth(bool right_sidebar, float min_sidebar_width) {
   return std::max(
@@ -153,6 +154,13 @@ DungeonWorkbenchTestRect CaptureLastItemRectForTesting() {
 
 bool ResolveCompactInspectorDetailRequest(bool compact, bool detail_requested) {
   return compact && detail_requested;
+}
+
+DungeonWorkbenchToolRequestTarget ResolveDungeonWorkbenchToolRequestTarget(
+    bool standalone_window_open) {
+  return standalone_window_open
+             ? DungeonWorkbenchToolRequestTarget::kStandaloneWindow
+             : DungeonWorkbenchToolRequestTarget::kBottomDrawer;
 }
 
 DungeonWorkbenchResponsiveLayout ResolveDungeonWorkbenchResponsiveLayout(
@@ -428,7 +436,7 @@ void DungeonWorkbenchContent::OpenMinecartTool() {
 }
 
 bool DungeonWorkbenchContent::IsToolDrawerActiveForTesting() const {
-  return inspector_mode_ == InspectorMode::Tools;
+  return layout_state_.show_tool_drawer;
 }
 
 const char* DungeonWorkbenchContent::GetInspectorModeIdForTesting() const {
@@ -437,8 +445,6 @@ const char* DungeonWorkbenchContent::GetInspectorModeIdForTesting() const {
       return "room";
     case InspectorMode::Selection:
       return "selection";
-    case InspectorMode::Tools:
-      return "tools";
   }
   return "unknown";
 }
@@ -487,6 +493,14 @@ void DungeonWorkbenchContent::DrawSidebarHeader(float button_size,
             }
             if (ImGui::MenuItem(ICON_MD_MAP " Dungeon Map")) {
               RequestDungeonMapPopup();
+            }
+            ImGui::Separator();
+            const bool can_open_shortcuts =
+                static_cast<bool>(open_keyboard_shortcuts_);
+            if (ImGui::MenuItem(ICON_MD_KEYBOARD " Keyboard Shortcuts", "?",
+                                false, can_open_shortcuts) &&
+                open_keyboard_shortcuts_) {
+              open_keyboard_shortcuts_();
             }
             ImGui::EndPopup();
           }
@@ -702,8 +716,35 @@ void DungeonWorkbenchContent::Draw(bool* p_open) {
 void DungeonWorkbenchContent::DrawCanvasPane(
     float width, float height, DungeonCanvasViewer* primary_viewer,
     bool left_sidebar_visible) {
-  const bool canvas_open = ImGui::BeginChild("##DungeonWorkbenchCanvas",
-                                             ImVec2(width, height), false);
+  if (layout_state_.show_tool_drawer && IsStandaloneToolOpen(active_tool_)) {
+    CloseToolDrawer();
+  }
+  const float splitter_height = gui::UIConfig::kSplitterWidth;
+  const DungeonWorkbenchToolDrawerLayout drawer_layout =
+      ResolveDungeonWorkbenchToolDrawerLayout(
+          height, splitter_height, layout_state_.tool_drawer_height,
+          kWorkbenchMinCanvasHeight, kWorkbenchMinToolDrawerHeight,
+          layout_state_.show_tool_drawer);
+  if (drawer_layout.show_drawer && !drawer_layout.compact) {
+    layout_state_.tool_drawer_height = drawer_layout.drawer_height;
+  }
+
+  // The canvas, splitter, and drawer are one horizontal-layout item. Without
+  // this fixed column child, each nested child resets the parent cursor and
+  // the next SameLine() can attach the inspector beside the drawer's final
+  // row instead of beside the top of the canvas column.
+  const bool column_open = ImGui::BeginChild(
+      "##DungeonWorkbenchCanvasColumn", ImVec2(width, height), false,
+      ImGuiWindowFlags_NoScrollbar | ImGuiWindowFlags_NoScrollWithMouse);
+  if (!column_open) {
+    ImGui::EndChild();
+    return;
+  }
+  const float column_width = std::max(ImGui::GetContentRegionAvail().x, 1.0f);
+
+  const bool canvas_open = ImGui::BeginChild(
+      "##DungeonWorkbenchCanvas",
+      ImVec2(column_width, drawer_layout.canvas_height), false);
   if (canvas_open) {
     if (primary_viewer) {
       const bool show_recent_tabs =
@@ -796,6 +837,36 @@ void DungeonWorkbenchContent::DrawCanvasPane(
       DungeonStatusBar::Draw(status);
     } else {
       ImGui::TextDisabled(tr("No active viewer"));
+    }
+  }
+  ImGui::EndChild();
+
+  if (drawer_layout.show_drawer) {
+    // Child items normally add vertical ItemSpacing. Remove it around the
+    // splitter so the canvas + splitter + drawer consume exactly this
+    // column's resolved height, matching the zero-gap vertical pane splitters.
+    const float item_spacing_y = ImGui::GetStyle().ItemSpacing.y;
+    ImGui::SetCursorPosY(ImGui::GetCursorPosY() - item_spacing_y);
+    const float collapse_threshold = drawer_layout.min_drawer_height;
+    if (DrawDungeonWorkbenchHorizontalSplitter(
+            "##DungeonWorkbenchToolDrawerSplitter", column_width,
+            &layout_state_.tool_drawer_height, drawer_layout.min_drawer_height,
+            drawer_layout.max_drawer_height, collapse_threshold)) {
+      CloseToolDrawer();
+    } else {
+      ImGui::SetCursorPosY(ImGui::GetCursorPosY() - item_spacing_y);
+      if (primary_viewer) {
+        DrawToolDrawerPane(column_width, drawer_layout.drawer_height,
+                           *primary_viewer);
+      } else {
+        const bool drawer_open = ImGui::BeginChild(
+            "##DungeonWorkbenchToolDrawer",
+            ImVec2(column_width, drawer_layout.drawer_height), true);
+        if (drawer_open) {
+          ImGui::TextDisabled(tr("No active viewer"));
+        }
+        ImGui::EndChild();
+      }
     }
   }
   ImGui::EndChild();
@@ -1597,37 +1668,84 @@ void DungeonWorkbenchContent::OpenTool(WorkbenchTool tool) {
     return;
   }
   active_tool_ = tool;
-  inspector_mode_ = InspectorMode::Tools;
-  layout_state_.show_right_inspector = true;
+
+  if (ResolveDungeonWorkbenchToolRequestTarget(IsStandaloneToolOpen(tool)) ==
+      DungeonWorkbenchToolRequestTarget::kStandaloneWindow) {
+    // A pinned or explicitly popped-out tool remains the presentation owner.
+    // Re-open/focus it, and never draw the same WindowContent twice.
+    CloseToolDrawer();
+    if (open_and_focus_standalone_tool_) {
+      if (WindowContent* content = GetWorkbenchToolContent(tool)) {
+        (void)open_and_focus_standalone_tool_(content->GetId());
+      }
+    }
+    return;
+  }
+
+  layout_state_.show_tool_drawer = true;
+}
+
+WindowContent* DungeonWorkbenchContent::GetWorkbenchToolContent(
+    WorkbenchTool tool) const {
+  switch (tool) {
+    case WorkbenchTool::RoomTags:
+      return room_tag_panel_;
+    case WorkbenchTool::CustomCollision:
+      return custom_collision_panel_;
+    case WorkbenchTool::WaterFill:
+      return water_fill_panel_;
+    case WorkbenchTool::MinecartTracks:
+      return minecart_track_panel_;
+    case WorkbenchTool::ObjectSelector:
+      return object_selector_content_;
+    case WorkbenchTool::DoorEditor:
+      return door_editor_content_;
+    case WorkbenchTool::SpriteEditor:
+      return sprite_editor_content_;
+    case WorkbenchTool::ItemEditor:
+      return item_editor_content_;
+    case WorkbenchTool::RoomGraphics:
+      return room_graphics_content_;
+    case WorkbenchTool::Palette:
+      return palette_editor_content_;
+    case WorkbenchTool::None:
+      return nullptr;
+  }
+  return nullptr;
 }
 
 bool DungeonWorkbenchContent::IsWorkbenchToolAvailable(
     WorkbenchTool tool) const {
-  switch (tool) {
-    case WorkbenchTool::RoomTags:
-      return room_tag_panel_ != nullptr;
-    case WorkbenchTool::CustomCollision:
-      return custom_collision_panel_ != nullptr;
-    case WorkbenchTool::WaterFill:
-      return water_fill_panel_ != nullptr;
-    case WorkbenchTool::MinecartTracks:
-      return minecart_track_panel_ != nullptr;
-    case WorkbenchTool::ObjectSelector:
-      return object_selector_content_ != nullptr;
-    case WorkbenchTool::DoorEditor:
-      return door_editor_content_ != nullptr;
-    case WorkbenchTool::SpriteEditor:
-      return sprite_editor_content_ != nullptr;
-    case WorkbenchTool::ItemEditor:
-      return item_editor_content_ != nullptr;
-    case WorkbenchTool::RoomGraphics:
-      return room_graphics_content_ != nullptr;
-    case WorkbenchTool::Palette:
-      return palette_editor_content_ != nullptr;
-    case WorkbenchTool::None:
-      return false;
+  return GetWorkbenchToolContent(tool) != nullptr;
+}
+
+bool DungeonWorkbenchContent::IsStandaloneToolOpen(WorkbenchTool tool) const {
+  WindowContent* content = GetWorkbenchToolContent(tool);
+  if (!content || !is_standalone_tool_open_) {
+    return false;
   }
-  return false;
+  const std::string standalone_id = content->GetId();
+  return !standalone_id.empty() && is_standalone_tool_open_(standalone_id);
+}
+
+void DungeonWorkbenchContent::CloseToolDrawer() {
+  layout_state_.show_tool_drawer = false;
+}
+
+bool DungeonWorkbenchContent::PopOutActiveTool() {
+  WindowContent* content = GetWorkbenchToolContent(active_tool_);
+  if (!content || !open_and_focus_standalone_tool_) {
+    return false;
+  }
+
+  const std::string standalone_id = content->GetId();
+  if (standalone_id.empty() ||
+      !open_and_focus_standalone_tool_(standalone_id)) {
+    return false;
+  }
+
+  CloseToolDrawer();
+  return true;
 }
 
 const char* DungeonWorkbenchContent::GetWorkbenchToolId(
@@ -1657,35 +1775,6 @@ const char* DungeonWorkbenchContent::GetWorkbenchToolId(
       return "none";
   }
   return "unknown";
-}
-
-const char* DungeonWorkbenchContent::GetWorkbenchToolTitle(
-    WorkbenchTool tool) const {
-  switch (tool) {
-    case WorkbenchTool::RoomTags:
-      return ICON_MD_LABEL " Room Tags";
-    case WorkbenchTool::CustomCollision:
-      return ICON_MD_GRID_ON " Custom Collision";
-    case WorkbenchTool::WaterFill:
-      return ICON_MD_WATER_DROP " Water Fill";
-    case WorkbenchTool::MinecartTracks:
-      return ICON_MD_TRAIN " Minecart Tracks";
-    case WorkbenchTool::ObjectSelector:
-      return ICON_MD_CATEGORY " Object Selector";
-    case WorkbenchTool::DoorEditor:
-      return ICON_MD_DOOR_FRONT " Door Tools";
-    case WorkbenchTool::SpriteEditor:
-      return ICON_MD_PERSON " Sprite Tools";
-    case WorkbenchTool::ItemEditor:
-      return ICON_MD_INVENTORY " Item Tools";
-    case WorkbenchTool::RoomGraphics:
-      return ICON_MD_IMAGE " Room Graphics";
-    case WorkbenchTool::Palette:
-      return ICON_MD_PALETTE " Palette";
-    case WorkbenchTool::None:
-      return ICON_MD_BUILD " Tool";
-  }
-  return ICON_MD_BUILD " Tool";
 }
 
 const char* DungeonWorkbenchContent::GetWorkbenchToolIcon(
@@ -1910,26 +1999,89 @@ void DungeonWorkbenchContent::DrawInspectorToolStrip() {
   ImGui::EndTable();
 }
 
-void DungeonWorkbenchContent::DrawInspectorToolDrawer(
-    DungeonCanvasViewer& viewer) {
-  // Quick-switch strip first: users can hop between tools without leaving the
-  // drawer. The inspector primary segmented selector handles Room/Selection
-  // returns, so no in-drawer back button is needed.
+void DungeonWorkbenchContent::DrawToolDrawerPane(float width, float height,
+                                                 DungeonCanvasViewer& viewer) {
+  // A panel can also be opened from the global Windows menu. Re-check every
+  // frame so that path cannot make one WindowContent draw in two places.
+  if (IsStandaloneToolOpen(active_tool_)) {
+    CloseToolDrawer();
+    return;
+  }
+
+  const bool drawer_open = ImGui::BeginChild("##DungeonWorkbenchToolDrawer",
+                                             ImVec2(width, height), true);
+  if (drawer_open) {
+    const float button_size = gui::LayoutHelpers::GetTouchSafeWidgetHeight();
+    if (DrawToolDrawerHeader(button_size)) {
+      DrawToolDrawerBody(viewer);
+    }
+  }
+  ImGui::EndChild();
+}
+
+bool DungeonWorkbenchContent::DrawToolDrawerHeader(float button_size) {
+  constexpr const char* kPopOutLabel =
+      ICON_MD_OPEN_IN_NEW " Pop out##WorkbenchToolPopOut";
+  const ImGuiStyle& style = ImGui::GetStyle();
+  const float pop_out_width =
+      ImGui::CalcTextSize(kPopOutLabel, nullptr, true).x +
+      style.FramePadding.x * 2.0f;
+  const float close_width =
+      workbench::CalcIconButtonWidth(ICON_MD_CLOSE, button_size);
+  const float action_width = pop_out_width + style.ItemSpacing.x + close_width;
+  const bool compact = ImGui::GetContentRegionAvail().x < 520.0f;
+
+  workbench::DrawPaneHeader(
+      "##DungeonWorkbenchToolDrawerHeader", GetWorkbenchToolIcon(active_tool_),
+      GetWorkbenchToolShortLabel(active_tool_), "Tool", "Workbench drawer",
+      compact, action_width, [&]() {
+        const bool can_pop_out = IsWorkbenchToolAvailable(active_tool_) &&
+                                 open_and_focus_standalone_tool_;
+        if (!can_pop_out) {
+          ImGui::BeginDisabled();
+        }
+        const bool pop_out_requested = workbench::DrawActionButton(
+            kPopOutLabel, ImVec2(0.0f, button_size));
+        {
+          gui::AutoWidgetScope automation_scope("Dungeon/Workbench");
+          gui::AutoRegisterLastItem(
+              "button", "pop_out_tool",
+              "Open the active Workbench tool in its standalone window");
+        }
+        if (!can_pop_out) {
+          ImGui::EndDisabled();
+        }
+        if (pop_out_requested && can_pop_out) {
+          (void)PopOutActiveTool();
+        }
+
+        ImGui::SameLine(0.0f, style.ItemSpacing.x);
+        if (workbench::DrawHeaderIconAction("CloseToolDrawer", ICON_MD_CLOSE,
+                                            button_size, "Close tool drawer")) {
+          CloseToolDrawer();
+        }
+      });
+
+  return layout_state_.show_tool_drawer;
+}
+
+void DungeonWorkbenchContent::DrawToolDrawerBody(DungeonCanvasViewer& viewer) {
+  // Preserve the existing tool switch IDs and embedded WindowContent model so
+  // keyboard/automation users and each editor tool keep the same behavior.
   DrawInspectorToolStrip();
+  if (!layout_state_.show_tool_drawer || IsStandaloneToolOpen(active_tool_)) {
+    CloseToolDrawer();
+    return;
+  }
 
   ImGui::Dummy(ImVec2(0.0f, 2.0f));
-  workbench::DrawInspectorSectionHeader(GetWorkbenchToolTitle(active_tool_));
-
   const bool available = IsWorkbenchToolAvailable(active_tool_);
   if (!available) {
     ImGui::TextDisabled("%s", GetWorkbenchToolUnavailableMessage(active_tool_));
     return;
   }
 
-  // The strip + section header take ~70-90px depending on font scale. Anything
-  // remaining in the inspector belongs to the tool body, with a small floor so
-  // narrow inspectors still leave room for at least a few rows of controls.
-  const float available_h = std::max(180.0f, ImGui::GetContentRegionAvail().y);
+  const float available_h = std::max(1.0f, ImGui::GetContentRegionAvail().y);
   const bool body_open =
       ImGui::BeginChild("##WorkbenchToolDrawerBody", ImVec2(0.0f, available_h),
                         true, ImGuiWindowFlags_HorizontalScrollbar);
@@ -1976,16 +2128,15 @@ void DungeonWorkbenchContent::DrawInspectorPrimarySelector(
   draw_mode("Selection", selection_width, InspectorMode::Selection);
   const ImVec2 tools_size(
       stack ? ImGui::GetContentRegionAvail().x : tools_width, segment_height);
-  const bool tools_pressed = gui::ToggleButton(
-      "Tools", inspector_mode_ == InspectorMode::Tools, tools_size);
+  const bool tools_pressed =
+      gui::ToggleButton("Tools", layout_state_.show_tool_drawer, tools_size);
   {
     gui::AutoWidgetScope automation_scope("Dungeon/Workbench");
     gui::AutoRegisterLastItem("button", "mode_tools",
-                              "Switch Dungeon Workbench inspector mode");
+                              "Open Dungeon Workbench tool drawer");
   }
   if (tools_pressed) {
-    inspector_mode_ = InspectorMode::Tools;
-    compact_inspector_detail_requested_ = true;
+    OpenTool(active_tool_);
   }
 }
 
@@ -2026,11 +2177,10 @@ void DungeonWorkbenchContent::DrawInspectorCompactSummary(
     ImGui::TextDisabled(tr("Nothing selected"));
   }
 
-  // Apply Room, View overlays, and Tools quick-grid all live elsewhere now:
+  // Apply Room, View overlays, and tool switching all live elsewhere now:
   // Apply Room is on the canvas toolbar, the overlay checkboxes live in the
-  // toolbar's View Options popup, and Tools have their own inspector primary
-  // mode (the segmented selector at the inspector header). Compact summary
-  // stays focused on what's selected.
+  // toolbar's View Options popup, and the Tools segment opens the bottom
+  // drawer. Compact summary stays focused on what's selected.
 }
 
 void DungeonWorkbenchContent::DrawInspectorShelf(DungeonCanvasViewer& viewer,
@@ -2038,8 +2188,7 @@ void DungeonWorkbenchContent::DrawInspectorShelf(DungeonCanvasViewer& viewer,
   const auto& interaction = viewer.object_interaction();
   const bool has_selection =
       interaction.GetSelectionCount() > 0 || interaction.HasEntitySelection();
-  if (has_selection && !inspector_selection_was_active_ &&
-      inspector_mode_ != InspectorMode::Tools) {
+  if (has_selection && !inspector_selection_was_active_) {
     inspector_mode_ = InspectorMode::Selection;
   }
   inspector_selection_was_active_ = has_selection;
@@ -2050,8 +2199,7 @@ void DungeonWorkbenchContent::DrawInspectorShelf(DungeonCanvasViewer& viewer,
   // Use the resolved pane layout instead of GetContentRegionAvail().x. The
   // latter changes when a vertical scrollbar appears, which can make the
   // inspector alternate between full and compact content every frame.
-  if (compact && inspector_mode_ != InspectorMode::Tools &&
-      !compact_inspector_detail_requested_) {
+  if (compact && !compact_inspector_detail_requested_) {
     DrawInspectorCompactSummary(viewer);
     return;
   }
@@ -2063,16 +2211,13 @@ void DungeonWorkbenchContent::DrawInspectorShelf(DungeonCanvasViewer& viewer,
     case InspectorMode::Selection:
       DrawInspectorShelfSelection(viewer);
       break;
-    case InspectorMode::Tools:
-      DrawInspectorToolDrawer(viewer);
-      return;
   }
 
-  // Stitched Rooms, View Options, and Tools collapsibles intentionally
+  // Stitched Rooms, View Options, and the old Tools collapsible intentionally
   // removed: the canvas toolbar exposes the Stitched Rooms toggle directly,
   // the View Options popup off the toolbar's eye icon owns all 11 overlay
-  // checkboxes, and the inspector primary segmented selector at the header
-  // already routes between Room / Selection / Tools modes.
+  // checkboxes, and the inspector header's Tools action opens the bottom
+  // drawer without replacing the Room / Selection inspector mode.
 }
 
 void DungeonWorkbenchContent::DrawInspectorShelfRoom(
@@ -2211,9 +2356,9 @@ void DungeonWorkbenchContent::DrawInspectorShelfRoom(
     DrawLayerCompositingControls(viewer, room_id);
   }
 
-  // ZScream-style compact room header: keep the raw ROM fields together so
-  // experienced dungeon authors can scan and edit them without panel hopping.
-  workbench::DrawInspectorSectionHeader(ICON_MD_TUNE " Room Header");
+  // Preserve the ZScream-style raw ROM controls, but keep them collapsed until
+  // an experienced author asks for them. Normal room navigation and selection
+  // work should not begin with a wall of header bytes.
   if (auto* rooms = viewer.rooms();
       rooms && room_id >= 0 && room_id < static_cast<int>(rooms->size())) {
     auto& room = (*rooms)[room_id];
@@ -2279,7 +2424,8 @@ void DungeonWorkbenchContent::DrawInspectorShelfRoom(
       }
     };
 
-    if (ImGui::BeginTable("##WorkbenchRoomHeader", 4, kHeaderFlags)) {
+    if (workbench::BeginInspectorSection(ICON_MD_TUNE " Room Header", false) &&
+        ImGui::BeginTable("##WorkbenchRoomHeader", 4, kHeaderFlags)) {
       ImGui::TableSetupColumn("L1", ImGuiTableColumnFlags_WidthFixed, 44.0f);
       ImGui::TableSetupColumn("V1", ImGuiTableColumnFlags_WidthFixed, 66.0f);
       ImGui::TableSetupColumn("L2", ImGuiTableColumnFlags_WidthFixed, 44.0f);
@@ -2369,9 +2515,9 @@ void DungeonWorkbenchContent::DrawInspectorShelfRoom(
       ImGui::EndTable();
     }
 
-    ImGui::Dummy(ImVec2(0.0f, 2.0f));
-    workbench::DrawInspectorSectionHeader(ICON_MD_ALT_ROUTE " Destinations");
-    if (ImGui::BeginTable("##WorkbenchRoomDestinations", 4, kHeaderFlags)) {
+    if (workbench::BeginInspectorSection(ICON_MD_ALT_ROUTE " Destinations",
+                                         false) &&
+        ImGui::BeginTable("##WorkbenchRoomDestinations", 4, kHeaderFlags)) {
       ImGui::TableSetupColumn("L1", ImGuiTableColumnFlags_WidthFixed, 44.0f);
       ImGui::TableSetupColumn("V1", ImGuiTableColumnFlags_WidthFixed, 66.0f);
       ImGui::TableSetupColumn("L2", ImGuiTableColumnFlags_WidthFixed, 44.0f);
@@ -2422,10 +2568,10 @@ void DungeonWorkbenchContent::DrawInspectorShelfRoom(
     ImGui::TextDisabled(tr("Room header unavailable"));
   }
 
-  workbench::DrawInspectorSectionHeader(ICON_MD_BUILD " Editing Status");
   auto& interaction = viewer.object_interaction();
   const bool placing = interaction.mode_manager().IsPlacementActive();
   if (placing) {
+    workbench::DrawInspectorSectionHeader(ICON_MD_BUILD " Editing Status");
     ImGui::TextColored(theme.text_info, tr("Placement active"));
     ImGui::SameLine();
     if (ImGui::SmallButton(ICON_MD_CLOSE " Cancel")) {
@@ -2823,118 +2969,6 @@ void DungeonWorkbenchContent::DrawInspectorShelfSelection(
         break;
     }
   }
-}
-
-void DungeonWorkbenchContent::DrawInspectorShelfTools(
-    DungeonCanvasViewer& viewer) {
-  (void)viewer;
-  workbench::DrawInspectorSectionHeader(ICON_MD_EDIT_NOTE " Edit");
-  constexpr ImGuiTableFlags kFlags =
-      ImGuiTableFlags_SizingStretchSame | ImGuiTableFlags_NoPadOuterX;
-  if (!ImGui::BeginTable("##WorkbenchToolsGrid", 2, kFlags)) {
-    return;
-  }
-
-  auto draw_tool_button = [&](const char* label, WorkbenchTool tool,
-                              bool enabled = true) {
-    if (!enabled) {
-      ImGui::BeginDisabled();
-    }
-    const bool active =
-        inspector_mode_ == InspectorMode::Tools && active_tool_ == tool;
-    if (gui::ToggleButton(label, active, ImVec2(-1, 0)) && enabled) {
-      OpenTool(tool);
-    }
-    if (!enabled) {
-      ImGui::EndDisabled();
-    }
-  };
-
-  // Edit row holds entity tools only. Mode switches (Selection / Room Details)
-  // moved out — the inspector primary segmented selector at the inspector
-  // header is the canonical mode switch.
-  ImGui::TableNextRow();
-  ImGui::TableNextColumn();
-  draw_tool_button(ICON_MD_CATEGORY " Selector", WorkbenchTool::ObjectSelector,
-                   object_selector_content_ != nullptr);
-  ImGui::TableNextColumn();
-  draw_tool_button(ICON_MD_DOOR_FRONT " Doors", WorkbenchTool::DoorEditor,
-                   door_editor_content_ != nullptr);
-
-  ImGui::TableNextRow();
-  ImGui::TableNextColumn();
-  draw_tool_button(ICON_MD_PERSON " Sprites", WorkbenchTool::SpriteEditor,
-                   sprite_editor_content_ != nullptr);
-  ImGui::TableNextColumn();
-  draw_tool_button(ICON_MD_INVENTORY " Items", WorkbenchTool::ItemEditor,
-                   item_editor_content_ != nullptr);
-
-  ImGui::EndTable();
-
-  workbench::DrawInspectorSectionHeader(ICON_MD_BUILD " Room Tools");
-  if (ImGui::BeginTable("##WorkbenchRoomToolsGrid", 2, kFlags)) {
-    auto room_tool_button = [&](const char* label, WorkbenchTool tool,
-                                bool enabled) {
-      ImGui::TableNextColumn();
-      if (!enabled) {
-        ImGui::BeginDisabled();
-      }
-      const bool active =
-          inspector_mode_ == InspectorMode::Tools && active_tool_ == tool;
-      if (gui::ToggleButton(label, active, ImVec2(-1, 0)) && enabled) {
-        OpenTool(tool);
-      }
-      if (!enabled) {
-        ImGui::EndDisabled();
-      }
-    };
-
-    ImGui::TableNextRow();
-    room_tool_button(ICON_MD_LABEL " Room Tags", WorkbenchTool::RoomTags,
-                     room_tag_panel_ != nullptr);
-    room_tool_button(ICON_MD_GRID_ON " Collision",
-                     WorkbenchTool::CustomCollision,
-                     custom_collision_panel_ != nullptr);
-    ImGui::TableNextRow();
-    room_tool_button(ICON_MD_WATER_DROP " Water Fill", WorkbenchTool::WaterFill,
-                     water_fill_panel_ != nullptr);
-    room_tool_button(ICON_MD_TRAIN " Minecart", WorkbenchTool::MinecartTracks,
-                     minecart_track_panel_ != nullptr);
-    ImGui::EndTable();
-  }
-
-  workbench::DrawInspectorSectionHeader(ICON_MD_TRAVEL_EXPLORE " Review");
-  if (ImGui::BeginTable("##WorkbenchReviewGrid", 2, kFlags)) {
-    ImGui::TableNextRow();
-    ImGui::TableNextColumn();
-    if (workbench::DrawActionButton(ICON_MD_GRID_VIEW " Matrix",
-                                    ImVec2(-1, 0))) {
-      ShowConnectedGraph();
-    }
-    ImGui::TableNextColumn();
-    if (workbench::DrawActionButton(ICON_MD_MAP " Dungeon Map",
-                                    ImVec2(-1, 0))) {
-      RequestDungeonMapPopup();
-    }
-
-    ImGui::TableNextRow();
-    ImGui::TableNextColumn();
-    if (workbench::DrawActionButton(ICON_MD_DOOR_FRONT " Entrances",
-                                    ImVec2(-1, 0))) {
-      FocusEntranceBrowser();
-    }
-    ImGui::TableNextColumn();
-    draw_tool_button(ICON_MD_PALETTE " Palette", WorkbenchTool::Palette,
-                     palette_editor_content_ != nullptr);
-    ImGui::EndTable();
-  }
-
-  workbench::DrawInspectorSectionHeader(ICON_MD_KEYBOARD " Reference");
-  if (workbench::DrawActionButton(ICON_MD_KEYBOARD " Keyboard Shortcuts",
-                                  ImVec2(-1, 0))) {
-    show_shortcut_legend_ = true;
-  }
-  ShortcutLegendPanel::Draw(&show_shortcut_legend_);
 }
 
 }  // namespace yaze::editor

--- a/src/app/editor/dungeon/workspace/dungeon_workbench_content.h
+++ b/src/app/editor/dungeon/workspace/dungeon_workbench_content.h
@@ -76,6 +76,11 @@ DungeonWorkbenchPaneLayout ResolveDungeonWorkbenchPaneLayout(
 
 bool ResolveCompactInspectorDetailRequest(bool compact, bool detail_requested);
 
+int ResolveDungeonWorkbenchToolStripColumns(float available_width,
+                                            float button_size,
+                                            float item_spacing,
+                                            int item_count = 10);
+
 // An already-open standalone tool owns its WindowContent for that frame. Route
 // repeated Workbench requests back to that window instead of drawing the same
 // instance in both presentations.

--- a/src/app/editor/dungeon/workspace/dungeon_workbench_content.h
+++ b/src/app/editor/dungeon/workspace/dungeon_workbench_content.h
@@ -61,7 +61,7 @@ struct DungeonWorkbenchPitDamageControlRects {
 };
 
 enum class DungeonWorkbenchToolRequestTarget : uint8_t {
-  kBottomDrawer,
+  kEmbeddedInspector,
   kStandaloneWindow,
 };
 
@@ -75,11 +75,6 @@ DungeonWorkbenchPaneLayout ResolveDungeonWorkbenchPaneLayout(
     bool want_left, bool want_right);
 
 bool ResolveCompactInspectorDetailRequest(bool compact, bool detail_requested);
-
-int ResolveDungeonWorkbenchToolStripColumns(float available_width,
-                                            float button_size,
-                                            float item_spacing,
-                                            int item_count = 10);
 
 // An already-open standalone tool owns its WindowContent for that frame. Route
 // repeated Workbench requests back to that window instead of drawing the same
@@ -150,7 +145,6 @@ class DungeonWorkbenchContent : public WindowContent {
   void OpenWaterFillTool();
   void OpenMinecartTool();
   bool PopOutActiveTool();
-  void CloseToolDrawer();
 
   // Mirror toggle: when true, the inspector renders on the LEFT and the
   // sidebar renders on the RIGHT (ZScream-style). Width semantics are
@@ -170,7 +164,7 @@ class DungeonWorkbenchContent : public WindowContent {
 
   // Lightweight state probes for unit tests; production rendering remains
   // driven by the Workbench inspector.
-  bool IsToolDrawerActiveForTesting() const;
+  bool IsToolInspectorActiveForTesting() const;
   const char* GetInspectorModeIdForTesting() const;
   const char* GetActiveToolIdForTesting() const;
   void DrawPitDamageControlsForTesting(int room_id) {
@@ -241,18 +235,15 @@ class DungeonWorkbenchContent : public WindowContent {
   void DrawInspectorShelf(DungeonCanvasViewer& viewer, bool compact);
   void DrawInspectorShelfRoom(DungeonCanvasViewer& viewer);
   void DrawInspectorShelfSelection(DungeonCanvasViewer& viewer);
-  void DrawToolDrawerPane(float width, float height,
-                          DungeonCanvasViewer& viewer);
-  bool DrawToolDrawerHeader(float button_size);
-  void DrawToolDrawerBody(DungeonCanvasViewer& viewer);
+  void DrawInspectorToolPanel(DungeonCanvasViewer& viewer);
+  void DrawInspectorToolPicker();
   void DrawWorkbenchTool(DungeonCanvasViewer& viewer, WorkbenchTool tool);
-  void DrawInspectorToolStrip();
   void OpenTool(WorkbenchTool tool);
+  void CloseToolInspector();
   WindowContent* GetWorkbenchToolContent(WorkbenchTool tool) const;
   bool IsStandaloneToolOpen(WorkbenchTool tool) const;
   bool IsWorkbenchToolAvailable(WorkbenchTool tool) const;
   const char* GetWorkbenchToolId(WorkbenchTool tool) const;
-  const char* GetWorkbenchToolIcon(WorkbenchTool tool) const;
   const char* GetWorkbenchToolShortLabel(WorkbenchTool tool) const;
   const char* GetWorkbenchToolUnavailableMessage(WorkbenchTool tool) const;
   void DrawApplyScopeControls(int room_id);
@@ -294,8 +285,9 @@ class DungeonWorkbenchContent : public WindowContent {
 
   enum class SidebarMode : uint8_t { Rooms, Entrances };
   SidebarMode sidebar_mode_ = SidebarMode::Rooms;
-  enum class InspectorMode : uint8_t { Room, Selection };
+  enum class InspectorMode : uint8_t { Room, Selection, Tools };
   InspectorMode inspector_mode_ = InspectorMode::Room;
+  InspectorMode inspector_mode_before_tools_ = InspectorMode::Room;
   bool inspector_selection_was_active_ = false;
   bool compact_inspector_detail_requested_ = false;
   WorkbenchTool active_tool_ = WorkbenchTool::ObjectSelector;

--- a/src/app/editor/dungeon/workspace/dungeon_workbench_content.h
+++ b/src/app/editor/dungeon/workspace/dungeon_workbench_content.h
@@ -7,6 +7,7 @@
 #include <memory>
 #include <string>
 #include <unordered_map>
+#include <utility>
 
 #include "app/editor/dungeon/dungeon_workbench_state.h"
 #include "app/editor/system/editor_panel.h"
@@ -59,6 +60,11 @@ struct DungeonWorkbenchPitDamageControlRects {
   DungeonWorkbenchTestRect replace_current;
 };
 
+enum class DungeonWorkbenchToolRequestTarget : uint8_t {
+  kBottomDrawer,
+  kStandaloneWindow,
+};
+
 DungeonWorkbenchResponsiveLayout ResolveDungeonWorkbenchResponsiveLayout(
     float total_width, float min_canvas_width, float min_sidebar_width,
     float splitter_width, bool want_left, bool want_right);
@@ -69,6 +75,12 @@ DungeonWorkbenchPaneLayout ResolveDungeonWorkbenchPaneLayout(
     bool want_left, bool want_right);
 
 bool ResolveCompactInspectorDetailRequest(bool compact, bool detail_requested);
+
+// An already-open standalone tool owns its WindowContent for that frame. Route
+// repeated Workbench requests back to that window instead of drawing the same
+// instance in both presentations.
+DungeonWorkbenchToolRequestTarget ResolveDungeonWorkbenchToolRequestTarget(
+    bool standalone_window_open);
 
 // Single stable window for dungeon editing. This is step 2 in the Workbench plan.
 class DungeonWorkbenchContent : public WindowContent {
@@ -104,6 +116,15 @@ class DungeonWorkbenchContent : public WindowContent {
                                WindowContent* item_editor,
                                WindowContent* room_graphics,
                                WindowContent* palette_editor);
+  void SetStandaloneToolCallbacks(
+      std::function<bool(const std::string&)> is_window_open,
+      std::function<bool(const std::string&)> open_and_focus_window) {
+    is_standalone_tool_open_ = std::move(is_window_open);
+    open_and_focus_standalone_tool_ = std::move(open_and_focus_window);
+  }
+  void SetOpenKeyboardShortcutsCallback(std::function<void()> callback) {
+    open_keyboard_shortcuts_ = std::move(callback);
+  }
   void SetPitDamageTableProvider(
       std::function<zelda3::PitDamageTable*()> provider) {
     get_pit_damage_table_ = std::move(provider);
@@ -123,6 +144,8 @@ class DungeonWorkbenchContent : public WindowContent {
   void OpenCustomCollisionTool();
   void OpenWaterFillTool();
   void OpenMinecartTool();
+  bool PopOutActiveTool();
+  void CloseToolDrawer();
 
   // Mirror toggle: when true, the inspector renders on the LEFT and the
   // sidebar renders on the RIGHT (ZScream-style). Width semantics are
@@ -213,14 +236,17 @@ class DungeonWorkbenchContent : public WindowContent {
   void DrawInspectorShelf(DungeonCanvasViewer& viewer, bool compact);
   void DrawInspectorShelfRoom(DungeonCanvasViewer& viewer);
   void DrawInspectorShelfSelection(DungeonCanvasViewer& viewer);
-  void DrawInspectorShelfTools(DungeonCanvasViewer& viewer);
-  void DrawInspectorToolDrawer(DungeonCanvasViewer& viewer);
+  void DrawToolDrawerPane(float width, float height,
+                          DungeonCanvasViewer& viewer);
+  bool DrawToolDrawerHeader(float button_size);
+  void DrawToolDrawerBody(DungeonCanvasViewer& viewer);
   void DrawWorkbenchTool(DungeonCanvasViewer& viewer, WorkbenchTool tool);
   void DrawInspectorToolStrip();
   void OpenTool(WorkbenchTool tool);
+  WindowContent* GetWorkbenchToolContent(WorkbenchTool tool) const;
+  bool IsStandaloneToolOpen(WorkbenchTool tool) const;
   bool IsWorkbenchToolAvailable(WorkbenchTool tool) const;
   const char* GetWorkbenchToolId(WorkbenchTool tool) const;
-  const char* GetWorkbenchToolTitle(WorkbenchTool tool) const;
   const char* GetWorkbenchToolIcon(WorkbenchTool tool) const;
   const char* GetWorkbenchToolShortLabel(WorkbenchTool tool) const;
   const char* GetWorkbenchToolUnavailableMessage(WorkbenchTool tool) const;
@@ -253,6 +279,9 @@ class DungeonWorkbenchContent : public WindowContent {
   std::function<const std::deque<int>&()> get_recent_rooms_;
   std::function<void(int)> forget_recent_room_;
   std::function<void(bool)> set_workflow_mode_;
+  std::function<bool(const std::string&)> is_standalone_tool_open_;
+  std::function<bool(const std::string&)> open_and_focus_standalone_tool_;
+  std::function<void()> open_keyboard_shortcuts_;
   std::function<void(bool)> on_inspector_side_changed_;
   std::function<void(DungeonCanvasViewer&)> on_primary_canvas_drawn_;
   std::function<zelda3::PitDamageTable*()> get_pit_damage_table_;
@@ -260,7 +289,7 @@ class DungeonWorkbenchContent : public WindowContent {
 
   enum class SidebarMode : uint8_t { Rooms, Entrances };
   SidebarMode sidebar_mode_ = SidebarMode::Rooms;
-  enum class InspectorMode : uint8_t { Room, Selection, Tools };
+  enum class InspectorMode : uint8_t { Room, Selection };
   InspectorMode inspector_mode_ = InspectorMode::Room;
   bool inspector_selection_was_active_ = false;
   bool compact_inspector_detail_requested_ = false;
@@ -281,8 +310,6 @@ class DungeonWorkbenchContent : public WindowContent {
   std::function<std::string()> redo_desc_;
   std::function<int()> undo_depth_;
 
-  // Shortcut legend toggle.
-  bool show_shortcut_legend_ = false;
   bool open_dungeon_map_popup_ = false;
   uint16_t pit_damage_replacement_room_id_ = 0;
   uint16_t pit_damage_victim_room_id_ = 0;

--- a/src/app/editor/dungeon/workspace/dungeon_workbench_content.h
+++ b/src/app/editor/dungeon/workspace/dungeon_workbench_content.h
@@ -215,16 +215,13 @@ class DungeonWorkbenchContent : public WindowContent {
     Palette,
   };
 
-  void DrawRecentRoomTabs();
   void DrawSidebarPane(float width, float height, float button_size,
                        bool compact);
   void DrawSidebarHeader(float button_size, bool compact);
   void DrawSidebarModeTabs(bool stacked, float segment_height);
   void DrawSidebarContent();
   void DrawCanvasPane(float width, float height,
-                      DungeonCanvasViewer* primary_viewer,
-                      bool left_sidebar_visible);
-  void DrawSelectionShelf(DungeonCanvasViewer& viewer);
+                      DungeonCanvasViewer* primary_viewer);
   void DrawSplitView(DungeonCanvasViewer& primary_viewer);
   void DrawInspectorPane(float width, float height, float button_size,
                          bool compact, DungeonCanvasViewer* viewer);

--- a/src/app/editor/dungeon/workspace/dungeon_workbench_layout.cc
+++ b/src/app/editor/dungeon/workspace/dungeon_workbench_layout.cc
@@ -18,7 +18,7 @@ float ClampWorkbenchPaneWidth(float desired_width, float min_width,
 }  // namespace
 
 DungeonWorkbenchToolDrawerLayout ResolveDungeonWorkbenchToolDrawerLayout(
-    float total_height, float splitter_height, float stored_drawer_height,
+    float total_height, float splitter_height, float preferred_drawer_ratio,
     float min_canvas_height, float min_drawer_height, bool want_drawer) {
   DungeonWorkbenchToolDrawerLayout layout;
   const float safe_total_height = std::max(total_height, 1.0f);
@@ -30,27 +30,30 @@ DungeonWorkbenchToolDrawerLayout ResolveDungeonWorkbenchToolDrawerLayout(
   layout.show_drawer = true;
   const float safe_splitter_height = std::clamp(
       splitter_height, 0.0f, std::max(safe_total_height - 1.0f, 0.0f));
-  const float available_height =
+  layout.available_height =
       std::max(safe_total_height - safe_splitter_height, 1.0f);
   const float safe_min_canvas_height = std::max(min_canvas_height, 1.0f);
   const float safe_min_drawer_height = std::max(min_drawer_height, 1.0f);
 
   layout.compact =
-      available_height < safe_min_canvas_height + safe_min_drawer_height;
+      layout.available_height < safe_min_canvas_height + safe_min_drawer_height;
   if (layout.compact) {
     // Preserve useful space for both surfaces. The tool remains visible even
     // in a short Workbench instead of silently falling back to a side pane.
-    layout.min_drawer_height = available_height * 0.4f;
+    layout.min_drawer_height = layout.available_height * 0.4f;
     layout.max_drawer_height = layout.min_drawer_height;
   } else {
     layout.min_drawer_height = safe_min_drawer_height;
-    layout.max_drawer_height = available_height - safe_min_canvas_height;
+    layout.max_drawer_height = layout.available_height - safe_min_canvas_height;
   }
 
-  layout.drawer_height = std::clamp(
-      stored_drawer_height, layout.min_drawer_height, layout.max_drawer_height);
+  const float safe_drawer_ratio =
+      std::clamp(preferred_drawer_ratio, 0.0f, 1.0f);
+  layout.drawer_height =
+      std::clamp(layout.available_height * safe_drawer_ratio,
+                 layout.min_drawer_height, layout.max_drawer_height);
   layout.canvas_height =
-      std::max(available_height - layout.drawer_height, 1.0f);
+      std::max(layout.available_height - layout.drawer_height, 1.0f);
   return layout;
 }
 

--- a/src/app/editor/dungeon/workspace/dungeon_workbench_layout.cc
+++ b/src/app/editor/dungeon/workspace/dungeon_workbench_layout.cc
@@ -17,6 +17,43 @@ float ClampWorkbenchPaneWidth(float desired_width, float min_width,
 
 }  // namespace
 
+DungeonWorkbenchToolDrawerLayout ResolveDungeonWorkbenchToolDrawerLayout(
+    float total_height, float splitter_height, float stored_drawer_height,
+    float min_canvas_height, float min_drawer_height, bool want_drawer) {
+  DungeonWorkbenchToolDrawerLayout layout;
+  const float safe_total_height = std::max(total_height, 1.0f);
+  layout.canvas_height = safe_total_height;
+  if (!want_drawer) {
+    return layout;
+  }
+
+  layout.show_drawer = true;
+  const float safe_splitter_height = std::clamp(
+      splitter_height, 0.0f, std::max(safe_total_height - 1.0f, 0.0f));
+  const float available_height =
+      std::max(safe_total_height - safe_splitter_height, 1.0f);
+  const float safe_min_canvas_height = std::max(min_canvas_height, 1.0f);
+  const float safe_min_drawer_height = std::max(min_drawer_height, 1.0f);
+
+  layout.compact =
+      available_height < safe_min_canvas_height + safe_min_drawer_height;
+  if (layout.compact) {
+    // Preserve useful space for both surfaces. The tool remains visible even
+    // in a short Workbench instead of silently falling back to a side pane.
+    layout.min_drawer_height = available_height * 0.4f;
+    layout.max_drawer_height = layout.min_drawer_height;
+  } else {
+    layout.min_drawer_height = safe_min_drawer_height;
+    layout.max_drawer_height = available_height - safe_min_canvas_height;
+  }
+
+  layout.drawer_height = std::clamp(
+      stored_drawer_height, layout.min_drawer_height, layout.max_drawer_height);
+  layout.canvas_height =
+      std::max(available_height - layout.drawer_height, 1.0f);
+  return layout;
+}
+
 bool DrawDungeonWorkbenchVerticalSplitter(const char* id, float height,
                                           float* pane_width, float min_width,
                                           float max_width,
@@ -57,6 +94,54 @@ bool DrawDungeonWorkbenchVerticalSplitter(const char* id, float height,
   ImGui::GetWindowDrawList()->AddLine(
       ImVec2(splitter_pos.x + splitter_width * 0.5f, splitter_pos.y),
       ImVec2(splitter_pos.x + splitter_width * 0.5f, splitter_pos.y + height),
+      ImGui::GetColorU32(splitter_color), active ? 2.0f : 1.0f);
+  return collapse_requested;
+}
+
+bool DrawDungeonWorkbenchHorizontalSplitter(const char* id, float width,
+                                            float* pane_height,
+                                            float min_height, float max_height,
+                                            float collapse_threshold) {
+  if (!pane_height) {
+    return false;
+  }
+
+  bool collapse_requested = false;
+  const float splitter_height = gui::UIConfig::kSplitterWidth;
+  const ImVec2 splitter_pos = ImGui::GetCursorScreenPos();
+  ImGui::InvisibleButton(id, ImVec2(std::max(width, 1.0f), splitter_height));
+  const bool hovered = ImGui::IsItemHovered();
+  const bool active = ImGui::IsItemActive();
+  if (hovered || active) {
+    ImGui::SetMouseCursor(ImGuiMouseCursor_ResizeNS);
+  }
+  if (hovered && ImGui::IsMouseDoubleClicked(ImGuiMouseButton_Left)) {
+    *pane_height =
+        ClampWorkbenchPaneWidth(*pane_height, min_height, max_height);
+  }
+  if (active) {
+    // The splitter is the bottom pane's top edge. Dragging down shrinks it.
+    const float proposed = *pane_height - ImGui::GetIO().MouseDelta.y;
+    // Once the pane reaches its minimum, the next downward drag collapses it.
+    // A threshold below min_height is otherwise unreachable because every
+    // frame clamps pane_height back to min_height.
+    const float reachable_collapse_threshold =
+        std::max(collapse_threshold, min_height);
+    if (proposed < reachable_collapse_threshold) {
+      collapse_requested = true;
+      *pane_height = min_height;
+      ImGui::SetTooltip(tr("Collapse tool drawer"));
+    } else {
+      *pane_height = ClampWorkbenchPaneWidth(proposed, min_height, max_height);
+      ImGui::SetTooltip(tr("Height: %.0f px"), *pane_height);
+    }
+  }
+
+  ImVec4 splitter_color = gui::GetOutlineVec4();
+  splitter_color.w = active ? 0.95f : (hovered ? 0.72f : 0.35f);
+  ImGui::GetWindowDrawList()->AddLine(
+      ImVec2(splitter_pos.x, splitter_pos.y + splitter_height * 0.5f),
+      ImVec2(splitter_pos.x + width, splitter_pos.y + splitter_height * 0.5f),
       ImGui::GetColorU32(splitter_color), active ? 2.0f : 1.0f);
   return collapse_requested;
 }

--- a/src/app/editor/dungeon/workspace/dungeon_workbench_layout.cc
+++ b/src/app/editor/dungeon/workspace/dungeon_workbench_layout.cc
@@ -17,46 +17,6 @@ float ClampWorkbenchPaneWidth(float desired_width, float min_width,
 
 }  // namespace
 
-DungeonWorkbenchToolDrawerLayout ResolveDungeonWorkbenchToolDrawerLayout(
-    float total_height, float splitter_height, float preferred_drawer_ratio,
-    float min_canvas_height, float min_drawer_height, bool want_drawer) {
-  DungeonWorkbenchToolDrawerLayout layout;
-  const float safe_total_height = std::max(total_height, 1.0f);
-  layout.canvas_height = safe_total_height;
-  if (!want_drawer) {
-    return layout;
-  }
-
-  layout.show_drawer = true;
-  const float safe_splitter_height = std::clamp(
-      splitter_height, 0.0f, std::max(safe_total_height - 1.0f, 0.0f));
-  layout.available_height =
-      std::max(safe_total_height - safe_splitter_height, 1.0f);
-  const float safe_min_canvas_height = std::max(min_canvas_height, 1.0f);
-  const float safe_min_drawer_height = std::max(min_drawer_height, 1.0f);
-
-  layout.compact =
-      layout.available_height < safe_min_canvas_height + safe_min_drawer_height;
-  if (layout.compact) {
-    // Preserve useful space for both surfaces. The tool remains visible even
-    // in a short Workbench instead of silently falling back to a side pane.
-    layout.min_drawer_height = layout.available_height * 0.4f;
-    layout.max_drawer_height = layout.min_drawer_height;
-  } else {
-    layout.min_drawer_height = safe_min_drawer_height;
-    layout.max_drawer_height = layout.available_height - safe_min_canvas_height;
-  }
-
-  const float safe_drawer_ratio =
-      std::clamp(preferred_drawer_ratio, 0.0f, 1.0f);
-  layout.drawer_height =
-      std::clamp(layout.available_height * safe_drawer_ratio,
-                 layout.min_drawer_height, layout.max_drawer_height);
-  layout.canvas_height =
-      std::max(layout.available_height - layout.drawer_height, 1.0f);
-  return layout;
-}
-
 bool DrawDungeonWorkbenchVerticalSplitter(const char* id, float height,
                                           float* pane_width, float min_width,
                                           float max_width,
@@ -97,54 +57,6 @@ bool DrawDungeonWorkbenchVerticalSplitter(const char* id, float height,
   ImGui::GetWindowDrawList()->AddLine(
       ImVec2(splitter_pos.x + splitter_width * 0.5f, splitter_pos.y),
       ImVec2(splitter_pos.x + splitter_width * 0.5f, splitter_pos.y + height),
-      ImGui::GetColorU32(splitter_color), active ? 2.0f : 1.0f);
-  return collapse_requested;
-}
-
-bool DrawDungeonWorkbenchHorizontalSplitter(const char* id, float width,
-                                            float* pane_height,
-                                            float min_height, float max_height,
-                                            float collapse_threshold) {
-  if (!pane_height) {
-    return false;
-  }
-
-  bool collapse_requested = false;
-  const float splitter_height = gui::UIConfig::kSplitterWidth;
-  const ImVec2 splitter_pos = ImGui::GetCursorScreenPos();
-  ImGui::InvisibleButton(id, ImVec2(std::max(width, 1.0f), splitter_height));
-  const bool hovered = ImGui::IsItemHovered();
-  const bool active = ImGui::IsItemActive();
-  if (hovered || active) {
-    ImGui::SetMouseCursor(ImGuiMouseCursor_ResizeNS);
-  }
-  if (hovered && ImGui::IsMouseDoubleClicked(ImGuiMouseButton_Left)) {
-    *pane_height =
-        ClampWorkbenchPaneWidth(*pane_height, min_height, max_height);
-  }
-  if (active) {
-    // The splitter is the bottom pane's top edge. Dragging down shrinks it.
-    const float proposed = *pane_height - ImGui::GetIO().MouseDelta.y;
-    // Once the pane reaches its minimum, the next downward drag collapses it.
-    // A threshold below min_height is otherwise unreachable because every
-    // frame clamps pane_height back to min_height.
-    const float reachable_collapse_threshold =
-        std::max(collapse_threshold, min_height);
-    if (proposed < reachable_collapse_threshold) {
-      collapse_requested = true;
-      *pane_height = min_height;
-      ImGui::SetTooltip(tr("Collapse tool drawer"));
-    } else {
-      *pane_height = ClampWorkbenchPaneWidth(proposed, min_height, max_height);
-      ImGui::SetTooltip(tr("Height: %.0f px"), *pane_height);
-    }
-  }
-
-  ImVec4 splitter_color = gui::GetOutlineVec4();
-  splitter_color.w = active ? 0.95f : (hovered ? 0.72f : 0.35f);
-  ImGui::GetWindowDrawList()->AddLine(
-      ImVec2(splitter_pos.x, splitter_pos.y + splitter_height * 0.5f),
-      ImVec2(splitter_pos.x + width, splitter_pos.y + splitter_height * 0.5f),
       ImGui::GetColorU32(splitter_color), active ? 2.0f : 1.0f);
   return collapse_requested;
 }

--- a/src/app/editor/dungeon/workspace/dungeon_workbench_layout.h
+++ b/src/app/editor/dungeon/workspace/dungeon_workbench_layout.h
@@ -10,15 +10,17 @@ struct DungeonWorkbenchToolDrawerLayout {
   bool compact = false;
   float canvas_height = 0.0f;
   float drawer_height = 0.0f;
+  float available_height = 0.0f;
   float min_drawer_height = 0.0f;
   float max_drawer_height = 0.0f;
 };
 
 // Resolve the vertical canvas/tool split without touching ImGui state. When
-// height is constrained, both regions remain visible and use a stable 60/40
-// split instead of hiding the requested tool.
+// space permits, preferred_drawer_ratio scales the drawer with the Workbench.
+// When height is constrained, both regions remain visible and use a stable
+// 60/40 split instead of hiding the requested tool.
 DungeonWorkbenchToolDrawerLayout ResolveDungeonWorkbenchToolDrawerLayout(
-    float total_height, float splitter_height, float stored_drawer_height,
+    float total_height, float splitter_height, float preferred_drawer_ratio,
     float min_canvas_height, float min_drawer_height, bool want_drawer);
 
 // Draw a workbench-standard vertical splitter that mutates pane_width.

--- a/src/app/editor/dungeon/workspace/dungeon_workbench_layout.h
+++ b/src/app/editor/dungeon/workspace/dungeon_workbench_layout.h
@@ -5,24 +5,6 @@
 
 namespace yaze::editor {
 
-struct DungeonWorkbenchToolDrawerLayout {
-  bool show_drawer = false;
-  bool compact = false;
-  float canvas_height = 0.0f;
-  float drawer_height = 0.0f;
-  float available_height = 0.0f;
-  float min_drawer_height = 0.0f;
-  float max_drawer_height = 0.0f;
-};
-
-// Resolve the vertical canvas/tool split without touching ImGui state. When
-// space permits, preferred_drawer_ratio scales the drawer with the Workbench.
-// When height is constrained, both regions remain visible and use a stable
-// 60/40 split instead of hiding the requested tool.
-DungeonWorkbenchToolDrawerLayout ResolveDungeonWorkbenchToolDrawerLayout(
-    float total_height, float splitter_height, float preferred_drawer_ratio,
-    float min_canvas_height, float min_drawer_height, bool want_drawer);
-
 // Draw a workbench-standard vertical splitter that mutates pane_width.
 // Returns true when the drag moves past collapse_threshold.
 bool DrawDungeonWorkbenchVerticalSplitter(const char* id, float height,
@@ -30,14 +12,6 @@ bool DrawDungeonWorkbenchVerticalSplitter(const char* id, float height,
                                           float max_width,
                                           bool resize_from_left_edge,
                                           float collapse_threshold = 100.0f);
-
-// Draw a horizontal splitter above a bottom pane. Returns true when the drag
-// continues below the pane's minimum size (or an explicitly larger collapse
-// threshold), requesting that the bottom pane collapse.
-bool DrawDungeonWorkbenchHorizontalSplitter(const char* id, float width,
-                                            float* pane_height,
-                                            float min_height, float max_height,
-                                            float collapse_threshold = 100.0f);
 
 }  // namespace yaze::editor
 

--- a/src/app/editor/dungeon/workspace/dungeon_workbench_layout.h
+++ b/src/app/editor/dungeon/workspace/dungeon_workbench_layout.h
@@ -5,6 +5,22 @@
 
 namespace yaze::editor {
 
+struct DungeonWorkbenchToolDrawerLayout {
+  bool show_drawer = false;
+  bool compact = false;
+  float canvas_height = 0.0f;
+  float drawer_height = 0.0f;
+  float min_drawer_height = 0.0f;
+  float max_drawer_height = 0.0f;
+};
+
+// Resolve the vertical canvas/tool split without touching ImGui state. When
+// height is constrained, both regions remain visible and use a stable 60/40
+// split instead of hiding the requested tool.
+DungeonWorkbenchToolDrawerLayout ResolveDungeonWorkbenchToolDrawerLayout(
+    float total_height, float splitter_height, float stored_drawer_height,
+    float min_canvas_height, float min_drawer_height, bool want_drawer);
+
 // Draw a workbench-standard vertical splitter that mutates pane_width.
 // Returns true when the drag moves past collapse_threshold.
 bool DrawDungeonWorkbenchVerticalSplitter(const char* id, float height,
@@ -12,6 +28,14 @@ bool DrawDungeonWorkbenchVerticalSplitter(const char* id, float height,
                                           float max_width,
                                           bool resize_from_left_edge,
                                           float collapse_threshold = 100.0f);
+
+// Draw a horizontal splitter above a bottom pane. Returns true when the drag
+// continues below the pane's minimum size (or an explicitly larger collapse
+// threshold), requesting that the bottom pane collapse.
+bool DrawDungeonWorkbenchHorizontalSplitter(const char* id, float width,
+                                            float* pane_height,
+                                            float min_height, float max_height,
+                                            float collapse_threshold = 100.0f);
 
 }  // namespace yaze::editor
 

--- a/src/app/editor/menu/window_sidebar.cc
+++ b/src/app/editor/menu/window_sidebar.cc
@@ -124,9 +124,25 @@ void WindowSidebar::Draw(size_t session_id, const std::string& category,
       std::clamp(gui::LayoutHelpers::GetStandardSpacing(), 4.0f, 8.0f);
   const float compact_spacing = std::max(4.0f, standard_spacing * 0.75f);
   const float search_spacing = compact_spacing;
-  const float search_width =
-      std::max(140.0f, ImGui::GetContentRegionAvail().x - search_button_size.x -
-                           search_spacing);
+
+  auto read_dungeon_workbench_mode = [&]() -> bool {
+    if (category != "Dungeon") {
+      return false;
+    }
+    if (is_dungeon_workbench_mode_) {
+      return is_dungeon_workbench_mode_();
+    }
+    return window_manager_.IsWindowOpen(session_id, "dungeon.workbench");
+  };
+  bool dungeon_workbench_mode = read_dungeon_workbench_mode();
+  const bool rom_loaded = has_rom ? has_rom() : true;
+  const bool disable_windows = !rom_loaded && category != "Emulator";
+  const bool bulk_actions_enabled =
+      !disable_windows && !(category == "Dungeon" && dungeon_workbench_mode);
+
+  const float search_width = std::max(96.0f, ImGui::GetContentRegionAvail().x -
+                                                 (search_button_size.x * 2.0f) -
+                                                 (search_spacing * 2.0f));
   ImGui::SetNextItemWidth(search_width);
   ImGui::InputTextWithHint("##SidebarSearch", ICON_MD_SEARCH " Filter...",
                            sidebar_search_, sizeof(sidebar_search_));
@@ -144,17 +160,48 @@ void WindowSidebar::Draw(size_t session_id, const std::string& category,
   if (filter_empty) {
     ImGui::EndDisabled();
   }
-
-  auto read_dungeon_workbench_mode = [&]() -> bool {
-    if (category != "Dungeon") {
-      return false;
+  ImGui::SameLine(0.0f, search_spacing);
+  if (gui::TransparentIconButton(ICON_MD_MORE_HORIZ, search_button_size,
+                                 "Window actions", false,
+                                 gui::GetTextSecondaryVec4(), "window_sidebar",
+                                 "open_sidebar_actions")) {
+    ImGui::OpenPopup("##WindowSidebarActions");
+  }
+  if (ImGui::BeginPopup("##WindowSidebarActions")) {
+    const auto category_windows =
+        window_manager_.GetWindowsInCategory(session_id, category);
+    int visible_windows = 0;
+    for (const auto& category_window : category_windows) {
+      if (category_window.visibility_flag && *category_window.visibility_flag) {
+        ++visible_windows;
+      }
     }
-    if (is_dungeon_workbench_mode_) {
-      return is_dungeon_workbench_mode_();
+    ImGui::TextDisabled(tr("%d of %zu visible"), visible_windows,
+                        category_windows.size());
+    ImGui::Separator();
+    if (ImGui::MenuItem(ICON_MD_APPS " Window Browser")) {
+      window_manager_.TriggerShowWindowBrowser();
     }
-    return window_manager_.IsWindowOpen(session_id, "dungeon.workbench");
-  };
-  bool dungeon_workbench_mode = read_dungeon_workbench_mode();
+    ImGui::Separator();
+    if (ImGui::MenuItem(ICON_MD_VISIBILITY " Show all", nullptr, false,
+                        bulk_actions_enabled)) {
+      window_manager_.ShowAllWindowsInCategory(session_id, category);
+    }
+    const bool show_all_hovered =
+        ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled);
+    if (ImGui::MenuItem(ICON_MD_VISIBILITY_OFF " Hide all", nullptr, false,
+                        bulk_actions_enabled)) {
+      window_manager_.HideAllWindowsInCategory(session_id, category);
+    }
+    const bool hide_all_hovered =
+        ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled);
+    if (!bulk_actions_enabled && (show_all_hovered || hide_all_hovered) &&
+        category == "Dungeon" && dungeon_workbench_mode) {
+      ImGui::SetTooltip(
+          tr("Switch to Window workflow to bulk-manage room windows."));
+    }
+    ImGui::EndPopup();
+  }
 
   auto switch_to_dungeon_workbench_mode = [&]() -> bool {
     if (category != "Dungeon" || dungeon_workbench_mode) {
@@ -272,96 +319,6 @@ void WindowSidebar::Draw(size_t session_id, const std::string& category,
     ImGui::Spacing();
     ImGui::Separator();
     ImGui::Spacing();
-  }
-
-  ImGui::Spacing();
-
-  const bool rom_loaded = has_rom ? has_rom() : true;
-  const bool disable_windows = !rom_loaded && category != "Emulator";
-
-  const auto category_windows =
-      window_manager_.GetWindowsInCategory(session_id, category);
-  int visible_windows_in_category = 0;
-  int total_windows_in_category = 0;
-  for (const auto& category_window : category_windows) {
-    ++total_windows_in_category;
-    if (category_window.visibility_flag && *category_window.visibility_flag) {
-      ++visible_windows_in_category;
-    }
-  }
-
-  ImGui::TextDisabled(tr("%d / %d visible"), visible_windows_in_category,
-                      total_windows_in_category);
-  ImGui::Spacing();
-
-  const float action_gap = compact_spacing;
-  const float action_min_button_width = 84.0f;
-  const float action_available_width =
-      std::max(1.0f, ImGui::GetContentRegionAvail().x);
-  const bool stack_action_buttons =
-      action_available_width <=
-      (action_min_button_width * 3.0f + (action_gap * 2.0f));
-  const float action_button_width =
-      stack_action_buttons
-          ? action_available_width
-          : std::max(action_min_button_width,
-                     (action_available_width - (action_gap * 2.0f)) / 3.0f);
-  const float action_button_height =
-      std::max(24.0f, gui::LayoutHelpers::GetStandardWidgetHeight());
-  auto draw_action_button = [&](const char* id, const char* icon,
-                                const char* label, const char* tooltip,
-                                const ImVec2& button_size) -> bool {
-    const std::string button_label =
-        absl::StrFormat("%s %s##%s", icon, label, id);
-    const bool clicked = ImGui::Button(button_label.c_str(), button_size);
-    if (ImGui::IsItemHovered() && tooltip && *tooltip) {
-      ImGui::SetTooltip("%s", tooltip);
-    }
-    return clicked;
-  };
-  const ImVec2 action_button_size(action_button_width, action_button_height);
-
-  if (draw_action_button("open_window_browser", ICON_MD_APPS, "Browser",
-                         "Open Window Browser", action_button_size)) {
-    window_manager_.TriggerShowWindowBrowser();
-  }
-  if (!stack_action_buttons) {
-    ImGui::SameLine(0.0f, action_gap);
-  }
-
-  const bool bulk_actions_enabled =
-      !disable_windows && !(category == "Dungeon" && dungeon_workbench_mode);
-  bool bulk_action_hovered = false;
-  if (!bulk_actions_enabled) {
-    ImGui::BeginDisabled();
-  }
-  if (draw_action_button("show_category_windows", ICON_MD_VISIBILITY, "Show",
-                         "Show all windows in this category",
-                         action_button_size)) {
-    window_manager_.ShowAllWindowsInCategory(session_id, category);
-  }
-  if (!stack_action_buttons) {
-    ImGui::SameLine(0.0f, action_gap);
-  }
-  if (!bulk_actions_enabled &&
-      ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled)) {
-    bulk_action_hovered = true;
-  }
-  if (draw_action_button("hide_category_windows", ICON_MD_VISIBILITY_OFF,
-                         "Hide", "Hide all windows in this category",
-                         action_button_size)) {
-    window_manager_.HideAllWindowsInCategory(session_id, category);
-  }
-  if (!bulk_actions_enabled) {
-    if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled)) {
-      bulk_action_hovered = true;
-    }
-    if (bulk_action_hovered && category == "Dungeon" &&
-        dungeon_workbench_mode) {
-      ImGui::SetTooltip(
-          tr("Switch to Window workflow to bulk-manage room windows."));
-    }
-    ImGui::EndDisabled();
   }
 
   ImGui::Spacing();

--- a/src/app/gui/widgets/palette_editor_widget.cc
+++ b/src/app/gui/widgets/palette_editor_widget.cc
@@ -123,6 +123,22 @@ bool AcceptImGuiColorDrop(gfx::SnesColor* color, ImVec2 min, ImVec2 max) {
 
 }  // namespace
 
+int ResolveDungeonRenderPaletteColumns(float available_width,
+                                       float min_swatch_size,
+                                       float item_spacing) {
+  const float safe_width = std::max(available_width, 1.0f);
+  const float safe_swatch = std::max(min_swatch_size, 1.0f);
+  const float safe_spacing = std::max(item_spacing, 0.0f);
+  for (const int columns : {16, 8, 4, 2, 1}) {
+    const float required_width =
+        safe_swatch * columns + safe_spacing * (columns - 1);
+    if (safe_width >= required_width) {
+      return columns;
+    }
+  }
+  return 1;
+}
+
 // Merged implementation from PaletteWidget and PaletteEditorWidget
 
 void PaletteEditorWidget::Initialize(zelda3::GameData* game_data) {
@@ -333,12 +349,19 @@ void PaletteEditorWidget::DrawColorPicker() {
 }
 
 void PaletteEditorWidget::DrawDungeonRenderPalette() {
-  ImGui::TextDisabled(
-      tr("Rows 0-1: HUD / floor / ceiling  |  Rows 2-7: Dungeon main"));
-  const float swatch_size = ComputeSwatchSize(/*columns=*/16, 14.0f, 28.0f);
+  ImGui::TextDisabled(tr("Slots 00-1F: HUD / floor / ceiling"));
+  ImGui::TextDisabled(tr("Slots 20-7F: Dungeon main"));
+  constexpr float kSwatchSpacing = 2.0f;
+  const ImVec2 previous_spacing = ImGui::GetStyle().ItemSpacing;
+  ImGui::PushStyleVar(ImGuiStyleVar_ItemSpacing,
+                      ImVec2(kSwatchSpacing, previous_spacing.y));
+  const int columns = ResolveDungeonRenderPaletteColumns(
+      ImGui::GetContentRegionAvail().x, /*min_swatch_size=*/14.0f,
+      kSwatchSpacing);
+  const float swatch_size = ComputeSwatchSize(columns, 14.0f, 28.0f);
 
   for (int i = 0; i < 128; ++i) {
-    if (i % 16 != 0) {
+    if (i % columns != 0) {
       ImGui::SameLine();
     }
 
@@ -417,6 +440,7 @@ void PaletteEditorWidget::DrawDungeonRenderPalette() {
     }
     ImGui::PopID();
   }
+  ImGui::PopStyleVar();
 }
 
 float PaletteEditorWidget::ComputeSwatchSize(int columns, float min_size,

--- a/src/app/gui/widgets/palette_editor_widget.h
+++ b/src/app/gui/widgets/palette_editor_widget.h
@@ -26,6 +26,12 @@ struct DungeonPaletteChange {
   DungeonRenderPaletteSource source;
 };
 
+// Keep the 16-slot CGRAM row readable when the widget is embedded in a narrow
+// inspector. Returned values are divisors of 16 so logical rows wrap cleanly.
+int ResolveDungeonRenderPaletteColumns(float available_width,
+                                       float min_swatch_size = 14.0f,
+                                       float item_spacing = 2.0f);
+
 class PaletteEditorWidget {
  public:
   PaletteEditorWidget() = default;

--- a/src/zelda3/dungeon/object_layer_semantics.h
+++ b/src/zelda3/dungeon/object_layer_semantics.h
@@ -45,11 +45,23 @@ inline bool IsTrackCornerAliasObjectId(int object_id) {
   return object_id >= 0x100 && object_id <= 0x103;
 }
 
+inline bool IsMinecartTrackCustomObject(const RoomObject& object) {
+  if (object.id_ != 0x31) {
+    return false;
+  }
+
+  // Oracle overloads object 0x31's size nibble as a custom subtype. Subtypes
+  // 0..12 and 14 are track pieces; 13 is the sword-house wall decoration and
+  // 15 is the small statue used by Mushroom Grotto. Decorations must not opt
+  // ordinary subtype-2 wall corners into the custom track-corner alias path.
+  const int subtype = object.size_ & 0x1F;
+  return subtype <= 12 || subtype == 14;
+}
+
 inline bool RoomAllowsTrackCornerAliases(
     std::span<const RoomObject> room_objects) {
-  return std::any_of(
-      room_objects.begin(), room_objects.end(),
-      [](const RoomObject& object) { return object.id_ == 0x31; });
+  return std::any_of(room_objects.begin(), room_objects.end(),
+                     IsMinecartTrackCustomObject);
 }
 
 inline bool HasActiveCustomObjectOverride(const RoomObject& object,

--- a/src/zelda3/dungeon/object_tile_editor.cc
+++ b/src/zelda3/dungeon/object_tile_editor.cc
@@ -426,13 +426,17 @@ absl::Status ObjectTileEditor::RenderLayoutToBitmap(
   int bmp_h = layout.bounds_height * 8;
 
   // Create or resize bitmap
-  std::vector<uint8_t> pixel_data(bmp_w * bmp_h, 0);
+  std::vector<uint8_t> pixel_data(bmp_w * bmp_h, 255);
   bitmap.Create(bmp_w, bmp_h, 8, pixel_data);
 
   // Preview rendering uses tile palette bank offsets (pal * 16), so the bitmap
   // needs a combined banked palette rather than a single sub-palette.
   if (!palette.empty()) {
     bitmap.SetPalette(BuildCombinedPaletteBanks(palette));
+  }
+  if (bitmap.surface()) {
+    SDL_SetColorKey(bitmap.surface(), SDL_TRUE, 255);
+    SDL_SetSurfaceBlendMode(bitmap.surface(), SDL_BLENDMODE_BLEND);
   }
 
   // Use a temporary ObjectDrawer just for its DrawTileToBitmap utility
@@ -462,6 +466,10 @@ absl::Status ObjectTileEditor::BuildTile8Atlas(gfx::Bitmap& atlas,
   if (!palette.empty()) {
     atlas.SetPalette(
         BuildPaddedPaletteBank(palette.palette_ref(resolved_palette)));
+  }
+  if (atlas.surface()) {
+    SDL_SetColorKey(atlas.surface(), SDL_TRUE, 255);
+    SDL_SetSurfaceBlendMode(atlas.surface(), SDL_BLENDMODE_BLEND);
   }
 
   ObjectDrawer drawer(rom_, 0, room_gfx_buffer);

--- a/src/zelda3/dungeon/room.cc
+++ b/src/zelda3/dungeon/room.cc
@@ -113,6 +113,42 @@ std::vector<SDL_Color> BuildDungeonRenderPalette(
   return colors;
 }
 
+gfx::PaletteGroup BuildDungeonRenderPaletteGroup(
+    const gfx::SnesPalette& dungeon_palette,
+    const gfx::SnesPalette* hud_palette) {
+  constexpr int kRenderPaletteRows = 8;
+  constexpr int kColorsPerRow = 16;
+
+  gfx::PaletteGroup group("dungeon_render");
+  for (int row = 0; row < kRenderPaletteRows; ++row) {
+    gfx::SnesPalette palette_row;
+    for (int color = 0; color < kColorsPerRow; ++color) {
+      palette_row.AddColor(gfx::SnesColor());
+    }
+    group.AddPalette(std::move(palette_row));
+  }
+
+  PopulateDungeonRenderPaletteRows(
+      dungeon_palette, hud_palette,
+      [&group](int dst_index, const gfx::SnesColor& color) {
+        if (dst_index < 0 || dst_index >= kRenderPaletteRows * kColorsPerRow) {
+          return;
+        }
+        group.SetColor(dst_index / kColorsPerRow, dst_index % kColorsPerRow,
+                       color);
+      });
+  return group;
+}
+
+gfx::PaletteGroup BuildDungeonRenderPaletteGroupFromGameData(
+    const gfx::SnesPalette& dungeon_palette, const GameData* game_data) {
+  const gfx::SnesPalette* hud_palette = nullptr;
+  if (game_data != nullptr && !game_data->palette_groups.hud.empty()) {
+    hud_palette = &game_data->palette_groups.hud.palette_ref(0);
+  }
+  return BuildDungeonRenderPaletteGroup(dungeon_palette, hud_palette);
+}
+
 void LoadDungeonRenderPaletteToCgram(std::span<uint16_t> cgram,
                                      const gfx::SnesPalette& dungeon_palette,
                                      const gfx::SnesPalette* hud_palette) {

--- a/src/zelda3/dungeon/room.cc
+++ b/src/zelda3/dungeon/room.cc
@@ -92,6 +92,34 @@ void PopulateDungeonRenderPaletteRows(const gfx::SnesPalette& dungeon_palette,
   }
 }
 
+const gfx::SnesPalette* ResolvePaletteOrFirst(const gfx::PaletteGroup& group,
+                                              size_t requested_index) {
+  if (group.empty()) {
+    return nullptr;
+  }
+  const size_t resolved_index =
+      requested_index < group.size() ? requested_index : 0;
+  return &group.palette_ref(resolved_index);
+}
+
+void CopyPaletteToCgram(const gfx::SnesPalette* source, size_t source_offset,
+                        size_t max_colors, size_t destination_offset,
+                        std::array<SDL_Color, 256>* colors) {
+  if (source == nullptr || colors == nullptr ||
+      destination_offset >= colors->size() || source_offset >= source->size()) {
+    return;
+  }
+
+  const size_t count = std::min({max_colors, source->size() - source_offset,
+                                 colors->size() - destination_offset});
+  for (size_t i = 0; i < count; ++i) {
+    const auto rgb = (*source)[source_offset + i].rom_color();
+    (*colors)[destination_offset + i] = {static_cast<Uint8>(rgb.red),
+                                         static_cast<Uint8>(rgb.green),
+                                         static_cast<Uint8>(rgb.blue), 255};
+  }
+}
+
 }  // namespace
 
 std::vector<SDL_Color> BuildDungeonRenderPalette(
@@ -147,6 +175,62 @@ gfx::PaletteGroup BuildDungeonRenderPaletteGroupFromGameData(
     hud_palette = &game_data->palette_groups.hud.palette_ref(0);
   }
   return BuildDungeonRenderPaletteGroup(dungeon_palette, hud_palette);
+}
+
+std::array<SDL_Color, 256> BuildDungeonSpriteRenderPalette(
+    const Room& room, const GameData* game_data) {
+  constexpr size_t kCgramRowSize = 16;
+  constexpr size_t kHalfPaletteColorCount = 7;
+  constexpr size_t kFullPaletteColorCount = 15;
+  constexpr size_t kDefaultOverworldEnvironmentPalette = 0x07;
+  constexpr size_t kDefaultUnderworldEnvironmentPalette = 0x0A;
+
+  std::array<SDL_Color, 256> colors{};
+  if (game_data == nullptr) {
+    return colors;
+  }
+
+  // LoadRoomHeader stores the selected UnderworldPaletteSets row in the room
+  // header. USDASM then maps slots 1..3 to $0AAC/$0AAD/$0AAE. The latter two
+  // both index PaletteData_spriteaux_00, represented by sprites_aux3 in Yaze.
+  std::array<uint8_t, 4> palette_set{};
+  if (room.palette() < game_data->paletteset_ids.size()) {
+    palette_set = game_data->paletteset_ids[room.palette()];
+  }
+
+  const auto& groups = game_data->palette_groups;
+  CopyPaletteToCgram(ResolvePaletteOrFirst(groups.sprites_aux1, palette_set[1]),
+                     0, kHalfPaletteColorCount, 8 * kCgramRowSize + 1, &colors);
+  CopyPaletteToCgram(ResolvePaletteOrFirst(groups.sprites_aux2,
+                                           kDefaultOverworldEnvironmentPalette),
+                     0, kHalfPaletteColorCount, 8 * kCgramRowSize + 9, &colors);
+
+  // The runtime chooses Light/Dark World from overworld state ($8A). Dungeon
+  // rooms do not currently retain that entrance-world context, so preserve
+  // deterministic Light World and green-mail preview fallbacks. Row 8 right is
+  // inherited from Palettes_Load_SpriteEnvironment's outdoor path when the
+  // player enters a dungeon; the underworld path replaces row 14 right.
+  const auto* global = ResolvePaletteOrFirst(groups.global_sprites, 0);
+  for (size_t row = 9; row <= 12; ++row) {
+    CopyPaletteToCgram(global, (row - 9) * kFullPaletteColorCount,
+                       kFullPaletteColorCount, row * kCgramRowSize + 1,
+                       &colors);
+  }
+
+  CopyPaletteToCgram(ResolvePaletteOrFirst(groups.sprites_aux3, palette_set[2]),
+                     0, kHalfPaletteColorCount, 13 * kCgramRowSize + 1,
+                     &colors);
+  CopyPaletteToCgram(ResolvePaletteOrFirst(groups.sprites_aux3, palette_set[3]),
+                     0, kHalfPaletteColorCount, 14 * kCgramRowSize + 1,
+                     &colors);
+  CopyPaletteToCgram(
+      ResolvePaletteOrFirst(groups.sprites_aux2,
+                            kDefaultUnderworldEnvironmentPalette),
+      0, kHalfPaletteColorCount, 14 * kCgramRowSize + 9, &colors);
+  CopyPaletteToCgram(ResolvePaletteOrFirst(groups.armors, 0), 0,
+                     kFullPaletteColorCount, 15 * kCgramRowSize + 1, &colors);
+
+  return colors;
 }
 
 void LoadDungeonRenderPaletteToCgram(std::span<uint16_t> cgram,

--- a/src/zelda3/dungeon/room.h
+++ b/src/zelda3/dungeon/room.h
@@ -32,6 +32,7 @@ namespace yaze {
 namespace zelda3 {
 
 class DungeonState;
+class Room;
 class RoomLayerManager;
 struct DungeonStreamLayout;
 
@@ -51,6 +52,14 @@ gfx::PaletteGroup BuildDungeonRenderPaletteGroup(
 // blank while preserving the canonical dungeon rows.
 gfx::PaletteGroup BuildDungeonRenderPaletteGroupFromGameData(
     const gfx::SnesPalette& dungeon_palette, const GameData* game_data);
+
+// Builds the sprite half of the underworld CGRAM palette for editor previews.
+// Room palette-set slots select row 8 left and rows 13/14 left. The inherited
+// Light World environment fallback occupies row 8 right, while the standard
+// underworld environment palette occupies row 14 right. Missing or invalid
+// palette selectors fall back to palette 0 in the corresponding ROM group.
+std::array<SDL_Color, 256> BuildDungeonSpriteRenderPalette(
+    const Room& room, const GameData* game_data);
 
 void LoadDungeonRenderPaletteToCgram(
     std::span<uint16_t> cgram, const gfx::SnesPalette& dungeon_palette,

--- a/src/zelda3/dungeon/room.h
+++ b/src/zelda3/dungeon/room.h
@@ -39,6 +39,19 @@ std::vector<SDL_Color> BuildDungeonRenderPalette(
     const gfx::SnesPalette& dungeon_palette,
     const gfx::SnesPalette* hud_palette = nullptr);
 
+// Builds the same eight CGRAM rows as BuildDungeonRenderPalette, but keeps
+// them grouped for tools whose tile renderer indexes colors as
+// pixel + (tile_palette * 16).
+gfx::PaletteGroup BuildDungeonRenderPaletteGroup(
+    const gfx::SnesPalette& dungeon_palette,
+    const gfx::SnesPalette* hud_palette = nullptr);
+
+// Builds the editor-facing dungeon render group and resolves its HUD rows from
+// GameData. A null GameData, or one without HUD palettes, leaves those rows
+// blank while preserving the canonical dungeon rows.
+gfx::PaletteGroup BuildDungeonRenderPaletteGroupFromGameData(
+    const gfx::SnesPalette& dungeon_palette, const GameData* game_data);
+
 void LoadDungeonRenderPaletteToCgram(
     std::span<uint16_t> cgram, const gfx::SnesPalette& dungeon_palette,
     const gfx::SnesPalette* hud_palette = nullptr);

--- a/src/zelda3/game_data.h
+++ b/src/zelda3/game_data.h
@@ -91,15 +91,15 @@ struct GameData {
   // Game Data Structures
   gfx::PaletteGroupMap palette_groups;
 
-  std::array<std::array<uint8_t, 8>, kNumMainBlocksets> main_blockset_ids;
-  std::array<std::array<uint8_t, 4>, kNumRoomBlocksets> room_blockset_ids;
-  std::array<std::array<uint8_t, 4>, kNumSpritesets> spriteset_ids;
+  std::array<std::array<uint8_t, 8>, kNumMainBlocksets> main_blockset_ids{};
+  std::array<std::array<uint8_t, 4>, kNumRoomBlocksets> room_blockset_ids{};
+  std::array<std::array<uint8_t, 4>, kNumSpritesets> spriteset_ids{};
 
   // Palette set lookup table (72 entries × 4 bytes each)
   // Entry format: [bg_palette_offset, aux1, aux2, aux3]
   // NOTE: paletteset_ids[n][0] is a BYTE OFFSET into kDungeonPalettePointerTable,
   // NOT a direct palette index! See room.cc for correct lookup algorithm.
-  std::array<std::array<uint8_t, 4>, kNumPalettesets> paletteset_ids;
+  std::array<std::array<uint8_t, 4>, kNumPalettesets> paletteset_ids{};
 
   // Diagnostics
   GraphicsLoadDiagnostics diagnostics;

--- a/src/zelda3/sprite/sprite.cc
+++ b/src/zelda3/sprite/sprite.cc
@@ -1018,9 +1018,7 @@ void Sprite::Draw() {
   } else if (id_ == 0x8E)  // Terrorpin
   {
     DrawSpriteTile((x * 16), (y * 16), 14, 24, 12);
-  }
-
-  if (id_ == 0x8F)  // Slime
+  } else if (id_ == 0x8F)  // Slime
   {
     DrawSpriteTile((x * 16), (y * 16), 0, 20, 12);
   } else if (id_ == 0x90)  // Wall master
@@ -1188,7 +1186,10 @@ void Sprite::RenderPreviewGraphics(std::span<const uint8_t> graphics) {
     return;
   }
 
-  preview_gfx_.assign(64 * 64, 0xFF);
+  // External dungeon previews emit only non-zero CGRAM indices (0x71..0xFF),
+  // so index 0 is an unambiguous transparency sentinel. 0xFF is a visible
+  // armor-palette color and must remain available to sprites such as 0xE7.
+  preview_gfx_.assign(64 * 64, 0);
 
   external_gfx_ = graphics.data();
   external_gfx_size_ = graphics.size();

--- a/test/fixtures/gui/d6_edit_and_save.json
+++ b/test/fixtures/gui/d6_edit_and_save.json
@@ -28,6 +28,11 @@
       "expect": { "success": true, "status": "passed" }
     },
     {
+      "action": "click",
+      "widget_key": "Dungeon/Workbench/button:tool_picker",
+      "expect": { "success": true, "status": "passed" }
+    },
+    {
       "action": "wait",
       "widget_key": "Dungeon/Workbench/button:tool_door",
       "timeout_ms": 5000,
@@ -69,6 +74,11 @@
       "expect": { "success": true, "status": "passed" }
     },
     {
+      "action": "click",
+      "widget_key": "Dungeon/Workbench/button:mode_room",
+      "expect": { "success": true, "status": "passed" }
+    },
+    {
       "action": "type",
       "widget_key": "Dungeon/Workbench/input_scalar:room_id",
       "text": "B8",
@@ -79,11 +89,6 @@
       "action": "assert",
       "widget_key": "Dungeon/Workbench/input_scalar:room_id",
       "condition": "value_equals:00B8",
-      "expect": { "success": true, "status": "passed" }
-    },
-    {
-      "action": "click",
-      "widget_key": "Dungeon/Workbench/button:mode_room",
       "expect": { "success": true, "status": "passed" }
     },
     {
@@ -136,6 +141,11 @@
       "expect": { "success": true, "status": "passed" }
     },
     {
+      "action": "click",
+      "widget_key": "Dungeon/Workbench/button:tool_picker",
+      "expect": { "success": true, "status": "passed" }
+    },
+    {
       "action": "wait",
       "widget_key": "Dungeon/Workbench/button:tool_sprite",
       "timeout_ms": 5000,
@@ -178,6 +188,11 @@
     },
     {
       "action": "click",
+      "widget_key": "Dungeon/Workbench/button:tool_picker",
+      "expect": { "success": true, "status": "passed" }
+    },
+    {
+      "action": "click",
       "widget_key": "Dungeon/Workbench/button:tool_item",
       "expect": { "success": true, "status": "passed" }
     },
@@ -206,6 +221,11 @@
       "expect": { "success": true, "status": "passed" }
     },
     {
+      "action": "click",
+      "widget_key": "Dungeon/Workbench/button:mode_room",
+      "expect": { "success": true, "status": "passed" }
+    },
+    {
       "action": "type",
       "widget_key": "Dungeon/Workbench/input_scalar:room_id",
       "text": "DA",
@@ -221,6 +241,11 @@
     {
       "action": "click",
       "widget_key": "Dungeon/Workbench/button:mode_tools",
+      "expect": { "success": true, "status": "passed" }
+    },
+    {
+      "action": "click",
+      "widget_key": "Dungeon/Workbench/button:tool_picker",
       "expect": { "success": true, "status": "passed" }
     },
     {

--- a/test/fixtures/gui/d6_reopen_assert.json
+++ b/test/fixtures/gui/d6_reopen_assert.json
@@ -28,6 +28,11 @@
       "expect": { "success": true, "status": "passed" }
     },
     {
+      "action": "click",
+      "widget_key": "Dungeon/Workbench/button:tool_picker",
+      "expect": { "success": true, "status": "passed" }
+    },
+    {
       "action": "wait",
       "widget_key": "Dungeon/Workbench/button:tool_door",
       "timeout_ms": 5000,
@@ -62,6 +67,11 @@
       "expect": { "success": true, "status": "passed" }
     },
     {
+      "action": "click",
+      "widget_key": "Dungeon/Workbench/button:mode_room",
+      "expect": { "success": true, "status": "passed" }
+    },
+    {
       "action": "type",
       "widget_key": "Dungeon/Workbench/input_scalar:room_id",
       "text": "B8",
@@ -72,11 +82,6 @@
       "action": "assert",
       "widget_key": "Dungeon/Workbench/input_scalar:room_id",
       "condition": "value_equals:00B8",
-      "expect": { "success": true, "status": "passed" }
-    },
-    {
-      "action": "click",
-      "widget_key": "Dungeon/Workbench/button:mode_room",
       "expect": { "success": true, "status": "passed" }
     },
     {
@@ -123,6 +128,11 @@
       "expect": { "success": true, "status": "passed" }
     },
     {
+      "action": "click",
+      "widget_key": "Dungeon/Workbench/button:tool_picker",
+      "expect": { "success": true, "status": "passed" }
+    },
+    {
       "action": "wait",
       "widget_key": "Dungeon/Workbench/button:tool_sprite",
       "timeout_ms": 5000,
@@ -158,6 +168,11 @@
     },
     {
       "action": "click",
+      "widget_key": "Dungeon/Workbench/button:tool_picker",
+      "expect": { "success": true, "status": "passed" }
+    },
+    {
+      "action": "click",
       "widget_key": "Dungeon/Workbench/button:tool_item",
       "expect": { "success": true, "status": "passed" }
     },
@@ -179,6 +194,11 @@
       "expect": { "success": true, "status": "passed" }
     },
     {
+      "action": "click",
+      "widget_key": "Dungeon/Workbench/button:mode_room",
+      "expect": { "success": true, "status": "passed" }
+    },
+    {
       "action": "type",
       "widget_key": "Dungeon/Workbench/input_scalar:room_id",
       "text": "DA",
@@ -194,6 +214,11 @@
     {
       "action": "click",
       "widget_key": "Dungeon/Workbench/button:mode_tools",
+      "expect": { "success": true, "status": "passed" }
+    },
+    {
+      "action": "click",
+      "widget_key": "Dungeon/Workbench/button:tool_picker",
       "expect": { "success": true, "status": "passed" }
     },
     {

--- a/test/integration/dungeon_editor_v2_test.cc
+++ b/test/integration/dungeon_editor_v2_test.cc
@@ -1,5 +1,7 @@
 #include "integration/dungeon_editor_v2_test.h"
 
+#include <string_view>
+
 #include "app/editor/dungeon/workspace/dungeon_workbench_content.h"
 #include "core/features.h"
 
@@ -138,7 +140,7 @@ TEST_F(DungeonEditorV2IntegrationTest,
 }
 
 TEST_F(DungeonEditorV2IntegrationTest,
-       WorkbenchModeClosesUnpinnedDuplicateWindows) {
+       WorkbenchModeClosesNavigationButPreservesStandaloneTools) {
   DungeonFeatureFlagsGuard guard;
   core::FeatureFlags::get().dungeon.kUseWorkbench = true;
 
@@ -150,11 +152,13 @@ TEST_F(DungeonEditorV2IntegrationTest,
   dungeon_editor_v2_->SetWorkbenchWorkflowMode(false, /*show_toast=*/false);
   ASSERT_FALSE(window_manager_->IsWindowOpen(session_id, "dungeon.workbench"));
 
-  const char* duplicate_windows[] = {
+  const char* navigation_windows[] = {
       editor::DungeonEditorV2::kRoomSelectorId,
       editor::DungeonEditorV2::kEntranceListId,
       editor::DungeonEditorV2::kRoomMatrixId,
       "dungeon.room_0",
+  };
+  const char* standalone_tools[] = {
       editor::DungeonEditorV2::kObjectSelectorId,
       editor::DungeonEditorV2::kDoorEditorId,
       "dungeon.sprite_editor",
@@ -166,7 +170,12 @@ TEST_F(DungeonEditorV2IntegrationTest,
       "dungeon.water_fill",
   };
 
-  for (const char* window_id : duplicate_windows) {
+  for (const char* window_id : navigation_windows) {
+    window_manager_->OpenWindow(session_id, window_id);
+    ASSERT_TRUE(window_manager_->IsWindowOpen(session_id, window_id))
+        << window_id;
+  }
+  for (const char* window_id : standalone_tools) {
     window_manager_->OpenWindow(session_id, window_id);
     ASSERT_TRUE(window_manager_->IsWindowOpen(session_id, window_id))
         << window_id;
@@ -175,15 +184,34 @@ TEST_F(DungeonEditorV2IntegrationTest,
   dungeon_editor_v2_->SetWorkbenchWorkflowMode(true, /*show_toast=*/false);
 
   EXPECT_TRUE(window_manager_->IsWindowOpen(session_id, "dungeon.workbench"));
-  for (const char* window_id : duplicate_windows) {
+  for (const char* window_id : navigation_windows) {
     EXPECT_FALSE(window_manager_->IsWindowOpen(session_id, window_id))
         << window_id;
   }
+  for (const char* window_id : standalone_tools) {
+    EXPECT_TRUE(window_manager_->IsWindowOpen(session_id, window_id))
+        << window_id;
+  }
+
+  // A tool the user closes while in Workbench mode must stay closed when the
+  // Windows workflow is restored; it was never owned by the suspension set.
+  window_manager_->CloseWindow(session_id,
+                               editor::DungeonEditorV2::kObjectSelectorId);
 
   dungeon_editor_v2_->SetWorkbenchWorkflowMode(false, /*show_toast=*/false);
 
   EXPECT_FALSE(window_manager_->IsWindowOpen(session_id, "dungeon.workbench"));
-  for (const char* window_id : duplicate_windows) {
+  for (const char* window_id : navigation_windows) {
+    EXPECT_TRUE(window_manager_->IsWindowOpen(session_id, window_id))
+        << window_id;
+  }
+  EXPECT_FALSE(window_manager_->IsWindowOpen(
+      session_id, editor::DungeonEditorV2::kObjectSelectorId));
+  for (const char* window_id : standalone_tools) {
+    if (std::string_view(window_id) ==
+        editor::DungeonEditorV2::kObjectSelectorId) {
+      continue;
+    }
     EXPECT_TRUE(window_manager_->IsWindowOpen(session_id, window_id))
         << window_id;
   }
@@ -222,7 +250,7 @@ TEST_F(DungeonEditorV2IntegrationTest,
 }
 
 TEST_F(DungeonEditorV2IntegrationTest,
-       WorkbenchModePreservesPinnedDuplicateWindow) {
+       WorkbenchModePreservesPinnedNavigationWindow) {
   DungeonFeatureFlagsGuard guard;
   core::FeatureFlags::get().dungeon.kUseWorkbench = true;
 
@@ -234,15 +262,15 @@ TEST_F(DungeonEditorV2IntegrationTest,
   dungeon_editor_v2_->SetWorkbenchWorkflowMode(false, /*show_toast=*/false);
   ASSERT_FALSE(window_manager_->IsWindowOpen(session_id, "dungeon.workbench"));
 
-  const char* pinned_tool = editor::DungeonEditorV2::kObjectSelectorId;
-  window_manager_->OpenWindow(session_id, pinned_tool);
-  window_manager_->SetWindowPinned(session_id, pinned_tool, true);
+  const char* pinned_navigation = editor::DungeonEditorV2::kRoomSelectorId;
+  window_manager_->OpenWindow(session_id, pinned_navigation);
+  window_manager_->SetWindowPinned(session_id, pinned_navigation, true);
 
   dungeon_editor_v2_->SetWorkbenchWorkflowMode(true, /*show_toast=*/false);
 
   EXPECT_TRUE(window_manager_->IsWindowOpen(session_id, "dungeon.workbench"));
-  EXPECT_TRUE(window_manager_->IsWindowOpen(session_id, pinned_tool));
-  EXPECT_TRUE(window_manager_->IsWindowPinned(session_id, pinned_tool));
+  EXPECT_TRUE(window_manager_->IsWindowOpen(session_id, pinned_navigation));
+  EXPECT_TRUE(window_manager_->IsWindowPinned(session_id, pinned_navigation));
 }
 
 TEST_F(DungeonEditorV2IntegrationTest,
@@ -274,6 +302,44 @@ TEST_F(DungeonEditorV2IntegrationTest,
 }
 
 TEST_F(DungeonEditorV2IntegrationTest,
+       WorkbenchPopOutDefersStandaloneWindowUntilUpdate) {
+  DungeonFeatureFlagsGuard guard;
+  core::FeatureFlags::get().dungeon.kUseWorkbench = true;
+
+  dungeon_editor_v2_->Initialize();
+  auto load_status = dungeon_editor_v2_->Load();
+  ASSERT_TRUE(load_status.ok()) << load_status.message();
+  const size_t session_id = window_manager_->GetActiveSessionId();
+
+  auto* workbench = dynamic_cast<editor::DungeonWorkbenchContent*>(
+      window_manager_->GetWindowContent("dungeon.workbench"));
+  ASSERT_NE(workbench, nullptr);
+  ASSERT_FALSE(window_manager_->IsWindowOpen(
+      session_id, editor::DungeonEditorV2::kObjectSelectorId));
+
+  workbench->OpenObjectSelectorTool();
+  ASSERT_TRUE(workbench->IsToolInspectorActiveForTesting());
+
+  ImGui::Begin("DungeonWorkbenchPopOutHost");
+  ImGui::BeginChild("##DungeonWorkbenchPopOutChild");
+  const bool pop_out_requested = workbench->PopOutActiveTool();
+
+  // Avoid fatal assertions while an ImGui scope is open: failures must still
+  // reach EndChild()/End() so the test reports the Workbench defect directly.
+  EXPECT_TRUE(pop_out_requested);
+  EXPECT_FALSE(workbench->IsToolInspectorActiveForTesting());
+  EXPECT_FALSE(window_manager_->IsWindowOpen(
+      session_id, editor::DungeonEditorV2::kObjectSelectorId));
+  ImGui::EndChild();
+  ImGui::End();
+
+  auto status = dungeon_editor_v2_->Update();
+  ASSERT_TRUE(status.ok());
+  EXPECT_TRUE(window_manager_->IsWindowOpen(
+      session_id, editor::DungeonEditorV2::kObjectSelectorId));
+}
+
+TEST_F(DungeonEditorV2IntegrationTest,
        SetAgentModeOpensWorkbenchWhenWorkbenchWorkflowEnabled) {
   DungeonFeatureFlagsGuard guard;
   core::FeatureFlags::get().dungeon.kUseWorkbench = true;
@@ -294,7 +360,8 @@ TEST_F(DungeonEditorV2IntegrationTest,
   auto* workbench = dynamic_cast<editor::DungeonWorkbenchContent*>(
       window_manager_->GetWindowContent("dungeon.workbench"));
   ASSERT_NE(workbench, nullptr);
-  EXPECT_TRUE(workbench->IsToolDrawerActiveForTesting());
+  EXPECT_TRUE(workbench->IsToolInspectorActiveForTesting());
+  EXPECT_STREQ(workbench->GetInspectorModeIdForTesting(), "tools");
   EXPECT_STREQ(workbench->GetActiveToolIdForTesting(), "object_selector");
 }
 

--- a/test/integration/dungeon_editor_v2_test.cc
+++ b/test/integration/dungeon_editor_v2_test.cc
@@ -137,7 +137,8 @@ TEST_F(DungeonEditorV2IntegrationTest,
       session_id, editor::DungeonEditorV2::kRoomMatrixId));
 }
 
-TEST_F(DungeonEditorV2IntegrationTest, WorkbenchModeKeepsLocalToolWindowsOpen) {
+TEST_F(DungeonEditorV2IntegrationTest,
+       WorkbenchModeClosesUnpinnedDuplicateWindows) {
   DungeonFeatureFlagsGuard guard;
   core::FeatureFlags::get().dungeon.kUseWorkbench = true;
 
@@ -149,7 +150,11 @@ TEST_F(DungeonEditorV2IntegrationTest, WorkbenchModeKeepsLocalToolWindowsOpen) {
   dungeon_editor_v2_->SetWorkbenchWorkflowMode(false, /*show_toast=*/false);
   ASSERT_FALSE(window_manager_->IsWindowOpen(session_id, "dungeon.workbench"));
 
-  const char* local_tools[] = {
+  const char* duplicate_windows[] = {
+      editor::DungeonEditorV2::kRoomSelectorId,
+      editor::DungeonEditorV2::kEntranceListId,
+      editor::DungeonEditorV2::kRoomMatrixId,
+      "dungeon.room_0",
       editor::DungeonEditorV2::kObjectSelectorId,
       editor::DungeonEditorV2::kDoorEditorId,
       "dungeon.sprite_editor",
@@ -161,17 +166,83 @@ TEST_F(DungeonEditorV2IntegrationTest, WorkbenchModeKeepsLocalToolWindowsOpen) {
       "dungeon.water_fill",
   };
 
-  for (const char* tool_id : local_tools) {
-    window_manager_->OpenWindow(session_id, tool_id);
-    ASSERT_TRUE(window_manager_->IsWindowOpen(session_id, tool_id)) << tool_id;
+  for (const char* window_id : duplicate_windows) {
+    window_manager_->OpenWindow(session_id, window_id);
+    ASSERT_TRUE(window_manager_->IsWindowOpen(session_id, window_id))
+        << window_id;
   }
 
   dungeon_editor_v2_->SetWorkbenchWorkflowMode(true, /*show_toast=*/false);
 
   EXPECT_TRUE(window_manager_->IsWindowOpen(session_id, "dungeon.workbench"));
-  for (const char* tool_id : local_tools) {
-    EXPECT_TRUE(window_manager_->IsWindowOpen(session_id, tool_id)) << tool_id;
+  for (const char* window_id : duplicate_windows) {
+    EXPECT_FALSE(window_manager_->IsWindowOpen(session_id, window_id))
+        << window_id;
   }
+
+  dungeon_editor_v2_->SetWorkbenchWorkflowMode(false, /*show_toast=*/false);
+
+  EXPECT_FALSE(window_manager_->IsWindowOpen(session_id, "dungeon.workbench"));
+  for (const char* window_id : duplicate_windows) {
+    EXPECT_TRUE(window_manager_->IsWindowOpen(session_id, window_id))
+        << window_id;
+  }
+}
+
+TEST_F(DungeonEditorV2IntegrationTest,
+       WorkbenchModePreservesUnrelatedAuxiliaryWindows) {
+  DungeonFeatureFlagsGuard guard;
+  core::FeatureFlags::get().dungeon.kUseWorkbench = true;
+
+  dungeon_editor_v2_->Initialize();
+  auto load_status = dungeon_editor_v2_->Load();
+  ASSERT_TRUE(load_status.ok()) << load_status.message();
+  const size_t session_id = window_manager_->GetActiveSessionId();
+
+  dungeon_editor_v2_->SetWorkbenchWorkflowMode(false, /*show_toast=*/false);
+  ASSERT_FALSE(window_manager_->IsWindowOpen(session_id, "dungeon.workbench"));
+
+  const char* auxiliary_windows[] = {
+      "dungeon.object_tile_editor",
+      "dungeon.overlay_manager",
+  };
+  for (const char* window_id : auxiliary_windows) {
+    window_manager_->OpenWindow(session_id, window_id);
+    ASSERT_TRUE(window_manager_->IsWindowOpen(session_id, window_id))
+        << window_id;
+  }
+
+  dungeon_editor_v2_->SetWorkbenchWorkflowMode(true, /*show_toast=*/false);
+
+  EXPECT_TRUE(window_manager_->IsWindowOpen(session_id, "dungeon.workbench"));
+  for (const char* window_id : auxiliary_windows) {
+    EXPECT_TRUE(window_manager_->IsWindowOpen(session_id, window_id))
+        << window_id;
+  }
+}
+
+TEST_F(DungeonEditorV2IntegrationTest,
+       WorkbenchModePreservesPinnedDuplicateWindow) {
+  DungeonFeatureFlagsGuard guard;
+  core::FeatureFlags::get().dungeon.kUseWorkbench = true;
+
+  dungeon_editor_v2_->Initialize();
+  auto load_status = dungeon_editor_v2_->Load();
+  ASSERT_TRUE(load_status.ok()) << load_status.message();
+  const size_t session_id = window_manager_->GetActiveSessionId();
+
+  dungeon_editor_v2_->SetWorkbenchWorkflowMode(false, /*show_toast=*/false);
+  ASSERT_FALSE(window_manager_->IsWindowOpen(session_id, "dungeon.workbench"));
+
+  const char* pinned_tool = editor::DungeonEditorV2::kObjectSelectorId;
+  window_manager_->OpenWindow(session_id, pinned_tool);
+  window_manager_->SetWindowPinned(session_id, pinned_tool, true);
+
+  dungeon_editor_v2_->SetWorkbenchWorkflowMode(true, /*show_toast=*/false);
+
+  EXPECT_TRUE(window_manager_->IsWindowOpen(session_id, "dungeon.workbench"));
+  EXPECT_TRUE(window_manager_->IsWindowOpen(session_id, pinned_tool));
+  EXPECT_TRUE(window_manager_->IsWindowPinned(session_id, pinned_tool));
 }
 
 TEST_F(DungeonEditorV2IntegrationTest,

--- a/test/unit/editor/dungeon_editor_palette_refresh_test.cc
+++ b/test/unit/editor/dungeon_editor_palette_refresh_test.cc
@@ -497,15 +497,15 @@ TEST_F(DungeonEditorPaletteRefreshTest,
       palette_manager.SetColor("hud", 0, 17, gfx::SnesColor(0x03E0)).ok());
   ASSERT_TRUE(palette_manager.ApplyPreviewChanges().ok());
 
-  auto expected_palette_group = gfx::CreatePaletteGroupFromLargePalette(
-      game_data_.palette_groups.dungeon_main.palette_ref(2));
-  ASSERT_TRUE(expected_palette_group.ok());
+  const auto expected_palette_group = zelda3::BuildDungeonRenderPaletteGroup(
+      game_data_.palette_groups.dungeon_main.palette_ref(2),
+      &game_data_.palette_groups.hud.palette_ref(0));
   EXPECT_EQ(cached_viewer->current_palette_id_, 2);
   ASSERT_EQ(cached_viewer->current_palette_group_.size(),
-            expected_palette_group->size());
-  for (int i = 0; i < static_cast<int>(expected_palette_group->size()); ++i) {
+            expected_palette_group.size());
+  for (int i = 0; i < static_cast<int>(expected_palette_group.size()); ++i) {
     EXPECT_EQ(cached_viewer->current_palette_group_.palette_ref(i),
-              expected_palette_group->palette_ref(i));
+              expected_palette_group.palette_ref(i));
   }
 }
 

--- a/test/unit/editor/dungeon_editor_palette_refresh_test.cc
+++ b/test/unit/editor/dungeon_editor_palette_refresh_test.cc
@@ -8,6 +8,7 @@
 #include "app/editor/dungeon/dungeon_canvas_viewer.h"
 #include "app/gfx/resource/arena.h"
 #include "app/gfx/util/palette_manager.h"
+#include "app/gui/widgets/palette_editor_widget.h"
 #include "app/platform/sdl_compat.h"
 #include "core/features.h"
 #include "framework/mock_renderer.h"
@@ -715,6 +716,33 @@ TEST_F(DungeonEditorPaletteRefreshTest,
                       /*display_index=*/34, gfx::SnesColor(0x5294))
                   .ok());
   EXPECT_EQ(callback_count, 1);
+}
+
+TEST(DungeonPaletteResponsiveLayoutTest, UsesLogicalRowWidthsWhenTheyFit) {
+  EXPECT_EQ(gui::ResolveDungeonRenderPaletteColumns(
+                /*available_width=*/254.0f, /*min_swatch_size=*/14.0f,
+                /*item_spacing=*/2.0f),
+            16);
+  EXPECT_EQ(gui::ResolveDungeonRenderPaletteColumns(
+                /*available_width=*/126.0f, /*min_swatch_size=*/14.0f,
+                /*item_spacing=*/2.0f),
+            8);
+}
+
+TEST(DungeonPaletteResponsiveLayoutTest,
+     WrapsWithoutChangingLogicalPaletteIndices) {
+  EXPECT_EQ(gui::ResolveDungeonRenderPaletteColumns(
+                /*available_width=*/253.0f, /*min_swatch_size=*/14.0f,
+                /*item_spacing=*/2.0f),
+            8);
+  EXPECT_EQ(gui::ResolveDungeonRenderPaletteColumns(
+                /*available_width=*/125.0f, /*min_swatch_size=*/14.0f,
+                /*item_spacing=*/2.0f),
+            4);
+  EXPECT_EQ(gui::ResolveDungeonRenderPaletteColumns(
+                /*available_width=*/1.0f, /*min_swatch_size=*/14.0f,
+                /*item_spacing=*/2.0f),
+            1);
 }
 
 }  // namespace yaze::editor

--- a/test/unit/editor/dungeon_object_selector_palette_test.cc
+++ b/test/unit/editor/dungeon_object_selector_palette_test.cc
@@ -1,5 +1,7 @@
 #include "app/editor/dungeon/dungeon_object_selector.h"
 
+#include <algorithm>
+#include <array>
 #include <cstddef>
 #include <vector>
 
@@ -52,9 +54,20 @@ struct DungeonObjectSelectorTestAccess {
     selector.preview_cache_[cache_key] = std::move(preview);
     return bitmap;
   }
+
+  static void GetOrCreatePreview(DungeonObjectSelector& selector,
+                                 const zelda3::RoomObject& object,
+                                 gfx::BackgroundBuffer** preview) {
+    selector.GetOrCreatePreview(object, preview);
+  }
 };
 
 namespace {
+
+void StoreRomWord(std::vector<uint8_t>* data, uint32_t address, uint16_t word) {
+  (*data)[address] = static_cast<uint8_t>(word & 0xFF);
+  (*data)[address + 1] = static_cast<uint8_t>(word >> 8);
+}
 
 size_t ActiveArenaSurfaceCount() {
   const auto& arena = gfx::Arena::Get();
@@ -99,6 +112,61 @@ TEST(DungeonObjectSelectorPaletteTest,
   selector.SetCurrentPaletteGroup(gfx::PaletteGroup("ow_main"));
   selector.SetCurrentPaletteGroup(gfx::PaletteGroup("sprites_aux1"));
   EXPECT_EQ(selector.preview_cache_invalidations_for_testing(), 3u);
+}
+
+TEST(DungeonObjectSelectorPaletteTest,
+     PreviewBitmapUsesCanonicalDungeonCgramRows) {
+  std::vector<uint8_t> rom_data(0x200000, 0);
+  StoreRomWord(&rom_data, /*object 0x11F descriptor=*/0x842E, 0x0E9A);
+  for (uint32_t address = 0x29EC; address < 0x29F4; address += 2) {
+    // Tile 0x1EE, palette row 2. The preview graphics below use source color
+    // 9, so the rendered SDL index must be 2 * 16 + 9 = 41.
+    StoreRomWord(&rom_data, address, 0x09EE);
+  }
+
+  Rom rom;
+  ASSERT_TRUE(rom.LoadFromData(std::move(rom_data)).ok());
+  DungeonRoomStore rooms(&rom);
+  auto& room = rooms[0];
+  room.SetLoaded(true);
+  auto& room_gfx =
+      const_cast<std::array<uint8_t, 0x10000>&>(room.get_gfx_buffer());
+  room_gfx.fill(9);
+
+  gfx::SnesPalette hud_palette;
+  for (int color = 0; color < 32; ++color) {
+    hud_palette.AddColor(gfx::SnesColor(static_cast<uint16_t>(0x0100 + color)));
+  }
+  gfx::SnesPalette dungeon_palette;
+  for (int color = 0; color < 90; ++color) {
+    dungeon_palette.AddColor(
+        gfx::SnesColor(static_cast<uint16_t>(0x0200 + color)));
+  }
+
+  zelda3::GameData game_data;
+  game_data.palette_groups.hud.AddPalette(hud_palette);
+  DungeonObjectSelector selector(&rom);
+  selector.SetGameData(&game_data);
+  selector.set_rooms(&rooms);
+  selector.set_current_room_id(0);
+  selector.SetCurrentPaletteGroup(
+      zelda3::BuildDungeonRenderPaletteGroupFromGameData(dungeon_palette,
+                                                         &game_data));
+
+  zelda3::RoomObject object(/*object_id=*/0x11F, /*x=*/0, /*y=*/0,
+                            /*size=*/0, /*layer=*/0);
+  gfx::BackgroundBuffer* preview = nullptr;
+  DungeonObjectSelectorTestAccess::GetOrCreatePreview(selector, object,
+                                                      &preview);
+
+  ASSERT_NE(preview, nullptr);
+  auto& bitmap = preview->bitmap();
+  ASSERT_EQ(bitmap.palette().size(), 128u);
+  EXPECT_EQ(bitmap.palette()[1].snes(), hud_palette[1].snes());
+  EXPECT_EQ(bitmap.palette()[41].snes(), dungeon_palette[8].snes());
+  EXPECT_NE(
+      std::find(bitmap.mutable_data().begin(), bitmap.mutable_data().end(), 41),
+      bitmap.mutable_data().end());
 }
 
 TEST(DungeonObjectSelectorPaletteTest,

--- a/test/unit/editor/dungeon_object_selector_palette_test.cc
+++ b/test/unit/editor/dungeon_object_selector_palette_test.cc
@@ -267,14 +267,14 @@ TEST(DungeonObjectSelectorPaletteTest, ObjectPreviewsDefaultOn) {
 TEST(DungeonObjectSelectorLayoutTest,
      GridUsesAvailableWidthWithoutHorizontalOverflow) {
   constexpr float kAvailableWidth = 400.0f;
-  constexpr float kRequestedItemSize = 72.0f;
+  constexpr float kRequestedItemSize = 60.0f;
   constexpr float kItemSpacing = 4.0f;
   constexpr float kScrollbarWidth = 14.0f;
 
   const auto layout = ResolveDungeonObjectSelectorGridLayout(
       kAvailableWidth, kRequestedItemSize, kItemSpacing, kScrollbarWidth);
 
-  EXPECT_EQ(layout.columns, 5);
+  EXPECT_EQ(layout.columns, 6);
   EXPECT_FLOAT_EQ(layout.item_size, kRequestedItemSize);
   const float occupied_width =
       layout.columns * layout.item_size + (layout.columns - 1) * kItemSpacing;
@@ -282,7 +282,7 @@ TEST(DungeonObjectSelectorLayoutTest,
 }
 
 TEST(DungeonObjectSelectorLayoutTest,
-     GridShrinksToOneUsableItemWhenDrawerIsExtremelyNarrow) {
+     GridShrinksToOneUsableItemWhenSelectorIsExtremelyNarrow) {
   const auto layout = ResolveDungeonObjectSelectorGridLayout(
       /*available_width=*/28.0f, /*requested_item_size=*/72.0f,
       /*item_spacing=*/4.0f, /*reserved_scrollbar_width=*/14.0f);
@@ -302,88 +302,83 @@ TEST(DungeonObjectSelectorLayoutTest,
   EXPECT_FLOAT_EQ(layout.item_size, 32.0f);
 }
 
-TEST(DungeonObjectSelectorTypeTabTest, AllTabAndUnknownTabFailOpen) {
+TEST(DungeonObjectSelectorStreamFilterTest, AllAndUnknownFiltersFailOpen) {
   for (int object_id : {-1, 0x000, 0x0F8, 0x140, 0xF80, 0x1000}) {
-    EXPECT_TRUE(MatchesDungeonObjectTypeTab(object_id, 0));
-    EXPECT_TRUE(MatchesDungeonObjectTypeTab(object_id, 99));
+    EXPECT_TRUE(MatchesDungeonObjectStreamFilter(object_id, 0));
+    EXPECT_TRUE(MatchesDungeonObjectStreamFilter(object_id, 99));
   }
 }
 
-TEST(DungeonObjectSelectorTypeTabTest, TypeOneUsesCanonicalCodecRange) {
-  EXPECT_FALSE(MatchesDungeonObjectTypeTab(-1, 1));
-  EXPECT_TRUE(MatchesDungeonObjectTypeTab(0x000, 1));
-  EXPECT_TRUE(MatchesDungeonObjectTypeTab(0x0F7, 1));
-  EXPECT_FALSE(MatchesDungeonObjectTypeTab(0x0F8, 1));
-  EXPECT_FALSE(MatchesDungeonObjectTypeTab(0x100, 1));
+TEST(DungeonObjectSelectorStreamFilterTest, TypeOneUsesCanonicalCodecRange) {
+  EXPECT_FALSE(MatchesDungeonObjectStreamFilter(-1, 1));
+  EXPECT_TRUE(MatchesDungeonObjectStreamFilter(0x000, 1));
+  EXPECT_TRUE(MatchesDungeonObjectStreamFilter(0x0F7, 1));
+  EXPECT_FALSE(MatchesDungeonObjectStreamFilter(0x0F8, 1));
+  EXPECT_FALSE(MatchesDungeonObjectStreamFilter(0x100, 1));
 }
 
-TEST(DungeonObjectSelectorTypeTabTest, TypeTwoUsesCanonicalCodecRange) {
-  EXPECT_FALSE(MatchesDungeonObjectTypeTab(0x0FF, 2));
-  EXPECT_TRUE(MatchesDungeonObjectTypeTab(0x100, 2));
-  EXPECT_TRUE(MatchesDungeonObjectTypeTab(0x13F, 2));
-  EXPECT_FALSE(MatchesDungeonObjectTypeTab(0x140, 2));
+TEST(DungeonObjectSelectorStreamFilterTest, TypeTwoUsesCanonicalCodecRange) {
+  EXPECT_FALSE(MatchesDungeonObjectStreamFilter(0x0FF, 2));
+  EXPECT_TRUE(MatchesDungeonObjectStreamFilter(0x100, 2));
+  EXPECT_TRUE(MatchesDungeonObjectStreamFilter(0x13F, 2));
+  EXPECT_FALSE(MatchesDungeonObjectStreamFilter(0x140, 2));
 }
 
-TEST(DungeonObjectSelectorTypeTabTest, TypeThreeUsesCanonicalCodecRange) {
-  EXPECT_FALSE(MatchesDungeonObjectTypeTab(0xF7F, 3));
-  EXPECT_TRUE(MatchesDungeonObjectTypeTab(0xF80, 3));
-  EXPECT_TRUE(MatchesDungeonObjectTypeTab(0xFFF, 3));
-  EXPECT_FALSE(MatchesDungeonObjectTypeTab(0x1000, 3));
+TEST(DungeonObjectSelectorStreamFilterTest, TypeThreeUsesCanonicalCodecRange) {
+  EXPECT_FALSE(MatchesDungeonObjectStreamFilter(0xF7F, 3));
+  EXPECT_TRUE(MatchesDungeonObjectStreamFilter(0xF80, 3));
+  EXPECT_TRUE(MatchesDungeonObjectStreamFilter(0xFFF, 3));
+  EXPECT_FALSE(MatchesDungeonObjectStreamFilter(0x1000, 3));
 }
 
-TEST(DungeonObjectSelectorTypeTabLayoutTest,
-     UsesOneRowAtExactFitAndBalancedGridBelowIt) {
-  constexpr float kTabWidth = 56.0f;
-  constexpr float kSpacing = 4.0f;
-  constexpr int kTabCount = 4;
-  constexpr float kFourColumnWidth =
-      kTabCount * kTabWidth + (kTabCount - 1) * kSpacing;
+TEST(DungeonObjectSelectorPreviewFitTest,
+     FitsWideSourceAndCentersItVertically) {
+  const auto fit = ResolveDungeonObjectPreviewFit(
+      /*source_width=*/32.0f, /*source_height=*/8.0f,
+      /*box_width=*/40.0f, /*box_height=*/40.0f);
 
-  const auto exact_fit = ResolveDungeonObjectSelectorTypeTabLayout(
-      kFourColumnWidth, kTabWidth, kSpacing, kTabCount);
-  EXPECT_EQ(exact_fit.columns, 4);
-  EXPECT_FLOAT_EQ(exact_fit.item_width, kTabWidth);
-
-  const auto balanced_grid = ResolveDungeonObjectSelectorTypeTabLayout(
-      kFourColumnWidth - 1.0f, kTabWidth, kSpacing, kTabCount);
-  EXPECT_EQ(balanced_grid.columns, 2);
-  EXPECT_FLOAT_EQ(balanced_grid.item_width, kTabWidth);
+  EXPECT_TRUE(fit.valid);
+  EXPECT_FLOAT_EQ(fit.x, 0.0f);
+  EXPECT_FLOAT_EQ(fit.y, 15.0f);
+  EXPECT_FLOAT_EQ(fit.width, 40.0f);
+  EXPECT_FLOAT_EQ(fit.height, 10.0f);
 }
 
-TEST(DungeonObjectSelectorTypeTabLayoutTest,
-     UsesBalancedGridAtExactFitAndVerticalStackBelowIt) {
-  constexpr float kTabWidth = 56.0f;
-  constexpr float kSpacing = 4.0f;
-  constexpr float kTwoColumnWidth = 2.0f * kTabWidth + kSpacing;
+TEST(DungeonObjectSelectorPreviewFitTest,
+     FitsTallSourceAndCentersItHorizontally) {
+  const auto fit = ResolveDungeonObjectPreviewFit(
+      /*source_width=*/8.0f, /*source_height=*/32.0f,
+      /*box_width=*/40.0f, /*box_height=*/40.0f);
 
-  const auto exact_fit = ResolveDungeonObjectSelectorTypeTabLayout(
-      kTwoColumnWidth, kTabWidth, kSpacing);
-  EXPECT_EQ(exact_fit.columns, 2);
-  EXPECT_FLOAT_EQ(exact_fit.item_width, kTabWidth);
-
-  const auto vertical_stack = ResolveDungeonObjectSelectorTypeTabLayout(
-      kTwoColumnWidth - 1.0f, kTabWidth, kSpacing);
-  EXPECT_EQ(vertical_stack.columns, 1);
-  EXPECT_FLOAT_EQ(vertical_stack.item_width, kTabWidth);
+  EXPECT_TRUE(fit.valid);
+  EXPECT_FLOAT_EQ(fit.x, 15.0f);
+  EXPECT_FLOAT_EQ(fit.y, 0.0f);
+  EXPECT_FLOAT_EQ(fit.width, 10.0f);
+  EXPECT_FLOAT_EQ(fit.height, 40.0f);
 }
 
-TEST(DungeonObjectSelectorTypeTabLayoutTest,
-     NarrowAndEmptyLayoutsRemainReachable) {
-  const auto narrow = ResolveDungeonObjectSelectorTypeTabLayout(
-      /*available_width=*/20.0f, /*requested_tab_width=*/56.0f,
-      /*item_spacing=*/4.0f);
-  EXPECT_EQ(narrow.columns, 1);
-  EXPECT_FLOAT_EQ(narrow.item_width, 20.0f);
+TEST(DungeonObjectSelectorPreviewFitTest, SquareSourceFillsSquareBox) {
+  const auto fit = ResolveDungeonObjectPreviewFit(
+      /*source_width=*/16.0f, /*source_height=*/16.0f,
+      /*box_width=*/40.0f, /*box_height=*/40.0f);
 
-  const auto empty = ResolveDungeonObjectSelectorTypeTabLayout(
-      /*available_width=*/400.0f, /*requested_tab_width=*/56.0f,
-      /*item_spacing=*/4.0f, /*tab_count=*/0);
-  EXPECT_EQ(empty.columns, 0);
+  EXPECT_TRUE(fit.valid);
+  EXPECT_FLOAT_EQ(fit.x, 0.0f);
+  EXPECT_FLOAT_EQ(fit.y, 0.0f);
+  EXPECT_FLOAT_EQ(fit.width, 40.0f);
+  EXPECT_FLOAT_EQ(fit.height, 40.0f);
+}
 
-  const auto invalid = ResolveDungeonObjectSelectorTypeTabLayout(
-      /*available_width=*/400.0f, /*requested_tab_width=*/56.0f,
-      /*item_spacing=*/4.0f, /*tab_count=*/-1);
-  EXPECT_EQ(invalid.columns, 0);
+TEST(DungeonObjectSelectorPreviewFitTest,
+     NonPositiveSourceOrBoxDimensionsAreInvalid) {
+  EXPECT_FALSE(ResolveDungeonObjectPreviewFit(0.0f, 8.0f, 40.0f, 40.0f).valid);
+  EXPECT_FALSE(ResolveDungeonObjectPreviewFit(8.0f, 0.0f, 40.0f, 40.0f).valid);
+  EXPECT_FALSE(ResolveDungeonObjectPreviewFit(-8.0f, 8.0f, 40.0f, 40.0f).valid);
+  EXPECT_FALSE(ResolveDungeonObjectPreviewFit(8.0f, -8.0f, 40.0f, 40.0f).valid);
+  EXPECT_FALSE(ResolveDungeonObjectPreviewFit(8.0f, 8.0f, 0.0f, 40.0f).valid);
+  EXPECT_FALSE(ResolveDungeonObjectPreviewFit(8.0f, 8.0f, 40.0f, 0.0f).valid);
+  EXPECT_FALSE(ResolveDungeonObjectPreviewFit(8.0f, 8.0f, -40.0f, 40.0f).valid);
+  EXPECT_FALSE(ResolveDungeonObjectPreviewFit(8.0f, 8.0f, 40.0f, -40.0f).valid);
 }
 
 TEST(DungeonObjectSelectorCustomEditorTest,

--- a/test/unit/editor/dungeon_object_selector_palette_test.cc
+++ b/test/unit/editor/dungeon_object_selector_palette_test.cc
@@ -333,41 +333,86 @@ TEST(DungeonObjectSelectorPaletteTest, ObjectPreviewsDefaultOn) {
 }
 
 TEST(DungeonObjectSelectorLayoutTest,
-     GridUsesAvailableWidthWithoutHorizontalOverflow) {
+     GridBalancesRemainingWidthWithoutChangingDensity) {
   constexpr float kAvailableWidth = 400.0f;
-  constexpr float kRequestedItemSize = 60.0f;
+  constexpr float kPreferredItemSize = 60.0f;
   constexpr float kItemSpacing = 4.0f;
-  constexpr float kScrollbarWidth = 14.0f;
 
   const auto layout = ResolveDungeonObjectSelectorGridLayout(
-      kAvailableWidth, kRequestedItemSize, kItemSpacing, kScrollbarWidth);
+      kAvailableWidth, kPreferredItemSize, kItemSpacing);
 
   EXPECT_EQ(layout.columns, 6);
-  EXPECT_FLOAT_EQ(layout.item_size, kRequestedItemSize);
+  EXPECT_FLOAT_EQ(layout.item_size, kPreferredItemSize);
   const float occupied_width =
       layout.columns * layout.item_size + (layout.columns - 1) * kItemSpacing;
-  EXPECT_LE(occupied_width, kAvailableWidth - kScrollbarWidth);
+  EXPECT_NEAR(layout.leading_inset * 2.0f + occupied_width, kAvailableWidth,
+              0.001f);
 }
 
 TEST(DungeonObjectSelectorLayoutTest,
      GridShrinksToOneUsableItemWhenSelectorIsExtremelyNarrow) {
   const auto layout = ResolveDungeonObjectSelectorGridLayout(
-      /*available_width=*/28.0f, /*requested_item_size=*/72.0f,
-      /*item_spacing=*/4.0f, /*reserved_scrollbar_width=*/14.0f);
+      /*available_width=*/28.0f, /*preferred_item_size=*/72.0f,
+      /*item_spacing=*/4.0f);
 
   EXPECT_EQ(layout.columns, 1);
-  EXPECT_FLOAT_EQ(layout.item_size, 14.0f);
+  EXPECT_FLOAT_EQ(layout.item_size, 28.0f);
+  EXPECT_FLOAT_EQ(layout.leading_inset, 0.0f);
 }
 
 TEST(DungeonObjectSelectorLayoutTest,
      GridHonorsMinimumItemSizeWhenThereIsRoom) {
   const auto layout = ResolveDungeonObjectSelectorGridLayout(
-      /*available_width=*/100.0f, /*requested_item_size=*/10.0f,
-      /*item_spacing=*/4.0f, /*reserved_scrollbar_width=*/0.0f,
-      /*min_item_size=*/32.0f);
+      /*available_width=*/100.0f, /*preferred_item_size=*/10.0f,
+      /*item_spacing=*/4.0f, /*min_item_size=*/32.0f);
 
   EXPECT_EQ(layout.columns, 2);
   EXPECT_FLOAT_EQ(layout.item_size, 32.0f);
+  EXPECT_FLOAT_EQ(layout.leading_inset, 16.0f);
+}
+
+TEST(DungeonObjectSelectorLayoutTest,
+     GridPreservesDensityAcrossResizeBreakpoints) {
+  constexpr float kPreferredItemSize = 54.0f;
+  constexpr float kItemSpacing = 4.0f;
+
+  for (const float available_width :
+       std::array{28.0f, 80.0f, 170.0f, 285.0f, 286.0f, 400.0f}) {
+    SCOPED_TRACE(available_width);
+    const auto layout = ResolveDungeonObjectSelectorGridLayout(
+        available_width, kPreferredItemSize, kItemSpacing);
+    const float occupied_width =
+        layout.columns * layout.item_size + (layout.columns - 1) * kItemSpacing;
+
+    EXPECT_GE(layout.columns, 1);
+    EXPECT_GT(layout.item_size, 0.0f);
+    EXPECT_NEAR(layout.leading_inset * 2.0f + occupied_width, available_width,
+                0.001f);
+    if (available_width >= kPreferredItemSize) {
+      EXPECT_FLOAT_EQ(layout.item_size, kPreferredItemSize);
+    }
+  }
+}
+
+TEST(DungeonObjectSelectorLayoutTest,
+     DensityOptionsRemainDistinctAtTheSamePanelWidth) {
+  constexpr float kAvailableWidth = 400.0f;
+  constexpr float kItemSpacing = 4.0f;
+
+  const auto compact = ResolveDungeonObjectSelectorGridLayout(
+      kAvailableWidth, /*preferred_item_size=*/54.0f, kItemSpacing);
+  const auto medium = ResolveDungeonObjectSelectorGridLayout(
+      kAvailableWidth, /*preferred_item_size=*/60.0f, kItemSpacing);
+  const auto large = ResolveDungeonObjectSelectorGridLayout(
+      kAvailableWidth, /*preferred_item_size=*/76.0f, kItemSpacing);
+
+  EXPECT_FLOAT_EQ(compact.item_size, 54.0f);
+  EXPECT_FLOAT_EQ(medium.item_size, 60.0f);
+  EXPECT_FLOAT_EQ(large.item_size, 76.0f);
+  EXPECT_NE(compact.item_size, medium.item_size);
+  EXPECT_NE(medium.item_size, large.item_size);
+  EXPECT_EQ(large.columns, 5);
+  EXPECT_FLOAT_EQ(large.leading_inset, 2.0f);
 }
 
 TEST(DungeonObjectSelectorStreamFilterTest, AllAndUnknownFiltersFailOpen) {

--- a/test/unit/editor/dungeon_object_selector_palette_test.cc
+++ b/test/unit/editor/dungeon_object_selector_palette_test.cc
@@ -264,6 +264,128 @@ TEST(DungeonObjectSelectorPaletteTest, ObjectPreviewsDefaultOn) {
   EXPECT_TRUE(selector.object_previews_enabled_for_testing());
 }
 
+TEST(DungeonObjectSelectorLayoutTest,
+     GridUsesAvailableWidthWithoutHorizontalOverflow) {
+  constexpr float kAvailableWidth = 400.0f;
+  constexpr float kRequestedItemSize = 72.0f;
+  constexpr float kItemSpacing = 4.0f;
+  constexpr float kScrollbarWidth = 14.0f;
+
+  const auto layout = ResolveDungeonObjectSelectorGridLayout(
+      kAvailableWidth, kRequestedItemSize, kItemSpacing, kScrollbarWidth);
+
+  EXPECT_EQ(layout.columns, 5);
+  EXPECT_FLOAT_EQ(layout.item_size, kRequestedItemSize);
+  const float occupied_width =
+      layout.columns * layout.item_size + (layout.columns - 1) * kItemSpacing;
+  EXPECT_LE(occupied_width, kAvailableWidth - kScrollbarWidth);
+}
+
+TEST(DungeonObjectSelectorLayoutTest,
+     GridShrinksToOneUsableItemWhenDrawerIsExtremelyNarrow) {
+  const auto layout = ResolveDungeonObjectSelectorGridLayout(
+      /*available_width=*/28.0f, /*requested_item_size=*/72.0f,
+      /*item_spacing=*/4.0f, /*reserved_scrollbar_width=*/14.0f);
+
+  EXPECT_EQ(layout.columns, 1);
+  EXPECT_FLOAT_EQ(layout.item_size, 14.0f);
+}
+
+TEST(DungeonObjectSelectorLayoutTest,
+     GridHonorsMinimumItemSizeWhenThereIsRoom) {
+  const auto layout = ResolveDungeonObjectSelectorGridLayout(
+      /*available_width=*/100.0f, /*requested_item_size=*/10.0f,
+      /*item_spacing=*/4.0f, /*reserved_scrollbar_width=*/0.0f,
+      /*min_item_size=*/32.0f);
+
+  EXPECT_EQ(layout.columns, 2);
+  EXPECT_FLOAT_EQ(layout.item_size, 32.0f);
+}
+
+TEST(DungeonObjectSelectorTypeTabTest, AllTabAndUnknownTabFailOpen) {
+  for (int object_id : {-1, 0x000, 0x0F8, 0x140, 0xF80, 0x1000}) {
+    EXPECT_TRUE(MatchesDungeonObjectTypeTab(object_id, 0));
+    EXPECT_TRUE(MatchesDungeonObjectTypeTab(object_id, 99));
+  }
+}
+
+TEST(DungeonObjectSelectorTypeTabTest, TypeOneUsesCanonicalCodecRange) {
+  EXPECT_FALSE(MatchesDungeonObjectTypeTab(-1, 1));
+  EXPECT_TRUE(MatchesDungeonObjectTypeTab(0x000, 1));
+  EXPECT_TRUE(MatchesDungeonObjectTypeTab(0x0F7, 1));
+  EXPECT_FALSE(MatchesDungeonObjectTypeTab(0x0F8, 1));
+  EXPECT_FALSE(MatchesDungeonObjectTypeTab(0x100, 1));
+}
+
+TEST(DungeonObjectSelectorTypeTabTest, TypeTwoUsesCanonicalCodecRange) {
+  EXPECT_FALSE(MatchesDungeonObjectTypeTab(0x0FF, 2));
+  EXPECT_TRUE(MatchesDungeonObjectTypeTab(0x100, 2));
+  EXPECT_TRUE(MatchesDungeonObjectTypeTab(0x13F, 2));
+  EXPECT_FALSE(MatchesDungeonObjectTypeTab(0x140, 2));
+}
+
+TEST(DungeonObjectSelectorTypeTabTest, TypeThreeUsesCanonicalCodecRange) {
+  EXPECT_FALSE(MatchesDungeonObjectTypeTab(0xF7F, 3));
+  EXPECT_TRUE(MatchesDungeonObjectTypeTab(0xF80, 3));
+  EXPECT_TRUE(MatchesDungeonObjectTypeTab(0xFFF, 3));
+  EXPECT_FALSE(MatchesDungeonObjectTypeTab(0x1000, 3));
+}
+
+TEST(DungeonObjectSelectorTypeTabLayoutTest,
+     UsesOneRowAtExactFitAndBalancedGridBelowIt) {
+  constexpr float kTabWidth = 56.0f;
+  constexpr float kSpacing = 4.0f;
+  constexpr int kTabCount = 4;
+  constexpr float kFourColumnWidth =
+      kTabCount * kTabWidth + (kTabCount - 1) * kSpacing;
+
+  const auto exact_fit = ResolveDungeonObjectSelectorTypeTabLayout(
+      kFourColumnWidth, kTabWidth, kSpacing, kTabCount);
+  EXPECT_EQ(exact_fit.columns, 4);
+  EXPECT_FLOAT_EQ(exact_fit.item_width, kTabWidth);
+
+  const auto balanced_grid = ResolveDungeonObjectSelectorTypeTabLayout(
+      kFourColumnWidth - 1.0f, kTabWidth, kSpacing, kTabCount);
+  EXPECT_EQ(balanced_grid.columns, 2);
+  EXPECT_FLOAT_EQ(balanced_grid.item_width, kTabWidth);
+}
+
+TEST(DungeonObjectSelectorTypeTabLayoutTest,
+     UsesBalancedGridAtExactFitAndVerticalStackBelowIt) {
+  constexpr float kTabWidth = 56.0f;
+  constexpr float kSpacing = 4.0f;
+  constexpr float kTwoColumnWidth = 2.0f * kTabWidth + kSpacing;
+
+  const auto exact_fit = ResolveDungeonObjectSelectorTypeTabLayout(
+      kTwoColumnWidth, kTabWidth, kSpacing);
+  EXPECT_EQ(exact_fit.columns, 2);
+  EXPECT_FLOAT_EQ(exact_fit.item_width, kTabWidth);
+
+  const auto vertical_stack = ResolveDungeonObjectSelectorTypeTabLayout(
+      kTwoColumnWidth - 1.0f, kTabWidth, kSpacing);
+  EXPECT_EQ(vertical_stack.columns, 1);
+  EXPECT_FLOAT_EQ(vertical_stack.item_width, kTabWidth);
+}
+
+TEST(DungeonObjectSelectorTypeTabLayoutTest,
+     NarrowAndEmptyLayoutsRemainReachable) {
+  const auto narrow = ResolveDungeonObjectSelectorTypeTabLayout(
+      /*available_width=*/20.0f, /*requested_tab_width=*/56.0f,
+      /*item_spacing=*/4.0f);
+  EXPECT_EQ(narrow.columns, 1);
+  EXPECT_FLOAT_EQ(narrow.item_width, 20.0f);
+
+  const auto empty = ResolveDungeonObjectSelectorTypeTabLayout(
+      /*available_width=*/400.0f, /*requested_tab_width=*/56.0f,
+      /*item_spacing=*/4.0f, /*tab_count=*/0);
+  EXPECT_EQ(empty.columns, 0);
+
+  const auto invalid = ResolveDungeonObjectSelectorTypeTabLayout(
+      /*available_width=*/400.0f, /*requested_tab_width=*/56.0f,
+      /*item_spacing=*/4.0f, /*tab_count=*/-1);
+  EXPECT_EQ(invalid.columns, 0);
+}
+
 TEST(DungeonObjectSelectorCustomEditorTest,
      NewCustomObjectSessionOpensWorkspaceWindow) {
   Rom rom;

--- a/test/unit/editor/dungeon_workbench_content_test.cc
+++ b/test/unit/editor/dungeon_workbench_content_test.cc
@@ -324,6 +324,41 @@ TEST(DungeonWorkbenchContentLayoutTest,
   EXPECT_NEAR(exact_fit.canvas_height, 240.0f, 0.001f);
 }
 
+TEST(DungeonWorkbenchContentLayoutTest, ToolStripUsesOneRowAtItsExactFitWidth) {
+  constexpr float kButtonSize = 32.0f;
+  constexpr float kSpacing = 4.0f;
+  constexpr int kItemCount = 10;
+  constexpr float kExactFitWidth =
+      kItemCount * kButtonSize + (kItemCount - 1) * kSpacing;
+
+  EXPECT_EQ(ResolveDungeonWorkbenchToolStripColumns(kExactFitWidth, kButtonSize,
+                                                    kSpacing, kItemCount),
+            kItemCount);
+  EXPECT_EQ(ResolveDungeonWorkbenchToolStripColumns(
+                kExactFitWidth - 1.0f, kButtonSize, kSpacing, kItemCount),
+            kItemCount - 1);
+}
+
+TEST(DungeonWorkbenchContentLayoutTest,
+     ToolStripWrapsSafelyAtNarrowAndEmptyWidths) {
+  EXPECT_EQ(ResolveDungeonWorkbenchToolStripColumns(
+                /*available_width=*/1.0f, /*button_size=*/32.0f,
+                /*item_spacing=*/4.0f),
+            1);
+  EXPECT_EQ(ResolveDungeonWorkbenchToolStripColumns(
+                /*available_width=*/400.0f, /*button_size=*/32.0f,
+                /*item_spacing=*/4.0f, /*item_count=*/0),
+            0);
+}
+
+TEST(DungeonWorkbenchContentLayoutTest,
+     ToolStripNeverReturnsMoreColumnsThanItems) {
+  EXPECT_EQ(ResolveDungeonWorkbenchToolStripColumns(
+                /*available_width=*/1000.0f, /*button_size=*/32.0f,
+                /*item_spacing=*/4.0f, /*item_count=*/3),
+            3);
+}
+
 TEST(DungeonWorkbenchContentLayoutTest,
      ExistingStandaloneToolOwnsThePresentation) {
   EXPECT_EQ(ResolveDungeonWorkbenchToolRequestTarget(false),

--- a/test/unit/editor/dungeon_workbench_content_test.cc
+++ b/test/unit/editor/dungeon_workbench_content_test.cc
@@ -261,34 +261,67 @@ TEST(DungeonWorkbenchContentLayoutTest,
 }
 
 TEST(DungeonWorkbenchContentLayoutTest,
-     ToolDrawerLayoutPreservesCanvasAndRememberedHeight) {
+     ToolDrawerLayoutScalesWithRememberedProportion) {
   const auto closed = ResolveDungeonWorkbenchToolDrawerLayout(
-      708.0f, kSplitterWidth, 300.0f, 240.0f, 180.0f, false);
+      708.0f, kSplitterWidth, 0.4f, 240.0f, 180.0f, false);
   EXPECT_FALSE(closed.show_drawer);
   EXPECT_FALSE(closed.compact);
   EXPECT_NEAR(closed.canvas_height, 708.0f, 0.001f);
   EXPECT_NEAR(closed.drawer_height, 0.0f, 0.001f);
 
   const auto open = ResolveDungeonWorkbenchToolDrawerLayout(
-      708.0f, kSplitterWidth, 300.0f, 240.0f, 180.0f, true);
+      708.0f, kSplitterWidth, 0.4f, 240.0f, 180.0f, true);
   EXPECT_TRUE(open.show_drawer);
   EXPECT_FALSE(open.compact);
-  EXPECT_NEAR(open.canvas_height, 400.0f, 0.001f);
-  EXPECT_NEAR(open.drawer_height, 300.0f, 0.001f);
+  EXPECT_NEAR(open.canvas_height, 420.0f, 0.001f);
+  EXPECT_NEAR(open.drawer_height, 280.0f, 0.001f);
   EXPECT_NEAR(open.canvas_height + open.drawer_height + kSplitterWidth, 708.0f,
               0.001f);
+
+  const auto taller = ResolveDungeonWorkbenchToolDrawerLayout(
+      908.0f, kSplitterWidth, 0.4f, 240.0f, 180.0f, true);
+  EXPECT_FALSE(taller.compact);
+  EXPECT_NEAR(taller.canvas_height, 540.0f, 0.001f);
+  EXPECT_NEAR(taller.drawer_height, 360.0f, 0.001f);
 }
 
 TEST(DungeonWorkbenchContentLayoutTest,
      ToolDrawerLayoutUsesStableCompactSplitWhenHeightIsConstrained) {
   const auto compact = ResolveDungeonWorkbenchToolDrawerLayout(
-      400.0f, kSplitterWidth, 300.0f, 240.0f, 180.0f, true);
+      400.0f, kSplitterWidth, 0.55f, 240.0f, 180.0f, true);
   EXPECT_TRUE(compact.show_drawer);
   EXPECT_TRUE(compact.compact);
   EXPECT_NEAR(compact.drawer_height, 156.8f, 0.001f);
   EXPECT_NEAR(compact.canvas_height, 235.2f, 0.001f);
   EXPECT_NEAR(compact.canvas_height + compact.drawer_height + kSplitterWidth,
               400.0f, 0.001f);
+
+  const auto recovered = ResolveDungeonWorkbenchToolDrawerLayout(
+      908.0f, kSplitterWidth, 0.55f, 240.0f, 180.0f, true);
+  EXPECT_FALSE(recovered.compact);
+  EXPECT_NEAR(recovered.drawer_height, 495.0f, 0.001f);
+  EXPECT_NEAR(recovered.canvas_height, 405.0f, 0.001f);
+}
+
+TEST(DungeonWorkbenchContentLayoutTest,
+     ToolDrawerLayoutClampsProportionToUsableMinimums) {
+  const auto drawer_min = ResolveDungeonWorkbenchToolDrawerLayout(
+      708.0f, kSplitterWidth, 0.1f, 240.0f, 180.0f, true);
+  EXPECT_FALSE(drawer_min.compact);
+  EXPECT_NEAR(drawer_min.drawer_height, 180.0f, 0.001f);
+  EXPECT_NEAR(drawer_min.canvas_height, 520.0f, 0.001f);
+
+  const auto canvas_min = ResolveDungeonWorkbenchToolDrawerLayout(
+      708.0f, kSplitterWidth, 0.9f, 240.0f, 180.0f, true);
+  EXPECT_FALSE(canvas_min.compact);
+  EXPECT_NEAR(canvas_min.drawer_height, 460.0f, 0.001f);
+  EXPECT_NEAR(canvas_min.canvas_height, 240.0f, 0.001f);
+
+  const auto exact_fit = ResolveDungeonWorkbenchToolDrawerLayout(
+      428.0f, kSplitterWidth, 0.4f, 240.0f, 180.0f, true);
+  EXPECT_FALSE(exact_fit.compact);
+  EXPECT_NEAR(exact_fit.drawer_height, 180.0f, 0.001f);
+  EXPECT_NEAR(exact_fit.canvas_height, 240.0f, 0.001f);
 }
 
 TEST(DungeonWorkbenchContentLayoutTest,

--- a/test/unit/editor/dungeon_workbench_content_test.cc
+++ b/test/unit/editor/dungeon_workbench_content_test.cc
@@ -8,12 +8,14 @@
 #include <fstream>
 #include <initializer_list>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "absl/status/status.h"
 #include "app/editor/dungeon/dungeon_project_labels.h"
 #include "app/editor/dungeon/workspace/dungeon_pit_damage_view_model.h"
 #include "app/editor/dungeon/workspace/dungeon_workbench_inspector_helpers.h"
+#include "app/editor/dungeon/workspace/dungeon_workbench_layout.h"
 #include "core/features.h"
 #include "core/project.h"
 #include "imgui/imgui.h"
@@ -44,6 +46,20 @@ DungeonWorkbenchContent MakeWorkbenchForToolStateTests(
       [&recent_rooms]() -> const std::deque<int>& { return recent_rooms; },
       [](int) {}, [](bool) {});
 }
+
+class FakeWorkbenchToolContent final : public WindowContent {
+ public:
+  explicit FakeWorkbenchToolContent(std::string id) : id_(std::move(id)) {}
+
+  std::string GetId() const override { return id_; }
+  std::string GetDisplayName() const override { return "Fake Tool"; }
+  std::string GetIcon() const override { return ""; }
+  std::string GetEditorCategory() const override { return "Dungeon"; }
+  void Draw(bool*) override {}
+
+ private:
+  std::string id_;
+};
 
 zelda3::PitDamageTable MakePitDamageTable(
     std::initializer_list<uint16_t> room_ids) {
@@ -244,7 +260,47 @@ TEST(DungeonWorkbenchContentLayoutTest,
   EXPECT_GE(layout.center_width, kMinCanvasWidth);
 }
 
-TEST(DungeonWorkbenchContentLayoutTest, ToolRequestsSwitchInspectorToDrawer) {
+TEST(DungeonWorkbenchContentLayoutTest,
+     ToolDrawerLayoutPreservesCanvasAndRememberedHeight) {
+  const auto closed = ResolveDungeonWorkbenchToolDrawerLayout(
+      708.0f, kSplitterWidth, 300.0f, 240.0f, 180.0f, false);
+  EXPECT_FALSE(closed.show_drawer);
+  EXPECT_FALSE(closed.compact);
+  EXPECT_NEAR(closed.canvas_height, 708.0f, 0.001f);
+  EXPECT_NEAR(closed.drawer_height, 0.0f, 0.001f);
+
+  const auto open = ResolveDungeonWorkbenchToolDrawerLayout(
+      708.0f, kSplitterWidth, 300.0f, 240.0f, 180.0f, true);
+  EXPECT_TRUE(open.show_drawer);
+  EXPECT_FALSE(open.compact);
+  EXPECT_NEAR(open.canvas_height, 400.0f, 0.001f);
+  EXPECT_NEAR(open.drawer_height, 300.0f, 0.001f);
+  EXPECT_NEAR(open.canvas_height + open.drawer_height + kSplitterWidth, 708.0f,
+              0.001f);
+}
+
+TEST(DungeonWorkbenchContentLayoutTest,
+     ToolDrawerLayoutUsesStableCompactSplitWhenHeightIsConstrained) {
+  const auto compact = ResolveDungeonWorkbenchToolDrawerLayout(
+      400.0f, kSplitterWidth, 300.0f, 240.0f, 180.0f, true);
+  EXPECT_TRUE(compact.show_drawer);
+  EXPECT_TRUE(compact.compact);
+  EXPECT_NEAR(compact.drawer_height, 156.8f, 0.001f);
+  EXPECT_NEAR(compact.canvas_height, 235.2f, 0.001f);
+  EXPECT_NEAR(compact.canvas_height + compact.drawer_height + kSplitterWidth,
+              400.0f, 0.001f);
+}
+
+TEST(DungeonWorkbenchContentLayoutTest,
+     ExistingStandaloneToolOwnsThePresentation) {
+  EXPECT_EQ(ResolveDungeonWorkbenchToolRequestTarget(false),
+            DungeonWorkbenchToolRequestTarget::kBottomDrawer);
+  EXPECT_EQ(ResolveDungeonWorkbenchToolRequestTarget(true),
+            DungeonWorkbenchToolRequestTarget::kStandaloneWindow);
+}
+
+TEST(DungeonWorkbenchContentLayoutTest,
+     ToolRequestsOpenBottomDrawerWithoutReplacingInspector) {
   int current_room_id = 0x011;
   const std::deque<int> recent_rooms;
   auto content = MakeWorkbenchForToolStateTests(current_room_id, recent_rooms);
@@ -253,7 +309,7 @@ TEST(DungeonWorkbenchContentLayoutTest, ToolRequestsSwitchInspectorToDrawer) {
 
   content.OpenDoorTool();
   EXPECT_TRUE(content.IsToolDrawerActiveForTesting());
-  EXPECT_STREQ(content.GetInspectorModeIdForTesting(), "tools");
+  EXPECT_STREQ(content.GetInspectorModeIdForTesting(), "room");
   EXPECT_STREQ(content.GetActiveToolIdForTesting(), "door");
 
   content.OpenPaletteTool();
@@ -263,10 +319,9 @@ TEST(DungeonWorkbenchContentLayoutTest, ToolRequestsSwitchInspectorToDrawer) {
 
 TEST(DungeonWorkbenchContentLayoutTest,
      ToolStripCyclesAllToolsWithoutLeavingDrawer) {
-  // The compact tool-strip in the inspector calls Open*Tool() rapidly as users
-  // hop between tools. Switching active tools must not bounce the inspector
-  // back to Room mode, and re-opening the same tool must remain a no-op on
-  // mode (no toggle-off).
+  // The bottom drawer's compact tool-strip calls Open*Tool() rapidly as users
+  // hop between tools. Switching active tools must not replace the independent
+  // Room inspector or toggle the drawer off.
   int current_room_id = 0x011;
   const std::deque<int> recent_rooms;
   auto content = MakeWorkbenchForToolStateTests(current_room_id, recent_rooms);
@@ -291,7 +346,7 @@ TEST(DungeonWorkbenchContentLayoutTest,
   for (const auto& step : steps) {
     (content.*step.open)();
     EXPECT_TRUE(content.IsToolDrawerActiveForTesting()) << step.expected_id;
-    EXPECT_STREQ(content.GetInspectorModeIdForTesting(), "tools")
+    EXPECT_STREQ(content.GetInspectorModeIdForTesting(), "room")
         << step.expected_id;
     EXPECT_STREQ(content.GetActiveToolIdForTesting(), step.expected_id);
   }
@@ -305,6 +360,61 @@ TEST(DungeonWorkbenchContentLayoutTest,
 }
 
 TEST(DungeonWorkbenchContentLayoutTest,
+     PopOutUsesEmbeddedWindowIdentityAndClosesDrawer) {
+  int current_room_id = 0x011;
+  const std::deque<int> recent_rooms;
+  auto content = MakeWorkbenchForToolStateTests(current_room_id, recent_rooms);
+  FakeWorkbenchToolContent object_selector("dungeon.object_selector");
+  content.SetEmbeddedEditorPanels(&object_selector, nullptr, nullptr, nullptr,
+                                  nullptr, nullptr);
+
+  std::string opened_window_id;
+  content.SetStandaloneToolCallbacks([](const std::string&) { return false; },
+                                     [&](const std::string& window_id) {
+                                       opened_window_id = window_id;
+                                       return true;
+                                     });
+
+  content.OpenObjectSelectorTool();
+  ASSERT_TRUE(content.IsToolDrawerActiveForTesting());
+  EXPECT_TRUE(content.PopOutActiveTool());
+  EXPECT_EQ(opened_window_id, "dungeon.object_selector");
+  EXPECT_FALSE(content.IsToolDrawerActiveForTesting());
+}
+
+TEST(DungeonWorkbenchContentLayoutTest,
+     OpenToolClosesDrawerAndFocusesExistingStandalone) {
+  int current_room_id = 0x011;
+  const std::deque<int> recent_rooms;
+  auto content = MakeWorkbenchForToolStateTests(current_room_id, recent_rooms);
+  FakeWorkbenchToolContent object_selector("dungeon.object_selector");
+  content.SetEmbeddedEditorPanels(&object_selector, nullptr, nullptr, nullptr,
+                                  nullptr, nullptr);
+
+  int focus_count = 0;
+  bool standalone_open = false;
+  std::string focused_window_id;
+  content.SetStandaloneToolCallbacks(
+      [&](const std::string& window_id) {
+        return standalone_open && window_id == "dungeon.object_selector";
+      },
+      [&](const std::string& window_id) {
+        ++focus_count;
+        focused_window_id = window_id;
+        return true;
+      });
+
+  content.OpenObjectSelectorTool();
+  ASSERT_TRUE(content.IsToolDrawerActiveForTesting());
+
+  standalone_open = true;
+  content.OpenObjectSelectorTool();
+  EXPECT_FALSE(content.IsToolDrawerActiveForTesting());
+  EXPECT_EQ(focus_count, 1);
+  EXPECT_EQ(focused_window_id, "dungeon.object_selector");
+}
+
+TEST(DungeonWorkbenchContentLayoutTest,
      ToolDrawerSelectionSurvivesRoomChanges) {
   int current_room_id = 0x011;
   const std::deque<int> recent_rooms;
@@ -315,7 +425,7 @@ TEST(DungeonWorkbenchContentLayoutTest,
   content.NotifyRoomChanged(0x011);
 
   EXPECT_TRUE(content.IsToolDrawerActiveForTesting());
-  EXPECT_STREQ(content.GetInspectorModeIdForTesting(), "tools");
+  EXPECT_STREQ(content.GetInspectorModeIdForTesting(), "room");
   EXPECT_STREQ(content.GetActiveToolIdForTesting(), "custom_collision");
 }
 

--- a/test/unit/editor/dungeon_workbench_content_test.cc
+++ b/test/unit/editor/dungeon_workbench_content_test.cc
@@ -261,114 +261,14 @@ TEST(DungeonWorkbenchContentLayoutTest,
 }
 
 TEST(DungeonWorkbenchContentLayoutTest,
-     ToolDrawerLayoutScalesWithRememberedProportion) {
-  const auto closed = ResolveDungeonWorkbenchToolDrawerLayout(
-      708.0f, kSplitterWidth, 0.4f, 240.0f, 180.0f, false);
-  EXPECT_FALSE(closed.show_drawer);
-  EXPECT_FALSE(closed.compact);
-  EXPECT_NEAR(closed.canvas_height, 708.0f, 0.001f);
-  EXPECT_NEAR(closed.drawer_height, 0.0f, 0.001f);
-
-  const auto open = ResolveDungeonWorkbenchToolDrawerLayout(
-      708.0f, kSplitterWidth, 0.4f, 240.0f, 180.0f, true);
-  EXPECT_TRUE(open.show_drawer);
-  EXPECT_FALSE(open.compact);
-  EXPECT_NEAR(open.canvas_height, 420.0f, 0.001f);
-  EXPECT_NEAR(open.drawer_height, 280.0f, 0.001f);
-  EXPECT_NEAR(open.canvas_height + open.drawer_height + kSplitterWidth, 708.0f,
-              0.001f);
-
-  const auto taller = ResolveDungeonWorkbenchToolDrawerLayout(
-      908.0f, kSplitterWidth, 0.4f, 240.0f, 180.0f, true);
-  EXPECT_FALSE(taller.compact);
-  EXPECT_NEAR(taller.canvas_height, 540.0f, 0.001f);
-  EXPECT_NEAR(taller.drawer_height, 360.0f, 0.001f);
-}
-
-TEST(DungeonWorkbenchContentLayoutTest,
-     ToolDrawerLayoutUsesStableCompactSplitWhenHeightIsConstrained) {
-  const auto compact = ResolveDungeonWorkbenchToolDrawerLayout(
-      400.0f, kSplitterWidth, 0.55f, 240.0f, 180.0f, true);
-  EXPECT_TRUE(compact.show_drawer);
-  EXPECT_TRUE(compact.compact);
-  EXPECT_NEAR(compact.drawer_height, 156.8f, 0.001f);
-  EXPECT_NEAR(compact.canvas_height, 235.2f, 0.001f);
-  EXPECT_NEAR(compact.canvas_height + compact.drawer_height + kSplitterWidth,
-              400.0f, 0.001f);
-
-  const auto recovered = ResolveDungeonWorkbenchToolDrawerLayout(
-      908.0f, kSplitterWidth, 0.55f, 240.0f, 180.0f, true);
-  EXPECT_FALSE(recovered.compact);
-  EXPECT_NEAR(recovered.drawer_height, 495.0f, 0.001f);
-  EXPECT_NEAR(recovered.canvas_height, 405.0f, 0.001f);
-}
-
-TEST(DungeonWorkbenchContentLayoutTest,
-     ToolDrawerLayoutClampsProportionToUsableMinimums) {
-  const auto drawer_min = ResolveDungeonWorkbenchToolDrawerLayout(
-      708.0f, kSplitterWidth, 0.1f, 240.0f, 180.0f, true);
-  EXPECT_FALSE(drawer_min.compact);
-  EXPECT_NEAR(drawer_min.drawer_height, 180.0f, 0.001f);
-  EXPECT_NEAR(drawer_min.canvas_height, 520.0f, 0.001f);
-
-  const auto canvas_min = ResolveDungeonWorkbenchToolDrawerLayout(
-      708.0f, kSplitterWidth, 0.9f, 240.0f, 180.0f, true);
-  EXPECT_FALSE(canvas_min.compact);
-  EXPECT_NEAR(canvas_min.drawer_height, 460.0f, 0.001f);
-  EXPECT_NEAR(canvas_min.canvas_height, 240.0f, 0.001f);
-
-  const auto exact_fit = ResolveDungeonWorkbenchToolDrawerLayout(
-      428.0f, kSplitterWidth, 0.4f, 240.0f, 180.0f, true);
-  EXPECT_FALSE(exact_fit.compact);
-  EXPECT_NEAR(exact_fit.drawer_height, 180.0f, 0.001f);
-  EXPECT_NEAR(exact_fit.canvas_height, 240.0f, 0.001f);
-}
-
-TEST(DungeonWorkbenchContentLayoutTest, ToolStripUsesOneRowAtItsExactFitWidth) {
-  constexpr float kButtonSize = 32.0f;
-  constexpr float kSpacing = 4.0f;
-  constexpr int kItemCount = 10;
-  constexpr float kExactFitWidth =
-      kItemCount * kButtonSize + (kItemCount - 1) * kSpacing;
-
-  EXPECT_EQ(ResolveDungeonWorkbenchToolStripColumns(kExactFitWidth, kButtonSize,
-                                                    kSpacing, kItemCount),
-            kItemCount);
-  EXPECT_EQ(ResolveDungeonWorkbenchToolStripColumns(
-                kExactFitWidth - 1.0f, kButtonSize, kSpacing, kItemCount),
-            kItemCount - 1);
-}
-
-TEST(DungeonWorkbenchContentLayoutTest,
-     ToolStripWrapsSafelyAtNarrowAndEmptyWidths) {
-  EXPECT_EQ(ResolveDungeonWorkbenchToolStripColumns(
-                /*available_width=*/1.0f, /*button_size=*/32.0f,
-                /*item_spacing=*/4.0f),
-            1);
-  EXPECT_EQ(ResolveDungeonWorkbenchToolStripColumns(
-                /*available_width=*/400.0f, /*button_size=*/32.0f,
-                /*item_spacing=*/4.0f, /*item_count=*/0),
-            0);
-}
-
-TEST(DungeonWorkbenchContentLayoutTest,
-     ToolStripNeverReturnsMoreColumnsThanItems) {
-  EXPECT_EQ(ResolveDungeonWorkbenchToolStripColumns(
-                /*available_width=*/1000.0f, /*button_size=*/32.0f,
-                /*item_spacing=*/4.0f, /*item_count=*/3),
-            3);
-}
-
-TEST(DungeonWorkbenchContentLayoutTest,
      ExistingStandaloneToolOwnsThePresentation) {
   EXPECT_EQ(ResolveDungeonWorkbenchToolRequestTarget(false),
-            DungeonWorkbenchToolRequestTarget::kBottomDrawer);
+            DungeonWorkbenchToolRequestTarget::kEmbeddedInspector);
   EXPECT_EQ(ResolveDungeonWorkbenchToolRequestTarget(true),
             DungeonWorkbenchToolRequestTarget::kStandaloneWindow);
 }
 
-TEST(DungeonWorkbenchContentLayoutTest,
-     ToolRequestsOpenBottomDrawerWithoutReplacingInspector) {
+TEST(DungeonWorkbenchContentLayoutTest, ToolRequestsOpenEmbeddedInspector) {
   int current_room_id = 0x011;
   const std::deque<int> recent_rooms;
   auto content = MakeWorkbenchForToolStateTests(current_room_id, recent_rooms);
@@ -376,20 +276,21 @@ TEST(DungeonWorkbenchContentLayoutTest,
   EXPECT_STREQ(content.GetInspectorModeIdForTesting(), "room");
 
   content.OpenDoorTool();
-  EXPECT_TRUE(content.IsToolDrawerActiveForTesting());
-  EXPECT_STREQ(content.GetInspectorModeIdForTesting(), "room");
+  EXPECT_TRUE(content.IsToolInspectorActiveForTesting());
+  EXPECT_STREQ(content.GetInspectorModeIdForTesting(), "tools");
   EXPECT_STREQ(content.GetActiveToolIdForTesting(), "door");
 
   content.OpenPaletteTool();
-  EXPECT_TRUE(content.IsToolDrawerActiveForTesting());
+  EXPECT_TRUE(content.IsToolInspectorActiveForTesting());
+  EXPECT_STREQ(content.GetInspectorModeIdForTesting(), "tools");
   EXPECT_STREQ(content.GetActiveToolIdForTesting(), "palette");
 }
 
 TEST(DungeonWorkbenchContentLayoutTest,
-     ToolStripCyclesAllToolsWithoutLeavingDrawer) {
-  // The bottom drawer's compact tool-strip calls Open*Tool() rapidly as users
-  // hop between tools. Switching active tools must not replace the independent
-  // Room inspector or toggle the drawer off.
+     ToolPickerCyclesAllToolsWithoutLeavingInspector) {
+  // The sidebar's compact picker calls Open*Tool() rapidly as users hop
+  // between tools. Switching active tools must keep the inspector in Tools
+  // mode, and re-opening the same tool must remain a no-op on mode.
   int current_room_id = 0x011;
   const std::deque<int> recent_rooms;
   auto content = MakeWorkbenchForToolStateTests(current_room_id, recent_rooms);
@@ -413,22 +314,21 @@ TEST(DungeonWorkbenchContentLayoutTest,
 
   for (const auto& step : steps) {
     (content.*step.open)();
-    EXPECT_TRUE(content.IsToolDrawerActiveForTesting()) << step.expected_id;
-    EXPECT_STREQ(content.GetInspectorModeIdForTesting(), "room")
+    EXPECT_TRUE(content.IsToolInspectorActiveForTesting()) << step.expected_id;
+    EXPECT_STREQ(content.GetInspectorModeIdForTesting(), "tools")
         << step.expected_id;
     EXPECT_STREQ(content.GetActiveToolIdForTesting(), step.expected_id);
   }
 
-  // Re-opening the active tool must keep the drawer open on the same tool;
-  // strip taps are deliberately idempotent so users can confirm a selection
-  // without toggling the body off.
+  // Re-opening the active tool must keep the inspector on the same tool.
   content.OpenMinecartTool();
-  EXPECT_TRUE(content.IsToolDrawerActiveForTesting());
+  EXPECT_TRUE(content.IsToolInspectorActiveForTesting());
+  EXPECT_STREQ(content.GetInspectorModeIdForTesting(), "tools");
   EXPECT_STREQ(content.GetActiveToolIdForTesting(), "minecart");
 }
 
 TEST(DungeonWorkbenchContentLayoutTest,
-     PopOutUsesEmbeddedWindowIdentityAndClosesDrawer) {
+     PopOutUsesEmbeddedWindowIdentityAndRestoresRoomInspector) {
   int current_room_id = 0x011;
   const std::deque<int> recent_rooms;
   auto content = MakeWorkbenchForToolStateTests(current_room_id, recent_rooms);
@@ -443,15 +343,17 @@ TEST(DungeonWorkbenchContentLayoutTest,
                                        return true;
                                      });
 
+  EXPECT_STREQ(content.GetInspectorModeIdForTesting(), "room");
   content.OpenObjectSelectorTool();
-  ASSERT_TRUE(content.IsToolDrawerActiveForTesting());
+  ASSERT_TRUE(content.IsToolInspectorActiveForTesting());
   EXPECT_TRUE(content.PopOutActiveTool());
   EXPECT_EQ(opened_window_id, "dungeon.object_selector");
-  EXPECT_FALSE(content.IsToolDrawerActiveForTesting());
+  EXPECT_FALSE(content.IsToolInspectorActiveForTesting());
+  EXPECT_STREQ(content.GetInspectorModeIdForTesting(), "room");
 }
 
 TEST(DungeonWorkbenchContentLayoutTest,
-     OpenToolClosesDrawerAndFocusesExistingStandalone) {
+     OpenToolRestoresSelectionAndFocusesExistingStandalone) {
   int current_room_id = 0x011;
   const std::deque<int> recent_rooms;
   auto content = MakeWorkbenchForToolStateTests(current_room_id, recent_rooms);
@@ -472,18 +374,21 @@ TEST(DungeonWorkbenchContentLayoutTest,
         return true;
       });
 
+  content.FocusSelectionInspector();
+  EXPECT_STREQ(content.GetInspectorModeIdForTesting(), "selection");
   content.OpenObjectSelectorTool();
-  ASSERT_TRUE(content.IsToolDrawerActiveForTesting());
+  ASSERT_TRUE(content.IsToolInspectorActiveForTesting());
 
   standalone_open = true;
   content.OpenObjectSelectorTool();
-  EXPECT_FALSE(content.IsToolDrawerActiveForTesting());
+  EXPECT_FALSE(content.IsToolInspectorActiveForTesting());
+  EXPECT_STREQ(content.GetInspectorModeIdForTesting(), "selection");
   EXPECT_EQ(focus_count, 1);
   EXPECT_EQ(focused_window_id, "dungeon.object_selector");
 }
 
 TEST(DungeonWorkbenchContentLayoutTest,
-     ToolDrawerSelectionSurvivesRoomChanges) {
+     ToolInspectorSelectionSurvivesRoomChanges) {
   int current_room_id = 0x011;
   const std::deque<int> recent_rooms;
   auto content = MakeWorkbenchForToolStateTests(current_room_id, recent_rooms);
@@ -492,8 +397,8 @@ TEST(DungeonWorkbenchContentLayoutTest,
   current_room_id = 0x012;
   content.NotifyRoomChanged(0x011);
 
-  EXPECT_TRUE(content.IsToolDrawerActiveForTesting());
-  EXPECT_STREQ(content.GetInspectorModeIdForTesting(), "room");
+  EXPECT_TRUE(content.IsToolInspectorActiveForTesting());
+  EXPECT_STREQ(content.GetInspectorModeIdForTesting(), "tools");
   EXPECT_STREQ(content.GetActiveToolIdForTesting(), "custom_collision");
 }
 

--- a/test/unit/editor/dungeon_workbench_toolbar_test.cc
+++ b/test/unit/editor/dungeon_workbench_toolbar_test.cc
@@ -44,6 +44,115 @@ class DungeonWorkbenchToolbarTest : public ::testing::Test {
   ImGuiContext* context_ = nullptr;
 };
 
+struct ToolbarGeometry {
+  float consumed_height = 0.0f;
+  float content_height = 0.0f;
+  float cursor_max_right = 0.0f;
+  float content_right = 0.0f;
+};
+
+ToolbarGeometry DrawToolbarForHistoryGeometry(
+    const char* child_id, const std::deque<int>& recent_rooms) {
+  const bool child_open = ImGui::BeginChild(
+      child_id, ImVec2(760.0f, 80.0f), false,
+      ImGuiWindowFlags_NoScrollbar | ImGuiWindowFlags_NoScrollWithMouse);
+  EXPECT_TRUE(child_open);
+
+  ImGuiWindow* window = ImGui::GetCurrentWindow();
+  const ImVec2 start = ImGui::GetCursorScreenPos();
+
+  DungeonWorkbenchLayoutState layout;
+  int current_room_id = 0x010;
+  int previous_room_id = 0x00F;
+  bool split_view_enabled = false;
+  int compare_room_id = 0x011;
+  char compare_search[32] = {};
+
+  DungeonWorkbenchToolbarParams params;
+  params.layout = &layout;
+  params.current_room_id = &current_room_id;
+  params.previous_room_id = &previous_room_id;
+  params.split_view_enabled = &split_view_enabled;
+  params.compare_room_id = &compare_room_id;
+  params.get_recent_rooms = [&recent_rooms]() -> const std::deque<int>& {
+    return recent_rooms;
+  };
+  params.compare_search_buf = compare_search;
+  params.compare_search_buf_size = sizeof(compare_search);
+
+  EXPECT_FALSE(DungeonWorkbenchToolbar::Draw(params));
+
+  const ToolbarGeometry geometry{
+      .consumed_height = ImGui::GetCursorScreenPos().y - start.y,
+      .content_height = window->DC.CursorMaxPos.y - start.y,
+      .cursor_max_right = window->DC.CursorMaxPos.x,
+      .content_right =
+          ImGui::GetWindowPos().x + ImGui::GetWindowContentRegionMax().x,
+  };
+  ImGui::EndChild();
+  return geometry;
+}
+
+ToolbarGeometry DrawWorstCaseToolbarGeometry(const char* child_id, float width,
+                                             DungeonCanvasViewer* viewer,
+                                             bool open_overflow = false,
+                                             bool compare_active = false) {
+  const bool child_open = ImGui::BeginChild(
+      child_id, ImVec2(width, 96.0f), false,
+      ImGuiWindowFlags_NoScrollbar | ImGuiWindowFlags_NoScrollWithMouse);
+  EXPECT_TRUE(child_open);
+
+  ImGuiWindow* window = ImGui::GetCurrentWindow();
+  const ImVec2 start = ImGui::GetCursorScreenPos();
+  DungeonWorkbenchLayoutState layout;
+  int current_room_id = 0x010;
+  int previous_room_id = 0x00F;
+  bool split_view_enabled = compare_active;
+  int compare_room_id = 0x011;
+  const std::deque<int> recent_rooms = {0x011, 0x00F, 0x002};
+  char compare_search[32] = {};
+
+  DungeonWorkbenchToolbarParams params;
+  params.layout = &layout;
+  params.current_room_id = &current_room_id;
+  params.previous_room_id = &previous_room_id;
+  params.split_view_enabled = &split_view_enabled;
+  params.compare_room_id = &compare_room_id;
+  params.primary_viewer = viewer;
+  params.on_room_selected = [](int) {
+  };
+  params.get_recent_rooms = [&recent_rooms]() -> const std::deque<int>& {
+    return recent_rooms;
+  };
+  params.on_open_room_panel = [](int) {
+  };
+  params.forget_recent_room = [](int) {
+  };
+  params.set_workflow_mode = [](bool) {
+  };
+  params.on_save_room = [](int) {
+  };
+  params.on_request_dungeon_map = []() {
+  };
+  params.compare_search_buf = compare_search;
+  params.compare_search_buf_size = sizeof(compare_search);
+
+  if (open_overflow) {
+    ImGui::OpenPopup("##WorkbenchToolbarOverflow");
+  }
+  EXPECT_FALSE(DungeonWorkbenchToolbar::Draw(params));
+
+  const ToolbarGeometry geometry{
+      .consumed_height = ImGui::GetCursorScreenPos().y - start.y,
+      .content_height = window->DC.CursorMaxPos.y - start.y,
+      .cursor_max_right = window->DC.CursorMaxPos.x,
+      .content_right =
+          ImGui::GetWindowPos().x + ImGui::GetWindowContentRegionMax().x,
+  };
+  ImGui::EndChild();
+  return geometry;
+}
+
 TEST(DungeonWorkbenchToolbarLogicTest, InlineRoomNavNeverHides) {
   EXPECT_TRUE(DungeonWorkbenchToolbar::ShouldShowInlineRoomNav(960.0f));
   EXPECT_TRUE(DungeonWorkbenchToolbar::ShouldShowInlineRoomNav(760.0f));
@@ -115,6 +224,110 @@ TEST_F(DungeonWorkbenchToolbarTest,
   EXPECT_EQ(context->StyleVarStack.Size, style_before);
   EXPECT_EQ(context->ColorStack.Size, color_before);
   EXPECT_EQ(context->CurrentWindowStack.Size, window_stack_before);
+}
+
+TEST_F(DungeonWorkbenchToolbarTest,
+       HistoryControlKeepsToolbarHeightStableWhenHistoryChanges) {
+  const std::deque<int> empty_history;
+  const std::deque<int> populated_history = {0x011, 0x00F, 0x002};
+
+  const ToolbarGeometry empty =
+      DrawToolbarForHistoryGeometry("##EmptyHistoryToolbar", empty_history);
+  const ToolbarGeometry populated = DrawToolbarForHistoryGeometry(
+      "##PopulatedHistoryToolbar", populated_history);
+
+  EXPECT_FLOAT_EQ(empty.consumed_height, populated.consumed_height);
+  EXPECT_FLOAT_EQ(empty.content_height, populated.content_height);
+}
+
+TEST_F(DungeonWorkbenchToolbarTest,
+       WorstCaseToolbarFitsNarrowAndScaledContentWidths) {
+  std::vector<uint8_t> rom_data(0x8000, 0);
+  Rom rom;
+  ASSERT_TRUE(rom.LoadFromData(rom_data).ok());
+  DungeonRoomStore rooms(&rom);
+  auto& room = rooms[0x010];
+  room.SetLoaded(true);
+  DungeonCanvasViewer viewer(&rom);
+  viewer.SetRooms(&rooms);
+
+  const ToolbarGeometry narrow = DrawWorstCaseToolbarGeometry(
+      "##NarrowToolbar", 320.0f, &viewer, /*open_overflow=*/true);
+  EXPECT_LE(narrow.cursor_max_right, narrow.content_right + 0.5f);
+
+  ImGui::GetStyle().ScaleAllSizes(1.5f);
+  const ToolbarGeometry scaled = DrawWorstCaseToolbarGeometry(
+      "##ScaledToolbar", 420.0f, &viewer, /*open_overflow=*/true);
+  EXPECT_LE(scaled.cursor_max_right, scaled.content_right + 0.5f);
+}
+
+TEST_F(DungeonWorkbenchToolbarTest,
+       ActiveCompareOverflowRendersRoomPickerWithoutStackLeaks) {
+  ImGuiContext* context = ImGui::GetCurrentContext();
+  ASSERT_NE(context, nullptr);
+
+  std::vector<uint8_t> rom_data(0x8000, 0);
+  Rom rom;
+  ASSERT_TRUE(rom.LoadFromData(rom_data).ok());
+  DungeonRoomStore rooms(&rom);
+  auto& room = rooms[0x010];
+  room.SetLoaded(true);
+  DungeonCanvasViewer viewer(&rom);
+  viewer.SetRooms(&rooms);
+
+  const int style_before = context->StyleVarStack.Size;
+  const int color_before = context->ColorStack.Size;
+  const int window_stack_before = context->CurrentWindowStack.Size;
+  const int popup_stack_before = context->BeginPopupStack.Size;
+
+  const ToolbarGeometry geometry = DrawWorstCaseToolbarGeometry(
+      "##ActiveCompareOverflow", 320.0f, &viewer, /*open_overflow=*/true,
+      /*compare_active=*/true);
+
+  EXPECT_LE(geometry.cursor_max_right, geometry.content_right + 0.5f);
+  EXPECT_EQ(context->StyleVarStack.Size, style_before);
+  EXPECT_EQ(context->ColorStack.Size, color_before);
+  EXPECT_EQ(context->CurrentWindowStack.Size, window_stack_before);
+  EXPECT_EQ(context->BeginPopupStack.Size, popup_stack_before);
+}
+
+TEST_F(DungeonWorkbenchToolbarTest,
+       DrawRecentRoomsPopupKeepsImGuiStacksBalanced) {
+  ImGuiContext* context = ImGui::GetCurrentContext();
+  ASSERT_NE(context, nullptr);
+
+  const int style_before = context->StyleVarStack.Size;
+  const int color_before = context->ColorStack.Size;
+  const int window_stack_before = context->CurrentWindowStack.Size;
+  const int popup_stack_before = context->BeginPopupStack.Size;
+
+  DungeonWorkbenchLayoutState layout;
+  int current_room_id = 0x010;
+  int previous_room_id = 0x00F;
+  bool split_view_enabled = false;
+  int compare_room_id = 0x011;
+  const std::deque<int> recent_rooms = {0x011, 0x00F, 0x002};
+  char compare_search[32] = {};
+
+  DungeonWorkbenchToolbarParams params;
+  params.layout = &layout;
+  params.current_room_id = &current_room_id;
+  params.previous_room_id = &previous_room_id;
+  params.split_view_enabled = &split_view_enabled;
+  params.compare_room_id = &compare_room_id;
+  params.get_recent_rooms = [&recent_rooms]() -> const std::deque<int>& {
+    return recent_rooms;
+  };
+  params.compare_search_buf = compare_search;
+  params.compare_search_buf_size = sizeof(compare_search);
+
+  ImGui::OpenPopup("##WorkbenchRecentRooms");
+  EXPECT_FALSE(DungeonWorkbenchToolbar::Draw(params));
+
+  EXPECT_EQ(context->StyleVarStack.Size, style_before);
+  EXPECT_EQ(context->ColorStack.Size, color_before);
+  EXPECT_EQ(context->CurrentWindowStack.Size, window_stack_before);
+  EXPECT_EQ(context->BeginPopupStack.Size, popup_stack_before);
 }
 
 TEST_F(DungeonWorkbenchToolbarTest,

--- a/test/unit/editor/object_tile_editor_panel_test.cc
+++ b/test/unit/editor/object_tile_editor_panel_test.cc
@@ -536,19 +536,17 @@ TEST(DungeonEditorV2ObjectTileEditorTest,
   ASSERT_TRUE(ObjectTileEditorPanelTestAccess::Layout(*panel_ptr)
                   .source_provenance.has_value());
 
-  auto expected_palette = game_data.palette_groups.dungeon_main.palette_ref(3);
-  auto expected_group =
-      gfx::CreatePaletteGroupFromLargePalette(expected_palette);
-  ASSERT_TRUE(expected_group.ok()) << expected_group.status();
-  auto default_palette = game_data.palette_groups.dungeon_main.palette_ref(0);
-  auto default_group = gfx::CreatePaletteGroupFromLargePalette(default_palette);
-  ASSERT_TRUE(default_group.ok()) << default_group.status();
+  const auto& hud_palette = game_data.palette_groups.hud.palette_ref(0);
+  const auto expected_group = zelda3::BuildDungeonRenderPaletteGroup(
+      game_data.palette_groups.dungeon_main.palette_ref(3), &hud_palette);
+  const auto default_group = zelda3::BuildDungeonRenderPaletteGroup(
+      game_data.palette_groups.dungeon_main.palette_ref(0), &hud_palette);
   EXPECT_EQ(ObjectTileEditorPanelTestAccess::CurrentPaletteColor(
-                *panel_ptr, /*palette=*/0, /*color=*/0),
-            expected_group->GetColor(/*palette=*/0, /*color=*/0).snes());
+                *panel_ptr, /*palette=*/2, /*color=*/1),
+            expected_group.GetColor(/*palette=*/2, /*color=*/1).snes());
   EXPECT_NE(ObjectTileEditorPanelTestAccess::CurrentPaletteColor(
-                *panel_ptr, /*palette=*/0, /*color=*/0),
-            default_group->GetColor(/*palette=*/0, /*color=*/0).snes());
+                *panel_ptr, /*palette=*/2, /*color=*/1),
+            default_group.GetColor(/*palette=*/2, /*color=*/1).snes());
 }
 
 TEST(DungeonEditorV2ObjectTileEditorTest,

--- a/test/unit/editor/sidebar_sort_test.cc
+++ b/test/unit/editor/sidebar_sort_test.cc
@@ -98,12 +98,12 @@ TEST(SidebarSortTest, OrderEntriesNotInInputAreIgnored) {
 }
 
 // Mode-parity contract: Dungeon Workbench mode no longer hides per-tool
-// standalone windows from the sidebar / Window Browser. The Workbench drawer
-// still embeds the same tools, but users can keep a standalone copy open
-// alongside it. The previous `IsDungeonWorkbenchLocalToolWindow` policy was
-// removed in the 2026-04-26 polish pass; only navigation-mode handling
-// (room selector / room matrix / per-room windows) remains as a workflow
-// switch concern.
+// standalone windows from the sidebar / Window Browser. The Tools inspector
+// embeds the same WindowContent instance until the user pops it out; the two
+// presentations are mutually exclusive. The previous
+// `IsDungeonWorkbenchLocalToolWindow` policy was removed in the 2026-04-26
+// polish pass; only navigation-mode handling (room selector / room matrix /
+// per-room windows) remains as a workflow switch concern.
 //
 // `IsDungeonWindowModeTarget` matches `dungeon.room_*` by prefix because
 // per-room windows use ids like `dungeon.room_42`. That prefix-match also

--- a/test/unit/zelda3/dungeon/custom_object_room_render_test.cc
+++ b/test/unit/zelda3/dungeon/custom_object_room_render_test.cc
@@ -311,6 +311,50 @@ TEST_F(CustomObjectRoomRenderTest,
 }
 
 TEST_F(CustomObjectRoomRenderTest,
+       MushroomStatueDoesNotEnableTrackAliasesForWallCorners) {
+  std::vector<std::string> custom_files = {
+      "track_LR.bin",
+      "track_UD.bin",
+      "track_corner_TL.bin",
+      "track_corner_TR.bin",
+      "track_corner_BL.bin",
+      "track_corner_BR.bin",
+      "track_floor_UD.bin",
+      "track_floor_LR.bin",
+      "track_floor_corner_TL.bin",
+      "track_floor_corner_TR.bin",
+      "track_floor_corner_BL.bin",
+      "track_floor_corner_BR.bin",
+      "track_floor_any.bin",
+      "wall_sword_house.bin",
+      "track_any.bin",
+      "small_statue.bin",
+  };
+  EnableCustomObjects(custom_files);
+  WriteSingleTileCustomObjectFile("track_corner_TL.bin",
+                                  /*tile_id=0 pal=2*/ 0x0800);
+  WriteSingleTileCustomObjectFile("small_statue.bin",
+                                  /*tile_id=0 pal=2*/ 0x0800);
+
+  Room room = MakeRoomWithObjects(
+      {RoomObject(/*id=*/0x31, /*x=*/1, /*y=*/1, /*size=*/15, /*layer=*/2),
+       RoomObject(/*id=*/0x100, /*x=*/6, /*y=*/7, /*size=*/0, /*layer=*/2)});
+  RenderObjectBuffers(room);
+
+  const auto& bitmap = room.object_bg1_buffer().bitmap();
+  const auto& coverage = room.object_bg1_buffer().coverage_data();
+  int wall_corner_pixels = 0;
+  for (int y = 7 * 8; y < 11 * 8; ++y) {
+    for (int x = 6 * 8; x < 10 * 8; ++x) {
+      wall_corner_pixels += coverage[PixelIndex(bitmap, x, y)] != 0 ? 1 : 0;
+    }
+  }
+  EXPECT_GT(wall_corner_pixels, 64)
+      << "A Mushroom Grotto small statue must leave the ordinary 4x4 wall "
+         "corner on its vanilla draw routine";
+}
+
+TEST_F(CustomObjectRoomRenderTest,
        LayoutCornerIgnoresTrackAliasFilesWithoutTrackBaseObject) {
   EnableCustomObjects({"track_LR.bin", "track_UD.bin", "track_corner_TL.bin",
                        "track_corner_TR.bin", "track_corner_BL.bin",

--- a/test/unit/zelda3/dungeon/object_layer_semantics_test.cc
+++ b/test/unit/zelda3/dungeon/object_layer_semantics_test.cc
@@ -215,6 +215,31 @@ TEST(ObjectLayerSemanticsTest,
 }
 
 TEST(ObjectLayerSemanticsTest,
+     OnlyMinecartTrackSubtypesEnableRoomCornerAliases) {
+  for (uint8_t subtype = 0; subtype <= 12; ++subtype) {
+    SCOPED_TRACE(static_cast<int>(subtype));
+    const std::array<RoomObject, 1> objects = {
+        RoomObject(/*id=*/0x31, /*x=*/0, /*y=*/0, subtype, /*layer=*/0)};
+    EXPECT_TRUE(RoomAllowsTrackCornerAliases(objects));
+  }
+
+  const std::array<RoomObject, 1> track_any = {
+      RoomObject(/*id=*/0x31, /*x=*/0, /*y=*/0, /*size=*/14, /*layer=*/0)};
+  EXPECT_TRUE(RoomAllowsTrackCornerAliases(track_any));
+
+  for (uint8_t decorative_subtype : {uint8_t{13}, uint8_t{15}}) {
+    SCOPED_TRACE(static_cast<int>(decorative_subtype));
+    const std::array<RoomObject, 1> objects = {RoomObject(
+        /*id=*/0x31, /*x=*/0, /*y=*/0, decorative_subtype, /*layer=*/0)};
+    EXPECT_FALSE(RoomAllowsTrackCornerAliases(objects));
+  }
+
+  const std::array<RoomObject, 1> unrelated = {
+      RoomObject(/*id=*/0x32, /*x=*/0, /*y=*/0, /*size=*/0, /*layer=*/0)};
+  EXPECT_FALSE(RoomAllowsTrackCornerAliases(unrelated));
+}
+
+TEST(ObjectLayerSemanticsTest,
      AuditedObjectIdsReportRoutingAcrossAllStoredStreams) {
   for (const auto& test_case : kAuditedRoutingCases) {
     for (uint8_t stored_stream : {uint8_t{0}, uint8_t{1}, uint8_t{2}}) {

--- a/test/unit/zelda3/dungeon/object_tile_editor_test.cc
+++ b/test/unit/zelda3/dungeon/object_tile_editor_test.cc
@@ -1012,6 +1012,59 @@ TEST(ObjectTileEditorTest, RenderLayoutToBitmapUsesThirdPaletteWhenAvailable) {
   EXPECT_EQ(bitmap.mutable_data()[8], 17);
 }
 
+TEST(ObjectTileEditorTest, RenderLayoutToBitmapUsesCanonicalDungeonCgramRows) {
+  Rom rom;
+  ASSERT_TRUE(rom.LoadFromData(std::vector<uint8_t>(0x200000, 0)).ok());
+
+  gfx::SnesPalette hud_palette;
+  for (int i = 0; i < 32; ++i) {
+    hud_palette.AddColor(gfx::SnesColor(static_cast<uint16_t>(0x0100 + i)));
+  }
+  gfx::SnesPalette dungeon_palette;
+  for (int i = 0; i < 90; ++i) {
+    dungeon_palette.AddColor(gfx::SnesColor(static_cast<uint16_t>(0x0200 + i)));
+  }
+  const auto palette_group =
+      BuildDungeonRenderPaletteGroup(dungeon_palette, &hud_palette);
+
+  ObjectTileLayout layout;
+  layout.bounds_width = 2;
+  layout.bounds_height = 1;
+  ObjectTileLayout::Cell first_bank;
+  first_bank.rel_x = 0;
+  first_bank.rel_y = 0;
+  first_bank.tile_info =
+      gfx::TileInfo(/*id=*/0, /*palette=*/2, false, false, false);
+  layout.cells.push_back(first_bank);
+  ObjectTileLayout::Cell last_bank;
+  last_bank.rel_x = 1;
+  last_bank.rel_y = 0;
+  last_bank.tile_info =
+      gfx::TileInfo(/*id=*/1, /*palette=*/7, false, false, false);
+  layout.cells.push_back(last_bank);
+
+  std::vector<uint8_t> gfx_buffer(0x10000, 0);
+  gfx_buffer[0] = 1;
+  gfx_buffer[8] = 15;
+  gfx::Bitmap bitmap;
+  ObjectTileEditor editor(&rom);
+
+  const auto status = editor.RenderLayoutToBitmap(
+      layout, bitmap, gfx_buffer.data(), palette_group);
+
+  ASSERT_TRUE(status.ok()) << status.message();
+  ASSERT_EQ(bitmap.palette().size(), 128u);
+  EXPECT_EQ(bitmap.palette()[33].snes(), dungeon_palette[0].snes());
+  EXPECT_EQ(bitmap.palette()[127].snes(), dungeon_palette[89].snes());
+  EXPECT_EQ(bitmap.mutable_data()[0], 33);
+  EXPECT_EQ(bitmap.mutable_data()[8], 127);
+  ASSERT_NE(bitmap.surface(), nullptr);
+  EXPECT_EQ(SDL_HasColorKey(bitmap.surface()), SDL_TRUE);
+  Uint32 transparent_key = 0;
+  ASSERT_EQ(SDL_GetColorKey(bitmap.surface(), &transparent_key), 0);
+  EXPECT_EQ(transparent_key, 255u);
+}
+
 TEST(ObjectTileEditorTest, BuildTile8AtlasUsesRequestedPaletteIndex) {
   Rom rom;
   ASSERT_TRUE(rom.LoadFromData(std::vector<uint8_t>(0x200000, 0)).ok());

--- a/test/unit/zelda3/dungeon/room_graphics_palette_test.cc
+++ b/test/unit/zelda3/dungeon/room_graphics_palette_test.cc
@@ -1,5 +1,6 @@
 #include <gtest/gtest.h>
 
+#include <algorithm>
 #include <cstdint>
 #include <memory>
 #include <vector>
@@ -11,6 +12,68 @@
 #include "zelda3/game_data.h"
 
 namespace yaze::zelda3::test {
+
+namespace {
+
+gfx::SnesPalette MakeDistinctPalette(uint16_t base, size_t color_count) {
+  gfx::SnesPalette palette;
+  for (size_t i = 0; i < color_count; ++i) {
+    palette.AddColor(gfx::SnesColor(static_cast<uint16_t>(base + i)));
+  }
+  return palette;
+}
+
+void AddDistinctPaletteSeries(gfx::PaletteGroup& group, size_t palette_count,
+                              size_t color_count, uint16_t base) {
+  for (size_t i = 0; i < palette_count; ++i) {
+    group.AddPalette(MakeDistinctPalette(static_cast<uint16_t>(base + i * 0x20),
+                                         color_count));
+  }
+}
+
+void ExpectSdlColorMatches(const SDL_Color& actual,
+                           const gfx::SnesColor& expected) {
+  const auto rgb = expected.rom_color();
+  EXPECT_EQ(actual.r, rgb.red);
+  EXPECT_EQ(actual.g, rgb.green);
+  EXPECT_EQ(actual.b, rgb.blue);
+  EXPECT_EQ(actual.a, 255);
+}
+
+void PopulateDistinctSpritePaletteData(GameData& game_data) {
+  AddDistinctPaletteSeries(game_data.palette_groups.global_sprites, 2, 60,
+                           0x1000);
+  AddDistinctPaletteSeries(game_data.palette_groups.armors, 5, 15, 0x2000);
+  AddDistinctPaletteSeries(game_data.palette_groups.sprites_aux1, 12, 7,
+                           0x3000);
+  AddDistinctPaletteSeries(game_data.palette_groups.sprites_aux2, 11, 7,
+                           0x4000);
+  AddDistinctPaletteSeries(game_data.palette_groups.sprites_aux3, 24, 7,
+                           0x5000);
+}
+
+}  // namespace
+
+TEST(GameDataTest, DefaultGraphicsLookupTablesAreZeroInitialized) {
+  const GameData game_data;
+
+  for (const auto& blockset : game_data.main_blockset_ids) {
+    EXPECT_TRUE(std::all_of(blockset.begin(), blockset.end(),
+                            [](uint8_t value) { return value == 0; }));
+  }
+  for (const auto& blockset : game_data.room_blockset_ids) {
+    EXPECT_TRUE(std::all_of(blockset.begin(), blockset.end(),
+                            [](uint8_t value) { return value == 0; }));
+  }
+  for (const auto& spriteset : game_data.spriteset_ids) {
+    EXPECT_TRUE(std::all_of(spriteset.begin(), spriteset.end(),
+                            [](uint8_t value) { return value == 0; }));
+  }
+  for (const auto& paletteset : game_data.paletteset_ids) {
+    EXPECT_TRUE(std::all_of(paletteset.begin(), paletteset.end(),
+                            [](uint8_t value) { return value == 0; }));
+  }
+}
 
 // USDASM grounding:
 // - bank_00.asm LoadBackgroundGraphics chooses Expand3bppToVRAM_RightPalette for
@@ -155,6 +218,91 @@ TEST(RoomGraphicsPaletteTest, BuildDungeonRenderPaletteIncludesHudRows) {
 
   // Undrawn fill color remains transparent.
   EXPECT_EQ(colors[255].a, 0);
+}
+
+TEST(RoomGraphicsPaletteTest,
+     BuildDungeonSpriteRenderPaletteUsesMushroomGrottoSelectors) {
+  GameData game_data;
+  PopulateDistinctSpritePaletteData(game_data);
+  game_data.paletteset_ids[0x0F] = {0x10, 0x05, 0x0A, 0x07};
+  Room room;
+  room.SetPalette(0x0F);
+
+  const auto colors = BuildDungeonSpriteRenderPalette(room, &game_data);
+
+  ASSERT_EQ(colors.size(), 256u);
+  for (size_t color = 0; color < 7; ++color) {
+    ExpectSdlColorMatches(
+        colors[8 * 16 + 1 + color],
+        game_data.palette_groups.sprites_aux1.palette_ref(5)[color]);
+    ExpectSdlColorMatches(
+        colors[8 * 16 + 9 + color],
+        game_data.palette_groups.sprites_aux2.palette_ref(7)[color]);
+    ExpectSdlColorMatches(
+        colors[13 * 16 + 1 + color],
+        game_data.palette_groups.sprites_aux3.palette_ref(10)[color]);
+    ExpectSdlColorMatches(
+        colors[14 * 16 + 1 + color],
+        game_data.palette_groups.sprites_aux3.palette_ref(7)[color]);
+    ExpectSdlColorMatches(
+        colors[14 * 16 + 9 + color],
+        game_data.palette_groups.sprites_aux2.palette_ref(10)[color]);
+  }
+
+  ExpectSdlColorMatches(
+      colors[9 * 16 + 1],
+      game_data.palette_groups.global_sprites.palette_ref(0)[0]);
+  ExpectSdlColorMatches(
+      colors[12 * 16 + 15],
+      game_data.palette_groups.global_sprites.palette_ref(0)[59]);
+  ExpectSdlColorMatches(colors[15 * 16 + 1],
+                        game_data.palette_groups.armors.palette_ref(0)[0]);
+}
+
+TEST(RoomGraphicsPaletteTest,
+     BuildDungeonSpriteRenderPaletteFallsBackForInvalidIds) {
+  GameData game_data;
+  game_data.palette_groups.global_sprites.AddPalette(
+      MakeDistinctPalette(0x1000, 60));
+  game_data.palette_groups.armors.AddPalette(MakeDistinctPalette(0x2000, 15));
+  game_data.palette_groups.sprites_aux1.AddPalette(
+      MakeDistinctPalette(0x3000, 7));
+  game_data.palette_groups.sprites_aux2.AddPalette(
+      MakeDistinctPalette(0x4000, 7));
+  game_data.palette_groups.sprites_aux3.AddPalette(
+      MakeDistinctPalette(0x5000, 7));
+  game_data.paletteset_ids[0] = {0, 0xFE, 0xFD, 0xFC};
+  Room room;
+  room.SetPalette(0);
+
+  const auto colors = BuildDungeonSpriteRenderPalette(room, &game_data);
+
+  ASSERT_EQ(colors.size(), 256u);
+  ExpectSdlColorMatches(
+      colors[8 * 16 + 1],
+      game_data.palette_groups.sprites_aux1.palette_ref(0)[0]);
+  ExpectSdlColorMatches(
+      colors[8 * 16 + 9],
+      game_data.palette_groups.sprites_aux2.palette_ref(0)[0]);
+  ExpectSdlColorMatches(
+      colors[13 * 16 + 1],
+      game_data.palette_groups.sprites_aux3.palette_ref(0)[0]);
+  ExpectSdlColorMatches(
+      colors[14 * 16 + 1],
+      game_data.palette_groups.sprites_aux3.palette_ref(0)[0]);
+  ExpectSdlColorMatches(
+      colors[14 * 16 + 9],
+      game_data.palette_groups.sprites_aux2.palette_ref(0)[0]);
+
+  room.SetPalette(0xFF);
+  const auto invalid_set_colors =
+      BuildDungeonSpriteRenderPalette(room, &game_data);
+  ExpectSdlColorMatches(
+      invalid_set_colors[8 * 16 + 1],
+      game_data.palette_groups.sprites_aux1.palette_ref(0)[0]);
+  ExpectSdlColorMatches(
+      invalid_set_colors[13 * 16 + 1],
+      game_data.palette_groups.sprites_aux3.palette_ref(0)[0]);
 }
 
 TEST(RoomGraphicsPaletteTest, BuildDungeonRenderPaletteGroupMatchesCgramRows) {

--- a/test/unit/zelda3/dungeon/room_graphics_palette_test.cc
+++ b/test/unit/zelda3/dungeon/room_graphics_palette_test.cc
@@ -157,6 +157,35 @@ TEST(RoomGraphicsPaletteTest, BuildDungeonRenderPaletteIncludesHudRows) {
   EXPECT_EQ(colors[255].a, 0);
 }
 
+TEST(RoomGraphicsPaletteTest, BuildDungeonRenderPaletteGroupMatchesCgramRows) {
+  gfx::SnesPalette hud_palette;
+  for (int i = 0; i < 32; ++i) {
+    hud_palette.AddColor(gfx::SnesColor(i, i + 1, i + 2));
+  }
+
+  gfx::SnesPalette dungeon_palette;
+  for (int i = 0; i < 90; ++i) {
+    dungeon_palette.AddColor(gfx::SnesColor(i + 32, i + 33, i + 34));
+  }
+
+  const auto group =
+      BuildDungeonRenderPaletteGroup(dungeon_palette, &hud_palette);
+
+  ASSERT_EQ(group.size(), 8u);
+  for (int row = 0; row < 8; ++row) {
+    EXPECT_EQ(group.palette_ref(row).size(), 16u);
+  }
+
+  EXPECT_EQ(group.palette_ref(0)[0].snes(), hud_palette[0].snes());
+  EXPECT_EQ(group.palette_ref(1)[15].snes(), hud_palette[31].snes());
+  EXPECT_EQ(group.palette_ref(2)[0].snes(), gfx::SnesColor().snes());
+  EXPECT_EQ(group.palette_ref(2)[1].snes(), dungeon_palette[0].snes());
+  EXPECT_EQ(group.palette_ref(2)[15].snes(), dungeon_palette[14].snes());
+  EXPECT_EQ(group.palette_ref(3)[1].snes(), dungeon_palette[15].snes());
+  EXPECT_EQ(group.palette_ref(7)[1].snes(), dungeon_palette[75].snes());
+  EXPECT_EQ(group.palette_ref(7)[15].snes(), dungeon_palette[89].snes());
+}
+
 TEST(RoomGraphicsPaletteTest,
      PaletteDebuggerSamplesMappedDungeonRenderPalette) {
   gfx::SnesPalette hud_palette;

--- a/test/unit/zelda3/sprite_render_preview_test.cc
+++ b/test/unit/zelda3/sprite_render_preview_test.cc
@@ -1,6 +1,9 @@
 #include "zelda3/sprite/sprite.h"
 
+#include <algorithm>
+#include <array>
 #include <cstdint>
+#include <iomanip>
 #include <span>
 #include <vector>
 
@@ -43,7 +46,7 @@ TEST(SpriteRenderPreviewTest, RendersDungeonGraphicsAtPreviewOrigin) {
   // 16px anchor instead of using the sprite's room coordinate directly.
   EXPECT_EQ((*preview)[16 + (16 * kPreviewSize)], 195);
   EXPECT_EQ((*preview)[31 + (16 * kPreviewSize)], 196);
-  EXPECT_EQ((*preview)[17 + (16 * kPreviewSize)], 0xFF);
+  EXPECT_EQ((*preview)[17 + (16 * kPreviewSize)], 0);
 
   EXPECT_EQ(sprite.x(), 14);
   EXPECT_EQ(sprite.y(), 20);
@@ -58,6 +61,43 @@ TEST(SpriteRenderPreviewTest, EmptyGraphicsClearsPreview) {
   sprite.RenderPreviewGraphics(std::span<const uint8_t>());
 
   EXPECT_TRUE(sprite.preview_graphics()->empty());
+}
+
+TEST(SpriteRenderPreviewTest, EmitsIndicesForDungeonAuxiliaryPaletteRows) {
+  std::vector<uint8_t> graphics(kGraphicsBufferSize, 1);
+  struct PreviewCase {
+    uint8_t sprite_id;
+    uint8_t expected_palette_index;
+  };
+  constexpr std::array<PreviewCase, 4> kCases = {
+      {{0x13, 129}, {0x42, 209}, {0x4C, 225}, {0x1C, 233}}};
+
+  for (const auto& test_case : kCases) {
+    Sprite sprite(test_case.sprite_id, 0, 0, 0, 0);
+    sprite.RenderPreviewGraphics(graphics);
+
+    const auto* preview = sprite.preview_graphics();
+    ASSERT_NE(preview, nullptr);
+    EXPECT_NE(std::find(preview->begin(), preview->end(),
+                        test_case.expected_palette_index),
+              preview->end())
+        << "sprite 0x" << std::hex << static_cast<int>(test_case.sprite_id);
+  }
+}
+
+TEST(SpriteRenderPreviewTest, PreservesCgramIndex255AsVisibleDungeonPixel) {
+  std::vector<uint8_t> graphics(kGraphicsBufferSize, 15);
+  Sprite sprite(0xE7, 0, 0, 0,
+                0);  // Mushroom uses preview palette selector 16.
+
+  sprite.RenderPreviewGraphics(graphics);
+
+  const auto* preview = sprite.preview_graphics();
+  ASSERT_NE(preview, nullptr);
+  ASSERT_EQ(preview->size(), kPreviewSize * kPreviewSize);
+  EXPECT_EQ((*preview)[0], 0);
+  EXPECT_NE(std::find(preview->begin(), preview->end(), uint8_t{0xFF}),
+            preview->end());
 }
 
 }  // namespace


### PR DESCRIPTION
## Summary
- keep the dungeon canvas vertically stable: remove transient selection text and dynamic room tabs above it
- move recent rooms into a History popup and make the one-row toolbar responsive; low-frequency actions move into **More** while NESW room navigation remains visible
- preserve full Compare behavior in compact mode, including searchable room selection, direct room ID, Swap, Sync, and End
- replace the canvas-height-changing bottom drawer and permanent tool strip with a variable-width **Tools** mode in the existing right inspector
- use one grouped tool chooser for Object Selector, Door, Sprite, Item, Room Graphics, Palette, Room Tags, Custom Collision, Water Fill, and Minecart tools
- keep **Pop out** as the traditional standalone-panel path while enforcing one presentation owner per `WindowContent` instance
- streamline Object Selector controls into search, category, stream, and **More**; add Compact 54 / Medium 60 / Large 76 cards with aspect-fit previews and stable hex footers
- center fixed-size selector rows and make the dungeon palette grid responsive at 16 / 8 / 4 / 2 / 1 columns

## Rendering fixes found during the Mushroom Grotto audit
- stop Oracle custom object `0x31` decorative subtypes 13 and 15 from enabling minecart corner aliases; ordinary `0x100`-`0x103` wall corners now remain wall corners in Mushroom Grotto
- build dungeon sprite previews from the room palette-set selectors instead of the generic dungeon tile palette
- restore the inherited Light World sprite-environment half-palette at CGRAM row 8 right (`sprites_aux2[7]`), matching USDASM when entrance-world state is unavailable
- fix the sprite preview dispatch chain that let the generic fallback overdraw earlier sprite-specific previews
- use index `0` as the external-preview transparency sentinel so valid visible CGRAM index `0xFF` remains renderable
- zero-initialize graphics and palette lookup tables so an unloaded sheet cannot depend on allocator contents

## UX correctness found during review
- fixed Object Selector **Pop out** docking mutation by deferring standalone window opening until `DungeonEditorV2::Update()`
- fixed stale workflow restoration that could reopen a tool after the user explicitly closed it
- keep standalone editing tools open across Workbench / Windows switches; suspend only room-navigation panels
- expose **Open as Panel** only when the callback is actually wired
- keep status-bar selection details clickable without adding a layout-changing row above the canvas

## Verification for `95008860e`
- owned focused suite: **51 passed**, 0 failed
- direct unit binary excluding one known machine-settings-dependent test: **3,283 passed**, **19 skipped**, 0 failed
  - excluded: `EditorManagerRomWritePolicyTest.CleanSaveDoesNotMaterializeUnopenedOverworldEditor`
  - that test reads `/Users/scawful/Documents/Yaze/settings.json` despite `YAZE_APP_DATA_DIR`; it fails before `SaveRom()` when the saved active category is Overworld
- ROM regression fixtures with Vanilla + Oracle: **19 passed**, **3 intentional helper skips**
- five-tier dungeon visual audit:
  - synthetic registry: **32/32**
  - ROM parser/drawer: **10/10 Vanilla**
  - room fingerprint / independent ROI chain: **17 passed**, **3 intentional helper skips**
  - tile-count audit: pass
  - `z3ed dungeon-object-validate`: `mismatch_count: 0`, `empty_traces: 0`, **1190 objects**
- pre-push gate: build pass, **13 smoke tests**, **43 UI regression tests**, formatting pass
- `git diff --check`: pass
- independent final owned-diff review: no remaining actionable findings

## Installed app validation
- deployed and opened exact commit `95008860e` at `/Applications/yaze.app`
- deep strict code-sign verification: pass
- source and installed executable SHA-256: `7be10cf2051d9fa79529a4db9901f3779fe037e7d79f6547fd09c3a2b8dc8588`
- Oracle project, Mushroom Grotto room `0x04A`: **2/2** launch/render/normal-Quit cycles
- `oos168.sfc` remained unchanged: SHA-256 `b13ef69ede313756dcf560bf0f993663d68d0365609f2c20dcdec2c17f31f7b9`

## Honest remaining scope
- static water, ice, bar, and remaining small corner objects still need exact room/object witnesses or independent Mesen ROIs before changing their draw rules; shared synthetic routines alone are not sufficient truth
- dynamic water control objects `0xD8`/`0xDA` remain structural-only by design because vanilla uses them for HDMA control rather than stamped pixels
- Dark World sprite previews still use the deterministic Light World environment fallback because `Room` does not retain the entrance-world `$8A` context

## Merge order
Draft pending hands-on UX and Mushroom Grotto acceptance. This PR is stacked on #211 (`codex/dungeon-door-layering-fixes`), so merge the base first. PR #211's remaining red `WASM Build Smoke Test` lost hosted-runner communication and exited 143 during final linking; the independent WASM workflow passed at the exact same SHA, so this is inherited flaky CI rather than a dungeon source failure.
